### PR TITLE
determine router expose ports by parsing HTTP_EXPOSE and TCP_EXPOSE per site container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ WebTag ?= v0.4.0
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.3.0
 RouterImage ?= drud/nginx-proxy
-RouterTag ?= router-expose
+RouterTag ?= v0.4.0
 DBAImg ?= drud/phpmyadmin
 DBATag ?= v0.2.0
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ WebTag ?= v0.4.0
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.3.0
 RouterImage ?= drud/nginx-proxy
-RouterTag ?= v0.3.0
+RouterTag ?= router-expose
 DBAImg ?= drud/phpmyadmin
 DBATag ?= v0.2.0
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -12,7 +12,8 @@ services:
       - "./data:/db"
     restart: always
     environment:
-      - TCP_PORT={{ .dbport }}
+      # TCP_EXPOSE allows for TCP ports to be accessible from <site>.ddev.local:<port>
+      - TCP_EXPOSE={{ .dbport }}
     ports:
       - 3306
     labels:
@@ -40,7 +41,8 @@ services:
     environment:
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_PORT=80,{{ .mailhogport }}
+      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
+      - HTTP_EXPOSE=80,{{ .mailhogport }}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .plugin }}
@@ -69,7 +71,8 @@ services:
       - PMA_USER=root
       - PMA_PASSWORD=root
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - VIRTUAL_PORT={{ .dbaport }}
+      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
+      - HTTP_EXPOSE={{ .dbaport }}
 networks:
   default:
     external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -13,6 +13,8 @@ services:
     restart: always
     environment:
       # TCP_EXPOSE allows for TCP ports to be accessible from <site>.ddev.local:<port>
+      # To expose a container port to a different host port, define the port as hostPort:containerPort
+      # e.g., to expose db traffic on port 8086, define port as 8086:3036
       - TCP_EXPOSE={{ .dbport }}
     ports:
       - 3306
@@ -42,6 +44,7 @@ services:
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
+      # To expose a container port to a different host port, define the port as hostPort:containerPort
       - HTTP_EXPOSE=80,{{ .mailhogport }}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -12,7 +12,7 @@ services:
       - "./data:/db"
     restart: always
     environment:
-      - TCP_PORT=$DDEV_HOSTNAME:{{ .dbport }}
+      - TCP_PORT={{ .dbport }}
     ports:
       - 3306
     labels:

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -320,21 +320,7 @@ func (l *LocalApp) Start() error {
 		return err
 	}
 
-	// Retrieve ports from containers to expose in router
-	var exposePorts []string
-	siteContainers, err := util.GetAppContainers(l.GetName())
-	if err != nil {
-		return err
-	}
-	for _, container := range siteContainers {
-		expose := util.GetContainerEnv("VIRTUAL_PORT", container)
-		if expose != "" {
-			ports := strings.Split(expose, ",")
-			exposePorts = append(exposePorts, ports...)
-		}
-	}
-
-	StartDockerRouter(exposePorts)
+	StartDockerRouter()
 
 	return nil
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -322,7 +322,10 @@ func (l *LocalApp) Start() error {
 
 	// Retrieve ports from containers to expose in router
 	var exposePorts []string
-	siteContainers := util.GetAppContainers(l.GetName())
+	siteContainers, err := util.GetAppContainers(l.GetName())
+	if err != nil {
+		return err
+	}
 	for _, container := range siteContainers {
 		expose := util.GetContainerEnv("VIRTUAL_PORT", container)
 		if expose != "" {

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -135,12 +135,23 @@ func TestGetApps(t *testing.T) {
 	}
 }
 
+// TestGetCurrentRouterPorts tests retrieval of currently exposed ports on the router
 func TestGetCurrentRouterPorts(t *testing.T) {
 	assert := assert.New(t)
 	ports := GetCurrentRouterPorts()
-	assert.Contains(ports, "80")
-	assert.Contains(ports, appports.GetPort("mailhog"))
-	assert.Contains(ports, appports.GetPort("dba"))
+	assert.Contains(ports, "80:80")
+	assert.Contains(ports, appports.GetPort("mailhog")+":"+appports.GetPort("mailhog"))
+	assert.Contains(ports, appports.GetPort("dba")+":"+appports.GetPort("dba"))
+}
+
+// TestSetRouterPorts tests determination of router ports from current router and site container definitions.
+func TestSetRouterPorts(t *testing.T) {
+	assert := assert.New(t)
+	ports := []string{"8080", "8050:8025"}
+	exposedPorts := SetRouterPorts(ports)
+	assert.Contains(exposedPorts, "80:80")
+	assert.Contains(exposedPorts, "8080:8080")
+	assert.Contains(exposedPorts, "8050:8025")
 }
 
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -134,6 +134,14 @@ func TestGetApps(t *testing.T) {
 	}
 }
 
+func TestGetCurrentRouterPorts(t *testing.T) {
+	assert := assert.New(t)
+	ports := GetCurrentRouterPorts()
+	assert.Contains(ports, "80")
+	assert.Contains(ports, "8025")
+	assert.Contains(ports, "3306")
+}
+
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed
 func TestLocalImportDB(t *testing.T) {
 	assert := assert.New(t)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/system"
@@ -138,8 +139,8 @@ func TestGetCurrentRouterPorts(t *testing.T) {
 	assert := assert.New(t)
 	ports := GetCurrentRouterPorts()
 	assert.Contains(ports, "80")
-	assert.Contains(ports, "8025")
-	assert.Contains(ports, "8036")
+	assert.Contains(ports, appports.GetPort("mailhog"))
+	assert.Contains(ports, appports.GetPort("dba"))
 }
 
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -139,9 +139,9 @@ func TestGetApps(t *testing.T) {
 func TestGetCurrentRouterPorts(t *testing.T) {
 	assert := assert.New(t)
 	ports := GetCurrentRouterPorts()
-	assert.Contains(ports, "80:80")
-	assert.Contains(ports, appports.GetPort("mailhog")+":"+appports.GetPort("mailhog"))
-	assert.Contains(ports, appports.GetPort("dba")+":"+appports.GetPort("dba"))
+	assert.Contains(ports, "80:80", "port 80 not retrieved from existing router config")
+	assert.Contains(ports, appports.GetPort("mailhog")+":"+appports.GetPort("mailhog"), "mailhog port not retrieved from existing router config")
+	assert.Contains(ports, appports.GetPort("dba")+":"+appports.GetPort("dba"), "dba port not retrieved from existing router config")
 }
 
 // TestSetRouterPorts tests determination of router ports from current router and site container definitions.
@@ -149,9 +149,9 @@ func TestSetRouterPorts(t *testing.T) {
 	assert := assert.New(t)
 	ports := []string{"8080", "8050:8025"}
 	exposedPorts := SetRouterPorts(ports)
-	assert.Contains(exposedPorts, "80:80")
-	assert.Contains(exposedPorts, "8080:8080")
-	assert.Contains(exposedPorts, "8050:8025")
+	assert.Contains(exposedPorts, "80:80", "port 80 not present from existing router config")
+	assert.Contains(exposedPorts, "8080:8080", "port 8080 not added to new router ports")
+	assert.Contains(exposedPorts, "8050:8025", "port 8050:8025 mapping not added to new router ports")
 }
 
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/system"
@@ -133,25 +132,6 @@ func TestGetApps(t *testing.T) {
 		}
 		assert.True(found, "Found site %s in list", site.Name)
 	}
-}
-
-// TestGetCurrentRouterPorts tests retrieval of currently exposed ports on the router
-func TestGetCurrentRouterPorts(t *testing.T) {
-	assert := assert.New(t)
-	ports := GetCurrentRouterPorts()
-	assert.Contains(ports, "80:80", "port 80 not retrieved from existing router config")
-	assert.Contains(ports, appports.GetPort("mailhog")+":"+appports.GetPort("mailhog"), "mailhog port not retrieved from existing router config")
-	assert.Contains(ports, appports.GetPort("dba")+":"+appports.GetPort("dba"), "dba port not retrieved from existing router config")
-}
-
-// TestSetRouterPorts tests determination of router ports from current router and site container definitions.
-func TestSetRouterPorts(t *testing.T) {
-	assert := assert.New(t)
-	ports := []string{"8080", "8050:8025"}
-	exposedPorts := SetRouterPorts(ports)
-	assert.Contains(exposedPorts, "80:80", "port 80 not present from existing router config")
-	assert.Contains(exposedPorts, "8080:8080", "port 8080 not added to new router ports")
-	assert.Contains(exposedPorts, "8050:8025", "port 8050:8025 mapping not added to new router ports")
 }
 
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -139,7 +139,7 @@ func TestGetCurrentRouterPorts(t *testing.T) {
 	ports := GetCurrentRouterPorts()
 	assert.Contains(ports, "80")
 	assert.Contains(ports, "8025")
-	assert.Contains(ports, "3306")
+	assert.Contains(ports, "8036")
 }
 
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -100,13 +100,13 @@ func determineRouterPorts() []string {
 		if _, ok := container.Labels["com.ddev.site-name"]; ok {
 			var exposePorts []string
 
-			httpPorts := util.GetContainerEnv("VIRTUAL_PORT", container)
+			httpPorts := util.GetContainerEnv("HTTP_EXPOSE", container)
 			if httpPorts != "" {
 				ports := strings.Split(httpPorts, ",")
 				exposePorts = append(exposePorts, ports...)
 			}
 
-			tcpPorts := util.GetContainerEnv("TCP_PORT", container)
+			tcpPorts := util.GetContainerEnv("TCP_EXPOSE", container)
 			if tcpPorts != "" {
 				ports := strings.Split(tcpPorts, ",")
 				exposePorts = append(exposePorts, ports...)

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -99,9 +99,16 @@ func determineRouterPorts() []string {
 	for _, container := range containers {
 		if _, ok := container.Labels["com.ddev.site-name"]; ok {
 			var exposePorts []string
-			expose := util.GetContainerEnv("VIRTUAL_PORT", container)
-			if expose != "" {
-				ports := strings.Split(expose, ",")
+
+			httpPorts := util.GetContainerEnv("VIRTUAL_PORT", container)
+			if httpPorts != "" {
+				ports := strings.Split(httpPorts, ",")
+				exposePorts = append(exposePorts, ports...)
+			}
+
+			tcpPorts := util.GetContainerEnv("TCP_PORT", container)
+			if tcpPorts != "" {
+				ports := strings.Split(tcpPorts, ",")
 				exposePorts = append(exposePorts, ports...)
 			}
 
@@ -111,7 +118,7 @@ func determineRouterPorts() []string {
 				// should be hostPort:hostPort so router can determine what port a request came from
 				// and route the request to the correct upstream
 				if strings.Contains(exposePort, ":") {
-					ports := strings.Split(expose, ":")
+					ports := strings.Split(exposePort, ":")
 					exposePort = ports[0]
 				}
 

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -106,9 +106,13 @@ func determineRouterPorts() []string {
 			}
 
 			for _, exposePort := range exposePorts {
-				// ports defined without : are 1:1 mapping
-				if !strings.Contains(exposePort, ":") {
-					exposePort = exposePort + ":" + exposePort
+				// ports defined as hostPort:containerPort allow for router to configure upstreams
+				// for containerPort, with server listening on hostPort. exposed ports for router
+				// should be hostPort:hostPort so router can determine what port a request came from
+				// and route the request to the correct upstream
+				if strings.Contains(exposePort, ":") {
+					ports := strings.Split(expose, ":")
+					exposePort = ports[0]
 				}
 
 				var match bool

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -69,7 +69,7 @@ services:
     image: {{ .router_image }}:{{ .router_tag }}
     container_name: nginx-proxy
     ports:
-      {{ range $port := .ports }}- "{{ $port }}"
+      {{ range $port := .ports }}- "{{ $port }}:{{ $port }}"
       {{ end }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -69,7 +69,7 @@ services:
     image: {{ .router_image }}:{{ .router_tag }}
     container_name: nginx-proxy
     ports:
-      {{ range $port := .ports }}- "{{ $port }}:{{ $port }}"
+      {{ range $port := .ports }}- "{{ $port }}"
       {{ end }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -69,10 +69,8 @@ services:
     image: {{ .router_image }}:{{ .router_tag }}
     container_name: nginx-proxy
     ports:
-      - "80:80"
-      - {{ .mailhogport }}:{{ .mailhogport }}
-      - {{ .dbaport }}:{{ .dbaport }}
-      - {{ .dbport }}:{{ .dbport }}
+      {{ range $port := .ports }}- "{{ $port }}:{{ $port }}"
+      {{ end }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
 networks:

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -258,14 +258,13 @@ func GetAppContainers(sitename string) ([]docker.APIContainers, error) {
 func GetContainerEnv(key string, container docker.APIContainers) string {
 	client := GetDockerClient()
 	inspect, err := client.InspectContainer(container.ID)
-	if err != nil {
-		log.Debug("failed to retreive container ", ContainerName(container))
-	}
-	envVars := inspect.Config.Env
+	if err == nil {
+		envVars := inspect.Config.Env
 
-	for _, env := range envVars {
-		if strings.HasPrefix(env, key) {
-			return strings.TrimPrefix(env, key+"=")
+		for _, env := range envVars {
+			if strings.HasPrefix(env, key) {
+				return strings.TrimPrefix(env, key+"=")
+			}
 		}
 	}
 	return ""

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -245,13 +245,13 @@ func ComposeCmd(composeFiles []string, action ...string) error {
 }
 
 // GetAppContainers retrieves docker containers for a given sitename.
-func GetAppContainers(sitename string) []docker.APIContainers {
+func GetAppContainers(sitename string) ([]docker.APIContainers, error) {
 	label := map[string]string{"com.ddev.site-name": sitename}
 	sites, err := FindContainersByLabels(label)
 	if err != nil {
-		log.Fatal("failed to retrieve containers for ", sitename, err)
+		return sites, err
 	}
-	return sites
+	return sites, nil
 }
 
 // GetContainerEnv returns the value of a given environment variable from a given container.

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -263,8 +263,7 @@ func GetContainerEnv(key string, container docker.APIContainers) string {
 	}
 	envVars := inspect.Config.Env
 
-	for i, env := range envVars {
-		fmt.Printf("%v %s\n", i, env)
+	for _, env := range envVars {
 		if strings.HasPrefix(env, key) {
 			return strings.TrimPrefix(env, key+"=")
 		}

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -243,3 +243,31 @@ func ComposeCmd(composeFiles []string, action ...string) error {
 
 	return proc.Run()
 }
+
+// GetAppContainers retrieves docker containers for a given sitename.
+func GetAppContainers(sitename string) []docker.APIContainers {
+	label := map[string]string{"com.ddev.site-name": sitename}
+	sites, err := FindContainersByLabels(label)
+	if err != nil {
+		log.Fatal("failed to retrieve containers for ", sitename, err)
+	}
+	return sites
+}
+
+// GetContainerEnv returns the value of a given environment variable from a given container.
+func GetContainerEnv(key string, container docker.APIContainers) string {
+	client := GetDockerClient()
+	inspect, err := client.InspectContainer(container.ID)
+	if err != nil {
+		log.Debug("failed to retreive container ", ContainerName(container))
+	}
+	envVars := inspect.Config.Env
+
+	for i, env := range envVars {
+		fmt.Printf("%v %s\n", i, env)
+		if strings.HasPrefix(env, key) {
+			return strings.TrimPrefix(env, key+"=")
+		}
+	}
+	return ""
+}

--- a/pkg/util/dockerutils_test.go
+++ b/pkg/util/dockerutils_test.go
@@ -96,7 +96,7 @@ func TestGetAppContainers(t *testing.T) {
 func TestGetContainerEnv(t *testing.T) {
 	assert := assert.New(t)
 
-	container, err := FindContainerByLabels(map[string]string{"com.docker.compose.service": "test"})
+	container, err := FindContainerByLabels(map[string]string{"com.docker.compose.service": "ddevrouter"})
 	assert.NoError(err)
 
 	env := GetContainerEnv("HOTDOG", container)

--- a/pkg/util/dockerutils_test.go
+++ b/pkg/util/dockerutils_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/drud/ddev/pkg/testcommon"
 	. "github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/version"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -83,4 +84,25 @@ func TestComposeCmd(t *testing.T) {
 	composeFiles = []string{"invalid.yml"}
 	err = ComposeCmd(composeFiles, "config", "--services")
 	assert.Error(err)
+}
+
+func TestGetAppContainers(t *testing.T) {
+	assert := assert.New(t)
+	sites, err := GetAppContainers("dockertest")
+	assert.NoError(err)
+	assert.Equal(sites[0].Image, version.RouterImage+":"+version.RouterTag)
+}
+
+func TestGetContainerEnv(t *testing.T) {
+	assert := assert.New(t)
+
+	container, err := FindContainerByLabels(map[string]string{"com.docker.compose.service": "test"})
+	assert.NoError(err)
+
+	env := GetContainerEnv("HOTDOG", container)
+	assert.Equal("superior-to-corndog", env)
+	env = GetContainerEnv("POTATO", container)
+	assert.Equal("future-fry", env)
+	env = GetContainerEnv("NONEXISTENT", container)
+	assert.Equal("", env)
 }

--- a/pkg/util/files_test.go
+++ b/pkg/util/files_test.go
@@ -1,8 +1,6 @@
 package util_test
 
 import (
-	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,43 +11,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	testArchiveURL        = "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz"
-	testArchiveExtractDir = "wordpress-0.4.0/"
-	testArchivePath       string
-)
-
-func TestMain(m *testing.M) {
-	testPath, err := ioutil.TempDir("", "filetest")
-	util.CheckErr(err)
-	testPath, err = filepath.EvalSymlinks(testPath)
-	util.CheckErr(err)
-	testPath = filepath.Clean(testPath)
-	testArchivePath = filepath.Join(testPath, "files.tar.gz")
-
-	err = system.DownloadFile(testArchivePath, testArchiveURL)
-	if err != nil {
-		log.Fatalf("archive download failed: %s", err)
-	}
-
-	testRun := m.Run()
-
-	os.Exit(testRun)
-}
-
 // TestUntar tests untar functionality, including the starting directory
 func TestUntar(t *testing.T) {
 	assert := assert.New(t)
 	exDir := testcommon.CreateTmpDir("TestUnTar1")
 
-	err := util.Untar(testArchivePath, exDir, "")
+	err := util.Untar(TestArchivePath, exDir, "")
 	assert.NoError(err)
 
 	// Make sure that our base extraction directory is there
-	finfo, err := os.Stat(filepath.Join(exDir, testArchiveExtractDir))
+	finfo, err := os.Stat(filepath.Join(exDir, TestArchiveExtractDir))
 	assert.NoError(err)
 	assert.True(err == nil && finfo.IsDir())
-	finfo, err = os.Stat(filepath.Join(exDir, testArchiveExtractDir, ".ddev/config.yaml"))
+	finfo, err = os.Stat(filepath.Join(exDir, TestArchiveExtractDir, ".ddev/config.yaml"))
 	assert.NoError(err)
 	assert.True(err == nil && !finfo.IsDir())
 
@@ -58,7 +32,7 @@ func TestUntar(t *testing.T) {
 
 	// Now do the untar with an extraction root
 	exDir = testcommon.CreateTmpDir("TestUnTar2")
-	err = util.Untar(testArchivePath, exDir, testArchiveExtractDir)
+	err = util.Untar(TestArchivePath, exDir, TestArchiveExtractDir)
 	assert.NoError(err)
 
 	finfo, err = os.Stat(filepath.Join(exDir, ".ddev"))
@@ -77,9 +51,9 @@ func TestUntar(t *testing.T) {
 func TestCopyFile(t *testing.T) {
 	assert := assert.New(t)
 	tmpTargetDir := testcommon.CreateTmpDir("TestCopyFile")
-	tmpTargetFile := filepath.Join(tmpTargetDir, filepath.Base(testArchivePath))
+	tmpTargetFile := filepath.Join(tmpTargetDir, filepath.Base(TestArchivePath))
 
-	err := util.CopyFile(testArchivePath, tmpTargetFile)
+	err := util.CopyFile(TestArchivePath, tmpTargetFile)
 	assert.NoError(err)
 
 	file, err := os.Stat(tmpTargetFile)
@@ -103,7 +77,7 @@ func TestCopyDir(t *testing.T) {
 	assert.NoError(err)
 
 	// test source not a directory
-	err = util.CopyDir(testArchivePath, sourceDir)
+	err = util.CopyDir(TestArchivePath, sourceDir)
 	assert.Error(err)
 	assert.Contains(err.Error(), "source is not a directory")
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -14,8 +14,11 @@ import (
 )
 
 var (
-	TestArchiveURL        = "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz"
-	TestArchivePath       string
+	// TestArchiveURL provides the URL of the test tar.gz asset
+	TestArchiveURL = "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz"
+	// TestArchivePath provides the path the test tar.gz asset is downloaded to
+	TestArchivePath string
+	// TestArchiveExtractDir is the directory in the archive to extract
 	TestArchiveExtractDir = "wordpress-0.4.0/"
 )
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -65,6 +65,9 @@ func TestMain(m *testing.M) {
 		ID:    container.ID,
 		Force: true,
 	})
+	if err != nil {
+		log.Fatal("failed to remove test container: ", err)
+	}
 
 	// cleanup test file
 	err = os.Remove(TestArchivePath)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	TestArchiveURL        = "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz"
+	TestArchiveURL        = "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz"
 	TestArchivePath       string
 	TestArchiveExtractDir = "wordpress-0.4.0/"
 )

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -67,7 +67,10 @@ func TestMain(m *testing.M) {
 	})
 
 	// cleanup test file
-	os.Remove(TestArchivePath)
+	err = os.Remove(TestArchivePath)
+	if err != nil {
+		log.Fatal("failed to remove test asset: ", err)
+	}
 
 	os.Exit(testRun)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -35,6 +35,14 @@ func TestMain(m *testing.M) {
 
 	// prep docker container for docker util tests
 	client := util.GetDockerClient()
+	err = client.PullImage(docker.PullImageOptions{
+		Repository: version.RouterImage,
+		Tag:        version.RouterTag,
+	}, docker.AuthConfiguration{})
+	if err != nil {
+		log.Fatal("failed to pull test image ", err)
+	}
+
 	container, err := client.CreateContainer(docker.CreateContainerOptions{
 		Name: "envtest",
 		Config: &docker.Config{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -30,7 +30,7 @@ var DBATag = "v0.2.0"
 var RouterImage = "drud/nginx-proxy" // Note that this is overridden by make
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "router-expose" // Note that this is overridden by make
+var RouterTag = "v0.4.0" // Note that this is overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -30,7 +30,7 @@ var DBATag = "v0.2.0"
 var RouterImage = "drud/nginx-proxy" // Note that this is overridden by make
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.3.0" // Note that this is overridden by make
+var RouterTag = "router-expose" // Note that this is overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem:
We want to provide support for users to define their own additional services to run as part of a ddev app. We are providing support for multiple extending/overriding compose files in #198, but we also need a way to expose new ports on the router, so that users can define a new service to be available at `sitename.ddev.local:portNo`.

## The Fix:
This PR changes how ports are exposed on the router container. Previously, each port we needed to expose was explicitly defined as a value in the router template. The new approach works by:
- Leveraging the existing `VIRTUAL_PORT` env var used to determine which ports are configured as upstreams in the router.
- Retrieving values of `VIRTUAL_PORT` from all site containers
- Retrieving existing port mappings from the router if it is running
- Reconciling the two, adding any new port mappings from the site containers that aren't present in any current router port mappings

The `VIRTUAL_PORT` env var can accept multiple port definitions for a container via comma separated values. Ports can also be defined in the docker `hostPort:containerPort` format, allowing for the exposed port to differ from the internal container port.

## The Test:
drud/nginx-proxy#10 is required to test this change. This PR is configured to use the image from this PR, so grabbing the binary for this PR is sufficient to test.

You should be able to test this PR in the following ways:
- Test the binary built from this PR  against a site with default ddev configuration. The site should work as normally expected. With this change, no ports are exposed on the router unless a container tells it to, so normal operation should indicate this is working.
- To test `hostPort:containerPort` port definition, you can change the `VIRTUAL_PORT` env var on the web container for a site, changing the mailhog port definition from `8025` to `8050:8025`.
- The sample solr config file at https://github.com/drud/ddev/issues/121#issuecomment-297839323 can be used to expose another service for a site. You should be able to access the solr container at `sitename.ddev.local:8983`

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Test cases have been introduced for the new router functionality

## Related Issue Link(s):
#121 ability to use custom containers
drud/nginx-proxy#10 directly relates to this PR - it will need to be merged and a new release tagged prior to this PR coming in.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

