### PR TITLE
Rework `ddev list` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ To see a list of your current sites you can use `ddev list`.
 ```
 ➜  ddev list
 1 local site found.
-NAME   	TYPE   	LOCATION               	URL                      	DATABASE URL           	STATUS
-drupal8	drupal8	~/Projects/ddev/drupal8	http://drupal8.ddev.local	drupal8.ddev.local:3306	running
+NAME     TYPE     LOCATION                 URL                        STATUS
+drupal8  drupal8  ~/Projects/ddev/drupal8  http://drupal8.ddev.local  running
 ```
 
 You can also see more detailed information about a site by running `ddev describe` or `ddev describe [site-name]`.
 
 ```
-NAME   	TYPE   	LOCATION               	URL                      	DATABASE URL           	STATUS
-drupal8	drupal8	~/Projects/ddev/drupal8	http://drupal8.ddev.local	drupal8.ddev.local:3306	running
+NAME     TYPE     LOCATION                 URL                        STATUS
+drupal8  drupal8  ~/Projects/ddev/drupal8  http://drupal8.ddev.local  running
 
 MySQL Credentials
 -----------------
@@ -197,7 +197,7 @@ Instructions for IDE setup are in [step-debugging](docs/step-debugging.md).
  make test
  make clean
  ```
- 
+
  Note that although this git repository contains submodules (in the containers/ directory) they are not used in a normal build, but rather by the nightly build. You can safely ignore the git submodules and the containers/ directory.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ To see a list of your current sites you can use `ddev list`.
 ```
 ➜  ddev list
 1 local site found.
-NAME   	TYPE   	LOCATION                        URL                      	DATABASE URL
-drupal8	drupal8	/Users/username/drupal8/docroot	http://drupal8.ddev.local	drupal8.ddev.local:3306
+NAME   	TYPE   	LOCATION               	URL                      	DATABASE URL           	STATUS
+drupal8	drupal8	~/Projects/ddev/drupal8	http://drupal8.ddev.local	drupal8.ddev.local:3306	running
 ```
 
 You can also see more detailed information about a site by running `ddev describe` or `ddev describe [site-name]`.
 
 ```
-NAME   	DOCROOT                                         	TYPE   	URL                      	STATUS
-drupal8	/Users/username/drupal8/docroot                  	drupal8	http://drupal8.ddev.local	running
+NAME   	TYPE   	LOCATION               	URL                      	DATABASE URL           	STATUS
+drupal8	drupal8	~/Projects/ddev/drupal8	http://drupal8.ddev.local	drupal8.ddev.local:3306	running
 
 MySQL Credentials
 -----------------

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ To see a list of your current sites you can use `ddev list`.
 ```
 ➜  ddev list
 1 local site found.
-NAME   	TYPE   	URL                      	DATABASE URL   	STATUS
-drupal8	drupal8	http://drupal8.ddev.local	127.0.0.1:32852	running
+NAME   	TYPE   	LOCATION                        URL                      	DATABASE URL
+drupal8	drupal8	/Users/username/drupal8/docroot	http://drupal8.ddev.local	drupal8.ddev.local:3306
 ```
 
 You can also see more detailed information about a site by running `ddev describe` or `ddev describe [site-name]`.

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"strings"
+	"fmt"
+	"os"
 
 	"github.com/drud/ddev/pkg/plugins/platform"
-	"github.com/drud/ddev/pkg/util"
-	"github.com/drud/drud-go/utils/dockerutil"
-	"github.com/fsouza/go-dockerclient"
 	"github.com/spf13/cobra"
 )
 
@@ -16,32 +14,16 @@ var DevListCmd = &cobra.Command{
 	Short: "List applications that exist locally",
 	Long:  `List applications that exist locally.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		apps := platform.GetApps()
 
-		var prefixes []string
-
-		for _, instance := range platform.PluginMap {
-			prefixes = append(prefixes, instance.ContainerPrefix())
+		if len(apps) < 1 {
+			fmt.Println("There are no running ddev applications.")
+			os.Exit(0)
 		}
 
-		client, _ := dockerutil.GetDockerClient()
-		containers, _ := client.ListContainers(docker.ListContainersOptions{All: true})
-
-		containers = func(containers []docker.APIContainers) []docker.APIContainers {
-			var vsf []docker.APIContainers
-			for _, c := range containers {
-				for _, p := range prefixes {
-					container := c.Names[0][1:]
-					if !strings.HasPrefix(container, p) {
-						continue
-					}
-					vsf = append(vsf, c)
-				}
-			}
-			return vsf
-		}(containers)
-
-		err := platform.SiteList(containers)
-		util.CheckErr(err)
+		for platformType, sites := range apps {
+			platform.RenderAppTable(platformType, sites)
+		}
 	},
 }
 

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -22,7 +22,7 @@ func TestDevList(t *testing.T) {
 		assert.Contains(string(out), v.Name)
 		assert.Contains(string(out), app.URL())
 		assert.Contains(string(out), app.GetType())
-
+		assert.Contains(string(out), app.AppRoot())
 		cleanup()
 	}
 

--- a/pkg/appimport/appimport_test.go
+++ b/pkg/appimport/appimport_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const netName = "ddev_default"
+
 var (
 	testArchiveURL  = "https://github.com/drud/wordpress/releases/download/v0.1.0/db.tar.gz"
 	testArchivePath = path.Join(testcommon.CreateTmpDir("appimport"), "db.tar.gz")

--- a/pkg/appports/ports.go
+++ b/pkg/appports/ports.go
@@ -14,9 +14,13 @@ var dbaPort = "8036"
 // mailHogPort defines the default mailhog exposed by the router.
 var mailhogPort = "8025"
 
+// dbPort defines the default DB (MySQL) port.
+var dbPort = "3306"
+
 var ports = map[string]string{
 	"mailhog": mailhogPort,
 	"dba":     dbaPort,
+	"db":      dbPort,
 }
 
 // GetPort returns the external router (as a string) for the given service. This can be used to find a given port for docker-compose manifests,

--- a/pkg/cms/model/drupal.go
+++ b/pkg/cms/model/drupal.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/drud/ddev/pkg/appports"
+
 // DrupalConfig encapsulates all the configurations for a Drupal site.
 type DrupalConfig struct {
 	DeployName       string
@@ -9,7 +11,7 @@ type DrupalConfig struct {
 	DatabasePassword string
 	DatabaseHost     string
 	DatabaseDriver   string
-	DatabasePort     int
+	DatabasePort     string
 	DatabasePrefix   string
 	HashSalt         string
 	IsDrupal8        bool
@@ -23,7 +25,7 @@ func NewDrupalConfig() *DrupalConfig {
 		DatabasePassword: "root",
 		DatabaseHost:     "127.0.0.1",
 		DatabaseDriver:   "mysql",
-		DatabasePort:     3306,
+		DatabasePort:     appports.GetPort("db"),
 		DatabasePrefix:   "",
 		IsDrupal8:        false,
 	}
@@ -31,7 +33,7 @@ func NewDrupalConfig() *DrupalConfig {
 
 // DrushConfig encapsulates configuration for a drush settings file.
 type DrushConfig struct {
-	DatabasePort int64
+	DatabasePort string
 	DatabaseHost string
 	IsDrupal8    bool
 }
@@ -40,7 +42,7 @@ type DrushConfig struct {
 func NewDrushConfig() *DrushConfig {
 	return &DrushConfig{
 		DatabaseHost: "127.0.0.1",
-		DatabasePort: 3306,
+		DatabasePort: appports.GetPort("db"),
 		IsDrupal8:    false,
 	}
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -223,6 +223,7 @@ func (c *Config) RenderComposeYAML() (string, error) {
 		"appType":     c.AppType,
 		"mailhogport": appports.GetPort("mailhog"),
 		"dbaport":     appports.GetPort("dba"),
+		"dbport":      appports.GetPort("db"),
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -12,12 +12,13 @@ services:
       - "./data:/db"
     restart: always
     environment:
-      - TCP_PORT=$DDEV_HOSTNAME:3306
+      - TCP_PORT=$DDEV_HOSTNAME:{{ .dbport }}
     ports:
-      - "3306"
+      - {{ .dbport }}:3306
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.container-type: db
+      com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
       com.ddev.docroot: $DDEV_DOCROOT
       com.ddev.approot: $DDEV_APPROOT
@@ -44,6 +45,7 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.container-type: web
+      com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
       com.ddev.docroot: $DDEV_DOCROOT
       com.ddev.approot: $DDEV_APPROOT
@@ -52,6 +54,11 @@ services:
     container_name: local-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
     restart: always
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.container-type: db
+      com.ddev.platform: {{ .plugin }}
+      com.ddev.app-type: {{ .appType }}
     depends_on:
       - local-${DDEV_SITENAME}-db
     links:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -56,9 +56,12 @@ services:
     restart: always
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.container-type: db
+      com.ddev.container-type: dba
       com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
+      com.ddev.docroot: $DDEV_DOCROOT
+      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.app-url: $DDEV_URL
     depends_on:
       - local-${DDEV_SITENAME}-db
     links:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -14,7 +14,7 @@ services:
     environment:
       - TCP_PORT=$DDEV_HOSTNAME:{{ .dbport }}
     ports:
-      - {{ .dbport }}:3306
+      - 3306
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.container-type: db

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -80,11 +80,9 @@ func (l *LocalApp) Describe() (string, error) {
 	}
 
 	var output string
-	app := uitable.New()
-	app.MaxColWidth = maxWidth
-	app.AddRow("NAME", "LOCATION", "TYPE", "URL", "STATUS")
-	app.AddRow(l.GetName(), l.AppRoot(), l.GetType(), l.URL(), "running")
-	output = fmt.Sprint(app)
+	appTable := CreateAppTable()
+	RenderAppRow(appTable, l)
+	output = fmt.Sprint(appTable)
 
 	output = output + "\n\nMySQL Credentials\n-----------------\n"
 	dbTable := uitable.New()

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -187,6 +187,16 @@ func (l *LocalApp) ImportDB(imPath string) error {
 	return nil
 }
 
+func (l *LocalApp) SiteStatus() string {
+	webContainer, err := l.FindContainerByType("web")
+
+	if err != nil {
+		return "Not Found"
+	}
+
+	return "Running"
+}
+
 // ImportFiles takes a source directory or archive and copies to the uploaded files directory of a given app.
 func (l *LocalApp) ImportFiles(imPath string) error {
 	var uploadDir string

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"strings"
 
@@ -91,7 +92,7 @@ func (l *LocalApp) Describe() (string, error) {
 	dbTable.AddRow("Username:", "root")
 	dbTable.AddRow("Password:", "root")
 	dbTable.AddRow("Database name:", "data")
-	dbTable.AddRow("Connection Info:", l.HostName()+":3306")
+	dbTable.AddRow("Connection Info:", l.HostName()+":"+appports.GetPort("db"))
 	output = output + fmt.Sprint(dbTable)
 
 	output = output + "\n\nOther Services\n--------------\n"
@@ -405,7 +406,7 @@ func (l *LocalApp) Config() error {
 
 		drushSettingsPath := path.Join(basePath, "drush.settings.php")
 		drushConfig := model.NewDrushConfig()
-		drushConfig.DatabasePort = dbPort
+		drushConfig.DatabasePort = strconv.FormatInt(dbPort, 10)
 		if l.GetType() == "drupal8" {
 			drushConfig.IsDrupal8 = true
 		}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -187,14 +187,22 @@ func (l *LocalApp) ImportDB(imPath string) error {
 	return nil
 }
 
+// SiteStatus returns the current status of an application based on the web container.
 func (l *LocalApp) SiteStatus() string {
 	webContainer, err := l.FindContainerByType("web")
-
 	if err != nil {
-		return "Not Found"
+		return "not found"
 	}
 
-	return "Running"
+	status := util.GetContainerHealth(webContainer)
+	if status == "exited" {
+		return "stopped"
+	}
+	if status == "healthy" {
+		return "running"
+	}
+
+	return status
 }
 
 // ImportFiles takes a source directory or archive and copies to the uploaded files directory of a given app.

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -142,6 +142,7 @@ func TestGetApps(t *testing.T) {
 		for _, siteInList := range apps["local"] {
 			if site.Name == siteInList.GetName() {
 				found = true
+				break
 			}
 		}
 		assert.True(found, "Found site %s in list", site.Name)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/system"
-	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,7 +70,7 @@ func ContainerCheck(checkName string, checkState string) (bool, error) {
 		log.Fatal(err)
 	}
 
-	containers, err := client.ListContainers(docker.ListContainersOptions{All: true})
+	containers, err := util.GetDockerContainers(true)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -133,6 +133,22 @@ func TestLocalStart(t *testing.T) {
 	}
 }
 
+func TestGetApps(t *testing.T) {
+	assert := assert.New(t)
+	apps := GetApps()
+	assert.Equal(len(apps["local"]), len(TestSites))
+
+	for _, site := range TestSites {
+		var found bool
+		for _, siteInList := range apps["local"] {
+			if site.Name == siteInList.GetName() {
+				found = true
+			}
+		}
+		assert.True(found, "Found site %s in list", site.Name)
+	}
+}
+
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed
 func TestLocalImportDB(t *testing.T) {
 	assert := assert.New(t)
@@ -253,4 +269,10 @@ func TestLocalRemove(t *testing.T) {
 
 		cleanup()
 	}
+}
+
+func TestGetAppsEmpty(t *testing.T) {
+	assert := assert.New(t)
+	apps := GetApps()
+	assert.Equal(len(apps["local"]), 0)
 }

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -132,6 +132,7 @@ func TestLocalStart(t *testing.T) {
 	}
 }
 
+// TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.
 func TestGetApps(t *testing.T) {
 	assert := assert.New(t)
 	apps := GetApps()
@@ -271,6 +272,7 @@ func TestLocalRemove(t *testing.T) {
 	}
 }
 
+// TestGetappsEmpty ensures that GetApps returns an empty list when no applications are running.
 func TestGetAppsEmpty(t *testing.T) {
 	assert := assert.New(t)
 	apps := GetApps()

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -72,7 +72,7 @@ services:
       - "80:80"
       - {{ .mailhogport }}:{{ .mailhogport }}
       - {{ .dbaport }}:{{ .dbaport }}
-      - "3306:3306"
+      - {{ .dbport }}:{{ .dbport }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
 networks:

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -1,5 +1,7 @@
 package platform
 
+import "log"
+
 // App is an interface apps for Drud Local must implement to use shared functionality
 type App interface {
 	Init(string) error
@@ -34,4 +36,16 @@ type AppBase struct {
 // PluginMap maps the name of the plugins to their implementation.
 var PluginMap = map[string]App{
 	"local": &LocalApp{},
+}
+
+// GetPluginApp will return an application of the type specified by pluginType
+func GetPluginApp(pluginType string) App {
+	switch pluginType {
+	case "local":
+		return &LocalApp{}
+	default:
+		log.Fatalf("Could not find plugin type %s", pluginType)
+	}
+
+	return nil
 }

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -22,6 +22,7 @@ type App interface {
 	URL() string
 	ImportDB(string) error
 	ImportFiles(string) error
+	SiteStatus() string
 }
 
 // AppBase is the parent type for all local app implementations

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -115,8 +115,9 @@ func RenderAppRow(table *uitable.Table, site App) {
 // EnsureDockerRouter ensures the router is running.
 func EnsureDockerRouter() {
 	userHome, err := homedir.Dir()
-	log.Fatal("could not get home directory for current user. is it set?")
-
+	if err != nil {
+		log.Fatal("could not get home directory for current user. is it set?")
+	}
 	routerdir := path.Join(userHome, ".ddev")
 	err = os.MkdirAll(routerdir, 0755)
 	if err != nil {

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/gosuri/uitable"
 
 	"errors"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/drud/drud-go/utils/system"
+	"github.com/drud/drud-go/utils/try"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -39,43 +42,147 @@ func PrepLocalSiteDirs(base string) error {
 	return nil
 }
 
-// SiteList will prepare and render a list of ddev sites running locally.
-func SiteList(containers []docker.APIContainers) error {
-	apps := map[string]map[string]map[string]string{}
-	var appsFound bool
+// GetPort determines and returns the public port for a given container.
+func GetPort(name string) (int64, error) {
+	client, _ := GetDockerClient()
+	var publicPort int64
 
-	for pName := range PluginMap {
-		apps[pName] = map[string]map[string]string{}
+	containers, err := client.ListContainers(docker.ListContainersOptions{All: false})
+	if err != nil {
+		return publicPort, err
 	}
 
-	for _, container := range containers {
-		for _, containerName := range container.Names {
-			for pName, plugin := range PluginMap {
-				if strings.HasPrefix(containerName[1:], plugin.ContainerPrefix()) {
-					util.ProcessContainer(apps[pName], pName, containerName[1:], container)
-					break
+	for _, ctr := range containers {
+		if strings.Contains(ctr.Names[0][1:], name) {
+			for _, port := range ctr.Ports {
+				if port.PublicPort != 0 {
+					publicPort = port.PublicPort
+					return publicPort, nil
 				}
 			}
 		}
 	}
+	return publicPort, fmt.Errorf("%s container not ready", name)
+}
 
+// GetPodPort provides a wait loop to help in successfully returning the public port for a given container.
+func GetPodPort(name string) (int64, error) {
+	var publicPort int64
+
+	err := try.Do(func(attempt int) (bool, error) {
+		var err error
+		publicPort, err = GetPort(name)
+		if err != nil {
+			time.Sleep(2 * time.Second) // wait a couple seconds
+		}
+		return attempt < 70, err
+	})
+	if err != nil {
+		return publicPort, err
+	}
+
+	return publicPort, nil
+}
+
+// GetDockerClient returns a docker client for a docker-machine.
+func GetDockerClient() (*docker.Client, error) {
+	// Create a new docker client talking to the default docker-machine.
+	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return client, err
+}
+
+// FormatPlural is a simple wrapper which returns different strings based on the count value.
+func FormatPlural(count int, single string, plural string) string {
+	if count == 1 {
+		return single
+	}
+	return plural
+}
+
+// GetApps returns a list of ddev applictions keyed by platform.
+func GetApps() map[string][]App {
+	apps := make(map[string][]App)
+	for platformType, instance := range PluginMap {
+		labels := map[string]string{
+			"com.ddev.platform":       instance.ContainerPrefix(),
+			"com.ddev.container-type": "web",
+		}
+		sites, err := util.FindContainersByLabels(labels)
+
+		if err == nil {
+			for _, siteContainer := range sites {
+
+				site := PluginMap[platformType]
+				approot, ok := siteContainer.Labels["com.ddev.approot"]
+				if !ok {
+					break
+				}
+				_, ok = apps[platformType]
+				if !ok {
+					fmt.Println("creating slice for " + platformType)
+					apps[platformType] = []App{}
+				}
+
+				site.Init(approot)
+				apps[platformType] = append(apps[platformType], site)
+			}
+		}
+	}
+
+	return apps
+}
+
+// RenderAppTable will format a table for user display based on a list of apps.
+func RenderAppTable(platform string, apps []App) {
 	if len(apps) > 0 {
-		for k, v := range apps {
-			util.RenderAppTable(v, k)
+		fmt.Printf("%v %s %v found.\n", len(apps), platform, FormatPlural(len(apps), "site", "sites"))
+		table := uitable.New()
+		table.MaxColWidth = 200
+		table.AddRow("NAME", "TYPE", "LOCATION", "URL", "DATABASE URL")
+		for _, site := range apps {
+			table.AddRow(
+				site.GetName(),
+				site.GetType(),
+				site.AppRoot(),
+				site.URL(),
+				fmt.Sprintf("%s:%s", site.HostName(), appports.GetPort("db")),
+			)
+		}
+		fmt.Println(table)
+	}
+
+}
+
+// DetermineAppType uses some predetermined file checks to determine if a local app
+// is of any of the known types
+func DetermineAppType(basePath string) (string, error) {
+	defaultLocations := map[string]string{
+		"docroot/scripts/drupal.sh":      "drupal",
+		"docroot/core/scripts/drupal.sh": "drupal8",
+		"docroot/wp":                     "wp",
+	}
+
+	for k, v := range defaultLocations {
+		if FileExists(path.Join(basePath, k)) {
+			return v, nil
 		}
 	}
 
-	for _, appList := range apps {
-		if len(appList) > 0 {
-			appsFound = true
+	return "", fmt.Errorf("unable to determine the application type")
+}
+
+// FileExists checks a file's existence
+// @todo replace this with drud-go/utils version when merged
+func FileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
 		}
 	}
-
-	if appsFound == false {
-		fmt.Println("No Applications Found.")
-	}
-
-	return nil
+	return true
 }
 
 // EnsureDockerRouter ensures the router is running.
@@ -106,6 +213,7 @@ func EnsureDockerRouter() {
 		"router_tag":   version.RouterTag,
 		"mailhogport":  appports.GetPort("mailhog"),
 		"dbaport":      appports.GetPort("dba"),
+		"dbport":       appports.GetPort("db"),
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -126,8 +126,10 @@ func GetApps() map[string][]App {
 					apps[platformType] = []App{}
 				}
 
-				site.Init(approot)
-				apps[platformType] = append(apps[platformType], site)
+				err := site.Init(approot)
+				if err == nil {
+					apps[platformType] = append(apps[platformType], site)
+				}
 			}
 		}
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -17,7 +17,6 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/drud/drud-go/utils/system"
-	"github.com/fsouza/go-dockerclient"
 	homedir "github.com/mitchellh/go-homedir"
 )
 
@@ -168,9 +167,8 @@ func ComposeFileExists(app App) bool {
 
 // Cleanup will clean up ddev apps even if the composer file has been deleted.
 func Cleanup(app App) error {
-	client, _ := util.GetDockerClient()
 
-	containers, err := client.ListContainers(docker.ListContainersOptions{All: false})
+	containers, err := util.GetDockerContainers()
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -90,6 +90,7 @@ func RenderAppTable(platform string, apps []App) {
 func CreateAppTable() *uitable.Table {
 	table := uitable.New()
 	table.MaxColWidth = 140
+	table.Separator = "  "
 	table.AddRow("NAME", "TYPE", "LOCATION", "URL", "STATUS")
 	return table
 }

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -78,29 +78,39 @@ func RenderAppTable(platform string, apps []App) {
 
 	if len(apps) > 0 {
 		fmt.Printf("%v %s %v found.\n", len(apps), platform, util.FormatPlural(len(apps), "site", "sites"))
-		table := uitable.New()
-		table.MaxColWidth = 200
-
-		table.AddRow("NAME", "TYPE", "LOCATION", "URL", "DATABASE URL", "STATUS")
+		table := CreateAppTable()
 		for _, site := range apps {
-			// test tilde expansion
-			appRoot := site.AppRoot()
-			userDir, err := homedir.Dir()
-			if err == nil {
-				appRoot = strings.Replace(appRoot, userDir, "~", 1)
-			}
-			table.AddRow(
-				site.GetName(),
-				site.GetType(),
-				appRoot,
-				site.URL(),
-				fmt.Sprintf("%s:%s", site.HostName(), appports.GetPort("db")),
-				site.SiteStatus(),
-			)
+			RenderAppRow(table, site)
 		}
 		fmt.Println(table)
 	}
 
+}
+
+// CreateAppTable will create a new app table for describe and list output
+func CreateAppTable() *uitable.Table {
+	table := uitable.New()
+	table.MaxColWidth = 200
+	table.AddRow("NAME", "TYPE", "LOCATION", "URL", "DATABASE URL", "STATUS")
+	return table
+}
+
+// RenderAppRow will add an application row to an existing table for describe and list output.
+func RenderAppRow(table *uitable.Table, site App) {
+	// test tilde expansion
+	appRoot := site.AppRoot()
+	userDir, err := homedir.Dir()
+	if err == nil {
+		appRoot = strings.Replace(appRoot, userDir, "~", 1)
+	}
+	table.AddRow(
+		site.GetName(),
+		site.GetType(),
+		appRoot,
+		site.URL(),
+		fmt.Sprintf("%s:%s", site.HostName(), appports.GetPort("db")),
+		site.SiteStatus(),
+	)
 }
 
 // EnsureDockerRouter ensures the router is running.

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -115,7 +115,7 @@ func RenderAppRow(table *uitable.Table, site App) {
 // EnsureDockerRouter ensures the router is running.
 func EnsureDockerRouter() {
 	userHome, err := homedir.Dir()
-	util.CheckErr(err)
+	log.Fatal("could not get home directory for current user. is it set?")
 
 	routerdir := path.Join(userHome, ".ddev")
 	err = os.MkdirAll(routerdir, 0755)
@@ -167,8 +167,7 @@ func ComposeFileExists(app App) bool {
 
 // Cleanup will clean up ddev apps even if the composer file has been deleted.
 func Cleanup(app App) error {
-
-	containers, err := util.GetDockerContainers()
+	containers, err := util.GetDockerContainers(true)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -89,8 +89,8 @@ func RenderAppTable(platform string, apps []App) {
 // CreateAppTable will create a new app table for describe and list output
 func CreateAppTable() *uitable.Table {
 	table := uitable.New()
-	table.MaxColWidth = 200
-	table.AddRow("NAME", "TYPE", "LOCATION", "URL", "DATABASE URL", "STATUS")
+	table.MaxColWidth = 140
+	table.AddRow("NAME", "TYPE", "LOCATION", "URL", "STATUS")
 	return table
 }
 
@@ -107,7 +107,6 @@ func RenderAppRow(table *uitable.Table, site App) {
 		site.GetType(),
 		appRoot,
 		site.URL(),
-		fmt.Sprintf("%s:%s", site.HostName(), appports.GetPort("db")),
 		site.SiteStatus(),
 	)
 }

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -114,15 +114,13 @@ func GetApps() map[string][]App {
 
 		if err == nil {
 			for _, siteContainer := range sites {
-
-				site := PluginMap[platformType]
+				site := GetPluginApp(platformType)
 				approot, ok := siteContainer.Labels["com.ddev.approot"]
 				if !ok {
 					break
 				}
 				_, ok = apps[platformType]
 				if !ok {
-					fmt.Println("creating slice for " + platformType)
 					apps[platformType] = []App{}
 				}
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -134,6 +134,12 @@ func Chdir(path string) func() {
 
 var letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
+// setLetterBytes exists solely so that tests can override the default characters used by
+// RandString. It should probably be avoided for 'normal' operations.
+func setLetterBytes(lb string) {
+	letterBytes = lb
+}
+
 // RandString returns a random string of given length n.
 func RandString(n int) string {
 	b := make([]byte, n)
@@ -171,10 +177,6 @@ func CaptureStdOut() func() string {
 		return out
 	}
 
-}
-
-func setLetterBytes(lb string) {
-	letterBytes = lb
 }
 
 // ClearDockerEnv unsets env vars set in platform DockerEnv() so that

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -162,6 +162,9 @@ func ContainerWait(timeout time.Duration, labels map[string]string) error {
 				doneChan <- true
 			}
 			status := GetContainerHealth(container)
+			if status == "restarting" {
+				return fmt.Errorf("container %s: detected container restart; invalid configuration or container. consider using `docker logs %s` to debug", container.Names[0], container.ID)
+			}
 			if status == "healthy" {
 				containerErr = nil
 				doneChan <- true

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -84,44 +84,6 @@ func GetDockerClient() (*docker.Client, error) {
 	return client, err
 }
 
-// ProcessContainer will process a docker container for an app listing.
-// Since apps contain multiple containers, ProcessContainer will be called once per container.
-func ProcessContainer(l map[string]map[string]string, plugin string, containerName string, container docker.APIContainers) {
-	label := container.Labels
-	appName := label["com.ddev.site-name"]
-	appType := label["com.ddev.app-type"]
-	containerType := label["com.ddev.container-type"]
-	appRoot := label["com.ddev.approot"]
-	url := label["com.ddev.app-url"]
-
-	_, exists := l[appName]
-	if exists == false {
-		l[appName] = map[string]string{
-			"name":    appName,
-			"status":  container.State,
-			"url":     url,
-			"type":    appType,
-			"approot": appRoot,
-		}
-	}
-
-	var publicPort int64
-	for _, port := range container.Ports {
-		if port.PublicPort != 0 {
-			publicPort = port.PublicPort
-		}
-	}
-
-	if containerType == "web" {
-		l[appName]["WebPublicPort"] = fmt.Sprintf("%d", publicPort)
-	}
-
-	if containerType == "db" {
-		l[appName]["DbPublicPort"] = fmt.Sprintf("%d", publicPort)
-	}
-
-}
-
 // FindContainerByLabels takes a map of label names and values and returns any docker containers which match all labels.
 func FindContainerByLabels(labels map[string]string) (docker.APIContainers, error) {
 	containers, err := FindContainersByLabels(labels)

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -96,7 +96,6 @@ func FindContainersByLabels(labels map[string]string) ([]docker.APIContainers, e
 	client, _ := dockerutil.GetDockerClient()
 	containers, _ := client.ListContainers(docker.ListContainersOptions{All: true})
 	containerMatches := []docker.APIContainers{}
-
 	if len(labels) < 1 {
 		return []docker.APIContainers{}, fmt.Errorf("the provided list of labels was empty")
 	}
@@ -189,7 +188,7 @@ outer:
 // return only the health status.
 func GetContainerHealth(container docker.APIContainers) string {
 	// If the container is not running, then return exited as the health.
-	if container.State == "exited" {
+	if container.State == "exited" || container.State == "restarting" {
 		return container.State
 	}
 

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -188,6 +188,12 @@ outer:
 // by docker contains uptime and the health status in parenths. This function will filter the uptime and
 // return only the health status.
 func GetContainerHealth(container docker.APIContainers) string {
+	// If the container is not running, then return exited as the health.
+	if container.State == "exited" {
+		return container.State
+	}
+
+	// Otherwise parse the container status.
 	status := container.Status
 	re := regexp.MustCompile(`\(([^\)]+)\)`)
 	match := re.FindString(status)

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -156,6 +156,7 @@ func NetExists(client *docker.Client, name string) bool {
 // ContainerWait provides a wait loop to check for container in "healthy" status.
 // timeout is in seconds.
 func ContainerWait(timeout time.Duration, labels map[string]string) error {
+
 	ticker := time.NewTicker(500 * time.Millisecond)
 	// doneChan is triggered when we find containers or have an error trying
 	doneChan := make(chan bool)
@@ -174,7 +175,7 @@ func ContainerWait(timeout time.Duration, labels map[string]string) error {
 			}
 			status := GetContainerHealth(container)
 			if status == "restarting" {
-				return fmt.Errorf("container %s: detected container restart; invalid configuration or container. consider using `docker logs %s` to debug", container.Names[0], container.ID)
+				containerErr = fmt.Errorf("container %s: detected container restart; invalid configuration or container. consider using `docker logs %s` to debug", container.Names[0], container.ID)
 			}
 			if status == "healthy" {
 				containerErr = nil

--- a/pkg/util/dockerutils_test.go
+++ b/pkg/util/dockerutils_test.go
@@ -21,6 +21,12 @@ func TestGetContainerHealth(t *testing.T) {
 	}
 	out = GetContainerHealth(container)
 	assert.Equal(out, "healthy")
+
+	container = docker.APIContainers{
+		State: "exited",
+	}
+	out = GetContainerHealth(container)
+	assert.Equal(out, container.State)
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.

--- a/pkg/util/dockerutils_test.go
+++ b/pkg/util/dockerutils_test.go
@@ -27,6 +27,12 @@ func TestGetContainerHealth(t *testing.T) {
 	}
 	out = GetContainerHealth(container)
 	assert.Equal(out, container.State)
+
+	container = docker.APIContainers{
+		State: "restarting",
+	}
+	out = GetContainerHealth(container)
+	assert.Equal(out, container.State)
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -3,10 +3,7 @@ package util
 import (
 	"os"
 
-	"fmt"
-
 	"github.com/fatih/color"
-	"github.com/gosuri/uitable"
 )
 
 // Failed will print an red error message and exit with failure.
@@ -26,26 +23,4 @@ func FormatPlural(count int, single string, plural string) string {
 		return single
 	}
 	return plural
-}
-
-// RenderAppTable will format a table for user display based on a list of apps.
-func RenderAppTable(apps map[string]map[string]string, name string) {
-	if len(apps) > 0 {
-		fmt.Printf("%v %s %v found.\n", len(apps), name, FormatPlural(len(apps), "site", "sites"))
-		table := uitable.New()
-		table.MaxColWidth = 200
-		table.AddRow("NAME", "TYPE", "URL", "DATABASE URL", "STATUS")
-
-		for _, site := range apps {
-			table.AddRow(
-				site["name"],
-				site["type"],
-				site["url"],
-				fmt.Sprintf("127.0.0.1:%s", site["DbPublicPort"]),
-				site["status"],
-			)
-		}
-		fmt.Println(table)
-	}
-
 }


### PR DESCRIPTION
## The Problem:
The current `ddev list` command is some of the oldest code in ddev, and not particularly well written as it doesn't take advantage of a lot of the newer structs we've introduced. It's also lagging behind on things like the router update.

## The Fix:
Let's rework this code to use the `FindContainersByLabel` function and the app interface, while updating the output to be current.

Here's some example output (from during a test run) with these changes applied:
```
1 local site found.
NAME   	TYPE   	LOCATION               	URL                      	DATABASE URL           	STATUS
drupal8	drupal8	~/Projects/ddev/drupal8	http://drupal8.ddev.local	drupal8.ddev.local:3306	running
```

Describe output:
```
NAME   	TYPE   	LOCATION               	URL                      	DATABASE URL           	STATUS
drupal8	drupal8	~/Projects/ddev/drupal8	http://drupal8.ddev.local	drupal8.ddev.local:3306	running

MySQL Credentials
-----------------
Username:       	root
Password:       	root
Database name:  	data
Connection Info:	drupal8.ddev.local:3306

Other Services
--------------
MailHog:   	http://drupal8.ddev.local:8025
phpMyAdmin:	http://drupal8.ddev.local:8036
```

## The Test:
Simply spin up a site (or set of sites) and use `ddev list` as you normally would.

**NOTE:** this introduces a new `com.ddev.platform` container label which is used in sorting. You'll need to clear out existing docker-compose.yaml files for the list to work correctly 

## Automation Overview:
This keeps / updates the old binary based ddev list test. It also introduces unit tests for the `platform.GetApps()` function which does the heavy lifting for the `ddev list` command

## Related Issue Link(s):
#153 is the issues originally opened for this rework.
