### PR TITLE
Simplify time durations in test

### DIFF
--- a/pkg/updatecheck/updatecheck_test.go
+++ b/pkg/updatecheck/updatecheck_test.go
@@ -22,20 +22,19 @@ func TestUpdateNeeded(t *testing.T) {
 	updateFile := filepath.Join(tmpdir, ".update")
 
 	// Ensure updates are required when the update file doesn't exist yet.
-	updateRequired, err := IsUpdateNeeded(updateFile, time.Duration(60)*time.Second)
+	updateRequired, err := IsUpdateNeeded(updateFile, 60*time.Second)
 	assert.True(updateRequired, "Update is required when the update file does not exist")
 	assert.NoError(err)
 
 	// Ensure updates are not required when the update duration is impossibly far in the future.
-	updateRequired, err = IsUpdateNeeded(updateFile, time.Duration(9999999)*time.Second)
+	updateRequired, err = IsUpdateNeeded(updateFile, 9999999*time.Second)
 	assert.False(updateRequired, "Update is not required when the update interval has not been met")
 	assert.NoError(err)
 
-	// Sleep for 2 seconds.
-	time.Sleep(time.Duration(2) * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Ensure updates are required for a duration lower than the sleep.
-	updateRequired, err = IsUpdateNeeded(updateFile, time.Duration(1)*time.Second)
+	updateRequired, err = IsUpdateNeeded(updateFile, 1*time.Second)
 	assert.True(updateRequired, "Update is required after the update interval has passed")
 	assert.NoError(err)
 


### PR DESCRIPTION
## The Problem:

In test code in https://github.com/drud/ddev/pull/217 there were some uses of time.Duration() that seem add complexity to the code even though they're correct (time.Duration() just casts the constant provided to the Duration numeric type). IMO this patch is more readable but not more correct. 

I apologize for being so OCD about something so simple that's not doing any harm. It was just part of my golang education.

## The Fix:

Simple changes here should result in no behavior change.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

