### PR TITLE
Remove docker-compose pull from startup as we no longer need it

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -206,12 +206,6 @@ func (l LocalApp) Start() error {
 		log.Fatal(err)
 	}
 
-	cmdArgs := []string{"-f", composePath, "pull"}
-	_, err = system.RunCommand("docker-compose", cmdArgs)
-	if err != nil {
-		return err
-	}
-
 	return dockerutil.DockerCompose(
 		"-f", composePath,
 		"up",


### PR DESCRIPTION
## The Problem:

In the past we used the "latest" tag for docker images, which meant a need to check for newer ones. Now that we've switched to using specific tags we don't have to do this.

The existing (pull) technique means that a `ddev start` requires internet connectivity, which could annoy our users.

## The Fix:

Remove the `docker-compose pull`.

## The Test:

Should be fine if it passes existing tests.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

