### PR TITLE
Bump nginx-php-fpm-local to version 0.3.4 to add xdebug and docker health check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm7-local
-WebTag ?= v0.3.2
+WebTag ?= v0.3.4
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.2.0
 RouterImage ?= drud/nginx-proxy

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ var DdevVersion = "v0.1.0-dev" // Note that this is overridden by make
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.3.2" // Note that this is overridden by make
+var WebTag = "v0.3.4" // Note that this is overridden by make
 
 // DBImg defines the default db image for drud dev
 var DBImg = "drud/mysql-docker-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:

nginx-php-fpm-local has incremented a couple of versions.

## The Fix:

bump the version to 0.3.4

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

The dockerhub push has been done, https://hub.docker.com/r/drud/nginx-php-fpm7-local/tags/