### PR TITLE
Swap order of tests so pkg tests are done before cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 DDEV_BINARY_FULLPATH=$(shell pwd)/bin/$(TESTOS)/ddev
 
 # Override test section with tests specific to ddev
-test: testcmd testpkg
+test: testpkg testcmd
 
 testcmd: build setup
 	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 -timeout 20m -v -installsuffix 'static' -ldflags "$(LDFLAGS)" ./cmd/... $(TESTARGS)


### PR DESCRIPTION
## The Problem:

The faster tests are in the 'pkg' tests, @tannerjfco mentioned he'd like to run those first.

## The Fix:

Swap the order of the tests.

## The Test:

There should be no impact on anything.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

