### PR TITLE
Check return on Testsite.Prepare()

### DIFF
--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -2,12 +2,11 @@ package platform
 
 import (
 	"errors"
-	"fmt"
-	"log"
 	"testing"
 
 	"os"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/system"
@@ -28,10 +27,13 @@ var (
 const netName = "ddev_default"
 
 func TestMain(m *testing.M) {
-	TestSite.Prepare()
+	err := TestSite.Prepare()
+	if err != nil {
+		log.Fatalf("Prepare() failed on TestSite.Prepare(), err=%v", err)
+	}
 	defer TestSite.Chdir()()
 
-	fmt.Println("Running tests.")
+	log.Debugln("Running tests.")
 	testRun := m.Run()
 
 	TestSite.Cleanup()


### PR DESCRIPTION
## The Problem:

Studying the race condition we apparently had on download, I noted that this instance of Testsite.Prepare() didn't check the error return.

## The Fix:

Check the error return.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

