### PR TITLE
[nginx-container-tag] Update nginx container tag to new release

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -7,7 +7,7 @@ var VERSION = "0.3.2"
 var WebImg = "drud/nginx-php-fpm7-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "0.1.0"
+var WebTag = "0.2.0"
 
 // DBImg defines the default db image for drud dev
 var DBImg = "drud/mysql-docker-local"


### PR DESCRIPTION
## The Problem:

We need to update the web image tag to 0.2.0

## Related Issue Link(s):
https://github.com/drud/docker.nginx-php-fpm/pull/27
