### PR TITLE
updates test site tags

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -15,9 +15,9 @@ var (
 	DevTestSites = []testcommon.TestSite{
 		{
 			Name:      "drupal8",
-			SourceURL: "https://github.com/drud/drupal8/archive/v0.3.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.3.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.3.0/db.tar.gz",
+			SourceURL: "https://github.com/drud/drupal8/archive/v0.4.0.tar.gz",
+			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.4.0/files.tar.gz",
+			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.4.0/db.tar.gz",
 		},
 	}
 )

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -23,21 +23,21 @@ var (
 	TestSites             = []testcommon.TestSite{
 		{
 			Name:      "drupal8",
-			SourceURL: "https://github.com/drud/drupal8/archive/v0.3.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.3.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.3.0/db.tar.gz",
+			SourceURL: "https://github.com/drud/drupal8/archive/v0.4.0.tar.gz",
+			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.4.0/files.tar.gz",
+			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.4.0/db.tar.gz",
 		},
 		{
 			Name:      "wordpress",
-			SourceURL: "https://github.com/drud/wordpress/archive/v0.2.0.tar.gz",
-			FileURL:   "https://github.com/drud/wordpress/releases/download/v0.2.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/wordpress/releases/download/v0.2.0/db.tar.gz",
+			SourceURL: "https://github.com/drud/wordpress/archive/v0.3.0.tar.gz",
+			FileURL:   "https://github.com/drud/wordpress/releases/download/v0.3.0/files.tar.gz",
+			DBURL:     "https://github.com/drud/wordpress/releases/download/v0.3.0/db.tar.gz",
 		},
 		{
 			Name:      "kickstart",
-			SourceURL: "https://github.com/drud/drupal-kickstart/archive/v0.2.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal-kickstart/releases/download/v0.2.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal-kickstart/releases/download/v0.2.0/db.tar.gz",
+			SourceURL: "https://github.com/drud/drupal-kickstart/archive/v0.3.0.tar.gz",
+			FileURL:   "https://github.com/drud/drupal-kickstart/releases/download/v0.3.0/files.tar.gz",
+			DBURL:     "https://github.com/drud/drupal-kickstart/releases/download/v0.3.0/db.tar.gz",
 		},
 	}
 )


### PR DESCRIPTION
## The Problem:
With #166 we can now have config files that dont define db/web image tags.
## The Fix:
This PR updates to releases of test sites that have db/dba/web image tags ommitted, allowing test sites to always use the default ddev image tags.
## The Test:
If CI succeeds, this should be safe to bring in.
## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

