### PR TITLE
Add phpmyadmin submodule and add to nightly build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "containers/nginx-proxy"]
 	path = containers/nginx-proxy
 	url = git@github.com:drud/nginx-proxy.git
+[submodule "containers/docker.phpmyadmin"]
+	path = containers/docker.phpmyadmin
+	url = git@github.com:drud/docker.phpmyadmin.git

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PKG := github.com/drud/ddev
 SRC_DIRS := cmd pkg
 
 # Version variables to replace in build
-VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag
+VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag DBAImg DBATag
 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)

--- a/nightly_build.mak
+++ b/nightly_build.mak
@@ -3,13 +3,11 @@
 # Build with a technique like this:
 # export VERSION=nightly.$(date +%Y%m%d%H%M%S); make -f nightly_build.mak clean && make -f nightly_build.mak --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
 
-# TODO:
-#   * Set up a nightly build for it. https://circleci.com/docs/1.0/nightly-builds/ and https://circleci.com/docs/api/v1-reference/#new-build
 
 SHELL := /bin/bash
 
 # These dirs must be built in this order (nginx-php-fpm depends on php7)
-CONTAINER_DIRS = nginx-proxy docker.php7 docker.nginx-php-fpm docker.nginx-php-fpm-local mysql-docker-local
+CONTAINER_DIRS = nginx-proxy docker.php7 docker.nginx-php-fpm docker.nginx-php-fpm-local mysql-docker-local docker.phpmyadmin
 
 BASEDIR=./containers/
 


### PR DESCRIPTION
## The Problem:

We added docker.phpmyadmin as a new container, so it needs to be added to the nightly build.

## The Fix:

* Add the submodule
* Add it to the nightly build
* Add DBAVersion to VERSION_VARIABLES so it can be overridden

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

