### PR TITLE
fixes file path issues writing site config on windows, fixes #260

### DIFF
--- a/pkg/cms/config/config_test.go
+++ b/pkg/cms/config/config_test.go
@@ -18,9 +18,6 @@ func TestWriteDrupalConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	err = os.Chmod(file.Name(), 0444)
-	assert.NoError(t, err)
-
 	drupalConfig := model.NewDrupalConfig()
 	err = WriteDrupalConfig(drupalConfig, file.Name())
 	assert.NoError(t, err)
@@ -40,9 +37,6 @@ func TestWriteDrushConfig(t *testing.T) {
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
 
-	err = os.Chmod(file.Name(), 0444)
-	assert.NoError(t, err)
-
 	drushConfig := model.NewDrushConfig()
 	err = WriteDrushConfig(drushConfig, file.Name())
 	assert.NoError(t, err)
@@ -60,9 +54,6 @@ func TestWriteWordpressConfig(t *testing.T) {
 	dir := testcommon.CreateTmpDir("example")
 
 	file, err := ioutil.TempFile(dir, "file")
-	assert.NoError(t, err)
-
-	err = os.Chmod(file.Name(), 0444)
 	assert.NoError(t, err)
 
 	wpConfig := model.NewWordpressConfig()

--- a/pkg/cms/config/drupal.go
+++ b/pkg/cms/config/drupal.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"text/template"
 
-	"strings"
+	"path/filepath"
 
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/cms/model"
@@ -98,11 +98,12 @@ $config_directories = array(
 // object with a data-driven template.
 func WriteDrupalConfig(drupalConfig *model.DrupalConfig, filePath string) error {
 	tmpl, err := template.New("drupalConfig").Funcs(sprig.TxtFuncMap()).Parse(drupalTemplate)
-	dir := strings.TrimSuffix(filePath, "/settings.php")
 	if err != nil {
 		return err
 	}
+
 	// Ensure target directory is writable.
+	dir := filepath.Dir(filePath)
 	err = os.Chmod(dir, 0755)
 	if err != nil {
 		return err
@@ -122,11 +123,12 @@ func WriteDrupalConfig(drupalConfig *model.DrupalConfig, filePath string) error 
 // WriteDrushConfig writes out a drush config based on passed-in values.
 func WriteDrushConfig(drushConfig *model.DrushConfig, filePath string) error {
 	tmpl, err := template.New("drushConfig").Funcs(sprig.TxtFuncMap()).Parse(drushTemplate)
-	dir := strings.TrimSuffix(filePath, "/drush.settings.php")
 	if err != nil {
 		return err
 	}
+
 	// Ensure target directory is writable.
+	dir := filepath.Dir(filePath)
 	err = os.Chmod(dir, 0755)
 	if err != nil {
 		return err

--- a/pkg/cms/config/wordpress.go
+++ b/pkg/cms/config/wordpress.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"os"
-	"strings"
 	"text/template"
+
+	"path/filepath"
 
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/cms/model"
@@ -82,11 +83,12 @@ require_once(ABSPATH . '/wp-settings.php');
 // object with a data-driven template.
 func WriteWordpressConfig(wordpressConfig *model.WordpressConfig, filePath string) error {
 	tmpl, err := template.New("wordpressConfig").Funcs(sprig.TxtFuncMap()).Parse(wordpressTemplate)
-	dir := strings.TrimSuffix(filePath, "/wp-config.php")
 	if err != nil {
 		return err
 	}
+
 	// Ensure target directory is writable.
+	dir := filepath.Dir(filePath)
 	err = os.Chmod(dir, 0755)
 	if err != nil {
 		return err

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -440,7 +440,7 @@ func (l *LocalApp) Config() error {
 	settingsFilePath := filepath.Join(basePath, docroot)
 
 	if l.GetType() == "drupal7" || l.GetType() == "drupal8" {
-		settingsFilePath = filepath.Join(settingsFilePath, "sites/default/settings.php")
+		settingsFilePath = filepath.Join(settingsFilePath, "sites", "default", "settings.php")
 	}
 
 	if l.GetType() == "wordpress" {


### PR DESCRIPTION
## The Problem:
#260 Creation of settings.php fails after db import on Windows.

## The Fix:
This was caused by several instances where we were not handling file paths properly. This PR replaces instances where paths were defined with slashes in string form with proper filepath.Join() usage. It also uses filepath.Dir() where we need to remove the last part of a path, instead of trimming the path as a string.

## The Test:
Start a site using ddev on windows. Perform a database import using the import-files command. The command should succeed as it does on Linux and Mac.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#260
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

