### PR TITLE
Adds phpMyAdmin container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ WebTag ?= v0.3.4
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.3.0
 RouterImage ?= drud/nginx-proxy
-RouterTag ?= http-port-options
+RouterTag ?= v0.3.0
 DBAImg ?= drud/phpmyadmin
 DBATag ?= v0.1.0
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ WebTag ?= v0.3.4
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.3.0
 RouterImage ?= drud/nginx-proxy
-RouterTag ?= v0.2.0
+RouterTag ?= http-port-options
 DBAImg ?= drud/phpmyadmin
 DBATag ?= v0.1.0
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.3.0
 RouterImage ?= drud/nginx-proxy
 RouterTag ?= v0.2.0
+DBAImg ?= drud/phpmyadmin
+DBATag ?= v0.1.0
 
 # Optional to docker build
 #DOCKER_ARGS =

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Connection Info:	drupal8.ddev.local:3306
 Other Services
 --------------
 MailHog:   	http://drupal8.ddev.local:8025
-PHPMyAdmin:	http://drupal8.ddev.local:8036
+phpMyAdmin:	http://drupal8.ddev.local:8036
 ```
 
 ## Importing an existing site

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Usage:
 
 Available Commands:
   config      Create or modify a ddev application config in the current directory
+  describe    Get a detailed description of a running ddev site.
   exec        Execute a Linux shell command in the webserver container.
   hostname    Manage your hostfile entries.
   import      Import an existing site to the local dev environment
@@ -99,7 +100,8 @@ Connection Info:	drupal8.ddev.local:3306
 
 Other Services
 --------------
-MailHog:	http://drupal8.ddev.local:8025
+MailHog:   	http://drupal8.ddev.local:8025
+PHPMyAdmin:	http://drupal8.ddev.local:8036
 ```
 
 ## Importing an existing site

--- a/cmd/ddev/cmd/a_start_test.go
+++ b/cmd/ddev/cmd/a_start_test.go
@@ -35,12 +35,20 @@ func TestDevAddSites(t *testing.T) {
 		assert.Equal(true, dockerutil.IsRunning(app.ContainerName()+"-db"))
 		assert.Equal(true, dockerutil.IsRunning(app.ContainerName()+"-dba"))
 
-		o := network.NewHTTPOptions("http://127.0.0.1/core/install.php")
-		o.ExpectedStatus = 200
-		o.Timeout = 180
-		o.Headers["Host"] = app.HostName()
-		err = network.EnsureHTTPStatus(o)
-		assert.NoError(err)
+		urls := []string{
+			"http://127.0.0.1/core/install.php",
+			"http://127.0.0.1:8025",
+			"http://127.0.0.1:8036",
+		}
+
+		for _, url := range urls {
+			o := network.NewHTTPOptions(url)
+			o.ExpectedStatus = 200
+			o.Timeout = 180
+			o.Headers["Host"] = app.HostName()
+			err = network.EnsureHTTPStatus(o)
+			assert.NoError(err)
+		}
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/a_start_test.go
+++ b/cmd/ddev/cmd/a_start_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/drud/ddev/pkg/version"
+	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/network"
 	"github.com/drud/drud-go/utils/system"

--- a/cmd/ddev/cmd/a_start_test.go
+++ b/cmd/ddev/cmd/a_start_test.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/drud/ddev/pkg/version"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/network"
 	"github.com/drud/drud-go/utils/system"
@@ -37,8 +38,8 @@ func TestDevAddSites(t *testing.T) {
 
 		urls := []string{
 			"http://127.0.0.1/core/install.php",
-			"http://127.0.0.1:8025",
-			"http://127.0.0.1:8036",
+			"http://127.0.0.1:" + version.MailHogPort,
+			"http://127.0.0.1:" + version.DBAPort,
 		}
 
 		for _, url := range urls {

--- a/cmd/ddev/cmd/a_start_test.go
+++ b/cmd/ddev/cmd/a_start_test.go
@@ -38,8 +38,8 @@ func TestDevAddSites(t *testing.T) {
 
 		urls := []string{
 			"http://127.0.0.1/core/install.php",
-			"http://127.0.0.1:" + version.MailHogPort,
-			"http://127.0.0.1:" + version.DBAPort,
+			"http://127.0.0.1:" + appports.GetPort("mailhog"),
+			"http://127.0.0.1:" + appports.GetPort("dba"),
 		}
 
 		for _, url := range urls {

--- a/cmd/ddev/cmd/a_start_test.go
+++ b/cmd/ddev/cmd/a_start_test.go
@@ -33,6 +33,7 @@ func TestDevAddSites(t *testing.T) {
 
 		assert.Equal(true, dockerutil.IsRunning(app.ContainerName()+"-web"))
 		assert.Equal(true, dockerutil.IsRunning(app.ContainerName()+"-db"))
+		assert.Equal(true, dockerutil.IsRunning(app.ContainerName()+"-dba"))
 
 		o := network.NewHTTPOptions("http://127.0.0.1/core/install.php")
 		o.ExpectedStatus = 200

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -26,8 +26,10 @@ func TestDevRestart(t *testing.T) {
 		format := fmt.Sprintf
 		assert.Contains(string(out), format("Stopping %s-web", app.ContainerName()))
 		assert.Contains(string(out), format("Stopping %s-db", app.ContainerName()))
+		assert.Contains(string(out), format("Stopping %s-dba", app.ContainerName()))
 		assert.Contains(string(out), format("Starting %s-web", app.ContainerName()))
 		assert.Contains(string(out), format("Starting %s-db", app.ContainerName()))
+		assert.Contains(string(out), format("Starting %s-dba", app.ContainerName()))
 		assert.Contains(string(out), "Your application can be reached at")
 		assert.Contains(string(out), app.URL())
 

--- a/cmd/ddev/cmd/version.go
+++ b/cmd/ddev/cmd/version.go
@@ -20,6 +20,7 @@ var versionCmd = &cobra.Command{
 		table.AddRow("cli:", version.DdevVersion)
 		table.AddRow("web:", version.WebImg+":"+version.WebTag)
 		table.AddRow("db:", version.DBImg+":"+version.DBTag)
+		table.AddRow("dba:", version.DBAImg+":"+version.DBATag)
 		table.AddRow("router:", version.RouterImage+":"+version.RouterTag)
 		table.AddRow("commit:", version.VERSION)
 

--- a/cmd/ddev/cmd/version_test.go
+++ b/cmd/ddev/cmd/version_test.go
@@ -19,4 +19,6 @@ func TestVersion(t *testing.T) {
 	assert.Contains(output, version.WebTag)
 	assert.Contains(output, version.DBImg)
 	assert.Contains(output, version.DBTag)
+	assert.Contains(output, version.DBAImg)
+	assert.Contains(output, version.DBATag)
 }

--- a/cmd/ddev/cmd/z_rm_test.go
+++ b/cmd/ddev/cmd/z_rm_test.go
@@ -25,8 +25,9 @@ func TestDevRm(t *testing.T) {
 		format := fmt.Sprintf
 		assert.Contains(string(out), format("Stopping %s-web ... done", app.ContainerName()))
 		assert.Contains(string(out), format("Stopping %s-db ... done", app.ContainerName()))
+		assert.Contains(string(out), format("Stopping %s-dba ... done", app.ContainerName()))
 		assert.Contains(string(out), format("Removing %s-web ... done", app.ContainerName()))
 		assert.Contains(string(out), format("Removing %s-db ... done", app.ContainerName()))
-		// site cleanup is handled in TestMain
+		assert.Contains(string(out), format("Removing %s-dba ... done", app.ContainerName()))
 	}
 }

--- a/pkg/appports/ports.go
+++ b/pkg/appports/ports.go
@@ -21,11 +21,11 @@ var ports = map[string]string{
 
 // GetPort returns the external router (as a string) for the given service. This can be used to find a given port for docker-compose manifests,
 // or for automated testing.
-func GetPort(port string) string {
-	port = strings.ToLower(port)
-	val, ok := ports[port]
+func GetPort(service string) string {
+	service = strings.ToLower(service)
+	val, ok := ports[service]
 	if !ok {
-		log.Fatalf("Could not find port for service %s", port)
+		log.Fatalf("Could not find port for service %s", service)
 	}
 
 	return val

--- a/pkg/appports/ports.go
+++ b/pkg/appports/ports.go
@@ -1,0 +1,32 @@
+package appports
+
+import (
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// Define the DBA and MailHog ports as variables so that we can override them with ldflags if required.
+
+// DBAPort defines the default phpmyadmin port used on the router.
+var dbaPort = "8036"
+
+// mailHogPort defines the default mailhog exposed by the router.
+var mailhogPort = "8025"
+
+var ports = map[string]string{
+	"mailhog": mailhogPort,
+	"dba":     dbaPort,
+}
+
+// GetPort returns the external router (as a string) for the given service. This can be used to find a given port for docker-compose manifests,
+// or for automated testing.
+func GetPort(port string) string {
+	port = strings.ToLower(port)
+	val, ok := ports[port]
+	if !ok {
+		log.Fatalf("Could not find port for service %s", port)
+	}
+
+	return val
+}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Docroot    string `yaml:"docroot"`
 	WebImage   string `yaml:"webimage"`
 	DBImage    string `yaml:"dbimage"`
+	DBAImage   string `yaml:"dbaimage"`
 	ConfigPath string `yaml:"-"`
 	AppRoot    string `yaml:"-"`
 	Platform   string `yaml:"-"`
@@ -58,6 +59,7 @@ func NewConfig(AppRoot string) (*Config, error) {
 	// These should always default to the latest image/tag names from the Version package.
 	c.WebImage = version.WebImg + ":" + version.WebTag
 	c.DBImage = version.DBImg + ":" + version.DBTag
+	c.DBAImage = version.DBAImg + ":" + version.DBATag
 
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -197,10 +197,12 @@ func (c *Config) RenderComposeYAML() (string, error) {
 		return "", err
 	}
 	templateVars := map[string]string{
-		"name":    c.Name,
-		"docroot": filepath.Join("../", c.Docroot),
-		"plugin":  c.Platform,
-		"appType": c.AppType,
+		"name":        c.Name,
+		"docroot":     filepath.Join("../", c.Docroot),
+		"plugin":      c.Platform,
+		"appType":     c.AppType,
+		"MailHogPort": version.MailHogPort,
+		"DBAPort":     version.DBAPort,
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -201,8 +201,8 @@ func (c *Config) RenderComposeYAML() (string, error) {
 		"docroot":     filepath.Join("../", c.Docroot),
 		"plugin":      c.Platform,
 		"appType":     c.AppType,
-		"MailHogPort": version.MailHogPort,
-		"DBAPort":     version.DBAPort,
+		"mailhogport": version.MailHogPort,
+		"dbaport":     version.DBAPort,
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/util/prompt"
 	"github.com/drud/ddev/pkg/version"
@@ -201,8 +202,8 @@ func (c *Config) RenderComposeYAML() (string, error) {
 		"docroot":     filepath.Join("../", c.Docroot),
 		"plugin":      c.Platform,
 		"appType":     c.AppType,
-		"mailhogport": version.MailHogPort,
-		"dbaport":     version.DBAPort,
+		"mailhogport": appports.GetPort("mailhog"),
+		"dbaport":     appports.GetPort("dba"),
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -36,6 +36,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(newConfig.Platform, DDevDefaultPlatform)
 	assert.Equal(newConfig.DBImage, version.DBImg+":"+version.DBTag)
 	assert.Equal(newConfig.WebImage, version.WebImg+":"+version.WebTag)
+	assert.Equal(newConfig.DBAImage, version.DBAImg+":"+version.DBATag)
 	newConfig.Name = testcommon.RandString(32)
 	newConfig.AppType = "drupal8"
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -62,7 +62,7 @@ services:
       - PMA_USER=root
       - PMA_PASSWORD=root
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_POST=8036
+      - VIRTUAL_PORT=8036
 networks:
   default:
     external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -35,12 +35,12 @@ services:
       - {{ .plugin }}-${DDEV_SITENAME}-db:db
     ports:
       - "80"
-      - "8025"
+      - "{{ .MailHogPort }}"
     working_dir: "/var/www/html/docroot"
     environment:
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_PORT=80,8025
+      - VIRTUAL_PORT=80,{{ .MailHogPort }}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.container-type: web
@@ -62,7 +62,7 @@ services:
       - PMA_USER=root
       - PMA_PASSWORD=root
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_PORT=8036
+      - VIRTUAL_PORT="{{ .DBAPort }}"
 networks:
   default:
     external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -35,7 +35,7 @@ services:
       - {{ .plugin }}-${DDEV_SITENAME}-db:db
     ports:
       - "80"
-      - "{{ .MailHogPort }}"
+      - {{ .mailhogport }}
     working_dir: "/var/www/html/docroot"
     environment:
       - DEPLOY_NAME=local
@@ -62,7 +62,7 @@ services:
       - PMA_USER=root
       - PMA_PASSWORD=root
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_PORT="{{ .DBAPort }}"
+      - VIRTUAL_PORT={{ .mailhogport }}
 networks:
   default:
     external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -40,6 +40,7 @@ services:
     environment:
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - VIRTUAL_PORT_ADD=8025
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.container-type: web
@@ -60,6 +61,7 @@ services:
     environment:
       - PMA_USER=root
       - PMA_PASSWORD=root
+      - VIRTUAL_HOST=$DDEV_HOSTNAME:8036
 networks:
   default:
     external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -47,6 +47,19 @@ services:
       com.ddev.docroot: $DDEV_DOCROOT
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
+  {{ .plugin }}-{{ .name }}-dba:
+    container_name: local-${DDEV_SITENAME}-dba
+    image: $DDEV_DBAIMAGE
+    restart: always
+    depends_on:
+      - local-${DDEV_SITENAME}-db
+    links:
+      - local-${DDEV_SITENAME}-db:db
+    ports:
+      - "80"
+    environment:
+      - PMA_USER=root
+      - PMA_PASSWORD=root
 networks:
   default:
     external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -40,7 +40,7 @@ services:
     environment:
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_PORT=80,{{ .MailHogPort }}
+      - VIRTUAL_PORT=80,{{ .mailhogport }}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.container-type: web
@@ -62,7 +62,7 @@ services:
       - PMA_USER=root
       - PMA_PASSWORD=root
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_PORT={{ .mailhogport }}
+      - VIRTUAL_PORT={{ .dbaport }}
 networks:
   default:
     external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -40,7 +40,7 @@ services:
     environment:
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_PORT_ADD=8025
+      - VIRTUAL_PORT=80,8025
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.container-type: web
@@ -61,7 +61,8 @@ services:
     environment:
       - PMA_USER=root
       - PMA_PASSWORD=root
-      - VIRTUAL_HOST=$DDEV_HOSTNAME:8036
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - VIRTUAL_POST=8036
 networks:
   default:
     external:

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -98,8 +98,8 @@ func (l *LocalApp) Describe() (string, error) {
 
 	output = output + "\n\nOther Services\n--------------\n"
 	other := uitable.New()
-	other.AddRow("MailHog:", l.URL()+":"+version.MailHogPort)
-	other.AddRow("phpMyAdmin:", l.URL()+":"+version.DBAPort)
+	other.AddRow("MailHog:", l.URL()+":"+appports.GetPort("mailhog"))
+	other.AddRow("phpMyAdmin:", l.URL()+":"+appports.GetPort("dba"))
 	output = output + fmt.Sprint(other)
 	return output, nil
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -16,6 +16,7 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/util/files"
 	"github.com/drud/ddev/pkg/util/prompt"
+	"github.com/drud/ddev/pkg/version"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/network"
 	"github.com/drud/drud-go/utils/stringutil"
@@ -97,8 +98,8 @@ func (l *LocalApp) Describe() (string, error) {
 
 	output = output + "\n\nOther Services\n--------------\n"
 	other := uitable.New()
-	other.AddRow("MailHog:", l.URL()+":8025")
-	other.AddRow("phpMyAdmin:", l.URL()+":8036")
+	other.AddRow("MailHog:", l.URL()+":"+version.MailHogPort)
+	other.AddRow("phpMyAdmin:", l.URL()+":"+version.DBAPort)
 	output = output + fmt.Sprint(other)
 	return output, nil
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -11,12 +11,12 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/appimport"
+	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/cms/config"
 	"github.com/drud/ddev/pkg/cms/model"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/util/files"
 	"github.com/drud/ddev/pkg/util/prompt"
-	"github.com/drud/ddev/pkg/version"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/network"
 	"github.com/drud/drud-go/utils/stringutil"

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -98,7 +98,7 @@ func (l *LocalApp) Describe() (string, error) {
 	output = output + "\n\nOther Services\n--------------\n"
 	other := uitable.New()
 	other.AddRow("MailHog:", l.URL()+":8025")
-
+	other.AddRow("PHPMyAdmin:", l.URL()+":8036")
 	output = output + fmt.Sprint(other)
 	return output, nil
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -289,6 +289,7 @@ func (l *LocalApp) DockerEnv() {
 		"COMPOSE_PROJECT_NAME": "ddev-" + l.AppConfig.Name,
 		"DDEV_SITENAME":        l.AppConfig.Name,
 		"DDEV_DBIMAGE":         l.AppConfig.DBImage,
+		"DDEV_DBAIMAGE":        l.AppConfig.DBAImage,
 		"DDEV_WEBIMAGE":        l.AppConfig.WebImage,
 		"DDEV_APPROOT":         l.AppConfig.AppRoot,
 		"DDEV_DOCROOT":         filepath.Join(l.AppConfig.AppRoot, l.AppConfig.Docroot),

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -98,7 +98,7 @@ func (l *LocalApp) Describe() (string, error) {
 	output = output + "\n\nOther Services\n--------------\n"
 	other := uitable.New()
 	other.AddRow("MailHog:", l.URL()+":8025")
-	other.AddRow("PHPMyAdmin:", l.URL()+":8036")
+	other.AddRow("phpMyAdmin:", l.URL()+":8036")
 	output = output + fmt.Sprint(other)
 	return output, nil
 }

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -70,8 +70,8 @@ services:
     container_name: nginx-proxy
     ports:
       - "80:80"
-      - "8025:8025"
-      - "8036:8036"
+      - "{{ .MailHogPort }}":"{{ .MailHogPort }}
+      - "{{ .DBAPort }}:{{ .DBAPort }}
       - "3306:3306"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -70,8 +70,8 @@ services:
     container_name: nginx-proxy
     ports:
       - "80:80"
-      - "{{ .MailHogPort }}":"{{ .MailHogPort }}
-      - "{{ .DBAPort }}:{{ .DBAPort }}
+      - {{ .mailhogport }}:{{ .mailhogport }}
+      - {{ .dbaport }}:{{ .dbaport }}
       - "3306:3306"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -71,6 +71,7 @@ services:
     ports:
       - "80:80"
       - "8025:8025"
+      - "8036:8036"
       - "3306:3306"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -223,7 +223,7 @@ func DetermineAppType(basePath string) (string, error) {
 // @todo replace this with drud-go/utils version when merged
 func FileExists(name string) bool {
 	if _, err := os.Stat(name); err != nil {
-		if os.IsNotExist(err) {@r
+		if os.IsNotExist(err) {
 			return false
 		}
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -255,6 +255,8 @@ func EnsureDockerRouter() {
 	templateVars := map[string]string{
 		"router_image": version.RouterImage,
 		"router_tag":   version.RouterTag,
+		"MailHogPort":  version.MailHogPort,
+		"DBAPort":      version.DBAPort,
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/docker/docker/pkg/homedir"
+	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/drud/drud-go/utils/dockerutil"
@@ -222,7 +223,7 @@ func DetermineAppType(basePath string) (string, error) {
 // @todo replace this with drud-go/utils version when merged
 func FileExists(name string) bool {
 	if _, err := os.Stat(name); err != nil {
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) {@r
 			return false
 		}
 	}
@@ -255,8 +256,8 @@ func EnsureDockerRouter() {
 	templateVars := map[string]string{
 		"router_image": version.RouterImage,
 		"router_tag":   version.RouterTag,
-		"MailHogPort":  version.MailHogPort,
-		"DBAPort":      version.DBAPort,
+		"mailhogport":  appports.GetPort("mailhog"),
+		"dbaport":      appports.GetPort("dba"),
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,8 +23,14 @@ var DBTag = "v0.3.0" // Note that this is overridden by make
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"
 
+// DBAPort defines the default phpmyadmin port used on the router.
+var DBAPort = "8036"
+
 // DBATag defines the default phpmyadmin image tag used for applications.
 var DBATag = "v0.1.0"
+
+// MailHogPort defines the default mailhog exposed by the router.
+var MailHogPort = "8025"
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/nginx-proxy" // Note that this is overridden by make

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,14 +23,8 @@ var DBTag = "v0.3.0" // Note that this is overridden by make
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"
 
-// DBAPort defines the default phpmyadmin port used on the router.
-var DBAPort = "8036"
-
 // DBATag defines the default phpmyadmin image tag used for applications.
 var DBATag = "v0.1.0"
-
-// MailHogPort defines the default mailhog exposed by the router.
-var MailHogPort = "8025"
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/nginx-proxy" // Note that this is overridden by make

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -30,4 +30,4 @@ var DBATag = "v0.1.0"
 var RouterImage = "drud/nginx-proxy" // Note that this is overridden by make
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.2.0" // Note that this is overridden by make
+var RouterTag = "v0.3.0" // Note that this is overridden by make

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,23 +5,29 @@ var VERSION = ""
 
 // IMPORTANT: These versions are overridden by version ldflags specifications VERSION_VARIABLES in the Makefile
 
-// DdevVersion is the current version of the ddev tool, by default the git committish (should be current git tag)
+// DdevVersion is the current version of ddev, by default the git committish (should be current git tag)
 var DdevVersion = "v0.1.0-dev" // Note that this is overridden by make
 
-// WebImg defines the default web image for drud dev
+// WebImg defines the default web image used for applications.
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
 var WebTag = "v0.3.4" // Note that this is overridden by make
 
-// DBImg defines the default db image for drud dev
+// DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-docker-local-57" // Note that this is overridden by make
 
 // DBTag defines the default db image tag for drud dev
 var DBTag = "v0.3.0" // Note that this is overridden by make
 
-// RouterImage defines the image used for the drud dev router.
+// DBAImg defines the default phpmyadmin image tag used for applications.
+var DBAImg = "drud/phpmyadmin"
+
+// DBATag defines the default phpmyadmin image tag used for applications.
+var DBATag = "v0.1.0"
+
+// RouterImage defines the image used for the router.
 var RouterImage = "drud/nginx-proxy" // Note that this is overridden by make
 
-// RouterTag defines the tag used for the drud dev router.
+// RouterTag defines the tag used for the router.
 var RouterTag = "v0.2.0" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:
See #91 for full problem description. We want phpMyAdmin as an available tool for developers.

## The Fix:
This PR introduces phpMyAdmin as well as exposing the correct ports on the router. 

## The Test:
- Compile this PR as a binary
- Ensure the site you are testing is stopped, and manually remove the .ddev/docker-compose.yaml file if one exists.
- Start a site. (optionally) import a database.
- Run `ddev describe`
- Load the URL listed under phpMyAdmin.


