### PR TITLE
Allow describe to work on a stopped site

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -69,18 +69,6 @@ func (l *LocalApp) FindContainerByType(containerType string) (docker.APIContaine
 // Describe returns a string which provides detailed information on services associated with the running site.
 func (l *LocalApp) Describe() (string, error) {
 	maxWidth := uint(200)
-	web, err := l.FindContainerByType("web")
-	if err != nil {
-		return "", err
-	}
-	db, err := l.FindContainerByType("db")
-	if err != nil {
-		return "", err
-	}
-
-	if db.State != "running" || web.State != "running" {
-		return "", fmt.Errorf("ddev site is configured but not currently running")
-	}
 
 	var output string
 	appTable := CreateAppTable()

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -308,7 +308,7 @@ func TestDescribeStopped(t *testing.T) {
 		out, err := app.Describe()
 		assert.NoError(err)
 
-		assert.Contains(out, "stopped", "describe correctly reports stopped on a non-running site.")
+		assert.Contains(out, SiteStopped, "Output did not include the word stopped when describing a stopped site.")
 		cleanup()
 	}
 }

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -292,6 +292,27 @@ func TestLocalStop(t *testing.T) {
 	}
 }
 
+// TestDescribeStopped tests that the describe command works properly on a stopped site.
+func TestDescribeStopped(t *testing.T) {
+	assert := assert.New(t)
+	app, err := GetPluginApp("local")
+	assert.NoError(err)
+
+	for _, site := range TestSites {
+		cleanup := site.Chdir()
+
+		testcommon.ClearDockerEnv()
+		err := app.Init(site.Dir)
+		assert.NoError(err)
+
+		out, err := app.Describe()
+		assert.NoError(err)
+
+		assert.Contains(out, "stopped", "describe correctly reports stopped on a non-running site.")
+		cleanup()
+	}
+}
+
 // TestLocalRemove tests the functionality that is called when "ddev rm" is executed
 func TestLocalRemove(t *testing.T) {
 	assert := assert.New(t)

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -7,8 +7,13 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
+// SiteRunning defines the string used to denote running sites.
 const SiteRunning = "running"
+
+// SiteNotFound defines the string used to denote a site where the containers were not found/do not exist.
 const SiteNotFound = "not found"
+
+// SiteStopped defines the string used to denote when a site is in the stopped state.
 const SiteStopped = "stopped"
 
 // App is an interface apps for Drud Local must implement to use shared functionality

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -7,6 +7,10 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
+const SiteRunning = "running"
+const SiteNotFound = "not found"
+const SiteStopped = "stopped"
+
 // App is an interface apps for Drud Local must implement to use shared functionality
 type App interface {
 	Init(string) error

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/fatih/color"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gosuri/uitable"
 
@@ -83,12 +84,18 @@ func RenderAppRow(table *uitable.Table, site App) {
 	if err == nil {
 		appRoot = strings.Replace(appRoot, userDir, "~", 1)
 	}
+	status := site.SiteStatus()
+	if status == "stopped" {
+		status = color.YellowString(status)
+	} else {
+		status = color.CyanString(status)
+	}
 	table.AddRow(
 		site.GetName(),
 		site.GetType(),
 		appRoot,
 		site.URL(),
-		site.SiteStatus(),
+		status,
 	)
 }
 


### PR DESCRIPTION
## The Problem:
Currently you cannot run describe on a stopped site. It reports the following error if you try:

`2017/05/17 13:14:27 Could not describe app: ddev site is configured but not currently running`

## The Fix:
No longer check to ensure a site is running, and instead show the describe command with proper "status" regardless of whether it is running or not.

## The Test:
1. Compile the binary from this branch
2. Stop a running site
3. Run `ddev describe`. It's probably a good idea to test both `ddev describe` from the working directory, as well as `ddev describe [sitename]` from outside the working directory.

## Automation Overview:
I've added automation to `local_test.go` to ensure describe reports properly when a site is stopped.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/164


