### PR TITLE
Fix #149 by using os.Getcwd() to get AppRoot

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/spf13/cobra"
@@ -14,7 +13,7 @@ var ConfigCommand = &cobra.Command{
 	Use:   "config",
 	Short: "Create or modify a ddev application config in the current directory",
 	Run: func(cmd *cobra.Command, args []string) {
-		appRoot, err := filepath.Abs(filepath.Dir(os.Args[0]))
+		appRoot, err := os.Getwd()
 		if err != nil {
 			log.Fatalf("Could not determine current working directory: %v\n", err)
 		}


### PR DESCRIPTION
## The Problem:

AppRoot was being derived from the arg[0] of the ddev execution; it should have been using os.Getcwd(). This caused the bug in #149.

## The Fix:

One-line fix to use os.Getcwd(). Oddly, reading the line after it, it's almost certain that was intended anyway.

## The Test:

1. Build ddev
2. copy the ddev binary into /tmp
3. cd into a site and rm -r .ddev or just the config.yaml
4. /tmp/ddev config

You should see the AppRoot being the current directory, not /tmp

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

I don't think there's need to add tests for this.

## Related Issue Link(s):

[ddev mistakenly uses directory of ddev as location for .ddev instead of actual site dir](https://github.com/drud/ddev/issues/149)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

Nothing is needed.