### PR TITLE
[template-revert] Revert template to be more interally focused for now

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,45 +1,12 @@
-<!-- Thanks for filing an issue! Before hitting the button, please answer these questions.-->
-
-<!-- If this is a request for help, you should use our troubleshooting guide and community support channels, see [TBD]-->
+## What happened (or feature request):
 
 
-**Is this a BUG REPORT or FEATURE REQUEST?** (choose one):
-
-<!--
-If this is a BUG REPORT, please:
-  - Fill in as much of the template below as you can.  If you leave out
-    information, we can't help you as well.
-
-If this is a FEATURE REQUEST, please:
-  - Describe *in detail* the feature/behavior/change you'd like to see.
-
-In both cases, be ready for followup questions, and please respond in a timely
-manner.  If we can't reproduce a bug or think a feature already exists, we
-might close your issue.  If we're wrong, PLEASE feel free to reopen it and
-explain why.
--->
-
-**Information**:
-- Full output of the command run with debug enabled (```export DRUD_DEBUG=true```)
-- Output of ```docker ps```
-- Page URL if this is a docs issue or the name of a man page
-- ddev version
-- OS Version:
-- Related source links or issues
-- Others:
+## What you expected to happen:
 
 
-**What happened**:
+## How to reproduce it (as minimally and precisely as possible):
 
 
-**What you expected to happen**:
+## Anything else do we need to know:
 
-
-**How to reproduce it** (as minimally and precisely as possible):
-
-1. ...
-2. ...
-
-
-**Anything else we need to know**:
-
+## Related source links or issues (like source JIRA issue):


### PR DESCRIPTION
## The Problem:

The old issue template is very end-user focused. We have no end-users as of now. Let's use something more internally focused until that changes.