### PR TITLE
Expand/check any symlinks in tmpdir creation (obsolete/unmerged)

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/drud-go/utils/system"
 	"github.com/stretchr/testify/assert"
+	"log"
 )
 
 // TestDescribeBadArgs ensures the binary behaves as expected when used with invalid arguments or working directories.
@@ -13,7 +14,10 @@ func TestDescribeBadArgs(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a temporary directory and switch to it for the duration of this test.
-	tmpdir := testcommon.CreateTmpDir()
+	tmpdir, err := testcommon.CreateTmpDir("badargs")
+	if err != nil {
+		log.Fatalln("Failed to CreateTmpDir()", err)
+	}
 	defer testcommon.Chdir(tmpdir)()
 	defer testcommon.CleanupDir(tmpdir)
 
@@ -43,7 +47,10 @@ func TestDescribe(t *testing.T) {
 
 	for _, v := range DevTestSites {
 		// First, try to do a describe from another directory.
-		tmpdir := testcommon.CreateTmpDir()
+		tmpdir, err := testcommon.CreateTmpDir("")
+		if err != nil {
+			log.Fatalln("Failed to CreateTmpDir", err)
+		}
 		cleanup := testcommon.Chdir(tmpdir)
 		defer testcommon.CleanupDir(tmpdir)
 
@@ -96,7 +103,10 @@ func TestDescribeAppUsingSitename(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a temporary directory and switch to it for the duration of this test.
-	tmpdir := testcommon.CreateTmpDir()
+	tmpdir, err := testcommon.CreateTmpDir("describeAppUsingSitename")
+	if err != nil {
+		log.Fatalln("Failed to CreateTmpDir", err)
+	}
 	defer testcommon.Chdir(tmpdir)()
 	defer testcommon.CleanupDir(tmpdir)
 
@@ -113,12 +123,15 @@ func TestDescribeAppWithInvalidParams(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a temporary directory and switch to it for the duration of this test.
-	tmpdir := testcommon.CreateTmpDir()
+	tmpdir, err := testcommon.CreateTmpDir("TestDescribeAppWithInvalidParams")
+	if err != nil {
+		log.Fatalln("Failed to CreateTmpDir", err)
+	}
 	defer testcommon.Chdir(tmpdir)()
 	defer testcommon.CleanupDir(tmpdir)
 
 	// Ensure describeApp fails from an invalid working directory.
-	_, err := describeApp("")
+	_, err = describeApp("")
 	assert.Error(err)
 
 	// Ensure describeApp fails with invalid site-names.

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"log"
 	"testing"
 
 	"os"
 
+	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/drud-go/utils/system"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,7 +14,7 @@ import (
 func TestDevLogsBadArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	testDir, err := ioutil.TempDir("", "no-valid-ddev-config")
+	testDir, err := testcommon.CreateTmpDir("no-valid-ddev-config")
 	if err != nil {
 		log.Fatalf("Could not create temporary directory %s ", testDir)
 	}

--- a/pkg/cms/config/config_test.go
+++ b/pkg/cms/config/config_test.go
@@ -8,11 +8,12 @@ import (
 	"io/ioutil"
 
 	"github.com/drud/ddev/pkg/cms/model"
+	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWriteDrupalConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := testcommon.CreateTmpDir("example")
 	assert.NoError(t, err)
 
 	file, err := ioutil.TempFile(dir, "file")
@@ -29,7 +30,7 @@ func TestWriteDrupalConfig(t *testing.T) {
 }
 
 func TestWriteDrushConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := testcommon.CreateTmpDir("example")
 	assert.NoError(t, err)
 
 	file, err := ioutil.TempFile(dir, "file")
@@ -46,7 +47,7 @@ func TestWriteDrushConfig(t *testing.T) {
 }
 
 func TestWriteWordpressConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := testcommon.CreateTmpDir("example")
 	assert.NoError(t, err)
 
 	file, err := ioutil.TempFile(dir, "file")

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -19,7 +19,9 @@ import (
 func TestNewConfig(t *testing.T) {
 	assert := assert.New(t)
 	// Create a temporary directory and change to it for the duration of this test.
-	testDir := testcommon.CreateTmpDir()
+	testDir, err := testcommon.CreateTmpDir("TestNewConfig")
+	assert.NoError(err)
+
 	defer testcommon.Chdir(testDir)()
 	defer testcommon.CleanupDir(testDir)
 
@@ -67,7 +69,8 @@ func TestAllowedAppTypes(t *testing.T) {
 func TestPrepDirectory(t *testing.T) {
 	assert := assert.New(t)
 	// Create a temporary directory and change to it for the duration of this test.
-	testDir := testcommon.CreateTmpDir()
+	testDir, err := testcommon.CreateTmpDir("TestPrepDirectory")
+	assert.NoError(err)
 	defer testcommon.Chdir(testDir)()
 	defer testcommon.CleanupDir(testDir)
 
@@ -87,7 +90,8 @@ func TestPrepDirectory(t *testing.T) {
 // TestHostName tests that the TestSite.Hostname() field returns the hostname as expected.
 func TestHostName(t *testing.T) {
 	assert := assert.New(t)
-	testDir := testcommon.CreateTmpDir()
+	testDir, err := testcommon.CreateTmpDir("TestHostName")
+	assert.NoError(err)
 	defer testcommon.Chdir(testDir)()
 	defer testcommon.CleanupDir(testDir)
 	config, err := NewConfig(testDir)
@@ -101,7 +105,8 @@ func TestHostName(t *testing.T) {
 func TestWriteDockerComposeYaml(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := assert.New(t)
-	testDir := testcommon.CreateTmpDir()
+	testDir, err := testcommon.CreateTmpDir("TestWriteDockerCompose")
+	assert.NoError(err)
 	defer testcommon.Chdir(testDir)()
 	defer testcommon.CleanupDir(testDir)
 
@@ -143,12 +148,13 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 func TestConfigCommand(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := assert.New(t)
-	testDir := testcommon.CreateTmpDir()
+	testDir, err := testcommon.CreateTmpDir("TestConfigCommand")
+	assert.NoError(err)
 	defer testcommon.Chdir(testDir)()
 	defer testcommon.CleanupDir(testDir)
 
 	// Create a docroot folder.
-	err := os.Mkdir(filepath.Join(testDir, "docroot"), 0644)
+	err = os.Mkdir(filepath.Join(testDir, "docroot"), 0644)
 	if err != nil {
 		t.Errorf("Could not create docroot directory under %s", testDir)
 	}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -24,12 +24,16 @@ type TestSite struct {
 }
 
 func (site *TestSite) archivePath() string {
-	return filepath.Join(os.TempDir(), site.Name+".tar.gz")
+	dir, err := OsTempDir()
+	if err != nil {
+		log.Fatalln("Failed to create OsTempDir", err)
+	}
+	return filepath.Join(dir, site.Name+".tar.gz")
 }
 
 // Prepare downloads and extracts a site codebase to a temporary directory.
 func (site *TestSite) Prepare() error {
-	testDir, err := ioutil.TempDir("", site.Name)
+	testDir, err := CreateTmpDir(site.Name)
 	if err != nil {
 		log.Fatalf("Could not create temporary directory %s for site %s", testDir, site.Name)
 	}
@@ -77,14 +81,30 @@ func CleanupDir(dir string) error {
 	return err
 }
 
-// CreateTmpDir creates a temporary directory and returns its path as a string.
-func CreateTmpDir() string {
-	testDir, err := ioutil.TempDir("", "")
+// TempDir gets os.TempDir() (usually provided by $TMPDIR) but expands any symlinks found within it.
+// This wrapper function can prevent problems with docker-for-mac trying to use /var/..., which is not typically
+// shared/mounted. It will be expanded via the /var symlink to /private/var/...
+func OsTempDir() (string, error) {
+	dirName := os.TempDir()
+	tmpDir, err := filepath.EvalSymlinks(dirName)
 	if err != nil {
-		log.Fatalf("Could not create temporary directory %s: %v", testDir, err)
+		return "", err
 	}
+	tmpDir = filepath.Clean(tmpDir)
+	return tmpDir, nil
+}
 
-	return testDir
+// CreateTmpDir creates a temporary directory and returns its path as a string.
+func CreateTmpDir(prefix string) (string, error) {
+	systemTempDir, err := OsTempDir()
+	if err != nil {
+		return "", err
+	}
+	fullPath, err := ioutil.TempDir(systemTempDir, prefix)
+	if err != nil {
+		return "", err
+	}
+	return fullPath, nil
 }
 
 // Chdir will change to the directory for the site specified by TestSite.

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -15,7 +15,8 @@ func TestTmpDir(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a temporary directory and ensure it exists.
-	testDir := CreateTmpDir()
+	testDir, err := CreateTmpDir("TestTmpDir")
+	assert.NoError(err)
 	dirStat, err := os.Stat(testDir)
 	assert.NoError(err, "There is no error when getting directory details")
 	assert.True(dirStat.IsDir(), "Temp Directory created and exists")
@@ -37,7 +38,8 @@ func TestChdir(t *testing.T) {
 	assert.NoError(err)
 
 	// Create a temporary directory.
-	testDir := CreateTmpDir()
+	testDir, err := CreateTmpDir("TestChdir")
+	assert.NoError(err)
 	assert.NotEqual(startingDir, testDir, "Ensure our starting directory and temporary directory are not the same")
 
 	// Change to the temporary directory.


### PR DESCRIPTION
## The Problem:

On MacOS tests are failing, perhaps because symlink doesn't expand properly in docker or golang. See https://github.com/drud/ddev/issues/134

## The Fix:

Explicitly expand any symlinks in the tmpdir.

## The Test:

This should do no harm if tests pass.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

