### PR TITLE
Change version test into non-binary test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test: testpkg testcmd
 testcmd: build setup
 	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
 
-testpkg: build setup
+testpkg: 
 	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) DRUD_DEBUG=true go test -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
 
 setup:

--- a/cmd/ddev/cmd/version.go
+++ b/cmd/ddev/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
@@ -14,21 +15,31 @@ var versionCmd = &cobra.Command{
 	Short: "print ddev version and component versions",
 	Long:  `Display the version of this ddev binary and its components.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		table := uitable.New()
-		table.MaxColWidth = 200
-
-		table.AddRow("cli:", version.DdevVersion)
-		table.AddRow("web:", version.WebImg+":"+version.WebTag)
-		table.AddRow("db:", version.DBImg+":"+version.DBTag)
-		table.AddRow("dba:", version.DBAImg+":"+version.DBATag)
-		table.AddRow("router:", version.RouterImage+":"+version.RouterTag)
-		table.AddRow("commit:", version.COMMIT)
-		table.AddRow("build info:", version.BUILDINFO)
-
-		fmt.Println(table)
+		if len(args) != 0 {
+			util.Failed("invalid arguments to version command: %v", args)
+			return
+		}
+		out := handleVersionCommand()
+		fmt.Println(out)
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(versionCmd)
+}
+
+// handleVersionCommand does the testable work of the version command.
+func handleVersionCommand() *uitable.Table {
+	table := uitable.New()
+	table.MaxColWidth = 200
+
+	table.AddRow("cli:", version.DdevVersion)
+	table.AddRow("web:", version.WebImg+":"+version.WebTag)
+	table.AddRow("db:", version.DBImg+":"+version.DBTag)
+	table.AddRow("dba:", version.DBAImg+":"+version.DBATag)
+	table.AddRow("router:", version.RouterImage+":"+version.RouterTag)
+	table.AddRow("commit:", version.COMMIT)
+	table.AddRow("build info:", version.BUILDINFO)
+
+	return table
 }

--- a/cmd/ddev/cmd/version.go
+++ b/cmd/ddev/cmd/version.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"os"
+
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/gosuri/uitable"
@@ -15,9 +17,10 @@ var versionCmd = &cobra.Command{
 	Short: "print ddev version and component versions",
 	Long:  `Display the version of this ddev binary and its components.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 0 {
-			util.Failed("invalid arguments to version command: %v", args)
-			return
+		if len(args) > 0 {
+			err := cmd.Usage()
+			util.CheckErr(err)
+			os.Exit(1)
 		}
 		out := handleVersionCommand()
 		fmt.Println(out)

--- a/cmd/ddev/cmd/version_test.go
+++ b/cmd/ddev/cmd/version_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -11,9 +10,8 @@ import (
 
 func TestVersion(t *testing.T) {
 	assert := assert.New(t)
-	v, err := exec.Command(DdevBin, "version").Output()
-	assert.NoError(err)
-	output := strings.TrimSpace(string(v))
+	v := handleVersionCommand().String()
+	output := strings.TrimSpace(v)
 	assert.Contains(output, version.DdevVersion)
 	assert.Contains(output, version.WebImg)
 	assert.Contains(output, version.WebTag)


### PR DESCRIPTION
## The Problem:

We've all been bit by the version test not working correctly when the binary has been recompiled and is then used. It's not doing us any good.

## The Fix:

* Change the version test into a non-binary test.
* Make testpkg not force a build of the binary, as testpkg doesn't rely on execution of the binary. We could probably sort out tests more - I'd kind of like to see most of the binary tests removed.

## The Test:

If it passes tests it should be fine.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

