### PR TITLE
Bump DBATag (phpmyadmin container version) to v0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DBTag ?= v0.3.0
 RouterImage ?= drud/nginx-proxy
 RouterTag ?= v0.3.0
 DBAImg ?= drud/phpmyadmin
-DBATag ?= v0.1.0
+DBATag ?= v0.2.0
 
 # Optional to docker build
 #DOCKER_ARGS =

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -24,7 +24,7 @@ var DBTag = "v0.3.0" // Note that this is overridden by make
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "v0.1.0"
+var DBATag = "v0.2.0"
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/nginx-proxy" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:

Upstream updates to phpmyadmin container version, v0.2.0

## The Fix:

Bump version

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

