### PR TITLE
Make the temp drud download auth in drud organization

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ stages:
 
       # This step is a temporary hack until we have some kind of auth built into ddev
       - type: shell
-        command: wget -q -O /tmp/drud $DRUD_DOWNLOAD_URL && chmod ugo+x /tmp/drud && /tmp/drud auth github
+        command: wget -q -O /tmp/drud $DRUD_DOWNLOAD_URL && chmod ugo+x /tmp/drud && /tmp/drud config set --githubauthorg drud && /tmp/drud auth github
         name: Download temporary drud binary and do gitub auth
 
       - type: shell
@@ -63,3 +63,5 @@ stages:
           cd ~/src/github.com/drud/ddev &&
           make GOPATH=~/ test
         name: ddev tests
+
+


### PR DESCRIPTION
## The Problem:

We deployed new vault policies and mounts yesterday in https://github.com/drud/general/issues/16 - and those affect the behavior of the downloaded drud binary.

## The Fix:

Change the downloaded drud's drud.yaml to have githubauthorg=drud

## The Test:

If circle runs we're good.

