### PR TITLE
adds run times for local tests per site

### DIFF
--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"os"
 
@@ -76,6 +77,7 @@ func TestLocalStart(t *testing.T) {
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalStart", site.Name))
 
 		testcommon.ClearDockerEnv()
 		err = app.Init(site.Dir)
@@ -99,6 +101,7 @@ func TestLocalStart(t *testing.T) {
 			assert.True(check, containerType, "container is running")
 		}
 
+		runTime()
 		cleanup()
 	}
 
@@ -142,6 +145,7 @@ func TestLocalImportDB(t *testing.T) {
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalImportDB", site.Name))
 		dbPath := filepath.Join(testcommon.CreateTmpDir("local-db"), "db.tar.gz")
 
 		err := system.DownloadFile(dbPath, site.DBURL)
@@ -157,6 +161,7 @@ func TestLocalImportDB(t *testing.T) {
 		err = os.Remove(dbPath)
 		assert.NoError(err)
 
+		runTime()
 		cleanup()
 	}
 }
@@ -169,6 +174,7 @@ func TestLocalImportFiles(t *testing.T) {
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalImportFiles", site.Name))
 		filePath := filepath.Join(testcommon.CreateTmpDir("local-files"), "files.tar.gz")
 
 		err := system.DownloadFile(filePath, site.FileURL)
@@ -184,6 +190,7 @@ func TestLocalImportFiles(t *testing.T) {
 		err = os.Remove(filePath)
 		assert.NoError(err)
 
+		runTime()
 		cleanup()
 	}
 }
@@ -196,6 +203,7 @@ func TestLocalExec(t *testing.T) {
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalExec", site.Name))
 
 		err := app.Init(site.Dir)
 		assert.NoError(err)
@@ -222,6 +230,7 @@ func TestLocalExec(t *testing.T) {
 
 		assert.Contains(string(out), "/etc/php/7.0/cli/php.ini")
 
+		runTime()
 		cleanup()
 
 	}
@@ -236,6 +245,7 @@ func TestLocalLogs(t *testing.T) {
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalLogs", site.Name))
 
 		err := app.Init(site.Dir)
 		assert.NoError(err)
@@ -259,6 +269,7 @@ func TestLocalLogs(t *testing.T) {
 		assert.Contains(out, "MySQL init process done. Ready for start up.")
 		assert.False(strings.Contains(out, "Database initialized"))
 
+		runTime()
 		cleanup()
 	}
 }
@@ -272,6 +283,7 @@ func TestLocalStop(t *testing.T) {
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalStop", site.Name))
 
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
@@ -288,6 +300,7 @@ func TestLocalStop(t *testing.T) {
 			assert.True(check, containerType, "container has exited")
 		}
 
+		runTime()
 		cleanup()
 	}
 }
@@ -314,16 +327,16 @@ func TestLocalRemove(t *testing.T) {
 		err = app.Wait("web")
 		assert.NoError(err)
 
-		if err == nil {
-			err = app.Down()
-			assert.NoError(err)
-		}
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalRemove", site.Name))
+		err = app.Down()
+		assert.NoError(err)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
 			_, err := constructContainerName(containerType, app)
 			assert.Error(err, "Received error on containerName search: ", err)
 		}
 
+		runTime()
 		cleanup()
 	}
 }

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -247,6 +247,6 @@ func ContainerCheck(checkName string, checkState string) (bool, error) {
 func TimeTrack(start time.Time, name string) func() {
 	return func() {
 		elapsed := time.Since(start)
-		log.Printf("%s took %s", name, elapsed)
+		log.Printf("PERF: %s took %s", name, elapsed)
 	}
 }

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -241,3 +241,12 @@ func ContainerCheck(checkName string, checkState string) (bool, error) {
 
 	return false, errors.New("unable to find container " + checkName)
 }
+
+// TimeTrack determines the amount of time a function takes to return. Timing starts when it is called.
+// It returns an anonymous function that, when called, will print the elapsed run time.
+func TimeTrack(start time.Time, name string) func() {
+	return func() {
+		elapsed := time.Since(start)
+		log.Printf("%s took %s", name, elapsed)
+	}
+}


### PR DESCRIPTION
## The Problem:
go tests provide test run times at package and test function level. This is useful information, but it does not give us a clear picture in terms of how long the functionality we are testing takes to run. This is because the run times for function-level tests include the time for any required setup and teardown for the tests. Additionally, for test functions that are iterating tests over several sites, the test function time provides the total run time of the test for all sites.

## The Fix:
This PR introduces a new utility function for testing that allows us to surface more specific run times for tests. It implements this new function in the local platform tests, where we have most of the tests iterate over several test sites. This provides additional log outputs for the run time of each site's specific test. These times should provide reasonable metrics for the underlying functionality we're testing, distinct from any setup/teardown time.

## The Test:
See the output for this test run. You should see additional log statements like this:

```
time="2017-05-22T17:31:11-06:00" level=info msg="TestMainPkgDrupal8 LocalStart took 34.30823186s"
```

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
This PR is specific to automation test improvements, no ddev functionality changes.

## Related Issue Link(s):
This PR was introduced in relation to #195, where we identified the desire to routinely capture run times for key operations. This should allow us to capture some basic run time information without introducing more significant efforts for performance testing. The addition of more granular run time information should also help surface if a major performance regression were introduced for particular functionality, though it would not cause tests to fail at this point to introduce such a regression.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

