### PR TITLE
requires unique names for running sites

### DIFF
--- a/cmd/ddev/cmd/dev_ssh.go
+++ b/cmd/ddev/cmd/dev_ssh.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
@@ -17,7 +16,7 @@ var LocalDevSSHCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to ssh %s: %s", app.GetName(), err)
 		}
 
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)
@@ -32,7 +31,7 @@ var LocalDevSSHCmd = &cobra.Command{
 			"bash",
 		)
 		if err != nil {
-			util.Failed("Failed DockerCompose exec bash command: %v", err)
+			util.Failed("Failed to ssh %s: %s", app.GetName(), err)
 		}
 
 	},

--- a/cmd/ddev/cmd/dev_ssh.go
+++ b/cmd/ddev/cmd/dev_ssh.go
@@ -16,7 +16,7 @@ var LocalDevSSHCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to ssh %s: %s", app.GetName(), err)
+			util.Failed("Failed to ssh: %v", err)
 		}
 
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -25,7 +25,7 @@ var LocalDevExecCmd = &cobra.Command{
 
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to exec command for %s: %s", app.GetName(), err)
+			util.Failed("Failed to exec command: %v", err)
 		}
 
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -25,7 +25,7 @@ var LocalDevExecCmd = &cobra.Command{
 
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to exec command for %s: %s", app.GetName(), err)
 		}
 
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)
@@ -49,7 +49,7 @@ var LocalDevExecCmd = &cobra.Command{
 		cmdArgs = append(cmdArgs, cmdSplit...)
 		err = dockerutil.DockerCompose(cmdArgs...)
 		if err != nil {
-			util.Failed("Could not execute command %s: %v", cmdString, err)
+			util.Failed("Failed to execute command %s: %v", cmdString, err)
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -34,14 +34,14 @@ var ImportDBCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to import database for %s: %s", app.GetName(), err)
+			util.Failed("Failed to import database: %v", app.GetName(), err)
 		}
 
 		err = app.ImportDB(dbSource)
 		if err != nil {
-			util.Failed("Failed to import database for %s: %s", app.GetName(), err)
+			util.Failed("Failed to import database for %s: %v", app.GetName(), err)
 		}
-		util.Success("Successfully imported database for %s", app.GetName())
+		util.Success("Successfully imported database for %v", app.GetName())
 	},
 }
 

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -34,7 +34,7 @@ var ImportDBCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to import database for %s: %s", app.GetName(), err)
 		}
 
 		err = app.ImportDB(dbSource)

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -33,14 +33,14 @@ var ImportFileCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to import files for %s: %s", app.GetName(), err)
+			util.Failed("Failed to import files: %v", err)
 		}
 
 		err = app.ImportFiles(fileSource)
 		if err != nil {
-			util.Failed("Failed to import files for %s: %s", app.GetName(), err)
+			util.Failed("Failed to import files for %s: %v", app.GetName(), err)
 		}
-		util.Success("Successfully imported files for %s", app.GetName())
+		util.Success("Successfully imported files for %v", app.GetName())
 	},
 }
 

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -33,7 +33,7 @@ var ImportFileCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to import files for %s: %s", app.GetName(), err)
 		}
 
 		err = app.ImportFiles(fileSource)

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -24,7 +24,7 @@ var LocalDevLogsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to retrieve logs for %s: %s", app.GetName(), err)
+			util.Failed("Failed to retrieve logs: %v", err)
 		}
 
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)
@@ -56,7 +56,7 @@ var LocalDevLogsCmd = &cobra.Command{
 		app.DockerEnv()
 		err = dockerutil.DockerCompose(cmdArgs...)
 		if err != nil {
-			util.Failed("Failed to retrieve logs for %s: %s", app.GetName(), err)
+			util.Failed("Failed to retrieve logs for %s: %v", app.GetName(), err)
 		}
 	},
 }

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"path"
 
 	"github.com/drud/ddev/pkg/plugins/platform"
@@ -25,7 +24,7 @@ var LocalDevLogsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to retrieve logs for %s: %s", app.GetName(), err)
 		}
 
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)
@@ -57,9 +56,8 @@ var LocalDevLogsCmd = &cobra.Command{
 		app.DockerEnv()
 		err = dockerutil.DockerCompose(cmdArgs...)
 		if err != nil {
-			log.Fatalln(err)
+			util.Failed("Failed to retrieve logs for %s: %s", app.GetName(), err)
 		}
-
 	},
 }
 

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -25,24 +25,24 @@ var LocalDevReconfigCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to restart %s: %s", app.GetName(), err)
+			util.Failed("Failed to restart: %v", err)
 		}
 
 		fmt.Printf("Restarting environment for %s...", app.GetName())
 		err = app.Stop()
 		if err != nil {
-			util.Failed("Failed to restart %s: %s", app.GetName(), err)
+			util.Failed("Failed to restart %s: %v", app.GetName(), err)
 		}
 
 		err = app.Start()
 		if err != nil {
-			util.Failed("Failed to restart %s: %s", app.GetName(), err)
+			util.Failed("Failed to restart %s: %v", app.GetName(), err)
 		}
 
 		fmt.Println("Waiting for the environment to become ready. This may take a couple of minutes...")
 		err = app.Wait("web")
 		if err != nil {
-			util.Failed("Failed to restart %s: %s", app.GetName(), err)
+			util.Failed("Failed to restart %s: %v", app.GetName(), err)
 		}
 
 		util.Success("Successfully restarted %s", app.GetName())

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -25,26 +25,24 @@ var LocalDevReconfigCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to restart %s: %s", app.GetName(), err)
 		}
 
 		fmt.Printf("Restarting environment for %s...", app.GetName())
 		err = app.Stop()
 		if err != nil {
-			log.Println(err)
-			util.Failed("Failed to stop application.")
+			util.Failed("Failed to restart %s: %s", app.GetName(), err)
 		}
 
 		err = app.Start()
 		if err != nil {
-			log.Println(err)
-			util.Failed("Failed to start application.")
+			util.Failed("Failed to restart %s: %s", app.GetName(), err)
 		}
 
 		fmt.Println("Waiting for the environment to become ready. This may take a couple of minutes...")
 		err = app.Wait("web")
 		if err != nil {
-			util.Failed("The environment for %s never became ready: %s", app.GetName(), err)
+			util.Failed("Failed to restart %s: %s", app.GetName(), err)
 		}
 
 		util.Success("Successfully restarted %s", app.GetName())

--- a/cmd/ddev/cmd/rm.go
+++ b/cmd/ddev/cmd/rm.go
@@ -16,7 +16,7 @@ var LocalDevRMCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to remove %s: %s", app.GetName(), err)
+			util.Failed("Failed to remove: %v", err)
 		}
 
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)

--- a/cmd/ddev/cmd/rm.go
+++ b/cmd/ddev/cmd/rm.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
@@ -17,7 +16,7 @@ var LocalDevRMCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to remove %s: %s", app.GetName(), err)
 		}
 
 		nameContainer := fmt.Sprintf("%s-%s", app.ContainerName(), serviceType)
@@ -27,7 +26,7 @@ var LocalDevRMCmd = &cobra.Command{
 
 		err = app.Down()
 		if err != nil {
-			util.Failed("Could not remove site: %s", app.ContainerName())
+			util.Failed("Failed to remove %s: %s", app.GetName(), err)
 		}
 
 		util.Success("Successfully removed the %s application.\n", app.GetName())

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -43,20 +43,20 @@ var StartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to start %s: %s", app.GetName(), err)
+			util.Failed("Failed to start: %s", err)
 		}
 
 		fmt.Printf("Starting environment for %s...\n", app.GetName())
 
 		err = app.Start()
 		if err != nil {
-			util.Failed("Failed to start %s: %s", app.GetName(), err)
+			util.Failed("Failed to start %s: %v", app.GetName(), err)
 		}
 
 		fmt.Println("Waiting for the environment to become ready. This may take a couple of minutes...")
 		err = app.Wait("web")
 		if err != nil {
-			util.Failed("The environment for %s never became ready: %s", app.GetName(), err)
+			util.Failed("The environment for %s never became ready: %v", app.GetName(), err)
 		}
 
 		util.Success("Successfully started %s", app.GetName())

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -43,7 +43,7 @@ var StartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to start %s: %s", app.GetName(), err)
 		}
 
 		fmt.Printf("Starting environment for %s...\n", app.GetName())

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +13,7 @@ var LocalDevStopCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			log.Fatalf("Could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+			util.Failed("Failed to stop %s: %s", app.GetName(), err)
 		}
 
 		err = app.Stop()

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -13,7 +13,7 @@ var LocalDevStopCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to stop %s: %s", app.GetName(), err)
+			util.Failed("Failed to stop: %v", err)
 		}
 
 		err = app.Stop()

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -283,15 +283,6 @@ func (l *LocalApp) Start() error {
 	composePath := l.DockerComposeYAMLPath()
 	l.DockerEnv()
 
-	existing, err := l.FindContainerByType("web")
-	if err != nil && !strings.Contains(err.Error(), "could not find containers which matched") {
-		return err
-	}
-
-	if existing.State == "running" {
-		return fmt.Errorf("a site with the name %s is already running", l.GetName())
-	}
-
 	// Write docker-compose.yaml (if it doesn't exist).
 	// If the user went through the `ddev config` process it will be written already, but
 	// we also do it here in the case of a manually created `.ddev/config.yaml` file.
@@ -304,7 +295,7 @@ func (l *LocalApp) Start() error {
 
 	EnsureDockerRouter()
 
-	err = l.AddHostsEntry()
+	err := l.AddHostsEntry()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -275,6 +275,15 @@ func (l *LocalApp) Start() error {
 	composePath := l.DockerComposeYAMLPath()
 	l.DockerEnv()
 
+	existing, err := l.FindContainerByType("web")
+	if err != nil && !strings.Contains(err.Error(), "could not find containers which matched") {
+		return err
+	}
+
+	if existing.State == "running" {
+		return fmt.Errorf("a site with the name %s is already running", l.GetName())
+	}
+
 	// Write docker-compose.yaml (if it doesn't exist).
 	// If the user went through the `ddev config` process it will be written already, but
 	// we also do it here in the case of a manually created `.ddev/config.yaml` file.
@@ -287,7 +296,7 @@ func (l *LocalApp) Start() error {
 
 	EnsureDockerRouter()
 
-	err := l.AddHostsEntry()
+	err = l.AddHostsEntry()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -40,7 +40,7 @@ func (l *LocalApp) GetType() string {
 func (l *LocalApp) Init(basePath string) error {
 	config, err := ddevapp.NewConfig(basePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
 	}
 
 	l.AppConfig = config
@@ -48,6 +48,14 @@ func (l *LocalApp) Init(basePath string) error {
 	err = PrepLocalSiteDirs(basePath)
 	if err != nil {
 		log.Fatalln(err)
+	}
+
+	web, err := l.FindContainerByType("web")
+	if err == nil {
+		containerApproot := web.Labels["com.ddev.approot"]
+		if containerApproot != l.AppConfig.AppRoot {
+			return fmt.Errorf("a container in %s state already exists for %s that was created at %s", web.State, l.AppConfig.Name, containerApproot)
+		}
 	}
 
 	return nil

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -137,6 +137,17 @@ func TestLocalStart(t *testing.T) {
 
 	err = app.Start()
 	assert.EqualError(err, fmt.Sprintf("a site with the name %s is already running", TestSites[0].Name))
+
+	// try to start a site of same name at different path
+	another := TestSites[0]
+	err = another.Prepare()
+	if err != nil {
+		log.Fatalf("Prepare() failed on TestSite.Prepare(), err=%v", err)
+	}
+
+	err = app.Init(another.Dir)
+	assert.EqualError(err, fmt.Sprintf("a container in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
+	another.Cleanup()
 }
 
 // TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -130,6 +130,13 @@ func TestLocalStart(t *testing.T) {
 
 		cleanup()
 	}
+
+	// try to start a site that is already running
+	err = app.Init(TestSites[0].Dir)
+	assert.NoError(err)
+
+	err = app.Start()
+	assert.EqualError(err, fmt.Sprintf("a site with the name %s is already running", TestSites[0].Name))
 }
 
 // TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -131,13 +131,6 @@ func TestLocalStart(t *testing.T) {
 		cleanup()
 	}
 
-	// try to start a site that is already running
-	err = app.Init(TestSites[0].Dir)
-	assert.NoError(err)
-
-	err = app.Start()
-	assert.EqualError(err, fmt.Sprintf("a site with the name %s is already running", TestSites[0].Name))
-
 	// try to start a site of same name at different path
 	another := TestSites[0]
 	err = another.Prepare()


### PR DESCRIPTION
## The Problem:
It is currently possible to start a site that has the same name of a site already running. This is undesirable, as it can apparently allow the new site's containers to replace the running site's containers without warning (per OP #136). 

## The Fix:
This introduces a check of containers in `Start()` to see if any match the name we are about to start and are running. If there's a match, an error will return and the site won't be started.

## The Test:
- Have 2 sites to test
- Set site 1's name (by config.yaml or ddev config) to "testsite"
- `ddev start` for site 1 should succeed
- Set site 2's name to "testsite" (same as site 1)
- `ddev start` for site 2 should immediately fail with error.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
A test case has been added to `TestLocalStart()` that attempts to start the first test site again, triggering this error.

## Related Issue Link(s):
#136 OP
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

