### PR TITLE
removes requirement for exec cmds to be wrapped in quotes, updates help, fixes #68

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -1,8 +1,7 @@
 package cmd
 
 import (
-	"log"
-	"strings"
+	"os"
 
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -10,15 +9,15 @@ import (
 
 // LocalDevExecCmd allows users to execute arbitrary bash commands within a container.
 var LocalDevExecCmd = &cobra.Command{
-	Use:   "exec \"[cmd]\"",
-	Short: "Execute a Linux shell command in the webserver container.",
-	Long:  `Execute a Linux shell command in the webserver container.`,
+	Use:     "exec <command>",
+	Aliases: []string{"."},
+	Short:   "Execute a shell command in the container for a service. Uses the web service by default.",
+	Long:    `Execute a shell command in the container for a service. Uses the web service by default. To run your command in the container for another service, run "ddev exec --service <service> <cmd>"`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// The command string will be the first argument if using a stored
-		// appConfig, or the third if passing in app/deploy names.
-		cmdString := args[0]
-		if len(args) > 2 {
-			cmdString = args[2]
+		if len(args) == 0 {
+			err := cmd.Usage()
+			util.CheckErr(err)
+			os.Exit(1)
 		}
 
 		app, err := getActiveApp()
@@ -32,21 +31,17 @@ var LocalDevExecCmd = &cobra.Command{
 
 		app.DockerEnv()
 
-		cmdSplit := strings.Split(cmdString, " ")
-
-		err = app.Exec(serviceType, true, cmdSplit...)
+		err = app.Exec(serviceType, true, args...)
 		if err != nil {
-			util.Failed("Failed to execute command %s: %v", cmdString, err)
-		}
-	},
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if len(args) != 1 {
-			log.Fatalf("Invalid arguments detected. Please use a command in the form of `ddev exec \"[cmd]\"`")
+			util.Failed("Failed to execute command %s: %v", args, err)
 		}
 	},
 }
 
 func init() {
-	LocalDevExecCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Which service to send the command to. [web, db]")
+	LocalDevExecCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to connect to. [e.g. web, db]")
+	// This requires flags for exec to be specified prior to any arguments, allowing for
+	// flags to be ignored by cobra for commands that are to be executed in a container.
+	LocalDevExecCmd.Flags().SetInterspersed(false)
 	RootCmd.AddCommand(LocalDevExecCmd)
 }

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -16,13 +16,7 @@ func TestDevExecBadArgs(t *testing.T) {
 	args := []string{"exec"}
 	out, err := system.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "Invalid arguments detected.")
-
-	// Try with an invalid number of args
-	args = []string{"exec", "RandomValue", "pwd"}
-	out, err = system.RunCommand(DdevBin, args)
-	assert.Error(err)
-	assert.Contains(string(out), "Invalid arguments detected")
+	assert.Contains(string(out), "Usage:")
 }
 
 // TestDevExec run `ddev exec pwd` with proper args
@@ -36,6 +30,11 @@ func TestDevExec(t *testing.T) {
 		out, err := system.RunCommand(DdevBin, args)
 		assert.NoError(err)
 		assert.Contains(string(out), "/var/www/html/docroot")
+
+		args = []string{"-s", "db", "exec", "pwd"}
+		out, err = system.RunCommand(DdevBin, args)
+		assert.NoError(err)
+		assert.Contains(string(out), "/")
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -36,7 +36,7 @@ var LocalDevLogsCmd = &cobra.Command{
 func init() {
 	LocalDevLogsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow the logs in real time.")
 	LocalDevLogsCmd.Flags().BoolVarP(&timestamp, "time", "t", false, "Add timestamps to logs")
-	LocalDevLogsCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Which service to send the command to. [web, db]")
+	LocalDevLogsCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to retrieve logs from. [e.g. web, db]")
 	LocalDevLogsCmd.Flags().StringVarP(&tail, "tail", "", "", "How many lines to show")
 	RootCmd.AddCommand(LocalDevLogsCmd)
 

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -8,8 +8,8 @@ import (
 // LocalDevSSHCmd represents the ssh command.
 var LocalDevSSHCmd = &cobra.Command{
 	Use:   "ssh",
-	Short: "SSH to an app container.",
-	Long:  `Connects user to the running container.`,
+	Short: "Starts a shell session in the container for a service. Uses web service by default.",
+	Long:  `Starts a shell session in the container for a service. Uses web service by default. To start a shell session for another service, run "ddev ssh --service <service>`,
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := getActiveApp()
 		if err != nil {
@@ -31,6 +31,6 @@ var LocalDevSSHCmd = &cobra.Command{
 }
 
 func init() {
-	LocalDevSSHCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Which service to send the command to. [web, db]")
+	LocalDevSSHCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to connect to. [e.g. web, db]")
 	RootCmd.AddCommand(LocalDevSSHCmd)
 }

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -12,7 +12,7 @@ Usage:
 Available Commands:
   config       Create or modify a ddev application config in the current directory
   describe     Get a detailed description of a running ddev site.
-  exec         Execute a Linux shell command in the webserver container.
+  exec         Execute a shell command in the container for a service. Uses the web service by default.
   hostname     Manage your hostfile entries.
   import-db    Import the database of an existing site to the local dev environment.
   import-files Import the uploaded files directory of an existing site to the default public upload directory of your application.
@@ -21,7 +21,7 @@ Available Commands:
   restart      Restart the local development environment for a site.
   remove       Remove an application's local services.
   sequelpro    Easily connect local site to sequelpro
-  ssh          SSH to an app container.
+  ssh          Starts a shell session in the container for a service. Uses the web service by default.
   start        Start the local development environment for a site.
   stop         Stop an application's local services.
   version      print ddev version and component versions
@@ -129,10 +129,14 @@ The `import-files` command allows you to specify the location of uploaded file a
 ddev provides several commands to facilitate interacting with your site in the development environment. These commands can be run within the working directory of your project while the site is running in ddev. 
 
 ### Executing Commands
-To run a command against your site use `ddev exec`. e.g. `ddev exec "drush core-status"` would execute `drush core-status` against your site root. Commands that are run in this way are executed in the webserver docroot. You are free to use any of [the tools included in the container](included-tools.md).
+The `ddev exec` command allows you to run shell commands in the container for a ddev service. By default, commands are executed against the web service container, in the docroot path of your site. This allows you to use [the developer tools included in the web container](included-tools.md). For example, to run the Drush CLI in the web container, you would run `ddev exec drush`.
+
+To run a shell command in the container for a different service, use the `--service` flag at the beginning of your exec command to specify the service the command should be run against. For example, to run the mysql client in the database, container, you would run `ddev exec --service db mysql`.
+
+Commands can also be executed using the shorter `ddev . <cmd>` alias.
 
 ### SSH Into The Container
-The `ddev ssh` command will open a bash shell session to the web container of your site. You can also access the database container with `ddev ssh -s db`.
+The `ddev ssh` command will open a bash shell session to the container for a ddev service. The web service is connected to by default. To connect to another service, use the `--service` flag to specify the service you want to connect to. For example, to connect to the database container, you would run `ddev ssh --service db`.
 
 ### Log Access
 The `ddev logs` command allows you to easily retrieve error logs from the web server. To follow the webserver  error log (watch the lines in real time), run `ddev logs -f`. When you are done, press CTRL+C to exit from the log trail.


### PR DESCRIPTION
## The Problem:
#68 identified some validation issues with ddev exec. Some of the issues have been addressed since the ticket was created, but the requirement to encapsulate multi-argument commands in quotes makes for a clunky experience compared to docker exec, which requires no quoting for such commands.

## The Fix:
This PR updates the exec function, removing the requirement for users to quote commands that had multiple arguments or flags. It achieves this by disabling support for interspersed option/non-option arguments on the exec command. This means that flags for ddev exec will need to be defined prior to the command that will be exec'd in a container. The PR also introduces the "." alias for exec, allowing users to run commands like `ddev . drush status`. It also updates the help text and documentation for exec and ssh.

## The Test:
The test is pretty straightforward for this - you should be able to run multi-argument commands, with flags, without wrapping in quotes.

A couple commands that should work:
`ddev exec drush --help` should return the drush help.
`ddev exec -s db mysql` should run the mysql client in the db container.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
The existing binary tests have been adjusted for these changes.

## Related Issue Link(s):
#68 validation for exec commands.
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

