### PR TITLE
Handle DockerCompose() errors

### DIFF
--- a/cmd/ddev/cmd/dev_ssh.go
+++ b/cmd/ddev/cmd/dev_ssh.go
@@ -32,7 +32,7 @@ var LocalDevSSHCmd = &cobra.Command{
 			"bash",
 		)
 		if err != nil {
-			log.Fatal("Failed DockerCompose exec bash command", err)
+			util.Failed("Failed DockerCompose exec bash command: %v", err)
 		}
 
 	},

--- a/cmd/ddev/cmd/dev_ssh.go
+++ b/cmd/ddev/cmd/dev_ssh.go
@@ -32,8 +32,7 @@ var LocalDevSSHCmd = &cobra.Command{
 			"bash",
 		)
 		if err != nil {
-			log.Println(err)
-			util.Failed("Failed to run exec command.")
+			log.Fatal("Failed DockerCompose exec bash command", err)
 		}
 
 	},

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -49,8 +49,7 @@ var LocalDevExecCmd = &cobra.Command{
 		cmdArgs = append(cmdArgs, cmdSplit...)
 		err = dockerutil.DockerCompose(cmdArgs...)
 		if err != nil {
-			log.Println(err)
-			util.Failed("Could not execute command.")
+			util.Failed("Could not execute command.", cmdString, err)
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -49,7 +49,7 @@ var LocalDevExecCmd = &cobra.Command{
 		cmdArgs = append(cmdArgs, cmdSplit...)
 		err = dockerutil.DockerCompose(cmdArgs...)
 		if err != nil {
-			util.Failed("Could not execute command.", cmdString, err)
+			util.Failed("Could not execute command %s: %v", cmdString, err)
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -23,12 +23,9 @@ var ImportDBCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		client, err := util.GetDockerClient()
-		if err != nil {
-			log.Fatal(err)
-		}
+		client := util.GetDockerClient()
 
-		err = util.EnsureNetwork(client, netName)
+		err := util.EnsureNetwork(client, netName)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -22,12 +22,9 @@ var ImportFileCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		client, err := util.GetDockerClient()
-		if err != nil {
-			log.Fatal(err)
-		}
+		client := util.GetDockerClient()
 
-		err = util.EnsureNetwork(client, netName)
+		err := util.EnsureNetwork(client, netName)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -14,12 +14,9 @@ var LocalDevReconfigCmd = &cobra.Command{
 	Short: "Restart the local development environment for a site.",
 	Long:  `Restart stops the containers for site's environment and starts them back up again.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		client, err := util.GetDockerClient()
-		if err != nil {
-			log.Fatal(err)
-		}
+		client := util.GetDockerClient()
 
-		err = util.EnsureNetwork(client, netName)
+		err := util.EnsureNetwork(client, netName)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ddev/cmd/rm.go
+++ b/cmd/ddev/cmd/rm.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/spf13/cobra"
@@ -26,19 +25,11 @@ var LocalDevRMCmd = &cobra.Command{
 			util.Failed("App not running locally. Try `ddev start`.")
 		}
 
-		if !platform.ComposeFileExists(app) {
-			fmt.Println("No docker-compose file exists for this site. Attempting manual cleanup.")
-			err = platform.Cleanup(app)
-			if err != nil {
-				util.Failed("Could not clean up site: %v", err)
-			}
-		} else {
-			err = app.Down()
-			if err != nil {
-				log.Println(err)
-				util.Failed("Could not remove site: %s", app.ContainerName())
-			}
+		err = app.Down()
+		if err != nil {
+			util.Failed("Could not remove site: %s", app.ContainerName())
 		}
+
 		util.Success("Successfully removed the %s application.\n", app.GetName())
 	},
 }

--- a/cmd/ddev/cmd/rm.go
+++ b/cmd/ddev/cmd/rm.go
@@ -27,15 +27,18 @@ var LocalDevRMCmd = &cobra.Command{
 		}
 
 		if !platform.ComposeFileExists(app) {
-			util.Failed("No docker-compose.yaml could be found for this application.")
+			fmt.Println("No docker-compose file exists for this site. Attempting manual cleanup.")
+			err = platform.Cleanup(app)
+			if err != nil {
+				util.Failed("Could not clean up site: %v", err)
+			}
+		} else {
+			err = app.Down()
+			if err != nil {
+				log.Println(err)
+				util.Failed("Could not remove site: %s", app.ContainerName())
+			}
 		}
-
-		err = app.Down()
-		if err != nil {
-			log.Println(err)
-			util.Failed("Could not remove site: %s", app.ContainerName())
-		}
-
 		util.Success("Successfully removed the %s application.\n", app.GetName())
 	},
 }

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -32,12 +32,9 @@ var StartCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		client, err := util.GetDockerClient()
-		if err != nil {
-			log.Fatal(err)
-		}
+		client := util.GetDockerClient()
 
-		err = util.EnsureNetwork(client, netName)
+		err := util.EnsureNetwork(client, netName)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -20,8 +20,7 @@ var LocalDevStopCmd = &cobra.Command{
 
 		err = app.Stop()
 		if err != nil {
-			log.Println(err)
-			util.Failed("Failed to stop containers for %s. Run `ddev list` to ensure your site exists. error=", app.ContainerName(), err)
+			util.Failed("Failed to stop containers for %s. Run `ddev list` to ensure your site exists: %v", app.ContainerName(), err)
 		}
 
 		util.Success("Application has been stopped.")

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -21,7 +21,7 @@ var LocalDevStopCmd = &cobra.Command{
 		err = app.Stop()
 		if err != nil {
 			log.Println(err)
-			util.Failed("Failed to stop containers for %s. Run `ddev list` to ensure your site exists.", app.ContainerName())
+			util.Failed("Failed to stop containers for %s. Run `ddev list` to ensure your site exists. error=", app.ContainerName(), err)
 		}
 
 		util.Success("Application has been stopped.")

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -20,7 +20,7 @@ var LocalDevStopCmd = &cobra.Command{
 
 		err = app.Stop()
 		if err != nil {
-			util.Failed("Failed to stop containers for %s. Run `ddev list` to ensure your site exists: %v", app.ContainerName(), err)
+			util.Failed("Failed to stop containers for %s: %v", app.ContainerName(), err)
 		}
 
 		util.Success("Application has been stopped.")

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -461,7 +461,7 @@ func (l *LocalApp) Down() error {
 		"down",
 	)
 	if err != nil {
-		return Cleanup(l)
+		log.Fatal("Failed DockerCompose 'down' command", err)
 	}
 
 	return nil

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -461,7 +461,8 @@ func (l *LocalApp) Down() error {
 		"down",
 	)
 	if err != nil {
-		log.Fatal("Failed DockerCompose 'down' command", err)
+		util.Warning("Could not stop site with docker-compose. Attempting manual cleanup.")
+		return Cleanup(l)
 	}
 
 	return nil

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -186,7 +186,7 @@ func Cleanup(app App) error {
 			fmt.Printf("Stopping container: %s\n", containerName)
 			err = client.StopContainer(containers[i].ID, 60)
 			if err != nil {
-				return fmt.Errorf("could not stop container %s: %v\n", containerName, err)
+				return fmt.Errorf("could not stop container %s: %v", containerName, err)
 			}
 		}
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -166,30 +166,6 @@ func ComposeFileExists(app App) bool {
 	return true
 }
 
-// Cleanup will clean up ddev apps even if the composer file has been deleted.
-func Cleanup(app App) error {
-	containers, err := util.GetDockerContainers(true)
-	if err != nil {
-		return err
-	}
-
-	actions := []string{"stop", "rm"}
-	for _, c := range containers {
-		if strings.Contains(c.Names[0], app.ContainerName()) {
-			for _, action := range actions {
-				args := []string{action, c.ID}
-				_, err := system.RunCommand("docker", args)
-				if err != nil {
-					return fmt.Errorf("Could not %s container %s: %s", action, c.Names[0], err)
-				}
-			}
-		}
-
-	}
-
-	return nil
-}
-
 // CheckForConf checks for a config.yaml at the cwd or parent dirs.
 func CheckForConf(confPath string) (string, error) {
 	if system.FileExists(confPath + "/.ddev/config.yaml") {

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -171,15 +171,16 @@ func ComposeFileExists(app App) bool {
 func Cleanup(app App) error {
 	client := util.GetDockerClient()
 
+	// Find all containers which match the current site name.
 	labels := map[string]string{
 		"com.ddev.site-name": app.GetName(),
 	}
-
 	containers, err := util.FindContainersByLabels(labels)
 	if err != nil {
 		return err
 	}
 
+	// First, try stopping the listed containers if they are running.
 	for i := range containers {
 		if containers[i].State == "running" || containers[i].State == "restarting" || containers[i].State == "paused" {
 			containerName := containers[i].Names[0][1:len(containers[i].Names[0])]
@@ -191,6 +192,7 @@ func Cleanup(app App) error {
 		}
 	}
 
+	// Try to remove the containers once they are stopped.
 	for i := range containers {
 		containerName := containers[i].Names[0][1:len(containers[i].Names[0])]
 		removeOpts := docker.RemoveContainerOptions{

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -77,7 +77,7 @@ func GetDockerClient() *docker.Client {
 	// Create a new docker client talking to the default docker-machine.
 	client, err := docker.NewClient("unix:///var/run/docker.sock")
 	if err != nil {
-		log.Fatalf("could not get docker client. is docker running?:", err)
+		log.Fatalf("could not get docker client. is docker running?: %v", err)
 	}
 	return client
 }

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -9,7 +9,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/drud/drud-go/utils/dockerutil"
 	"github.com/drud/drud-go/utils/try"
 	"github.com/fsouza/go-dockerclient"
 )
@@ -74,13 +73,13 @@ func GetPodPort(name string) (int64, error) {
 }
 
 // GetDockerClient returns a docker client for a docker-machine.
-func GetDockerClient() (*docker.Client, error) {
+func GetDockerClient() *docker.Client {
 	// Create a new docker client talking to the default docker-machine.
 	client, err := docker.NewClient("unix:///var/run/docker.sock")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("could not get docker client. is docker running?:", err)
 	}
-	return client, err
+	return client
 }
 
 // FindContainerByLabels takes a map of label names and values and returns any docker containers which match all labels.
@@ -91,10 +90,7 @@ func FindContainerByLabels(labels map[string]string) (docker.APIContainers, erro
 
 // GetDockerContainers returns a slice of all docker containers on the host system.
 func GetDockerContainers(allContainers bool) ([]docker.APIContainers, error) {
-	client, err := dockerutil.GetDockerClient()
-	if err != nil {
-		log.Fatal("could not get docker client. is docker running?")
-	}
+	client := GetDockerClient()
 	containers, err := client.ListContainers(docker.ListContainersOptions{All: allContainers})
 	return containers, err
 }


### PR DESCRIPTION
## The Problem:

There are a couple of (odd) circumstances in which we can get DockerCompose() errors that were kind of hidden before.  See [Missing error check](https://github.com/drud/ddev/issues/161).

## The Fix:

* Add some error checking, add some output to log statements.
* removed platform.Cleanup() which was what was being done by `ddev rm` before. Please check this to see if you approve.  It didn't seem to work at all, and AFAICT was only being used in that one place.

## The Test:

* Introduce an error into your docker-compose.yml - any error will do
* Try `ddev rm`

It should let you know what the problem is.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

[Missing error check](https://github.com/drud/ddev/issues/161)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

