### PR TITLE
Consistently use `GetPluginApp` to create new applications

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
@@ -58,7 +57,11 @@ func describeApp(appName string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			app = platform.PluginMap[strings.ToLower(plugin)]
+			app, err := platform.GetPluginApp(plugin)
+			if err != nil {
+				log.Fatalf("Could not find application type %s: %v", plugin, err)
+			}
+
 			err = app.Init(dir)
 			if err != nil {
 				return "", err

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -28,11 +28,11 @@ var DescribeCommand = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Could not describe app: %v", err)
 		}
-
 		fmt.Println(out)
 	},
 }
 
+// describeApp will load and describe the app specified by appName. You may leave appName blank to use the app from the current working directory.
 func describeApp(appName string) (string, error) {
 	var app platform.App
 	var err error
@@ -53,22 +53,22 @@ func describeApp(appName string) (string, error) {
 			return "", err
 		}
 
-		if dir, ok := webContainer.Labels["com.ddev.approot"]; ok {
-			if err != nil {
-				return "", err
-			}
-			app, err := platform.GetPluginApp(plugin)
-			if err != nil {
-				log.Fatalf("Could not find application type %s: %v", plugin, err)
-			}
-
-			err = app.Init(dir)
-			if err != nil {
-				return "", err
-			}
+		dir, ok := webContainer.Labels["com.ddev.approot"]
+		if !ok {
+			return "", fmt.Errorf("could not find webroot on container: %s", util.ContainerName(webContainer))
 		}
-	}
 
+		app, err = platform.GetPluginApp(plugin)
+		if err != nil {
+			log.Fatalf("Could not find application type %s: %v", plugin, err)
+		}
+
+		err = app.Init(dir)
+		if err != nil {
+			return "", err
+		}
+
+	}
 	out, err := app.Describe()
 	return out, err
 }

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -35,8 +35,8 @@ var RootCmd = &cobra.Command{
 		}
 
 		if !skip {
-			plugin = strings.ToLower(plugin)
-			if _, ok := platform.PluginMap[plugin]; !ok {
+			_, err := platform.GetPluginApp(plugin)
+			if err != nil {
 				util.Failed("Plugin %s is not registered", plugin)
 			}
 		}
@@ -80,7 +80,10 @@ func getActiveAppRoot() (string, error) {
 
 // getActiveApp returns the active platform.App based on the current working directory.
 func getActiveApp() (platform.App, error) {
-	app := platform.PluginMap[strings.ToLower(plugin)]
+	app, err := platform.GetPluginApp(plugin)
+	if err != nil {
+		return app, err
+	}
 	activeAppRoot, err := getActiveAppRoot()
 	if err != nil {
 		return app, err

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -284,9 +284,11 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	webContainer := fmt.Sprintf(localWebContainerName, site.Name)
 	dbContainer := fmt.Sprintf(localDBContainerName, site.Name)
 	revertDir := site.Chdir()
-	app := GetPluginApp("local")
+	app, err := GetPluginApp("local")
+	assert.NoError(err)
+
 	testcommon.ClearDockerEnv()
-	err := app.Init(site.Dir)
+	err = app.Init(site.Dir)
 	assert.NoError(err)
 
 	// Start a site so we have something to cleanup

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -76,7 +76,7 @@ func ContainerCheck(checkName string, checkState string) (bool, error) {
 	}
 
 	for _, container := range containers {
-		name := ContainerName(container)
+		name := util.ContainerName(container)
 		if name == checkName {
 			if container.State == checkState {
 				return true, nil

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -210,6 +210,7 @@ func TestLocalStop(t *testing.T) {
 	assert := assert.New(t)
 
 	app, err := GetPluginApp("local")
+	assert.NoError(err)
 
 	for _, site := range TestSites {
 		webContainer := fmt.Sprintf(localWebContainerName, site.Name)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -76,7 +76,7 @@ func ContainerCheck(checkName string, checkState string) (bool, error) {
 	}
 
 	for _, container := range containers {
-		name := container.Names[0][1:]
+		name := ContainerName(container)
 		if name == checkName {
 			if container.State == checkState {
 				return true, nil

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -99,7 +99,8 @@ func TestLocalStart(t *testing.T) {
 	}
 
 	assert := assert.New(t)
-	app := PluginMap["local"]
+	app, err := GetPluginApp("local")
+	assert.NoError(err)
 
 	for _, site := range TestSites {
 		webContainer := fmt.Sprintf(localWebContainerName, site.Name)
@@ -153,7 +154,8 @@ func TestGetApps(t *testing.T) {
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed
 func TestLocalImportDB(t *testing.T) {
 	assert := assert.New(t)
-	app := PluginMap["local"]
+	app, err := GetPluginApp("local")
+	assert.NoError(err)
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
@@ -179,7 +181,8 @@ func TestLocalImportDB(t *testing.T) {
 // TestLocalImportFiles tests the functionality that is called when "ddev import-files" is executed
 func TestLocalImportFiles(t *testing.T) {
 	assert := assert.New(t)
-	app := PluginMap["local"]
+	app, err := GetPluginApp("local")
+	assert.NoError(err)
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
@@ -206,7 +209,7 @@ func TestLocalImportFiles(t *testing.T) {
 func TestLocalStop(t *testing.T) {
 	assert := assert.New(t)
 
-	app := PluginMap["local"]
+	app, err := GetPluginApp("local")
 
 	for _, site := range TestSites {
 		webContainer := fmt.Sprintf(localWebContainerName, site.Name)
@@ -236,7 +239,8 @@ func TestLocalStop(t *testing.T) {
 func TestLocalRemove(t *testing.T) {
 	assert := assert.New(t)
 
-	app := GetPluginApp("local")
+	app, err := GetPluginApp("local")
+	assert.NoError(err)
 
 	for _, site := range TestSites {
 		webContainer := fmt.Sprintf(localWebContainerName, site.Name)

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -1,6 +1,7 @@
 package platform
 
-import "log"
+import "fmt"
+import "strings"
 
 // App is an interface apps for Drud Local must implement to use shared functionality
 type App interface {
@@ -40,13 +41,11 @@ var PluginMap = map[string]App{
 }
 
 // GetPluginApp will return an application of the type specified by pluginType
-func GetPluginApp(pluginType string) App {
-	switch pluginType {
+func GetPluginApp(pluginType string) (App, error) {
+	switch strings.ToLower(pluginType) {
 	case "local":
-		return &LocalApp{}
+		return &LocalApp{}, nil
 	default:
-		log.Fatalf("Could not find plugin type %s", pluginType)
+		return nil, fmt.Errorf("could not find plugin type %s", pluginType)
 	}
-
-	return nil
 }

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -52,7 +52,11 @@ func GetApps() map[string][]App {
 
 		if err == nil {
 			for _, siteContainer := range sites {
-				site := GetPluginApp(platformType)
+				site, err := GetPluginApp(platformType)
+				// This should absolutely never happen, so just fatal on the off chance it does.
+				if err != nil {
+					log.Fatalf("could not get application for plugin type %s", platformType)
+				}
 				approot, ok := siteContainer.Labels["com.ddev.approot"]
 				if !ok {
 					break
@@ -62,7 +66,7 @@ func GetApps() map[string][]App {
 					apps[platformType] = []App{}
 				}
 
-				err := site.Init(approot)
+				err = site.Init(approot)
 				if err == nil {
 					apps[platformType] = append(apps[platformType], site)
 				}

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -171,7 +171,7 @@ func ContainerWait(timeout time.Duration, labels map[string]string) error {
 			}
 			status := GetContainerHealth(container)
 			if status == "restarting" {
-				containerErr = fmt.Errorf("container %s: detected container restart; invalid configuration or container. consider using `docker logs %s` to debug", container.Names[0], container.ID)
+				containerErr = fmt.Errorf("container %s: detected container restart; invalid configuration or container. consider using `docker logs %s` to debug", ContainerName(container), container.ID)
 			}
 			if status == "healthy" {
 				containerErr = nil
@@ -192,6 +192,11 @@ outer:
 	}
 	ticker.Stop()
 	return containerErr
+}
+
+// ContainerName returns the containers human readable name.
+func ContainerName(container docker.APIContainers) string {
+	return container.Names[0][1:]
 }
 
 // GetContainerHealth retrieves the status of a given container. The status string returned


### PR DESCRIPTION
## The Problem:
We access `platform.PluginMap` all over the place to get a reference to an application. The problem is that this is a reference to a single global App, and what we really want is a **new** Application which does not have the potential to be tainted by other code.

## The Fix:
In the `ddev list` rework I introduced a `platform.GetPluginApp()` function which serves as an application factory. This PR updates all references to the PluginMap global to use that function.

## The Test:
Automated tests should be sufficient for this.



