### PR TITLE
reset docroot prompt val if dir invalid

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -246,6 +246,7 @@ func (c *Config) docrootPrompt() error {
 	fullPath := filepath.Join(c.AppRoot, c.Docroot)
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
 		fmt.Printf("No directory could be found at %s. Please enter a valid docroot", fullPath)
+		c.Docroot = ""
 		return c.docrootPrompt()
 	}
 	return nil


### PR DESCRIPTION
## The Problem:
Full problem described in #97 if provided docroot value is invalid, it can not be replaced with empty value
## The Fix:
If the directory not found condition is met, the c.Docroot value will be cleared, as it is not a valid value.
## The Test:
- Run "ddev config" anywhere
- Provide a non-existent path for docroot. You should receive the "No directory found" error, and a prompt again for docroot.
- You should be able to leave the 2nd docroot prompt value empty.
## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
I'm not certain a test change is necessary for this PR, if someone feels strongly I'm happy to consider it though.

## Related Issue Link(s):
#97 OP
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
