### PR TITLE
Explicitly set variables for the nginx container UID/GID - fixes #131

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm7-local
-WebTag ?= v0.4.0
+WebTag ?= v0.5.0
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.3.0
 RouterImage ?= drud/nginx-proxy

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 - [docker](https://www.docker.com/community-edition)
 - OS Support
   - macOS Sierra
-  - Linux
+  - Linux (See [Linux notes](users/linux_notes.md))
     * Ubuntu 16.04 LTS
     * Debian Jessie
     * Fedora 25

--- a/docs/users/linux_notes.md
+++ b/docs/users/linux_notes.md
@@ -1,0 +1,5 @@
+<h1>Linux Notes</h1>
+
+On Linux there are minor behavior differences due to the significant architecture differences of Docker for Linux.
+
+* File mounts are direct on Linux, and Docker always mounts filesystems as user uid 1000. As a result, if you are **not** using the default Linux user 1000 and you need to create files using the webserver, you may need to make directories in your filesystem writeable by all users. For example `find sites/default/files -type d | xargs chmod ugo+rwx`.

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -28,6 +28,7 @@ services:
   web:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
+    user: $DDEV_UID:$DDEV_GID
     volumes:
       - "{{ .docroot }}/:/var/www/html/docroot"
     restart: always
@@ -41,6 +42,8 @@ services:
       - {{ .mailhogport }}
     working_dir: "/var/www/html/docroot"
     environment:
+      - DDEV_UID=$DDEV_UID
+      - DDEV_GID=$DDEV_GID
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -28,7 +28,6 @@ services:
   web:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
-    user: $DDEV_UID:$DDEV_GID
     volumes:
       - "{{ .docroot }}/:/var/www/html/docroot"
     restart: always

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -383,6 +383,8 @@ func (l *LocalApp) DockerEnv() {
 		"DDEV_DOCROOT":         filepath.Join(l.AppConfig.AppRoot, l.AppConfig.Docroot),
 		"DDEV_URL":             l.URL(),
 		"DDEV_HOSTNAME":        l.HostName(),
+		"DDEV_UID":             "",
+		"DDEV_GID":             "",
 	}
 	if runtime.GOOS == "linux" {
 		curUser, err := user.Current()

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -12,6 +12,9 @@ import (
 	"net/url"
 	"os/exec"
 
+	"os/user"
+	"runtime"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/appimport"
 	"github.com/drud/ddev/pkg/appports"
@@ -380,6 +383,13 @@ func (l *LocalApp) DockerEnv() {
 		"DDEV_DOCROOT":         filepath.Join(l.AppConfig.AppRoot, l.AppConfig.Docroot),
 		"DDEV_URL":             l.URL(),
 		"DDEV_HOSTNAME":        l.HostName(),
+	}
+	if runtime.GOOS == "linux" {
+		curUser, err := user.Current()
+		util.CheckErr(err)
+
+		envVars["DDEV_UID"] = curUser.Uid
+		envVars["DDEV_GID"] = curUser.Gid
 	}
 
 	// Only set values if they don't already exist in env.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ var DdevVersion = "v0.3.0-dev" // Note that this is overridden by make
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.4.0" // Note that this is overridden by make
+var WebTag = "v0.5.0" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-docker-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:

On linux, files created or modified by the webserver are bleeding through to the host filesystem with root user/group. This is a security issue as well as an annoyance for our users, who have to use sudo to edit the files, and all kinds of things can happen.

## The Fix:

* ddev can provide environment variables to the nginx-php-fpm-local container (on linux only)
* The nginx-php-fpm-local container can then change the uid of its 'nginx' user before launching nginx.
* All files created by the webserver are then created with the correct uid/gid of the user that ran ddev.

There is a problem with this that seems unsolvable: docker mounts filesystems *always* with uid 1000, which happens to be Ubuntu's default UID for an ordinary user. That's fine for user 1000. But other users will have trouble getting the webserver to write to the mounted filesystem. The workaround is that directories in sites/default/files have to be set to 777 permissions.

That workaround needs to be added as documentation still.

## The Test:

* Set up a linux environment with ddev linux corresponding to this (it can be downloaded from the circle build)
* `ddev config`
* Change the fpm container to drud/nginx-php-fpm7-local:20170524_DDEV_UID  in config.yaml
* `ddev start` and set up your site any way you want so you can create files (like by attaching to a node)
* Create a file or two, on drupal in sites/default/files/*
* Check the owner/group on the *host* side to make sure that they are the same owner/group as the user that ran ddev.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

* #131 is the original description of the problem
* https://github.com/drud/docker.nginx-php-fpm-local/pull/22 provides the nginx container needed to change the behavior

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

