### PR TITLE
Add link to the roadmap to ddev Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 # ddev
 
-The purpose of *ddev* is to support developers with a local copy of a site for development purposes. It runs the site in Docker containers.
+The purpose of *ddev* is to help Drupal and WordPress abstract away the complexity and effort of adopting and maintaining a docker based local development stack. You can see all "ddev" usages using the help commands, like ddev -h, ddev start -h, etc.
 
-You can see all "ddev" usages using the help commands, like `ddev -h`, `ddev start -h`, etc.
+## Roadmap
+
+Each DRUD product has a dedicated product owner, who serves as the primary advocate for customers and end-users when making decisions regaring the public roadmap. For the [ddev roadmap](https://github.com/drud/ddev/wiki/roadmap), @rickmanelius is currently serving as the product owner.
+
+The purpose of our roadmaps is to balance high level, 1-6 month targets with short term fluidity that occurs within our weekly sprints. Feedback from customers and end-users does help shape both our short and long-term focus, so please review the roadmap and the [ddev issue queue](https://github.com/drud/ddev/issues) to see what's on the horizon as well as submit bugs and requests.
 
 ## System Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 [![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) [![Go Report Card](https://goreportcard.com/badge/github.com/drud/ddev)](https://goreportcard.com/report/github.com/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2017.svg)
 
-
-
 # ddev
 
-The purpose of *ddev* is to help Drupal and WordPress abstract away the complexity and effort of adopting and maintaining a docker based local development stack. You can see all "ddev" usages using the help commands, like ddev -h, ddev start -h, etc.
+The purpose of *ddev* is to help Drupal and WordPress developers abstract away the complexity and effort of adopting and maintaining a docker based local development stack. You can see all "ddev" usages using the help commands, like ddev -h, ddev start -h, etc.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The purpose of *ddev* is to help Drupal and WordPress abstract away the complexi
 
 Each DRUD product has a dedicated product owner, who serves as the primary advocate for customers and end-users when making decisions regaring the public roadmap. For the [ddev roadmap](https://github.com/drud/ddev/wiki/roadmap), @rickmanelius is currently serving as the product owner.
 
-The purpose of our roadmaps is to balance high level, 1-6 month targets with short term fluidity that occurs within our weekly sprints. Feedback from customers and end-users does help shape both our short and long-term focus, so please review the roadmap and the [ddev issue queue](https://github.com/drud/ddev/issues) to see what's on the horizon as well as submit bugs and requests.
+We use the longer-term roadmap to prioritize short-term sprints. Please review the [ddev roadmap](https://github.com/drud/ddev/wiki/roadmap) and [ddev issue queue](https://github.com/drud/ddev/issues) to see what's on the horizon.
 
 ## System Requirements
 


### PR DESCRIPTION
Also includes an update to the project overview verbiage and context as to why we use a roadmap, what it means, etc. Relates to issue [Update readme to include a link to the roadmap and a stronger introduction.](https://github.com/drud/ddev/issues/212).

## The Problem:

An end-user visiting the project page probably doesn't realize there is a roadmap as well as the expectations around it, how to submit feature requests/issues, etc.

## The Fix:

Update the readme to link to the current wiki and provide context as to what it means and how to contribute to its future.

## The Test:

NA

## Automation Overview:

NA

## Related Issue Link(s):

#212 

## Release/Deployment notes:

NA

