### PR TITLE
Make nightly_build work with DBATag properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
               echo VERSION=$VERSION
               git submodule update --init && git submodule update --remote
               make -f nightly_build.mak clean
-              make -f nightly_build.mak --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
+              make -f nightly_build.mak --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION DBATag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
               $GOPATH/src/github.com/drud/ddev/bin/linux/ddev version
             fi
           name: Run full nightly build  and tests if $RUN_NIGHTLY_BUILD

--- a/docs/Adding_container.md
+++ b/docs/Adding_container.md
@@ -1,0 +1,11 @@
+# Adding a container to the build
+
+Adding a container to the build/nightly build requires a few steps:
+
+1. Add container name/tag to version.XxxImage and version.XXXTag in pkg/version/version.go (and use them as needed of course.)
+2. In Makefile, add XXXImage and XXXTag to VERSION_VARIABLES.
+3. In Makefile, set the default values of XXXImage and XXXTag (currently below VERSION_VARIABLES)
+4. Add the container as a git submodule: `git submodule add git@gihub.com:drud/somecontainer.git containers/somecontainer`
+5. Add the container to nightly_build.mak's CONTAINER_DIRS
+6. Add any variables that should be overridden in the container's build in nightly_build.mak (especially XXXTag) to the nightly_build stanza .circleci/config.yml
+7. Add those same override variables to the comment in nightly_build.mak that explains how to run it.

--- a/nightly_build.mak
+++ b/nightly_build.mak
@@ -1,7 +1,7 @@
 # This makefile is structured to allow building a complete ddev, with clean/fresh containers at current HEAD.
 
 # Build with a technique like this:
-# export VERSION=nightly.$(date +%Y%m%d%H%M%S); make -f nightly_build.mak clean && make -f nightly_build.mak --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
+# export VERSION=nightly.$(date +%Y%m%d%H%M%S); make -f nightly_build.mak clean && make -f nightly_build.mak --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION WebTag=$VERSION DBATag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
 
 
 SHELL := /bin/bash

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ var VERSION = ""
 // IMPORTANT: These versions are overridden by version ldflags specifications VERSION_VARIABLES in the Makefile
 
 // DdevVersion is the current version of ddev, by default the git committish (should be current git tag)
-var DdevVersion = "v0.1.0-dev" // Note that this is overridden by make
+var DdevVersion = "v0.3.0-dev" // Note that this is overridden by make
 
 // WebImg defines the default web image used for applications.
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:

I noticed in tonight's nightly build that the DBATag (tag for the phpmyadmin container) was not set correctly. The default was in use instead of latest (built in the build)

## The Fix:

* Add DBATag to nightly_build.mak where it belongs.
* Add a document to docs/ with the steps to add a new container/submodule to the build, since it took me at least 3 commits/PRs to get it fully in there this time. 
* Bumped the canonical ddevVersion (in code, always overridden by make) to 0.3.0-dev. Hardly matters, but might as well.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

