### PR TITLE
Upgrade docker-compose to 1.11.2, docker to 17.03.0, remove drud in circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,6 @@ stages:
 
       - type: shell
         command: |
-          sudo apt-get install linux-image-extra-$(uname -r) linux-image-extra-virtual &&
           sudo apt-get remove docker docker-engine &&
           sudo apt-get update &&
           sudo apt-get install  apt-transport-https ca-certificates  curl software-properties-common &&


### PR DESCRIPTION
## The Problem:

We were using older docker-compose (1.9.0) in our circle tests, and older docker.

## The Fix:

* Upgrade docker-compose to current 1.11.2
* Upgrade docker to 17.03.0
* Since we're going hog-wild, upgrade golang to 1.7.5 (it is used for tests, although not for compile)
* Remove the stanza that was downloading drud and auth-ing as we don't need it any more.

## The Test:

If tests pass, we should be doing the right thing.

