### PR TITLE
Restore output during binary tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,9 @@ DDEV_BINARY_FULLPATH=$(shell pwd)/bin/$(TESTOS)/ddev
 test: testpkg testcmd
 
 testcmd: build setup
-	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 -timeout 20m -v -installsuffix 'static' -ldflags "$(LDFLAGS)" ./cmd/... $(TESTARGS)
+# We call this package directly to allow output to happen in real-time as tests are running. When using the shorthand ./cmd/... style to run all tests in all subdirectories, output will
+# not happen until completion, which makes tests very difficult to debug if there are problems.
+	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -timeout 20m -v -installsuffix 'static' -ldflags "$(LDFLAGS)" ./cmd/ddev/cmd/... $(TESTARGS)
 
 testpkg: build setup
 	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) DRUD_DEBUG=true go test -timeout 20m -v -installsuffix 'static' -ldflags "$(LDFLAGS)" ./pkg/... $(TESTARGS)


### PR DESCRIPTION
## The Problem:
We've lost output on our binary level tests, which makes them very difficult to debug.

## The Fix:
Be more explicit about what tests to run, and do not use the shorthand method of running all test in all subdirectories (`./cmd/...`) which prevents output until tests are complete.

## The Test:
I don't believe any manual testing is required here, automation passing should be sufficient.
