### PR TITLE
Bump to new releases and make site names unique per test

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -19,9 +19,9 @@ var (
 	DevTestSites = []testcommon.TestSite{
 		{
 			Name:      "drupal8",
-			SourceURL: "https://github.com/drud/drupal8/archive/v0.4.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.4.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.4.0/db.tar.gz",
+			SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
+			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
+			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
 		},
 	}
 )

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -18,7 +18,7 @@ var (
 	DdevBin      = "ddev"
 	DevTestSites = []testcommon.TestSite{
 		{
-			Name:      "drupal8",
+			Name:      "cmdrootD8",
 			SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
 			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
 			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -18,7 +18,7 @@ var (
 	DdevBin      = "ddev"
 	DevTestSites = []testcommon.TestSite{
 		{
-			Name:      "cmdrootD8",
+			Name:      "TestMainCmdDrupal8",
 			SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
 			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
 			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",

--- a/pkg/appimport/appimport_test.go
+++ b/pkg/appimport/appimport_test.go
@@ -23,7 +23,7 @@ import (
 const netName = "ddev_default"
 
 var (
-	testArchiveURL  = "https://github.com/drud/wordpress/releases/download/v0.1.0/db.tar.gz"
+	testArchiveURL  = "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz"
 	testArchivePath = path.Join(testcommon.CreateTmpDir("appimport"), "db.tar.gz")
 	composePath     = path.Join("testing", "db-compose.yaml")
 	cwd             string

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -29,7 +29,7 @@ const DDevDefaultPlatform = "local"
 // DDevTLD defines the tld to use for DDev site URLs.
 const DDevTLD = "ddev.local"
 
-var allowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}
+var AllowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}
 
 // Config defines the yaml config file format for ddev applications
 type Config struct {
@@ -73,7 +73,7 @@ func NewConfig(AppRoot string) (*Config, error) {
 
 // Write the app configuration to the .ddev folder.
 func (c *Config) Write() error {
-	err := prepDDevDirectory(filepath.Dir(c.ConfigPath))
+	err := PrepDdevDirectory(filepath.Dir(c.ConfigPath))
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func (c *Config) ConfigExists() bool {
 // appTypePrompt handles the AppType workflow.
 func (c *Config) appTypePrompt() error {
 	var appType string
-	typePrompt := fmt.Sprintf("Application Type [%s]", strings.Join(allowedAppTypes, ", "))
+	typePrompt := fmt.Sprintf("Application Type [%s]", strings.Join(AllowedAppTypes, ", "))
 
 	// First, see if we can auto detect what kind of site it is so we can set a sane default.
 	absDocroot := filepath.Join(c.AppRoot, c.Docroot)
@@ -280,21 +280,21 @@ func (c *Config) appTypePrompt() error {
 	}
 	typePrompt = fmt.Sprintf("%s (%s)", typePrompt, c.AppType)
 
-	for isAllowedAppType(appType) != true {
+	for IsAllowedAppType(appType) != true {
 		fmt.Printf(typePrompt + ": ")
 		appType = strings.ToLower(util.GetInput(c.AppType))
 
-		if isAllowedAppType(appType) != true {
-			fmt.Printf("%s is not a valid application type. Allowed application types are: %s\n", appType, strings.Join(allowedAppTypes, ", "))
+		if IsAllowedAppType(appType) != true {
+			fmt.Printf("%s is not a valid application type. Allowed application types are: %s\n", appType, strings.Join(AllowedAppTypes, ", "))
 		}
 		c.AppType = appType
 	}
 	return nil
 }
 
-// isAllowedAppType determines if a given string exists in the allowedAppTypes slice.
-func isAllowedAppType(appType string) bool {
-	for _, t := range allowedAppTypes {
+// IsAllowedAppType determines if a given string exists in the AllowedAppTypes slice.
+func IsAllowedAppType(appType string) bool {
+	for _, t := range AllowedAppTypes {
 		if appType == t {
 			return true
 		}
@@ -302,8 +302,8 @@ func isAllowedAppType(appType string) bool {
 	return false
 }
 
-// prepDDevDirectory creates a .ddev directory in the current working
-func prepDDevDirectory(dir string) error {
+// PrepDdevDirectory creates a .ddev directory in the current working
+func PrepDdevDirectory(dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 
 		log.WithFields(log.Fields{

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -29,6 +29,7 @@ const DDevDefaultPlatform = "local"
 // DDevTLD defines the tld to use for DDev site URLs.
 const DDevTLD = "ddev.local"
 
+// AllowedAppTypes lists the types of site/app that can be used.
 var AllowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}
 
 // Config defines the yaml config file format for ddev applications

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -205,7 +205,7 @@ func TestRead(t *testing.T) {
 		AppRoot:    "testing",
 		APIVersion: CurrentAppVersion,
 		Platform:   DDevDefaultPlatform,
-		Name:       "testing",
+		Name:       "TestRead",
 		WebImage:   version.WebImg + ":" + version.WebTag,
 		DBImage:    version.DBImg + ":" + version.DBTag,
 		DBAImage:   version.DBAImg + ":" + version.DBATag,
@@ -215,7 +215,7 @@ func TestRead(t *testing.T) {
 	assert.NoError(err)
 
 	// Values not defined in file, we should still have default values
-	assert.Equal(c.Name, "testing")
+	assert.Equal(c.Name, "TestRead")
 	assert.Equal(c.DBImage, version.DBImg+":"+version.DBTag)
 
 	// Values defined in file, we should have values from file

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1,4 +1,4 @@
-package ddevapp
+package ddevapp_test
 
 import (
 	"bufio"
@@ -11,6 +11,7 @@ import (
 
 	"io/ioutil"
 
+	. "github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -54,16 +55,16 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(newConfig.AppType, loadedConfig.AppType)
 }
 
-// TestAllowedAppType tests the isAllowedAppType function.
+// TestAllowedAppType tests the IsAllowedAppType function.
 func TestAllowedAppTypes(t *testing.T) {
 	assert := assert.New(t)
-	for _, v := range allowedAppTypes {
-		assert.True(isAllowedAppType(v))
+	for _, v := range AllowedAppTypes {
+		assert.True(IsAllowedAppType(v))
 	}
 
 	for i := 1; i <= 50; i++ {
 		randomType := testcommon.RandString(32)
-		assert.False(isAllowedAppType(randomType))
+		assert.False(IsAllowedAppType(randomType))
 	}
 }
 
@@ -80,7 +81,7 @@ func TestPrepDirectory(t *testing.T) {
 	assert.Error(err)
 
 	// Prep the directory.
-	err = prepDDevDirectory(filepath.Dir(config.ConfigPath))
+	err = PrepDdevDirectory(filepath.Dir(config.ConfigPath))
 	assert.NoError(err)
 
 	// Read directory info an ensure it exists.
@@ -113,7 +114,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	config, err := NewConfig(testDir)
 	assert.Error(err)
 	config.Name = testcommon.RandString(32)
-	config.AppType = allowedAppTypes[0]
+	config.AppType = AllowedAppTypes[0]
 	config.Docroot = testcommon.RandString(16)
 
 	err = config.WriteDockerComposeConfig()
@@ -190,7 +191,7 @@ func TestConfigCommand(t *testing.T) {
 	assert.Equal(name, config.Name)
 	assert.Equal("drupal8", config.AppType)
 	assert.Equal("docroot", config.Docroot)
-	err = prepDDevDirectory(testDir)
+	err = PrepDdevDirectory(testDir)
 	assert.NoError(err)
 
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -498,8 +498,3 @@ func (l *LocalApp) AddHostsEntry() error {
 	err = system.RunCommandPipe("sudo", hostnameArgs)
 	return err
 }
-
-// constructContainerName builds a container name given the type (web/db/dba) and the appName
-func constructContainerName(containerType string, appName string) string {
-	return "local-" + appName + "-" + containerType
-}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -53,7 +53,7 @@ func (l *LocalApp) Init(basePath string) error {
 	if err == nil {
 		containerApproot := web.Labels["com.ddev.approot"]
 		if containerApproot != l.AppConfig.AppRoot {
-			return fmt.Errorf("a container in %s state already exists for %s that was created at %s", web.State, l.AppConfig.Name, containerApproot)
+			return fmt.Errorf("a web container in %s state already exists for %s that was created at %s", web.State, l.AppConfig.Name, containerApproot)
 		}
 	}
 
@@ -497,4 +497,9 @@ func (l *LocalApp) AddHostsEntry() error {
 	fmt.Println("Please enter your password if prompted.")
 	err = system.RunCommandPipe("sudo", hostnameArgs)
 	return err
+}
+
+// constructContainerName builds a container name given the type (web/db/dba) and the appName
+func constructContainerName(containerType string, appName string) string {
+	return "local-" + appName + "-" + containerType
 }

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -22,21 +22,21 @@ var (
 	TestSites             = []testcommon.TestSite{
 		{
 			Name:      "drupal8",
-			SourceURL: "https://github.com/drud/drupal8/archive/v0.4.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.4.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.4.0/db.tar.gz",
+			SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
+			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
+			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
 		},
 		{
 			Name:      "wordpress",
-			SourceURL: "https://github.com/drud/wordpress/archive/v0.3.0.tar.gz",
-			FileURL:   "https://github.com/drud/wordpress/releases/download/v0.3.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/wordpress/releases/download/v0.3.0/db.tar.gz",
+			SourceURL: "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+			FileURL:   "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+			DBURL:     "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		},
 		{
 			Name:      "kickstart",
-			SourceURL: "https://github.com/drud/drupal-kickstart/archive/v0.3.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal-kickstart/releases/download/v0.3.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal-kickstart/releases/download/v0.3.0/db.tar.gz",
+			SourceURL: "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
+			FileURL:   "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
+			DBURL:     "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
 		},
 	}
 )

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -21,19 +21,19 @@ var (
 	localWebContainerName = "local-%s-web"
 	TestSites             = []testcommon.TestSite{
 		{
-			Name:      "drupal8",
+			Name:      "pkgTestMainDrupal8",
 			SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
 			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
 			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
 		},
 		{
-			Name:      "wordpress",
+			Name:      "pkgTestMainWordpress",
 			SourceURL: "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
 			FileURL:   "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 			DBURL:     "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		},
 		{
-			Name:      "kickstart",
+			Name:      "pkgTestMainDrupalKickstart",
 			SourceURL: "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
 			FileURL:   "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
 			DBURL:     "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -118,7 +118,7 @@ func TestLocalStart(t *testing.T) {
 		assert.True(composeFile)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
-			containerName := constructContainerName(containerType, app.GetName())
+			containerName := constructContainerName(containerType, app)
 			check, err := ContainerCheck(containerName, "running")
 			assert.NoError(err)
 			assert.True(check, containerType, "container is running")
@@ -231,7 +231,7 @@ func TestLocalStop(t *testing.T) {
 		assert.NoError(err)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
-			containerName := constructContainerName(containerType, app.GetName())
+			containerName := constructContainerName(containerType, app)
 			check, err := ContainerCheck(containerName, "exited")
 			assert.NoError(err)
 			assert.True(check, containerType, "container has exited")
@@ -269,7 +269,7 @@ func TestLocalRemove(t *testing.T) {
 		}
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
-			containerName := constructContainerName(containerType, app.GetName())
+			containerName := constructContainerName(containerType, app)
 			check, err := ContainerCheck(containerName, "running")
 			assert.Error(err)
 			assert.False(check, "%s container for %s is not running, err: %s", containerType, app.GetName(), err.Error())
@@ -304,7 +304,7 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	assert.NoError(err)
 
 	for _, containerType := range [3]string{"web", "db", "dba"} {
-		containerName := constructContainerName(containerType, app.GetName())
+		containerName := constructContainerName(containerType, app)
 		check, err := ContainerCheck(containerName, "running")
 		assert.Error(err)
 		assert.False(check, "%s container for %s is not running, err: %s", containerType, app.GetName(), err.Error())
@@ -318,4 +318,12 @@ func TestGetAppsEmpty(t *testing.T) {
 	assert := assert.New(t)
 	apps := GetApps()
 	assert.Equal(len(apps["local"]), 0)
+}
+
+// constructContainerName builds a container name given the type (web/db/dba) and the app
+func constructContainerName(containerType string, app App) string {
+	container, err := app.FindContainerByType(containerType)
+	util.CheckErr(err)
+	name := util.ContainerName(container)
+	return name
 }

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -136,7 +136,8 @@ func TestLocalStart(t *testing.T) {
 	}
 
 	err = app.Init(another.Dir)
-	assert.EqualError(err, fmt.Sprintf("a container in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
+	assert.Error(err)
+	assert.Contains(err.Error(), fmt.Sprintf("container in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
 	another.Cleanup()
 }
 
@@ -271,7 +272,7 @@ func TestLocalRemove(t *testing.T) {
 			containerName := constructContainerName(containerType, app.GetName())
 			check, err := ContainerCheck(containerName, "running")
 			assert.Error(err)
-			assert.True(check, "%s container for %s is not running", containerType, app.GetName())
+			assert.False(check, "%s container for %s is not running, err: %s", containerType, app.GetName(), err.Error())
 		}
 
 		cleanup()
@@ -306,7 +307,7 @@ func TestCleanupWithoutCompose(t *testing.T) {
 		containerName := constructContainerName(containerType, app.GetName())
 		check, err := ContainerCheck(containerName, "running")
 		assert.Error(err)
-		assert.True(check, "%s container for %s is not running", containerType, app.GetName())
+		assert.False(check, "%s container for %s is not running, err: %s", containerType, app.GetName(), err.Error())
 	}
 
 	revertDir()

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -19,19 +19,19 @@ import (
 var (
 	TestSites = []testcommon.TestSite{
 		{
-			Name:      "pkgTestMainDrupal8",
+			Name:      "TestMainPkgDrupal8",
 			SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
 			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
 			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
 		},
 		{
-			Name:      "pkgTestMainWordpress",
+			Name:      "TestMainPkgWordpress",
 			SourceURL: "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
 			FileURL:   "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 			DBURL:     "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		},
 		{
-			Name:      "pkgTestMainDrupalKickstart",
+			Name:      "TestMainPkgDrupalKickstart",
 			SourceURL: "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
 			FileURL:   "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
 			DBURL:     "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -1,7 +1,11 @@
 package platform
 
 import "fmt"
-import "strings"
+import (
+	"strings"
+
+	"github.com/fsouza/go-dockerclient"
+)
 
 // App is an interface apps for Drud Local must implement to use shared functionality
 type App interface {
@@ -24,6 +28,7 @@ type App interface {
 	ImportDB(string) error
 	ImportFiles(string) error
 	SiteStatus() string
+	FindContainerByType(containerType string) (docker.APIContainers, error)
 }
 
 // PluginMap maps the name of the plugins to their implementation.

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -81,7 +81,7 @@ func (site *TestSite) Prepare() error {
 			return errors.Errorf("Failed to read site config for site %s, dir %s, err: %v", site.Name, site.Dir, err)
 		}
 		config.Name = site.Name
-		config.Write()
+		err = config.Write()
 		if err != nil {
 			return errors.Errorf("Failed to write site config for site %s, dir %s, err: %v", site.Name, site.Dir, err)
 		}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -12,7 +12,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/util"
 
+	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/drud-go/utils/system"
+	"github.com/pkg/errors"
 )
 
 // TestSite describes a site for testing, with name, URL of tarball, and optional dir.
@@ -66,6 +68,23 @@ func (site *TestSite) Prepare() error {
 		// If we had an error extracting the archive, we should go ahead and clean up the temporary directory, since this
 		// testsite is useless.
 		site.Cleanup()
+	}
+
+	// If our test site has a Name: then update the config file to reflect that.
+	if site.Name != "" {
+		config, err := ddevapp.NewConfig(site.Dir)
+		if err != nil {
+			return errors.Errorf("Failed to read site config for site %s, dir %s, err:", site.Name, site.Dir, err)
+		}
+		err = config.Read()
+		if err != nil {
+			return errors.Errorf("Failed to read site config for site %s, dir %s, err:", site.Name, site.Dir, err)
+		}
+		config.Name = site.Name
+		config.Write()
+		if err != nil {
+			return errors.Errorf("Failed to write site config for site %s, dir %s, err:", site.Name, site.Dir, err)
+		}
 	}
 
 	return err

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -74,16 +74,16 @@ func (site *TestSite) Prepare() error {
 	if site.Name != "" {
 		config, err := ddevapp.NewConfig(site.Dir)
 		if err != nil {
-			return errors.Errorf("Failed to read site config for site %s, dir %s, err:", site.Name, site.Dir, err)
+			return errors.Errorf("Failed to read site config for site %s, dir %s, err:%v", site.Name, site.Dir, err)
 		}
 		err = config.Read()
 		if err != nil {
-			return errors.Errorf("Failed to read site config for site %s, dir %s, err:", site.Name, site.Dir, err)
+			return errors.Errorf("Failed to read site config for site %s, dir %s, err: %v", site.Name, site.Dir, err)
 		}
 		config.Name = site.Name
 		config.Write()
 		if err != nil {
-			return errors.Errorf("Failed to write site config for site %s, dir %s, err:", site.Name, site.Dir, err)
+			return errors.Errorf("Failed to write site config for site %s, dir %s, err: %v", site.Name, site.Dir, err)
 		}
 	}
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -79,7 +79,7 @@ func TestValidTestSite(t *testing.T) {
 	//not need to be updated over time.
 	ts := TestSite{
 		Name:      "drupal8",
-		SourceURL: "https://github.com/drud/drupal8/archive/v0.3.0.tar.gz",
+		SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
 	}
 
 	// Create a testsite and ensure the prepare() method extracts files into a temporary directory.

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -78,7 +78,7 @@ func TestValidTestSite(t *testing.T) {
 	// of the archive for this test, only that it exists and can be extracted. This should (knock on wood)
 	//not need to be updated over time.
 	ts := TestSite{
-		Name:      "TestValidTestSiteD8",
+		Name:      "TestValidTestSiteDrupal8",
 		SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
 	}
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -78,7 +78,7 @@ func TestValidTestSite(t *testing.T) {
 	// of the archive for this test, only that it exists and can be extracted. This should (knock on wood)
 	//not need to be updated over time.
 	ts := TestSite{
-		Name:      "drupal8",
+		Name:      "TestValidTestSiteD8",
 		SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
 	}
 
@@ -120,13 +120,13 @@ func TestInvalidTestSite(t *testing.T) {
 	testSites := []TestSite{
 		// This should generate a 404 page on github, which will be downloaded, but cannot be extracted (as it's not a true tar.gz)
 		TestSite{
-			Name:      "drupal8",
+			Name:      "TestInvalidTestSite404",
 			SourceURL: "https://github.com/drud/drupal8/archive/somevaluethatdoesnotexist.tar.gz",
 		},
 		// This is an invalid domain, so it can't even be downloaded. This tests error handling in the case of
 		// a site URL which does not exist
 		TestSite{
-			Name:      "drupal8",
+			Name:      "TestInvalidTestSiteInvalidDomain",
 			SourceURL: "http://invalid_domain/somefilethatdoesnotexists",
 		},
 	}

--- a/pkg/util/files_test.go
+++ b/pkg/util/files_test.go
@@ -16,7 +16,7 @@ import (
 var (
 	temp            = os.TempDir()
 	cwd             string
-	testArchiveURL  = "https://github.com/drud/wordpress/releases/download/v0.1.0/files.tar.gz"
+	testArchiveURL  = "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz"
 	testArchivePath string
 )
 


### PR DESCRIPTION
## The Problem:

* We upgraded to site repos without the Name: field in config.yaml - bump to new releases and test
* Now apps can have unique names instead of all having the Name: in the upstream test repo. Use unique names.

## The Fix:

* Add the Name: provided by the test. This is done in testcommon.Prepare()
* Note that because this means testcommon.Prepare() now uses functions from ddevapp, the ddevapp config_test.go encountered circular imports. The workaround was to make config_test.go be in ddevapp_test package (instead of ddevapp) for "black box testing" that avoid the circular import. [Lesser-known features of go test](https://splice.com/blog/lesser-known-features-go-test/) has a nice paragraph on "The black box test package"

## The Test:

Test should run successfully; you should see properly named apps created (and then destroyed)

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

