### PR TITLE
Bump version.VERSION for dev cycle

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ var VERSION = ""
 // IMPORTANT: These versions are overridden by version ldflags specifications VERSION_VARIABLES in the Makefile
 
 // Current version of the ddev tool, by default the git committish (should be current git tag)
-var DdevVersion = "0.4.0"  // Note that this is overridden by make
+var DdevVersion = "v0.1.0-dev"  // Note that this is overridden by make
 
 // WebImg defines the default web image for drud dev
 var WebImg = "drud/nginx-php-fpm7-local"  // Note that this is overridden by make


### PR DESCRIPTION
## The Problem: 

Time to bump version number for dev cycle

## The Fix: 

Bump default version to v0.1.0-dev (note that this is overridden by the git committish during build.

## Related Issue Link(s):

#42 on version bump

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

Deployment:
- [ ] After pulling this, tag and push the v0.1.0-dev git tag