### PR TITLE
removes empty Run func so that usage is returned

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -46,9 +46,6 @@ var RootCmd = &cobra.Command{
 	Use:   "ddev",
 	Short: "A CLI for interacting with DRUD.",
 	Long:  "This Command Line Interface (CLI) gives you the ability to interact with the DRUD platform to manage applications, create a local development environment, or deploy an application to production. DRUD also provides utilities for securely uploading files and secrets associated with applications.",
-	Run: func(cmd *cobra.Command, args []string) {
-		// fmt.Println(`Use "drud --help" for more information about this tool.`)
-	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		ignores := []string{"list", "config", "version", "update"}
 		skip := false


### PR DESCRIPTION
## The Problem:
Declaring a Run func for a command prevents the help/usage from being returned as expected on a parent command that has no functionality of its own.

## The Fix:
Simply removing the empty func allows the normal behavior to occur.

## The Test:
Manual test - run `ddev` with no args. Previously it exited silently, it now returns help/usage as expected.

## Automation Overview:
I do not believe tests are needed for this change, as I believe this issue was related to breaking out ddev from the mono project, with previous dev sub-commands becoming parent commands. This behavior shouldn't change unless a Run func is defined for the root command, at which point tests should be written.

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

Should be a simple, harmless change.
