### PR TITLE
fix spelling error and add link to wp search-replace

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -190,7 +190,7 @@ func (l *LocalApp) ImportDB(imPath string) error {
 	}
 
 	if l.GetType() == "wordpress" {
-		util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs acroos your database.", l.URL())
+		util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", l.URL())
 	}
 
 	return nil


### PR DESCRIPTION
## The Problem:
There was a spelling error in this wp search-replace message on import. This corrects it, and adds a link to more info on search-replace as requested in https://github.com/drud/ddev/issues/108#issuecomment-299086656
## The Fix:
This PR
## The Test:
Message change only, passing tests should be sufficient.
## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
No test changes necessary.
## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

