### PR TITLE
Fix error message about ddev.yaml

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -78,7 +78,7 @@ func setActiveApp() {
 
 	app, err := platform.CheckForConf(cwd)
 	if err != nil {
-		log.Fatalf("Unable to determine the application for this command: %s", err)
+		log.Fatalf("Unable to determine the application for this command. Have you run 'ddev config'? Error: %s", err)
 	}
 
 	activeApp = path.Base(app)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -69,7 +69,7 @@ func (l LocalApp) AbsPath() string {
 
 	appPath, err := CheckForConf(cwd)
 	if err != nil {
-		log.Fatalf("Unable to determine the application for this command: %s", err)
+		log.Fatalf("Unable to determine the application for this command - have you run 'ddev config'? Error: %s", err)
 	}
 
 	return appPath

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -328,7 +328,7 @@ func CheckForConf(confPath string) (string, error) {
 		}
 	}
 
-	return "", errors.New("no ddev.yaml file in this directory or any parent")
+	return "", errors.New("no .ddev/config.yaml file was found in this directory or any parent")
 }
 
 // NetExists checks to see if the docker network for DRUD local development exists.


### PR DESCRIPTION
## The Problem:

There's an out-of-date error message referring to ddev.yaml.

## The Fix:

Fix the error message. Suggest "ddev config"

## The Test:

Run `ddev start` before running `ddev config`. You should get a valid error message.

