### PR TITLE
Pull only a known image in util_test TestMain - breaks nightly build

### DIFF
--- a/pkg/util/dockerutils_test.go
+++ b/pkg/util/dockerutils_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/drud/ddev/pkg/testcommon"
 	. "github.com/drud/ddev/pkg/util"
-	"github.com/drud/ddev/pkg/version"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -90,7 +89,7 @@ func TestGetAppContainers(t *testing.T) {
 	assert := assert.New(t)
 	sites, err := GetAppContainers("dockertest")
 	assert.NoError(err)
-	assert.Equal(sites[0].Image, version.RouterImage+":"+version.RouterTag)
+	assert.Equal(sites[0].Image, TestRouterImage+":"+TestRouterTag)
 }
 
 func TestGetContainerEnv(t *testing.T) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/drud/ddev/pkg/util"
-	"github.com/drud/ddev/pkg/version"
 	"github.com/drud/drud-go/utils/system"
 	docker "github.com/fsouza/go-dockerclient"
 )
@@ -20,6 +19,10 @@ var (
 	TestArchivePath string
 	// TestArchiveExtractDir is the directory in the archive to extract
 	TestArchiveExtractDir = "wordpress-0.4.0/"
+
+	// The image here can be any image, it just has to exist so it can be used for labels, etc.
+	TestRouterImage = "drud/nginx-proxy"
+	TestRouterTag   = "test-do-not-delete"
 )
 
 func TestMain(m *testing.M) {
@@ -38,9 +41,10 @@ func TestMain(m *testing.M) {
 
 	// prep docker container for docker util tests
 	client := util.GetDockerClient()
+
 	err = client.PullImage(docker.PullImageOptions{
-		Repository: version.RouterImage,
-		Tag:        version.RouterTag,
+		Repository: TestRouterImage,
+		Tag:        TestRouterTag,
 	}, docker.AuthConfiguration{})
 	if err != nil {
 		log.Fatal("failed to pull test image ", err)
@@ -49,7 +53,7 @@ func TestMain(m *testing.M) {
 	container, err := client.CreateContainer(docker.CreateContainerOptions{
 		Name: "envtest",
 		Config: &docker.Config{
-			Image: version.RouterImage + ":" + version.RouterTag,
+			Image: TestRouterImage + ":" + TestRouterTag,
 			Labels: map[string]string{
 				"com.docker.compose.service": "ddevrouter",
 				"com.ddev.site-name":         "dockertest",
@@ -58,7 +62,7 @@ func TestMain(m *testing.M) {
 		},
 	})
 	if err != nil {
-		log.Fatal("failed to start docker container ", err)
+		log.Fatal("failed to create/start docker container ", err)
 	}
 
 	testRun := m.Run()

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -21,8 +21,8 @@ var (
 	TestArchiveExtractDir = "wordpress-0.4.0/"
 
 	// The image here can be any image, it just has to exist so it can be used for labels, etc.
-	TestRouterImage = "drud/nginx-proxy"
-	TestRouterTag   = "test-do-not-delete"
+	TestRouterImage = "busybox"
+	TestRouterTag   = "1"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## The Problem:

The nightly build failed [last night](https://circleci.com/gh/drud/ddev/878):
`2017/05/25 01:21:03 failed to pull test image API error (404): {"message":"manifest for drud/nginx-proxy:v0.4-16-g2ca92ae5-nightly.20170525011408 not found"}`

This was a result of the TestMain in util_test.go trying to do a pre-emptive pull on an image it assumed would have been pushed (but for the nightly build is built but not pushed).

## The Fix:

Pull an image that we know should exist on dockerhub. In this case drud/nginx-proxy:test-do-not-delete

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

