### PR TITLE
Add confirmation step to ddev remove

### DIFF
--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"os"
+
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -28,8 +30,8 @@ var LocalDevRMCmd = &cobra.Command{
 		if !skipConfirmation {
 			fmt.Printf("Is it ok to remove the site %s with all of its containers? All data will be lost. (y/N): ", app.GetName())
 			if !util.AskForConfirmation() {
-				util.Failed("Not removing site.")
-				return
+				util.Warning("App removal canceled by user.")
+				os.Exit(2)
 			}
 		}
 		err = app.Down()

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var skipConfirmation bool
+
 // LocalDevRMCmd represents the stop command
 var LocalDevRMCmd = &cobra.Command{
 	Use:     "remove",
@@ -23,10 +25,12 @@ var LocalDevRMCmd = &cobra.Command{
 			util.Failed("App not running locally. Try `ddev start`.")
 		}
 
-		fmt.Printf("Is it ok to remove the site %s with all of its containers? All data will be lost. (y/N): ", app.GetName())
-		if !util.AskForConfirmation() {
-			util.Failed("Not removing site.")
-			return
+		if !skipConfirmation {
+			fmt.Printf("Is it ok to remove the site %s with all of its containers? All data will be lost. (y/N): ", app.GetName())
+			if !util.AskForConfirmation() {
+				util.Failed("Not removing site.")
+				return
+			}
 		}
 		err = app.Down()
 		if err != nil {
@@ -38,5 +42,6 @@ var LocalDevRMCmd = &cobra.Command{
 }
 
 func init() {
+	LocalDevRMCmd.Flags().BoolVarP(&skipConfirmation, "skip-confirmation", "y", false, "Skip confirmation step.")
 	RootCmd.AddCommand(LocalDevRMCmd)
 }

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -14,13 +16,18 @@ var LocalDevRMCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
-			util.Failed("Failed to remove: %v", err)
+			util.Failed("Failed to get active app: %v", err)
 		}
 
 		if app.SiteStatus() == "not found" {
 			util.Failed("App not running locally. Try `ddev start`.")
 		}
 
+		fmt.Printf("Is it ok to remove the site %s with all of its containers? All data will be lost. (y/N): ", app.GetName())
+		if !util.AskForConfirmation() {
+			util.Failed("Not removing site.")
+			return
+		}
 		err = app.Down()
 		if err != nil {
 			util.Failed("Failed to remove %s: %s", app.GetName(), err)

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/drud/drud-go/utils/system"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDevRestart runs `drud legacy restart` on the test apps
+func TestDevRemove(t *testing.T) {
+	assert := assert.New(t)
+
+	// Make sure we have running sites.
+	addSites()
+
+	for _, site := range DevTestSites {
+		cleanup := site.Chdir()
+
+		// Note that the "ddev remove -y" case use used in the TestMain, so that should cover that option.
+
+		cmd := fmt.Sprintf("echo n | %s remove", DdevBin)
+		out, err := system.RunCommand("sh", []string{"-c", cmd})
+		assert.Error(err, "ddev remove should fail and instead succeeded ('n' response to prompt)")
+		assert.Contains(out, "App removal canceled")
+
+		cmd = fmt.Sprintf("echo so silly to expect this to work | %s remove", DdevBin)
+		out, err = system.RunCommand("sh", []string{"-c", cmd})
+		assert.Error(err, "ddev remove should fail and instead succeeded (silly response to prompt)")
+		assert.Contains(out, "App removal canceled")
+
+		cmd = fmt.Sprintf("echo y | %s remove", DdevBin)
+		out, err = system.RunCommand("sh", []string{"-c", cmd})
+		assert.NoError(err, "ddev remove should succeed but failed, err: %v, output: %s", err, out)
+		assert.Contains(out, "Successfully removed")
+
+		cleanup()
+	}
+	// Now put the sites back together so other tests can use them.
+	addSites()
+}

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -101,15 +101,10 @@ func removeSites() {
 	for _, site := range DevTestSites {
 		_ = site.Chdir()
 
-		args := []string{"remove"}
-		out, err := system.RunCommand(DdevBin, args)
+		cmd := fmt.Sprintf("echo y | %s remove", DdevBin)
+		out, err := system.RunCommand("sh", []string{"-c", cmd})
 		if err != nil {
-			log.Fatalln("Failed to runCommand ddev", args, "err:", err, "output:", out)
-		}
-
-		_, err = getActiveApp()
-		if err != nil {
-			log.Println("Could not find an active ddev configuration:", err)
+			log.Fatalln("Failed to run ddev remove comand %s err:%v, output:", cmd, err, out)
 		}
 	}
 }

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -101,10 +101,10 @@ func removeSites() {
 	for _, site := range DevTestSites {
 		_ = site.Chdir()
 
-		cmd := fmt.Sprintf("echo y | %s remove", DdevBin)
-		out, err := system.RunCommand("sh", []string{"-c", cmd})
+		args := []string{"remove", "-y"}
+		out, err := system.RunCommand(DdevBin, args)
 		if err != nil {
-			log.Fatalln("Failed to run ddev remove comand %s err:%v, output:", cmd, err, out)
+			log.Fatalln("Failed to run ddev remove -y command, err: %v, output: %s", err, out)
 		}
 	}
 }

--- a/pkg/util/prompt.go
+++ b/pkg/util/prompt.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
 )
@@ -25,4 +26,37 @@ func GetInput(defaultValue string) string {
 	}
 
 	return value
+}
+
+// AskForConfirmation requests a y/n from user.
+func AskForConfirmation() bool {
+	response := GetInput("")
+	okayResponses := []string{"y", "yes"}
+	nokayResponses := []string{"n", "no", ""}
+	responseLower := strings.ToLower(response)
+
+	if containsString(okayResponses, responseLower) {
+		return true
+	} else if containsString(nokayResponses, responseLower) {
+		return false
+	} else {
+		fmt.Println("Please type yes or no and then press enter:")
+		return AskForConfirmation()
+	}
+}
+
+// containsString returns true if slice contains element
+func containsString(slice []string, element string) bool {
+	return !(posString(slice, element) == -1)
+}
+
+// posString returns the first index of element in slice.
+// If slice does not contain element, returns -1.
+func posString(slice []string, element string) int {
+	for index, elem := range slice {
+		if elem == element {
+			return index
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
## The Problem:

ddev rm removes all data for a site, it might not be obvious to the user that they're about to lose their whole setup.

## The Fix:

* Add confirmation step
* Add Y/N prompting mechanism (copied from bootstrap drud cli)
* Fix test to use the confirm flag
* Add a cmd-side test for ddev remove to make sure the various options work

## The Test:

Run ddev rm and use the options available.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

A new TestDevRemove test was added. It uses a pipeline with "echo" as a very simple way to offer the option to ddev.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

