### PR TITLE
Updated build-tools to 1.0.5

### DIFF
--- a/build-tools/build_update.sh
+++ b/build-tools/build_update.sh
@@ -40,7 +40,7 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
-rm -rf build-tools/tests/
+rm -rf build-tools/tests/ build-tools/circle.yml
 git add build-tools
 echo "Updated build-tools to $tag
 

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -44,7 +44,7 @@ linux darwin: $(GOFILES)
 	    $(BUILD_IMAGE)                    \
 	    /bin/sh -c '                      \
 	        GOOS=$@                       \
-	        go install -installsuffix 'static' -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
+	        go install -installsuffix static -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
 	    '
 	@touch $@
 	@echo $(VERSION) >VERSION.txt

--- a/build-tools/makefile_components/base_container.mak
+++ b/build-tools/makefile_components/base_container.mak
@@ -12,7 +12,7 @@ container: linux .container-$(DOTFILE_IMAGE) container-name
 
 .container-$(DOTFILE_IMAGE): linux Dockerfile.in
 	@sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile
-	@echo "\n\n$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
+	@echo "$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
 	@echo "ADD .docker_image /$(SANITIZED_DOCKER_REPO)_VERSION_INFO.txt" >>.dockerfile
 	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
 	@docker images -q $(DOCKER_REPO):$(VERSION) > $@


### PR DESCRIPTION
https://github.com/drud/build-tools/releases/tag/1.0.5

## The Problem:

Minor changes upstream in build-tools, described in https://github.com/drud/build-tools/releases/tag/1.0.5

The most important was spurious single quotes around the build's -installsuffix static - they seemed to have been working but definitely not right. Since that was discovered here in ddev, pulling it in here right away.

## The Fix:

Update.

## Additional

There should be no action required, and no side-effects.
