### PR TITLE
Updated build-tools to 1.3.0

### DIFF
--- a/build-tools/gitignore.example
+++ b/build-tools/gitignore.example
@@ -7,6 +7,7 @@
 /.push*
 /linux
 /darwin
+/windows
 /.dockerfile
 /VERSION.txt
 /.docker_image


### PR DESCRIPTION
## The Problem:

Simple upgrade to build-tools 1.3.0, which adds gometalinter and windows targets

## The Fix:

https://github.com/drud/build-tools/releases/tag/1.3.0


## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

