### PR TITLE
Updated build-tools to 1.0.6 - brings in --rm on docker commands

### DIFF
--- a/build-tools/build_update.sh
+++ b/build-tools/build_update.sh
@@ -40,7 +40,7 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
-rm -rf build-tools/tests/
+rm -rf build-tools/tests/ build-tools/circle.yml
 git add build-tools
 echo "Updated build-tools to $tag
 

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -31,9 +31,7 @@ linux darwin: $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"
 	@rm -f VERSION.txt
 	@mkdir -p bin/$@ .go/std/$@ .go/bin .go/src/$(PKG)
-	docker run                                                            \
-	    -t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$@:/go/bin                                     \
@@ -44,7 +42,7 @@ linux darwin: $(GOFILES)
 	    $(BUILD_IMAGE)                    \
 	    /bin/sh -c '                      \
 	        GOOS=$@                       \
-	        go install -installsuffix 'static' -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
+	        go install -installsuffix static -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
 	    '
 	@touch $@
 	@echo $(VERSION) >VERSION.txt
@@ -53,9 +51,7 @@ static: govendor gofmt govet lint
 
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -64,9 +60,7 @@ govendor:
 
 gofmt:
 	@echo "Checking gofmt: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -75,9 +69,7 @@ gofmt:
 
 govet:
 	@echo -n "Checking go vet: "
-	docker run                                                            \
-		-t                                                                \
-		-u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -86,9 +78,7 @@ govet:
 
 golint:
 	@echo -n "Checking golint: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \

--- a/build-tools/makefile_components/base_container.mak
+++ b/build-tools/makefile_components/base_container.mak
@@ -12,7 +12,7 @@ container: linux .container-$(DOTFILE_IMAGE) container-name
 
 .container-$(DOTFILE_IMAGE): linux Dockerfile.in
 	@sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile
-	@echo "\n\n$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
+	@echo "$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
 	@echo "ADD .docker_image /$(SANITIZED_DOCKER_REPO)_VERSION_INFO.txt" >>.dockerfile
 	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
 	@docker images -q $(DOCKER_REPO):$(VERSION) > $@

--- a/build-tools/makefile_components/base_test_go.mak
+++ b/build-tools/makefile_components/base_test_go.mak
@@ -9,9 +9,7 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 test: build
 	@mkdir -p bin/linux
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
-	@docker run                                                            \
-	    -t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	@docker run -t --rm  -u $(shell id -u):$(shell id -g)                 \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
@@ -20,6 +18,6 @@ test: build
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/bash -c '                                                    \
-	        GOOS=`uname -s |  tr '[:upper:]' '[:lower:]'`  &&		\
-	        go test -v -installsuffix "static" -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)   \
+	        GOOS=`uname -s |  tr "[:upper:]" "[:lower:]"`  &&		\
+	        go test -v -installsuffix static -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)   \
 	    '


### PR DESCRIPTION
## The Problem:

We weren't doing --rm on docker commands, leaving a trail of broken-hearted never-again-used containers. Perhaps other side-effects. Update to https://github.com/drud/build-tools/releases/tag/1.0.6

## The Fix:

Update to https://github.com/drud/build-tools/releases/tag/1.0.6

## The Test:

If it passes tests it should be OK. Has been approved upstream.

