### PR TITLE
formatting and spelling fixes for extend doc

### DIFF
--- a/docs/users/customization-extendibility.md
+++ b/docs/users/customization-extendibility.md
@@ -5,28 +5,41 @@ For most standard web applications, ddev provides everything you need to success
 The majority of ddev's customization ability and extensibility comes from leveraging features and functionality provided by [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/overview/). Some working knowledge of these tools is required in order to customize or extend the environment ddev provides.
 
 ## Extending with additional docker-compose files
-Under the hood, ddev uses docker-compose to define and run the multiple containers that make up the local environment for a web application. Docker compose supports defining multiple compose files to facilitate [sharing Compose configurations between files and projects](https://docs.docker.com/compose/extends/), and ddev is designed to leverage this ability. Additional services can be added to your project by creating additonal docker-compose files in the `.ddev` directory for your project. Any files using the `docker-compose.[servicename].yml` naming convention will be automatically processed by ddev to include them in executing docker-compose functionality. A `docker-compose.override.yml` can additonally be created to override any configurations from the main docker-compose file or any service compose files added to your project. 
+Under the hood, ddev uses docker-compose to define and run the multiple containers that make up the local environment for a web application. Docker compose supports defining multiple compose files to facilitate [sharing Compose configurations between files and projects](https://docs.docker.com/compose/extends/), and ddev is designed to leverage this ability. Additional services can be added to your project by creating additional docker-compose files in the `.ddev` directory for your project. Any files using the `docker-compose.[servicename].yml` naming convention will be automatically processed by ddev to include them in executing docker-compose functionality. A `docker-compose.override.yml` can additionally be created to override any configurations from the main docker-compose file or any service compose files added to your project.
 
 ## Conventions for defining additonal services
 When defining additional services for your project, it is recommended to follow these conventions to ensure your service is handled by ddev the same way the default services are.
+
 - Containers should be follow the naming convention `local-[sitename]-[servicename]`
+
 - Containers should be provided the following labels:
+
   - `com.ddev.site-name: ${DDEV_SITENAME}`
+
   - `com.ddev.approot: $DDEV_APPROOT`
+
   - `com.ddev.app-url: $DDEV_URL`
+
   - `com.ddev.container-type: [servicename]`
+
 - Exposing ports for service: you can expose the port for a service to be accessible as `sitename.ddev.local:portNum` while your project is running. This is achieved by the following for the container(s) being added:
+
   - Define only the internal port in the `ports` section for docker-compose. The `hostPort:containerPort` convention normally used to expose ports in docker should not be used here, since we are leveraging the ddev router to expose the ports.
+
   - To expose a port for general TCP traffic, define the following environment variable:
-    - - `TCP_EXPOSE=portNum` The `hostPort:containerPort` convention may be used here to expose a container's port to a different external port. To expose multiple ports for a single container, define the ports as comma-separated values.
+
+    - `TCP_EXPOSE=portNum` The `hostPort:containerPort` convention may be used here to expose a container's port to a different external port. To expose multiple ports for a single container, define the ports as comma-separated values.
+
   - To expose a web interface to be accessible over HTTP, define the following environment variables in the `environment` section for docker-compose:
+
     - `VIRTUAL_HOST=$DDEV_HOSTNAME`
+
     - `HTTP_EXPOSE=portNum` The `hostPort:containerPort` convention may be used here to expose a container's port to a different external port. To expose multiple ports for a single container, define the ports as comma-separated values.
 
 ## Interacting with additional services
 Certain ddev commands, namely `ddev exec`, `ddev ssh`, and `ddev logs` interact with containers on an individual basis. By default, these commands interact with the web container for a project. All of these commands, however, provide a `--service` or `-s` flag allowing you to specify the service name of the container you want to interact with. For example, if you added a service to provide Apache Solr, and the service was named `solr`, you would be able to run `ddev logs --service solr` to retrieve the logs of the solr container.
 
-### Defining an additonal service - Apache Solr example
+### Defining an additional service - Apache Solr example
 The following is an example of an additional service that could be added to a project. This is a working example at time of writing. Annotations are added to highlight configurations important for running the service as part of a project in ddev. For full documentation on usage, see the [Docker Compose documentation](https://docs.docker.com/compose/overview/).
 
 This file would be saved as `docker-compose.solr.yml` in your project's `.ddev` folder.


### PR DESCRIPTION
## The Problem:
The lists on this page weren't properly formatted, so instead of lists we have a big wall of text. Additionally, I seemed to have struggled spelling Additional/Additionally correctly.

## The Fix:
This fixes the formatting and spelling issues.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

