### PR TITLE
Stop router when no sites are running

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -421,7 +421,7 @@ func (l *LocalApp) Stop() error {
 	}
 
 	if !containersRunning {
-		StopRouter()
+		return StopRouter()
 	}
 	return nil
 }
@@ -528,7 +528,7 @@ func (l *LocalApp) Down() error {
 	}
 
 	if !containersRunning {
-		StopRouter()
+		return StopRouter()
 	}
 
 	return nil

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -415,15 +415,8 @@ func (l *LocalApp) Stop() error {
 	if err != nil {
 		return err
 	}
-	containersRunning, err := ddevContainersRunning()
-	if err != nil {
-		return err
-	}
 
-	if !containersRunning {
-		return StopRouter()
-	}
-	return nil
+	return StopRouter()
 }
 
 // Wait ensures that the app appears to be read before returning
@@ -522,16 +515,8 @@ func (l *LocalApp) Down() error {
 		util.Warning("Could not stop site with docker-compose. Attempting manual cleanup.")
 		return Cleanup(l)
 	}
-	containersRunning, err := ddevContainersRunning()
-	if err != nil {
-		return err
-	}
 
-	if !containersRunning {
-		return StopRouter()
-	}
-
-	return nil
+	return StopRouter()
 }
 
 // URL returns the URL for a given application.

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -325,7 +325,7 @@ func TestLocalRemove(t *testing.T) {
 	}
 }
 
-// TestCleanupWithoutCompose
+// TestCleanupWithoutCompose ensures app containers can be properly cleaned up without a docker-compose config file present.
 func TestCleanupWithoutCompose(t *testing.T) {
 	assert := assert.New(t)
 	site := TestSites[0]
@@ -362,6 +362,17 @@ func TestGetAppsEmpty(t *testing.T) {
 	assert := assert.New(t)
 	apps := GetApps()
 	assert.Equal(len(apps["local"]), 0)
+}
+
+// TestRouterNotRunning ensures the router is shut down after all sites are stopped.
+func TestRouterNotRunning(t *testing.T) {
+	assert := assert.New(t)
+	containers, err := util.GetDockerContainers(false)
+	assert.NoError(err)
+
+	for _, container := range containers {
+		assert.NotEqual(util.ContainerName(container), "nginx-proxy", "Found nginx proxy running")
+	}
 }
 
 // constructContainerName builds a container name given the type (web/db/dba) and the app

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -2,7 +2,6 @@ package platform
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 	"log"
 	"os"
@@ -12,7 +11,6 @@ import (
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
-	"github.com/drud/drud-go/utils/system"
 	homedir "github.com/mitchellh/go-homedir"
 )
 
@@ -81,8 +79,8 @@ func StartDockerRouter() {
 	util.CheckErr(err)
 
 	// run docker-compose up -d in the newly created directory
-	out, err := system.RunCommand("docker-compose", []string{"-p", routerProjectName, "-f", dest, "up", "-d"})
+	err = util.ComposeCmd([]string{dest}, "-p", routerProjectName, "up", "-d")
 	if err != nil {
-		fmt.Println(fmt.Errorf("%s - %s", err.Error(), string(out)))
+		log.Fatalf("Could not start router: %v", err)
 	}
 }

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -30,10 +30,19 @@ func RouterComposeYAMLPath() string {
 	return dest
 }
 
-// StopRouter stops the local router.
+// StopRouter stops the local router if there are no ddev containers running.
 func StopRouter() error {
-	dest := RouterComposeYAMLPath()
-	return util.ComposeCmd([]string{dest}, "-p", routerProjectName, "down")
+
+	containersRunning, err := ddevContainersRunning()
+	if err != nil {
+		return err
+	}
+
+	if !containersRunning {
+		dest := RouterComposeYAMLPath()
+		return util.ComposeCmd([]string{dest}, "-p", routerProjectName, "down")
+	}
+	return nil
 }
 
 // StartDockerRouter ensures the router is running.

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -1,0 +1,79 @@
+package platform
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/drud/ddev/pkg/appports"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/version"
+	"github.com/drud/drud-go/utils/system"
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+const routerProjectName = "ddev-router"
+
+// RouterComposeYAMLPath returns the full filepath to the routers docker-compose yaml file.
+func RouterComposeYAMLPath() string {
+	userHome, err := homedir.Dir()
+	if err != nil {
+		log.Fatal("could not get home directory for current user. is it set?")
+	}
+	routerdir := path.Join(userHome, ".ddev")
+	dest := path.Join(routerdir, "router-compose.yaml")
+
+	return dest
+}
+
+// StopRouter stops the local router.
+func StopRouter() error {
+	dest := RouterComposeYAMLPath()
+	return util.ComposeCmd([]string{dest}, "-p", routerProjectName, "down")
+}
+
+// StartDockerRouter ensures the router is running.
+func StartDockerRouter() {
+	dest := RouterComposeYAMLPath()
+	routerdir := filepath.Dir(dest)
+	err := os.MkdirAll(routerdir, 0755)
+	if err != nil {
+		log.Fatalf("unable to create directory for ddev router: %s", err)
+	}
+
+	var doc bytes.Buffer
+	f, ferr := os.Create(dest)
+	if ferr != nil {
+		log.Fatal(ferr)
+	}
+	defer util.CheckClose(f)
+
+	templ := template.New("compose template")
+	templ, err = templ.Parse(DrudRouterTemplate)
+	if err != nil {
+		log.Fatal(ferr)
+	}
+
+	templateVars := map[string]string{
+		"router_image": version.RouterImage,
+		"router_tag":   version.RouterTag,
+		"mailhogport":  appports.GetPort("mailhog"),
+		"dbaport":      appports.GetPort("dba"),
+		"dbport":       appports.GetPort("db"),
+	}
+
+	err = templ.Execute(&doc, templateVars)
+	util.CheckErr(err)
+	_, err = f.WriteString(doc.String())
+	util.CheckErr(err)
+
+	// run docker-compose up -d in the newly created directory
+	out, err := system.RunCommand("docker-compose", []string{"-p", routerProjectName, "-f", dest, "up", "-d"})
+	if err != nil {
+		fmt.Println(fmt.Errorf("%s - %s", err.Error(), string(out)))
+	}
+}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -208,7 +208,7 @@ func Cleanup(app App) error {
 		}
 	}
 
-	return nil
+	return StopRouter()
 }
 
 // CheckForConf checks for a config.yaml at the cwd or parent dirs.


### PR DESCRIPTION
## The Problem:
Currently, the router does not shut down after you stop/remove all running sites. We should be good citizens and only be running the router when there are things to route to.

## The Fix:
This PR introduces changes which will perform a check during stop/rm for all running containers which have a `com.ddev.platform` label. It does not care what the value of the label is. If running containers are found with that label, it leaves the proxy up. It no containers are found with that label, it stops the proxy.

## The Test:
- Build this binary
- Use `ddev` as you normally would. The proxy should always be up if sites are running, and it should always be down if no sites are running.

## Automation Overview:
- Added a test case to ensure the router has been stopped at the end of the local platform tests.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/40



