### PR TITLE
adding contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ The rules:
 
 1. All code should be formatted with `gofmt -s`.
 2. All code should pass the default levels of [`golint`](https://github.com/golang/lint).
-3. All code should follow the guidelines covered in [Effective Go](http://golang.org/doc/effective_go.html) and [Go Code Review   Comments](https://github.com/golang/go/wiki/CodeReviewComments).
+3. All code should follow the guidelines covered in [Effective Go](http://golang.org/doc/effective_go.html) and [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments).
 4. Comment the code. Tell us the why, the history and the context.
 5. Document _all_ declarations and methods, even private ones. Declare expectations, caveats and anything else that may be important. If a type gets exported, having the comments already there will ensure it's ready.
 6. Variable name length should be proportional to its context and no longer. `noCommaALongVariableNameLikeThisIsNotMoreClearWhenASimpleCommentWouldDo`. In practice, short methods will have short variable names and globals will have longer names.


### PR DESCRIPTION
## The Problem:
Drud would like to engage the open source community in this project. Right now there is no contributing information in ddev.

## The Fix:
Add a contributing.md document that github will link a user to when creating an issue or PR.

## The Test:
create an issue, see if github notifies you with a link to the contributing guidelines at the top of the page

satisfies requirements in drud/general/issues/32