### PR TITLE
expand log access docs, add db access to ssh doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm7-local
-WebTag ?= v0.3.5
+WebTag ?= v0.4.0
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.3.0
 RouterImage ?= drud/nginx-proxy

--- a/README.md
+++ b/README.md
@@ -155,14 +155,16 @@ All of the commands can be performed by explicitly specifying the sitename or, t
 ### Retrieve Site Metadata
 To view information about a specific site (such as URL, MySQL credentials, mailhog credentials), run `ddev describe` from within the working directory of the site. To view information for any site, use `ddev describe sitename`.
 
-### Viewing Webserver Logs
-To follow the webserver  error log (watch the lines in real time), run `ddev logs -f`. When you are done, press CTRL+C to exit from the log trail. If you only want to view the most recent events, omit the `-f` flag.
-
 ### Executing Commands
 To run a command against your site use `ddev exec`. e.g. `ddev exec 'drush core-status'` would execute `drush core-status` against your site root. Commands ran in this way are executed in the webserver docroot. You are free to use any of [the tools included in the container](#tools-included-in-the-container).
 
 ### SSH Into The Container
-To interact with the site more fully, `ddev ssh` will drop you into a bash shell for your container.
+The `ddev ssh` command will open a bash shell session to the web container of your site. You can also access the database container with `ddev ssh -s db`.
+
+### Log Access
+The `ddev logs` command allows you to easily retrieve error logs from the web server. To follow the webserver  error log (watch the lines in real time), run `ddev logs -f`. When you are done, press CTRL+C to exit from the log trail.
+
+Additional logging can be accessed by using `ddev ssh` to manually retrieve the log files you are after. The web server stores access logs at `/var/log/nginx/access.log`, and PHP-FPM logs at `/var/log/php7.0-fpm.log`.
 
 ## Tools Included in the Container
 We have included several useful tools for Developers in our containers.

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"path"
 	"testing"
 
 	"os"
 
+	"io/ioutil"
+
 	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/drud-go/utils/network"
 	"github.com/drud/drud-go/utils/system"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,10 +37,23 @@ func TestDevLogs(t *testing.T) {
 	for _, v := range DevTestSites {
 		cleanup := v.Chdir()
 
+		confByte := []byte("<?php trigger_error(\"Fatal error\", E_USER_ERROR);")
+		err := ioutil.WriteFile(path.Join(v.Dir, "docroot", "index.php"), confByte, 0644)
+		assert.NoError(err)
+
+		o := network.NewHTTPOptions("http://127.0.0.1/index.php")
+		o.ExpectedStatus = 500
+		o.Timeout = 30
+		o.Headers["Host"] = v.Name + ".ddev.local"
+		err = network.EnsureHTTPStatus(o)
+		assert.NoError(err)
+
 		args := []string{"logs"}
 		out, err := system.RunCommand(DdevBin, args)
+
 		assert.NoError(err)
 		assert.Contains(string(out), "Server started")
+		assert.Contains(string(out), "PHP message: PHP Stack trace:")
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -37,7 +37,6 @@ func TestDevLogs(t *testing.T) {
 		out, err := system.RunCommand(DdevBin, args)
 		assert.NoError(err)
 		assert.Contains(string(out), "Server started")
-		assert.Contains(string(out), "GET")
 
 		cleanup()
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ var DdevVersion = "v0.3.0-dev" // Note that this is overridden by make
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.3.5" // Note that this is overridden by make
+var WebTag = "v0.4.0" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-docker-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:
With drud/docker.nginx-php-fpm#40 ddev logs will only output error log, but we still want to provide some info for advanced users to access other logs.
## The Fix:
This PR updates the log section of docs to document location of access logs and php-fpm logs in the web container. It also updates the ssh section to provide instruction for accessing the db container.

These changes are intended to be the documentation component of https://github.com/drud/ddev/issues/87#issuecomment-297091699

## The Test:
Docs change. If it makes sense, great! If not, suggestions are welcome for improving.
## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Docs change, no test changes.
## Related Issue Link(s):
https://github.com/drud/ddev/issues/87#issuecomment-297091699
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

