### PR TITLE
Add error checking for everything errcheck points out, errcheck library functions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,7 +58,8 @@ stages:
           cd  ~/src/github.com/drud/ddev &&
           make GOPATH=~/ gofmt &&
           make GOPATH=~/ govet &&
-          make GOPATH=~/ golint
+          make GOPATH=~/ golint &&
+          make GOPATH=~/ errcheck
         name: Static analysis targets govet/gofmt/golint
 
 

--- a/cmd/ddev/cmd/dev_sequelpro.go
+++ b/cmd/ddev/cmd/dev_sequelpro.go
@@ -11,6 +11,7 @@ import (
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/spf13/cobra"
+	"github.com/drud/ddev/pkg/util"
 )
 
 // LocalDevSequelproCmd represents the sequelpro command
@@ -45,9 +46,9 @@ var LocalDevSequelproCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalln(err)
 		}
-		defer tmpFile.Close()
+		defer util.CheckClose(tmpFile)
 
-		tmpFile.WriteString(fmt.Sprintf(
+		_, err = tmpFile.WriteString(fmt.Sprintf(
 			platform.SequelproTemplate,
 			"data",                  //dbname
 			"127.0.0.1",             //host
@@ -56,6 +57,7 @@ var LocalDevSequelproCmd = &cobra.Command{
 			strconv.FormatInt(dbPort, 10), // port
 			"root", //dbuser
 		))
+		util.CheckErr(err)
 
 		err = exec.Command("open", tmpFilePath).Run()
 		if err != nil {

--- a/cmd/ddev/cmd/dev_sequelpro.go
+++ b/cmd/ddev/cmd/dev_sequelpro.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 
 	"github.com/drud/ddev/pkg/plugins/platform"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/spf13/cobra"
-	"github.com/drud/ddev/pkg/util"
 )
 
 // LocalDevSequelproCmd represents the sequelpro command

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/spf13/cobra"
+	"github.com/drud/ddev/pkg/util"
 )
 
 // DevListCmd represents the list command
@@ -39,7 +40,8 @@ var DevListCmd = &cobra.Command{
 			return vsf
 		}(containers)
 
-		platform.SiteList(containers)
+		err := platform.SiteList(containers)
+		util.CheckErr(err)
 	},
 }
 

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 
 	"github.com/drud/ddev/pkg/plugins/platform"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/spf13/cobra"
-	"github.com/drud/ddev/pkg/util"
 )
 
 // DevListCmd represents the list command

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
 )
 
 var (
@@ -31,7 +32,8 @@ func TestMain(m *testing.M) {
 	}
 
 	for i := range DevTestSites {
-		DevTestSites[i].Prepare()
+		err = DevTestSites[i].Prepare()
+		util.CheckErr(err)
 	}
 
 	fmt.Println("Running tests.")

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/drud/ddev/pkg/util"
 )
 
 var (
@@ -33,7 +33,9 @@ func TestMain(m *testing.M) {
 
 	for i := range DevTestSites {
 		err = DevTestSites[i].Prepare()
-		util.CheckErr(err)
+		if err != nil {
+			log.Fatalln("Prepare() failed in TestMain site=%s, err=", DevTestSites[i].Name, err)
+		}
 	}
 
 	fmt.Println("Running tests.")

--- a/cmd/ddev/cmd/z_rm_test.go
+++ b/cmd/ddev/cmd/z_rm_test.go
@@ -12,7 +12,7 @@ import (
 func TestDevRm(t *testing.T) {
 	assert := assert.New(t)
 	for _, site := range DevTestSites {
-		cleanup := site.Chdir()
+		_ = site.Chdir()
 
 		args := []string{"rm"}
 		out, err := system.RunCommand(DdevBin, args)
@@ -27,7 +27,6 @@ func TestDevRm(t *testing.T) {
 		assert.Contains(string(out), format("Stopping %s-db ... done", app.ContainerName()))
 		assert.Contains(string(out), format("Removing %s-web ... done", app.ContainerName()))
 		assert.Contains(string(out), format("Removing %s-db ... done", app.ContainerName()))
-
-		cleanup()
+		// site cleanup is handled in TestMain
 	}
 }

--- a/pkg/cms/config/config_test.go
+++ b/pkg/cms/config/config_test.go
@@ -19,7 +19,6 @@ func TestWriteDrupalConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	err = os.Chmod(dir, 0555)
 	util.CheckErr(err)
 	err = os.Chmod(file.Name(), 0444)
 	util.CheckErr(err)
@@ -40,7 +39,6 @@ func TestWriteDrushConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	err = os.Chmod(dir, 0555)
 	util.CheckErr(err)
 	err = os.Chmod(file.Name(), 0444)
 	util.CheckErr(err)
@@ -61,7 +59,6 @@ func TestWriteWordpressConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	err = os.Chmod(dir, 0555)
 	util.CheckErr(err)
 	err = os.Chmod(file.Name(), 0444)
 	util.CheckErr(err)

--- a/pkg/cms/config/config_test.go
+++ b/pkg/cms/config/config_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/drud/ddev/pkg/cms/model"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/stretchr/testify/assert"
 	"github.com/drud/ddev/pkg/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWriteDrupalConfig(t *testing.T) {
@@ -28,7 +28,7 @@ func TestWriteDrupalConfig(t *testing.T) {
 	err = WriteDrupalConfig(drupalConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer func () {
+	defer func() {
 		err := os.RemoveAll(dir)
 		util.CheckErr(err)
 	}()
@@ -49,7 +49,7 @@ func TestWriteDrushConfig(t *testing.T) {
 	err = WriteDrushConfig(drushConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer func () {
+	defer func() {
 		err := os.RemoveAll(dir)
 		util.CheckErr(err)
 	}()
@@ -70,7 +70,7 @@ func TestWriteWordpressConfig(t *testing.T) {
 	err = WriteWordpressConfig(wpConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer func () {
+	defer func() {
 		err := os.RemoveAll(dir)
 		util.CheckErr(err)
 	}()

--- a/pkg/cms/config/config_test.go
+++ b/pkg/cms/config/config_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/drud/ddev/pkg/cms/model"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/drud/ddev/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,18 +18,15 @@ func TestWriteDrupalConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	util.CheckErr(err)
 	err = os.Chmod(file.Name(), 0444)
-	util.CheckErr(err)
+	assert.NoError(t, err)
 
 	drupalConfig := model.NewDrupalConfig()
 	err = WriteDrupalConfig(drupalConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer func() {
-		err := os.RemoveAll(dir)
-		util.CheckErr(err)
-	}()
+	err = os.RemoveAll(dir)
+	assert.NoError(t, err)
 }
 
 func TestWriteDrushConfig(t *testing.T) {
@@ -39,18 +35,15 @@ func TestWriteDrushConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	util.CheckErr(err)
 	err = os.Chmod(file.Name(), 0444)
-	util.CheckErr(err)
+	assert.NoError(t, err)
 
 	drushConfig := model.NewDrushConfig()
 	err = WriteDrushConfig(drushConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer func() {
-		err := os.RemoveAll(dir)
-		util.CheckErr(err)
-	}()
+	err = os.RemoveAll(dir)
+	assert.NoError(t, err)
 }
 
 func TestWriteWordpressConfig(t *testing.T) {
@@ -59,16 +52,13 @@ func TestWriteWordpressConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	util.CheckErr(err)
 	err = os.Chmod(file.Name(), 0444)
-	util.CheckErr(err)
+	assert.NoError(t, err)
 
 	wpConfig := model.NewWordpressConfig()
 	err = WriteWordpressConfig(wpConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer func() {
-		err := os.RemoveAll(dir)
-		util.CheckErr(err)
-	}()
+	err = os.RemoveAll(dir)
+	assert.NoError(t, err)
 }

--- a/pkg/cms/config/config_test.go
+++ b/pkg/cms/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/drud/ddev/pkg/cms/model"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/stretchr/testify/assert"
+	"github.com/drud/ddev/pkg/util"
 )
 
 func TestWriteDrupalConfig(t *testing.T) {
@@ -18,14 +19,19 @@ func TestWriteDrupalConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	os.Chmod(dir, 0555)
-	os.Chmod(file.Name(), 0444)
+	err = os.Chmod(dir, 0555)
+	util.CheckErr(err)
+	err = os.Chmod(file.Name(), 0444)
+	util.CheckErr(err)
 
 	drupalConfig := model.NewDrupalConfig()
 	err = WriteDrupalConfig(drupalConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer os.RemoveAll(dir)
+	defer func () {
+		err := os.RemoveAll(dir)
+		util.CheckErr(err)
+	}()
 }
 
 func TestWriteDrushConfig(t *testing.T) {
@@ -34,14 +40,19 @@ func TestWriteDrushConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	os.Chmod(dir, 0555)
-	os.Chmod(file.Name(), 0444)
+	err = os.Chmod(dir, 0555)
+	util.CheckErr(err)
+	err = os.Chmod(file.Name(), 0444)
+	util.CheckErr(err)
 
 	drushConfig := model.NewDrushConfig()
 	err = WriteDrushConfig(drushConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer os.RemoveAll(dir)
+	defer func () {
+		err := os.RemoveAll(dir)
+		util.CheckErr(err)
+	}()
 }
 
 func TestWriteWordpressConfig(t *testing.T) {
@@ -50,12 +61,17 @@ func TestWriteWordpressConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	os.Chmod(dir, 0555)
-	os.Chmod(file.Name(), 0444)
+	err = os.Chmod(dir, 0555)
+	util.CheckErr(err)
+	err = os.Chmod(file.Name(), 0444)
+	util.CheckErr(err)
 
 	wpConfig := model.NewWordpressConfig()
 	err = WriteWordpressConfig(wpConfig, file.Name())
 	assert.NoError(t, err)
 
-	defer os.RemoveAll(dir)
+	defer func () {
+		err := os.RemoveAll(dir)
+		util.CheckErr(err)
+	}()
 }

--- a/pkg/cms/config/drupal.go
+++ b/pkg/cms/config/drupal.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/cms/model"
+	"github.com/drud/ddev/pkg/util"
 )
 
 const (
@@ -103,9 +104,11 @@ func WriteDrupalConfig(drupalConfig *model.DrupalConfig, filePath string) error 
 		return err
 	}
 	// Ensure target directory is writable.
-	os.Chmod(dir, 0755)
+	err = os.Chmod(dir, 0755)
+	util.CheckErr(err)
 	// Ensure filePath is writable.
-	os.Chmod(filePath, 0644)
+	err = os.Chmod(filePath, 0644)
+	util.CheckErr(err)
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err
@@ -125,9 +128,11 @@ func WriteDrushConfig(drushConfig *model.DrushConfig, filePath string) error {
 		return err
 	}
 	// Ensure target directory is writable.
-	os.Chmod(dir, 0755)
+	err = os.Chmod(dir, 0755)
+	util.CheckErr(err)
 	// Ensure filePath is writable.
-	os.Chmod(filePath, 0644)
+	err = os.Chmod(filePath, 0644)
+	util.CheckErr(err)
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err

--- a/pkg/cms/config/drupal.go
+++ b/pkg/cms/config/drupal.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/cms/model"
-	"github.com/drud/ddev/pkg/util"
 )
 
 const (
@@ -105,10 +104,14 @@ func WriteDrupalConfig(drupalConfig *model.DrupalConfig, filePath string) error 
 	}
 	// Ensure target directory is writable.
 	err = os.Chmod(dir, 0755)
-	util.CheckErr(err)
+	if err != nil {
+		return err
+	}
 	// Ensure filePath is writable.
 	err = os.Chmod(filePath, 0644)
-	util.CheckErr(err)
+	if err != nil {
+		return err
+	}
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err
@@ -129,10 +132,14 @@ func WriteDrushConfig(drushConfig *model.DrushConfig, filePath string) error {
 	}
 	// Ensure target directory is writable.
 	err = os.Chmod(dir, 0755)
-	util.CheckErr(err)
+	if err != nil {
+		return err
+	}
 	// Ensure filePath is writable.
 	err = os.Chmod(filePath, 0644)
-	util.CheckErr(err)
+	if err != nil {
+		return err
+	}
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err

--- a/pkg/cms/config/wordpress.go
+++ b/pkg/cms/config/wordpress.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/cms/model"
-	"github.com/drud/ddev/pkg/util"
 )
 
 const (
@@ -215,10 +214,14 @@ func WriteWordpressConfig(wordpressConfig *model.WordpressConfig, filePath strin
 	}
 	// Ensure target directory is writable.
 	err = os.Chmod(dir, 0755)
-	util.CheckErr(err)
+	if err != nil {
+		return err
+	}
 	// Ensure filePath is writable.
 	err = os.Chmod(filePath, 0644)
-	util.CheckErr(err)
+	if err != nil {
+		return err
+	}
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err

--- a/pkg/cms/config/wordpress.go
+++ b/pkg/cms/config/wordpress.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/cms/model"
+	"github.com/drud/ddev/pkg/util"
 )
 
 const (
@@ -213,9 +214,11 @@ func WriteWordpressConfig(wordpressConfig *model.WordpressConfig, filePath strin
 		return err
 	}
 	// Ensure target directory is writable.
-	os.Chmod(dir, 0755)
+	err = os.Chmod(dir, 0755)
+	util.CheckErr(err)
 	// Ensure filePath is writable.
-	os.Chmod(filePath, 0644)
+	err = os.Chmod(filePath, 0644)
+	util.CheckErr(err)
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -13,10 +13,10 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
-	"github.com/drud/ddev/pkg/util"
 )
 
 // CurrentAppVersion sets the current YAML config file version.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/drud/ddev/pkg/version"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
+	"github.com/drud/ddev/pkg/util"
 )
 
 // CurrentAppVersion sets the current YAML config file version.
@@ -138,9 +139,10 @@ func (c *Config) Config() error {
 	fmt.Print(namePrompt + ": ")
 	c.Name = getInput(c.Name)
 
-	c.docrootPrompt()
+	err := c.docrootPrompt()
+	util.CheckErr(err)
 
-	err := c.appTypePrompt()
+	err = c.appTypePrompt()
 	if err != nil {
 		return err
 	}
@@ -173,7 +175,7 @@ func (c *Config) WriteDockerComposeConfig() error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer util.CheckClose(f)
 
 	rendered, err := c.RenderComposeYAML()
 	if err != nil {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/stretchr/testify/assert"
+	"github.com/drud/ddev/pkg/util"
 )
 
 // TestNewConfig tests functionality around creating a new config, writing it to disk, and reading the resulting config.
@@ -145,6 +146,8 @@ func TestConfigCommand(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := assert.New(t)
 	testDir := testcommon.CreateTmpDir("TestConfigCommand")
+
+	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
 	defer testcommon.Chdir(testDir)()
 	defer testcommon.CleanupDir(testDir)
 
@@ -171,7 +174,8 @@ func TestConfigCommand(t *testing.T) {
 	setInputScanner(scanner)
 
 	restoreOutput := testcommon.CaptureStdOut()
-	config.Config()
+	err = config.Config()
+	util.CheckErr(err)
 	out := restoreOutput()
 
 	// Ensure we have expected vales in output.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -11,9 +11,9 @@ import (
 	"io/ioutil"
 
 	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/stretchr/testify/assert"
-	"github.com/drud/ddev/pkg/util"
 )
 
 // TestNewConfig tests functionality around creating a new config, writing it to disk, and reading the resulting config.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/stretchr/testify/assert"
 )
@@ -175,7 +174,7 @@ func TestConfigCommand(t *testing.T) {
 
 	restoreOutput := testcommon.CaptureStdOut()
 	err = config.Config()
-	util.CheckErr(err)
+	assert.NoError(err, t)
 	out := restoreOutput()
 
 	// Ensure we have expected vales in output.

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -189,7 +189,9 @@ func (l *LocalApp) UnpackResources() error {
 	// Ensure sites/default is readable.
 	if l.GetType() == "drupal7" || l.GetType() == "drupal8" {
 		err := os.Chmod(path.Join(basePath, ".ddev", "files", "docroot", "sites", "default"), 0755)
-		util.CheckErr(err)
+		if err != nil {
+			return err
+		}
 	}
 
 	rsyncFrom := path.Join(basePath, ".ddev", "files", "docroot", fileDir)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -12,6 +12,7 @@ import (
 	"github.com/drud/ddev/pkg/cms/config"
 	"github.com/drud/ddev/pkg/cms/model"
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/network"
 	"github.com/drud/drud-go/utils/stringutil"
@@ -187,7 +188,8 @@ func (l *LocalApp) UnpackResources() error {
 
 	// Ensure sites/default is readable.
 	if l.GetType() == "drupal7" || l.GetType() == "drupal8" {
-		os.Chmod(path.Join(basePath, ".ddev", "files", "docroot", "sites", "default"), 0755)
+		err := os.Chmod(path.Join(basePath, ".ddev", "files", "docroot", "sites", "default"), 0755)
+		util.CheckErr(err)
 	}
 
 	rsyncFrom := path.Join(basePath, ".ddev", "files", "docroot", fileDir)
@@ -208,7 +210,10 @@ func (l *LocalApp) UnpackResources() error {
 	if err != nil {
 		return fmt.Errorf("%s - %s", err.Error(), string(out))
 	}
-	defer os.RemoveAll(path.Join(basePath, ".ddev", "files"))
+	defer func() {
+		err := os.RemoveAll(path.Join(basePath, ".ddev", "files"))
+		util.CheckErr(err)
+	}()
 
 	return nil
 }

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/system"
 	docker "github.com/fsouza/go-dockerclient"
@@ -131,7 +130,7 @@ func TestLocalRemove(t *testing.T) {
 	app := PluginMap["local"]
 
 	err := app.Init(TestSite.Dir)
-	util.CheckErr(err)
+	assert.NoError(err, t)
 
 	// start the previously stopped containers -
 	// stopped/removed have the same state

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/drud/drud-go/utils/system"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/drud/ddev/pkg/util"
 )
 
 var (
@@ -81,7 +82,8 @@ func TestLocalStart(t *testing.T) {
 	assert := assert.New(t)
 
 	app := PluginMap["local"]
-	app.Init(TestSite.Dir)
+	err = app.Init(TestSite.Dir)
+	assert.NoError(err)
 
 	err = app.Start()
 	assert.NoError(err)
@@ -107,9 +109,10 @@ func TestLocalStop(t *testing.T) {
 	assert := assert.New(t)
 
 	app := PluginMap["local"]
-	app.Init(TestSite.Dir)
+	err := app.Init(TestSite.Dir)
+	assert.NoError(err)
 
-	err := app.Stop()
+	err = app.Stop()
 	assert.NoError(err)
 
 	check, err := ContainerCheck(TestWebContainerName, "exited")
@@ -127,11 +130,12 @@ func TestLocalRemove(t *testing.T) {
 
 	app := PluginMap["local"]
 
-	app.Init(TestSite.Dir)
+	err := app.Init(TestSite.Dir)
+	util.CheckErr(err)
 
 	// start the previously stopped containers -
 	// stopped/removed have the same state
-	err := app.Start()
+	err = app.Start()
 	assert.NoError(err)
 
 	_, err = app.Wait()

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -8,11 +8,11 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/system"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
-	"github.com/drud/ddev/pkg/util"
 )
 
 var (

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -13,13 +13,13 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/docker/docker/pkg/homedir"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/system"
 	"github.com/drud/drud-go/utils/try"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gosuri/uitable"
-	"github.com/drud/ddev/pkg/util"
 )
 
 // PrepLocalSiteDirs creates a site's directories for local dev in ~/.drud/client/site

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -72,7 +72,6 @@ func (site *TestSite) Chdir() func() {
 
 // Cleanup removes the archive and codebase extraction for a site after a test run has completed.
 func (site *TestSite) Cleanup() {
-	log.Debugln("Cleanup(): site.createArchivePath()=", site.createArchivePath())
 	err := os.Remove(site.ArchivePath)
 	util.CheckErr(err)
 	// CleanupDir checks its own errors.

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -121,7 +121,9 @@ func Chdir(path string) func() {
 
 	return func() {
 		err := os.Chdir(curDir)
-		util.CheckErr(err)
+		if err != nil {
+			log.Fatalf("Failed to change directory to original dir=%s, err=%v", curDir, err)
+		}
 	}
 }
 
@@ -158,8 +160,7 @@ func CaptureStdOut() func() string {
 		}()
 
 		// back to normal state
-		err := w.Close()
-		util.CheckErr(err)
+		util.CheckClose(w)
 		os.Stdout = old // restoring the real stdout
 		out := <-outC
 		return out

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -21,8 +21,7 @@ func TestTmpDir(t *testing.T) {
 	assert.True(dirStat.IsDir(), "Temp Directory created and exists")
 
 	// Clean up tempoary directory and ensure it no longer exists.
-	err = CleanupDir(testDir)
-	assert.NoError(err, "Clean up temporary directory")
+	CleanupDir(testDir)
 	dirStat, err = os.Stat(testDir)
 	assert.Error(err, "Could not stat temporary directory")
 	assert.True(os.IsNotExist(err), "Error is of type IsNotExists")
@@ -53,8 +52,7 @@ func TestChdir(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(currentDir, startingDir, "Ensure we have changed back to the starting directory")
 
-	err = CleanupDir(testDir)
-	assert.NoError(err, "Clean up test directory")
+	CleanupDir(testDir)
 }
 
 // TestCaptureStdOut ensures capturing of standard out works as expected.

--- a/pkg/util/errcheck.go
+++ b/pkg/util/errcheck.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"io"
+	"log"
+)
+
+// CheckErr exits with a log.Fatal() if an error is encountered.
+// It is normally used for errors that we never expect to happen, and don't have any normal handling technique.
+// From https://davidnix.io/post/error-handling-in-go/
+func CheckErr(err error) {
+	if err != nil {
+		log.Fatal("ERROR:", err)
+	}
+}
+
+// checkClose is used to check the return from Close in a defer statement.
+// From https://groups.google.com/d/msg/golang-nuts/-eo7navkp10/BY3ym_vMhRcJ
+func CheckClose(c io.Closer) {
+	err := c.Close()
+	CheckErr(err)
+}

--- a/pkg/util/errcheck.go
+++ b/pkg/util/errcheck.go
@@ -14,7 +14,7 @@ func CheckErr(err error) {
 	}
 }
 
-// checkClose is used to check the return from Close in a defer statement.
+// CheckClose is used to check the return from Close in a defer statement.
 // From https://groups.google.com/d/msg/golang-nuts/-eo7navkp10/BY3ym_vMhRcJ
 func CheckClose(c io.Closer) {
 	err := c.Close()


### PR DESCRIPTION
## The Problem:

We had a lot of functions which could return errors where the error was not being checked.

## The Fix:

* Check the errors. In most of these we *never* expect to hit an error, so can use the new util.CheckErr(), which just checks, reports, and exits if there's a problem.
* Fix a couple of places where it was failing and never before detected
* Add standard errcheck target into circle.yml

## The Test:

There should be no change.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

