### PR TITLE
Build windows on nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,24 @@ jobs:
               echo VERSION=$VERSION
               git submodule update --init && git submodule update --remote
               make -f nightly_build.mak clean
-              make -f nightly_build.mak --print-directory linux darwin windows VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION DBATag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
+              make -f nightly_build.mak --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION DBATag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
               $GOPATH/src/github.com/drud/ddev/bin/linux/ddev version
             fi
           no_output_timeout: "20m"
           name: Run full nightly build  and tests if $RUN_NIGHTLY_BUILD
+
+      - run:
+          command: make clean linux darwin windows
+          name: Build the ddev executables
+
+      # Run the built-in ddev tests
+      - run:
+          command: |
+            if [ ! -n "${RUN_NIGHTLY_BUILD}" ]; then
+              make test
+            fi
+          name: ddev tests (not nightly build)
+          no_output_timeout: "20m"
 
       - run: make -s staticrequired
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
       - run:
           command: make linux darwin windows
-          name: Build the linux ddev executable binary
+          name: Build the ddev executables
 
       # Run the built-in ddev tests
       - run:
@@ -64,7 +64,7 @@ jobs:
               echo VERSION=$VERSION
               git submodule update --init && git submodule update --remote
               make -f nightly_build.mak clean
-              make -f nightly_build.mak --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION DBATag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
+              make -f nightly_build.mak --print-directory linux darwin windows VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION DBATag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
               $GOPATH/src/github.com/drud/ddev/bin/linux/ddev version
             fi
           no_output_timeout: "20m"


### PR DESCRIPTION
## The Problem:

The windows binary artifact isn't being built in the nightly build because that's a separate build and it does a `make clean` first.

## The Fix:

Explicitly add windows to the build.

## The Test:

Look at the artifacts tab after a nightly build and see if the windows binary is there.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

