### PR TITLE
Bump drupal8 repo to 0.6.0 (8.3.2)

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -19,10 +19,10 @@ var (
 	DevTestSites = []testcommon.TestSite{
 		{
 			Name:                          "TestMainCmdDrupal8",
-			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
-			ArchiveInternalExtractionPath: "drupal8-0.5.0/",
-			FileURL: "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
-			DBURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
+			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
+			ArchiveInternalExtractionPath: "drupal8-0.6.0/",
+			FileURL: "https://github.com/drud/drupal8/releases/download/v0.6.0/files.tar.gz",
+			DBURL:   "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 		},
 	}
 )

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -20,10 +20,10 @@ var (
 	TestSites = []testcommon.TestSite{
 		{
 			Name:                          "TestMainPkgDrupal8",
-			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
+			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
 			ArchiveInternalExtractionPath: "drupal8-0.5.0/",
-			FileURL: "https://github.com/drud/drupal8/releases/download/v0.5.0/files.tar.gz",
-			DBURL:   "https://github.com/drud/drupal8/releases/download/v0.5.0/db.tar.gz",
+			FileURL: "https://github.com/drud/drupal8/releases/download/v0.6.0/files.tar.gz",
+			DBURL:   "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 		},
 		{
 			Name:                          "TestMainPkgWordpress",

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -21,7 +21,7 @@ var (
 		{
 			Name:                          "TestMainPkgDrupal8",
 			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
-			ArchiveInternalExtractionPath: "drupal8-0.5.0/",
+			ArchiveInternalExtractionPath: "drupal8-0.6.0/",
 			FileURL: "https://github.com/drud/drupal8/releases/download/v0.6.0/files.tar.gz",
 			DBURL:   "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 		},

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -79,8 +79,8 @@ func TestValidTestSite(t *testing.T) {
 	//not need to be updated over time.
 	ts := TestSite{
 		Name:                          "TestValidTestSiteDrupal8",
-		SourceURL:                     "https://github.com/drud/drupal8/archive/v0.5.0.tar.gz",
-		ArchiveInternalExtractionPath: "drupal8-0.5.0/",
+		SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
+		ArchiveInternalExtractionPath: "drupal8-0.6.0/",
 	}
 
 	// Create a testsite and ensure the prepare() method extracts files into a temporary directory.


### PR DESCRIPTION
## The Problem:

https://github.com/drud/ddev/issues/230 requests update of our drupal8 repo to 8.3.2. This is pending in https://github.com/drud/drupal8/pull/4 - but here's the bump.

I already have a db.sql.gz ready (based on upgrade of our previous db); the files tarball doesn't change.

Tests on this will fail until https://github.com/drud/drupal8/pull/4  goes in and files/db are added to a release of 0.6.0 there.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

