### PR TITLE
provides warning for wp user to search-replace after import

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -182,6 +182,10 @@ func (l *LocalApp) ImportDB(imPath string) error {
 		fmt.Println("Run 'ddev describe' to find the database credentials for this application.")
 	}
 
+	if l.GetType() == "wordpress" {
+		util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs acroos your database.", l.URL())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## The Problem:
As noted in #108, WordPress sites rely heavily on the full URL of a site throughout its database, requiring search/replace of the URL across the database whenever it is changed. Our discussions to handle this scenario have led us to consider post-import hooks/commands, but this approach will need some time and further discussions to fully incubate.
## The Fix:
This PR introduces a warning message to WordPress users after a successful database import. The message quickly explains the search-replace need and provides an example command the user can run after import.

This change is intended to be a temporary notification until such time we complete post-import functionality.
## The Test:
Start a wordpress site, and import a database for the site. You should see the following output:
```
Importing database...
A settings file already exists for your application, so ddev did not generate one.
Run 'ddev describe' to find the database credentials for this application.
Wordpress sites require a search/replace of the database when the URL is changed. You can run "ddev exec 'wp search-replace [http://www.myproductionsite.example] http://wordpress.ddev.local'" to update the URLs acroos your database.
Successfully imported database for wordpress
```
## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Since this change is only introducing an additional message, and we intend for this to be a temporary message, I don't believe changes to tests are necessary.
## Related Issue Link(s):
#108 OP
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

