### PR TITLE
Simplify full static analysis in circleci config and Makefile, store away binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,3 +70,16 @@ jobs:
           name: Run full nightly build  and tests if $RUN_NIGHTLY_BUILD
 
       - run: make -s staticrequired
+
+      - run:
+          command: bin/linux/ddev version
+          name: ddev version information
+
+      - store_artifacts:
+          path: bin/darwin/darwin_amd64/ddev
+          destination: darwin/ddev
+          name: Upload ddev (darwin)
+      - store_artifacts:
+          path: bin/linux/ddev
+          destination: linux/ddev
+          name: Upload ddev (linux)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,4 @@ jobs:
           no_output_timeout: "20m"
           name: Run full nightly build  and tests if $RUN_NIGHTLY_BUILD
 
-      - run:
-          command: |
-            make gofmt &&
-            make govet &&
-            make golint &&
-            make errcheck &&
-            make staticcheck &&
-            make codecoroner
-          name: Static analysis targets gofmt/govet/golint/errcheck/staticcheck
+      - run: make -s staticrequired

--- a/Makefile
+++ b/Makefile
@@ -75,3 +75,4 @@ setup:
 
 # Required static analysis targets used in circleci - these cause fail if they don't work
 staticrequired: gofmt govet golint errcheck staticcheck codecoroner
+

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ include build-tools/makefile_components/base_build_go.mak
 #include build-tools/makefile_components/base_test_go.mak
 #include build-tools/makefile_components/base_test_python.mak
 
-.PHONY: test testcmd testpkg build setup
+.PHONY: test testcmd testpkg build setup staticrequired
 
 TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 DDEV_BINARY_FULLPATH=$(shell pwd)/bin/$(TESTOS)/ddev
@@ -72,3 +72,6 @@ setup:
 	@mkdir -p bin/darwin bin/linux
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
 	@if [ ! -L $$PWD/bin/darwin/ddev ] ; then ln -s $$PWD/bin/darwin/darwin_amd64/ddev $$PWD/bin/darwin/ddev; fi
+
+# Required static analysis targets used in circleci - these cause fail if they don't work
+staticrequired: gofmt govet golint errcheck staticcheck codecoroner


### PR DESCRIPTION
## The Problem:

* The static config in circle output makes a lot of noise
* It's a silly long unnecessary statement.
* We aren't saving the results of the build - it would be nice to have access to the binaries

## The Fix:

* Make a single target with dependencies in Makefile
* use `make -s` so we don't have to see the full silly docker commands
* Save the build artifacts (linux and darwin) - these now show up under the "artifacts" tab on the build, and can be used to get the exact binary that was built.

![drud_ddev__707_-_circleci](https://cloud.githubusercontent.com/assets/112444/25769853/b82dca9e-31e1-11e7-97c3-022bfb5cc9c8.png)


## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

