### PR TITLE
Be explicit about use of sudo - tell them what we're going to do

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -478,10 +478,11 @@ func (l *LocalApp) AddHostsEntry() error {
 	ddevFullpath, err := os.Executable()
 	util.CheckErr(err)
 
-	fmt.Println("\n\nddev needs to add an entry to your hostfile.\nIt will require root privileges via the sudo command,\nso you may be required to enter your password for sudo.")
+	fmt.Println("ddev needs to add an entry to your hostfile.\nIt will require root privileges via the sudo command, so you may be required\nto enter your password for sudo. ddev is about to issue the command:")
 	hostnameArgs := []string{ddevFullpath, "hostname", l.HostName(), "127.0.0.1"}
 	command := strings.Join(hostnameArgs, " ")
-	fmt.Printf("ddev is about to issue the command:\n    sudo %s\nPlease enter your password if prompted.\n", command)
+	util.Warning(fmt.Sprintf("    sudo %s", command))
+	fmt.Println("Please enter your password if prompted.")
 	err = system.RunCommandPipe("sudo", hostnameArgs)
 	return err
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -475,8 +475,13 @@ func (l *LocalApp) AddHostsEntry() error {
 		return nil
 	}
 
-	fmt.Println("\n\n\nAdding hostfile entry. You will be prompted for your password.")
-	hostnameArgs := []string{"ddev", "hostname", l.HostName(), "127.0.0.1"}
+	ddevFullpath, err := os.Executable()
+	util.CheckErr(err)
+
+	fmt.Println("\n\nddev needs to add an entry to your hostfile.\nIt will require root privileges via the sudo command,\nso you may be required to enter your password for sudo.")
+	hostnameArgs := []string{ddevFullpath, "hostname", l.HostName(), "127.0.0.1"}
+	command := strings.Join(hostnameArgs, " ")
+	fmt.Printf("ddev is about to issue the command\n    sudo %s\nplease enter your password if prompted.\n", command)
 	err = system.RunCommandPipe("sudo", hostnameArgs)
 	return err
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -481,7 +481,7 @@ func (l *LocalApp) AddHostsEntry() error {
 	fmt.Println("\n\nddev needs to add an entry to your hostfile.\nIt will require root privileges via the sudo command,\nso you may be required to enter your password for sudo.")
 	hostnameArgs := []string{ddevFullpath, "hostname", l.HostName(), "127.0.0.1"}
 	command := strings.Join(hostnameArgs, " ")
-	fmt.Printf("ddev is about to issue the command\n    sudo %s\nplease enter your password if prompted.\n", command)
+	fmt.Printf("ddev is about to issue the command:\n    sudo %s\nPlease enter your password if prompted.\n", command)
 	err = system.RunCommandPipe("sudo", hostnameArgs)
 	return err
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -15,6 +15,11 @@ func Failed(format string, a ...interface{}) {
 	os.Exit(1)
 }
 
+// Warning will present the user with warning text.
+func Warning(format string, a ...interface{}) {
+	color.Yellow(format, a...)
+}
+
 // Success will indicate an operation succeeded with colored confirmation text.
 func Success(format string, a ...interface{}) {
 	color.Cyan(format, a...)


### PR DESCRIPTION
## The Problem:

We were using sudo to get full root privileges without expressly saying what we were doing (and without controlling the path of what we were executing), see https://github.com/drud/ddev/issues/117

## The Fix:

* Say exactly what we're going to do
* Use the fullpath of the running executable (golang 1.8.1 os.Executable())
* Update circle.yml to install golang 1.8.1 (used in tests). Ooops. 

This does *not* stop and ask permission, which it probably could do.

## The Test:

* Manually remove current sitename from /etc/hosts
* Use `ddev start` to see the results

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

[Security: ddev can be used to sudo an arbitrary command](https://github.com/drud/ddev/issues/117)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

