### PR TITLE
Rework tar usage to avoid shelling out and improve Untar()

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -18,10 +18,11 @@ var (
 	DdevBin      = "ddev"
 	DevTestSites = []testcommon.TestSite{
 		{
-			Name:      "TestMainCmdDrupal8",
-			SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
+			Name:                          "TestMainCmdDrupal8",
+			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
+			ArchiveInternalExtractionPath: "drupal8-0.5.0/",
+			FileURL: "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
+			DBURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
 		},
 	}
 )

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -145,7 +145,7 @@ func (l *LocalApp) ImportDB(imPath string) error {
 					return fmt.Errorf("failed to extract provided archive: %v", err)
 				}
 			} else {
-				err := util.Untar(importPath, dbPath)
+				err := util.Untar(importPath, dbPath, "")
 				if err != nil {
 					return fmt.Errorf("failed to extract provided archive: %v", err)
 				}
@@ -250,7 +250,7 @@ func (l *LocalApp) ImportFiles(imPath string) error {
 		if err.Error() != "is archive" {
 			return err
 		}
-		err = util.Untar(importPath, destPath)
+		err = util.Untar(importPath, destPath, "")
 		if err != nil {
 			return fmt.Errorf("failed to extract provided archive: %v", err)
 		}

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -19,22 +19,25 @@ import (
 var (
 	TestSites = []testcommon.TestSite{
 		{
-			Name:      "TestMainPkgDrupal8",
-			SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
+			Name:                          "TestMainPkgDrupal8",
+			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
+			ArchiveInternalExtractionPath: "drupal8-0.5.0/",
+			FileURL: "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
+			DBURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
 		},
 		{
-			Name:      "TestMainPkgWordpress",
-			SourceURL: "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
-			FileURL:   "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+			Name:                          "TestMainPkgWordpress",
+			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
+			FileURL: "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+			DBURL:   "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		},
 		{
-			Name:      "TestMainPkgDrupalKickstart",
-			SourceURL: "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
-			FileURL:   "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
-			DBURL:     "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
+			Name:                          "TestMainPkgDrupalKickstart",
+			SourceURL:                     "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-kickstart-0.4.0/",
+			FileURL: "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
+			DBURL:   "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
 		},
 	}
 )
@@ -103,7 +106,7 @@ func TestLocalStart(t *testing.T) {
 	another := TestSites[0]
 	err = another.Prepare()
 	if err != nil {
-		assert.FailNow("Prepare() should have failed on TestSite.Prepare(), err=%v", err)
+		assert.FailNow("TestLocalStart: Prepare() failed on another.Prepare(), err=%v", err)
 		return
 	}
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -24,6 +24,8 @@ type TestSite struct {
 	ArchivePath string
 	// SourceURL is the URL of the source code tarball to be used for building the site.
 	SourceURL string
+	// ArchiveExtractionPath is the relative path within the tarball which should be extracted, ending with /
+	ArchiveInternalExtractionPath string
 	// FileURL is the URL of the archive of file uploads used for testing file import.
 	FileURL string
 	// DBURL is the URL of the database dump tarball used for testing database import.
@@ -55,14 +57,7 @@ func (site *TestSite) Prepare() error {
 	}
 	log.Debugln("File downloaded:", site.ArchivePath)
 
-	_, err = system.RunCommand("tar",
-		[]string{
-			"-xzf",
-			site.ArchivePath,
-			"--strip", "1",
-			"-C",
-			site.Dir,
-		})
+	err = util.Untar(site.ArchivePath, site.Dir, site.ArchiveInternalExtractionPath)
 	if err != nil {
 		log.Errorf("Tar extraction failed err=%v\n", err)
 		// If we had an error extracting the archive, we should go ahead and clean up the temporary directory, since this

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -78,8 +78,9 @@ func TestValidTestSite(t *testing.T) {
 	// of the archive for this test, only that it exists and can be extracted. This should (knock on wood)
 	//not need to be updated over time.
 	ts := TestSite{
-		Name:      "TestValidTestSiteDrupal8",
-		SourceURL: "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
+		Name:                          "TestValidTestSiteDrupal8",
+		SourceURL:                     "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
+		ArchiveInternalExtractionPath: "drupal8-0.5.0/",
 	}
 
 	// Create a testsite and ensure the prepare() method extracts files into a temporary directory.

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -153,25 +153,15 @@ func CopyFile(src string, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if e := in.Close(); e != nil {
-			err = e
-		}
-	}()
-
+	defer CheckClose(in)
 	out, err := os.Create(dst)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to create file %v, err: %v", src, err)
 	}
-	defer func() {
-		if e := out.Close(); e != nil {
-			err = e
-		}
-	}()
-
+	defer CheckClose(out)
 	_, err = io.Copy(out, in)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to copy file from %v to %v err:", src, dst, err)
 	}
 
 	err = out.Sync()
@@ -185,7 +175,7 @@ func CopyFile(src string, dst string) error {
 	}
 	err = os.Chmod(dst, si.Mode())
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to chmod file %v to mode %v", dst, si.Mode())
 	}
 
 	return nil

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -161,7 +161,7 @@ func CopyFile(src string, dst string) error {
 	defer CheckClose(out)
 	_, err = io.Copy(out, in)
 	if err != nil {
-		return fmt.Errorf("Failed to copy file from %v to %v err:", src, dst, err)
+		return fmt.Errorf("Failed to copy file from %v to %v err: %v", src, dst, err)
 	}
 
 	err = out.Sync()

--- a/pkg/util/files_test.go
+++ b/pkg/util/files_test.go
@@ -76,21 +76,19 @@ func TestUntar(t *testing.T) {
 // TestCopyFile tests copying a file.
 func TestCopyFile(t *testing.T) {
 	assert := assert.New(t)
-	temp := testcommon.CreateTmpDir("TestCopyFile")
+	tmpTargetDir := testcommon.CreateTmpDir("TestCopyFile")
+	tmpTargetFile := filepath.Join(tmpTargetDir, filepath.Base(testArchivePath))
 
-	dest := filepath.Join(temp, "testfile2")
-
-	err := os.Chmod(testArchivePath, 0644)
+	err := util.CopyFile(testArchivePath, tmpTargetFile)
 	assert.NoError(err)
 
-	err = util.CopyFile(testArchivePath, dest)
+	file, err := os.Stat(tmpTargetFile)
 	assert.NoError(err)
 
-	file, err := os.Stat(dest)
-	assert.NoError(err)
-	assert.Equal(int(file.Mode()), 0644)
-
-	err = os.RemoveAll(dest)
+	if err != nil {
+		assert.False(file.IsDir())
+	}
+	err = os.RemoveAll(tmpTargetDir)
 	assert.NoError(err)
 }
 

--- a/pkg/util/files_test.go
+++ b/pkg/util/files_test.go
@@ -1,29 +1,29 @@
-package util
+package util_test
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"testing"
 
-	"io/ioutil"
-	"path/filepath"
-
+	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/drud-go/utils/system"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	temp            = os.TempDir()
-	cwd             string
-	testArchiveURL  = "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz"
-	testArchivePath string
+	testArchiveURL        = "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz"
+	testArchiveExtractDir = "wordpress-0.4.0/"
+	testArchivePath       string
 )
 
 func TestMain(m *testing.M) {
 	testPath, err := ioutil.TempDir("", "filetest")
-	CheckErr(err)
+	util.CheckErr(err)
 	testPath, err = filepath.EvalSymlinks(testPath)
-	CheckErr(err)
+	util.CheckErr(err)
 	testPath = filepath.Clean(testPath)
 	testArchivePath = filepath.Join(testPath, "files.tar.gz")
 
@@ -32,36 +32,58 @@ func TestMain(m *testing.M) {
 		log.Fatalf("archive download failed: %s", err)
 	}
 
-	cwd, err = os.Getwd()
-	if err != nil {
-		log.Fatalf("failed to get cwd: %s", err)
-	}
-
 	testRun := m.Run()
 
 	os.Exit(testRun)
 }
 
+// TestUntar tests untar functionality, including the starting directory
 func TestUntar(t *testing.T) {
 	assert := assert.New(t)
-	exDir := filepath.Join(temp, "extract")
+	exDir := testcommon.CreateTmpDir("TestUnTar1")
 
-	err := Untar(testArchivePath, exDir)
+	err := util.Untar(testArchivePath, exDir, "")
 	assert.NoError(err)
+
+	// Make sure that our base extraction directory is there
+	finfo, err := os.Stat(filepath.Join(exDir, testArchiveExtractDir))
+	assert.NoError(err)
+	assert.True(err == nil && finfo.IsDir())
+	finfo, err = os.Stat(filepath.Join(exDir, testArchiveExtractDir, ".ddev/config.yaml"))
+	assert.NoError(err)
+	assert.True(err == nil && !finfo.IsDir())
 
 	err = os.RemoveAll(exDir)
 	assert.NoError(err)
+
+	// Now do the untar with an extraction root
+	exDir = testcommon.CreateTmpDir("TestUnTar2")
+	err = util.Untar(testArchivePath, exDir, testArchiveExtractDir)
+	assert.NoError(err)
+
+	finfo, err = os.Stat(filepath.Join(exDir, ".ddev"))
+	assert.NoError(err)
+	assert.True(err == nil && finfo.IsDir())
+	finfo, err = os.Stat(filepath.Join(exDir, ".ddev/config.yaml"))
+	assert.NoError(err)
+	assert.True(err == nil && !finfo.IsDir())
+
+	err = os.RemoveAll(exDir)
+	assert.NoError(err)
+
 }
 
 // TestCopyFile tests copying a file.
 func TestCopyFile(t *testing.T) {
 	assert := assert.New(t)
+	temp := testcommon.CreateTmpDir("TestCopyFile")
+
 	dest := filepath.Join(temp, "testfile2")
 
 	err := os.Chmod(testArchivePath, 0644)
 	assert.NoError(err)
 
-	err = CopyFile(testArchivePath, dest)
+	err = util.CopyFile(testArchivePath, dest)
 	assert.NoError(err)
 
 	file, err := os.Stat(dest)
@@ -75,28 +97,44 @@ func TestCopyFile(t *testing.T) {
 // TestCopyDir tests copying a directory.
 func TestCopyDir(t *testing.T) {
 	assert := assert.New(t)
-	dest := filepath.Join(temp, "copy")
-	err := os.Mkdir(dest, 0755)
+	sourceDir := testcommon.CreateTmpDir("TestCopyDir_source")
+	targetDir := testcommon.CreateTmpDir("TestCopyDir_target")
+
+	subdir := filepath.Join(sourceDir, "some_content")
+	err := os.Mkdir(subdir, 0755)
 	assert.NoError(err)
 
 	// test source not a directory
-	err = CopyDir(testArchivePath, temp)
+	err = util.CopyDir(testArchivePath, sourceDir)
 	assert.Error(err)
 	assert.Contains(err.Error(), "source is not a directory")
 
 	// test destination exists
-	err = CopyDir(temp, cwd)
+	err = util.CopyDir(sourceDir, targetDir)
 	assert.Error(err)
 	assert.Contains(err.Error(), "destination already exists")
-	err = os.RemoveAll(dest)
+	err = os.RemoveAll(subdir)
 	assert.NoError(err)
 
-	// copy a directory.
-	err = CopyDir(cwd, dest)
+	// copy a directory and validate that we find files elsewhere
+	err = os.RemoveAll(targetDir)
 	assert.NoError(err)
-	assert.True(system.FileExists(filepath.Join(dest, "files.go")))
-	assert.True(system.FileExists(filepath.Join(dest, "files_test.go")))
 
-	err = os.RemoveAll(dest)
+	file, err := os.Create(filepath.Join(sourceDir, "touch1.txt"))
 	assert.NoError(err)
+	_ = file.Close()
+	file, err = os.Create(filepath.Join(sourceDir, "touch2.txt"))
+	assert.NoError(err)
+	_ = file.Close()
+
+	err = util.CopyDir(sourceDir, targetDir)
+	assert.NoError(err)
+	assert.True(system.FileExists(filepath.Join(targetDir, "touch1.txt")))
+	assert.True(system.FileExists(filepath.Join(targetDir, "touch2.txt")))
+
+	err = os.RemoveAll(sourceDir)
+	assert.NoError(err)
+	err = os.RemoveAll(targetDir)
+	assert.NoError(err)
+
 }


### PR DESCRIPTION
## The Problem:

* We were shelling out to use tar in some places, which is a fragile technique
* We had an Untar() function (yay!) but it deferred closing all the files it created until the end of the function, so we ended up with "too many open files" errors. 
* Our Untar() didn't have the capability of starting at a particular directory level in the enclosed filesystem, which we require to unpack our release tarballs.
* Untar was dropping headers like 'pax_global_header' in the root directory as files

## The Fix:

* Improve the Untar() to close immediately
* Make it only save directories and files to solve the pax_global_header problem
* Add the ability to pull just a part of the tarball
* Improve the tests
* Change the usages that were shelling out

## The Test:

This should be ok if it passes tests

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

Tests are improved a little bit, not depending on the current directory, etc.

## Related Issue Link(s):

This was discovered in https://github.com/drud/ddev/issues/196 (Windows port for ddev)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

