### PR TITLE
Add not-to-worry about submodules/containers dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Instructions for IDE setup are in [step-debugging](docs/step-debugging.md).
  make test
  make clean
  ```
+ 
+ Note that although this git repository contains submodules (in the containers/ directory) they are not used in a normal build, but rather by the nightly build. You can safely ignore the git submodules and the containers/ directory.
 
 ## Testing
 Normal test invocation is just `make test`. Run a single test with an invocation like `go test -v -run TestDevAddSites ./pkg/...`

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,3 @@
+# Container builds for nightly build (git submodules)
+
+The directories beneath this 'containers' directory are used only for git submodules used by our standard nightly build, and can be ignored by developers. *Please ignore this directory and everything below it.*


### PR DESCRIPTION
## The Problem:

[The master build PR](https://github.com/drud/ddev/pull/133) adds submodules to the project, but they're not intended to be in the developer's way (and nobody needs to init them). I pointed this out in slack, but @tannerjfco pointed out that it belonged in the README, so here it is.


## The Fix:

* Add a note about the submodules to the readme
* Add a README to the containers directory

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

