### PR TITLE
Bump web container to v0.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm7-local
-WebTag ?= 0.2.0
+WebTag ?= v0.3.0
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.2.0
 RouterImage ?= drud/nginx-proxy

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ var DdevVersion = "v0.1.0-dev" // Note that this is overridden by make
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "0.2.0" // Note that this is overridden by make
+var WebTag = "v0.3.0" // Note that this is overridden by make
 
 // DBImg defines the default db image for drud dev
 var DBImg = "drud/mysql-docker-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:

The nginx web container has been updated per https://github.com/drud/ddev/issues/69

## The Fix:

Update usages of it here.

## The Test:

* Run `ddev start` and related commands. 
* Exec into the web container to make sure that the /drud_nginx-php-fpm7-local_VERSION_INFO.txt and /drud_nginx-php-fpm7_VERSION_INFO.txt files contain the correct values.

## Related Issue Link(s):

https://github.com/drud/ddev/issues/69

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

Per https://github.com/drud/ddev/issues/69 - the actual git tag will need to be created and the container pushed. In the meantime, I pushed a "provisional" v0.3.0 of the web-local container. 