### PR TITLE
Change error messages that say 'ddev add' to 'ddev start'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The purpose of *ddev* is to support developers with a local copy of a site for development purposes. It runs the site in Docker containers.
 
-You can see all "ddev" usages using the help commands, like `ddev -h`, `ddev add -h`, etc.
+You can see all "ddev" usages using the help commands, like `ddev -h`, `ddev start -h`, etc.
 
 ## Key prerequisites
 - A working [docker install](https://www.docker.com/community-edition)

--- a/cmd/ddev/cmd/dev_sequelpro.go
+++ b/cmd/ddev/cmd/dev_sequelpro.go
@@ -26,7 +26,7 @@ var LocalDevSequelproCmd = &cobra.Command{
 		nameContainer := fmt.Sprintf("%s-db", app.ContainerName())
 
 		if !dockerutil.IsRunning(nameContainer) {
-			Failed("App not running locally. Try `ddev add`.")
+			Failed("App not running locally. Try `ddev start`.")
 		}
 
 		mysqlContainer, err := dockerutil.GetContainer(nameContainer)

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -29,11 +29,11 @@ var LocalDevLogsCmd = &cobra.Command{
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)
 
 		if !dockerutil.IsRunning(nameContainer) {
-			Failed("App not running locally. Try `ddev add`.")
+			Failed("App not running locally. Try `ddev start`.")
 		}
 
 		if !platform.ComposeFileExists(app) {
-			Failed("No docker-compose yaml for this site. Try `ddev add`.")
+			Failed("No docker-compose yaml for this site. Try `ddev start`.")
 		}
 
 		cmdArgs := []string{


### PR DESCRIPTION
## The Problem:

Some old error messages reference "ddev add" but we now use "ddev start" by default.

## The Fix:

Change the error messages.

## The Test:

Nothing required.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

