### PR TITLE
fixes docroot mount path for windows, fixes #263

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -220,7 +220,9 @@ func (c *Config) RenderComposeYAML() (string, error) {
 		return "", err
 	}
 	templateVars := map[string]string{
-		"name":        c.Name,
+		"name": c.Name,
+		// path.Join is desired over filepath.Join here,
+		// as we always want a unix-style path for the mount.
 		"docroot":     path.Join("../", c.Docroot),
 		"plugin":      c.Platform,
 		"appType":     c.AppType,

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -220,7 +221,7 @@ func (c *Config) RenderComposeYAML() (string, error) {
 	}
 	templateVars := map[string]string{
 		"name":        c.Name,
-		"docroot":     "../" + c.Docroot,
+		"docroot":     path.Join("../", c.Docroot),
 		"plugin":      c.Platform,
 		"appType":     c.AppType,
 		"mailhogport": appports.GetPort("mailhog"),

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -220,7 +220,7 @@ func (c *Config) RenderComposeYAML() (string, error) {
 	}
 	templateVars := map[string]string{
 		"name":        c.Name,
-		"docroot":     filepath.Join("../", c.Docroot),
+		"docroot":     "../" + c.Docroot,
 		"plugin":      c.Platform,
 		"appType":     c.AppType,
 		"mailhogport": appports.GetPort("mailhog"),


### PR DESCRIPTION
## The Problem:
#263 docroot mount doesn't work with explicit docroot on Windows. This prevents a site using a defined docroot path from starting on Windows.

## The Fix:
This issue stemmed from using `filepath.Join()` in a context where we always want a unix-style path defined. For this situation, it seems reasonable to simply concat ../ with the provided docroot path.

## The Test:
On a Windows machine, run ddev config on a site that uses a docroot folder. Run ddev start. You should be able to successfully start the site.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#263 OP

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

