### PR TITLE
corrects container type labels for web and db

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -18,7 +18,7 @@ services:
       - "3306"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.container-type: web
+      com.ddev.container-type: db
       com.ddev.app-type: {{ .appType }}
       com.ddev.docroot: $DDEV_DOCROOT
       com.ddev.approot: $DDEV_APPROOT
@@ -42,7 +42,7 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.container-type: db
+      com.ddev.container-type: web
       com.ddev.app-type: {{ .appType }}
       com.ddev.docroot: $DDEV_DOCROOT
       com.ddev.approot: $DDEV_APPROOT


### PR DESCRIPTION
## The Problem:
The docker label values for container type are incorrect.
## The Fix:
Apply the correct label value to the correct container.
## The Test:
If this passes tests, I think we are safe to introduce this change. I don't believe any unexpected behavior has been encountered up to this point as a result of the labels being incorrect. 
## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

@beeradb may want to investigate impact to #116 as I know that is introducing more use of the container type label.