### PR TITLE
fail the local plugin tests if sites are already running

### DIFF
--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -44,6 +44,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	if len(GetApps()) > 0 {
+		log.Fatalf("Local plugin tests require no sites running. You have %v site(s) running.", len(GetApps()))
+	}
+
 	for i := range TestSites {
 		err := TestSites[i].Prepare()
 		if err != nil {


### PR DESCRIPTION
## The Problem:
#205 surfaces a pain point in running tests locally. There are a few tests in our platform package that will fail if sites are running on the system before the tests start. The problematic tests are TestGetApps, TestGetAppsEmpty, and TestRouterNotRunning. TestGetApps expects the listed sites to match the number of test sites, while TestGetAppsEmpty and TestRouterNotRunning both require there to be no sites running in order to succeed.

## The Fix:
Ideally, the tests would not fail as a result of there being sites running already. Unfortunately, this can't be achieved with TestGetAppsEmpty and TestRouterNotRunning. Both require a state of no running sites in order to truly test what they are out to test.

With that in mind, this PR introduces a check in the TestMain() for local plugin tests to see if any sites are running. If there are running sites, the test will immediately fail with an error displaying the number of sites running.  While this is not the ideal solution, it does reduce the feedback time on this scenario to <30s, whereas before, if you started tests and had a site running, you would not know until the local plugin tests iterated through all of the test sites and output the result, and it can take several minutes for this to occur.

## The Test:
Have a site running on your system, then run `make testpkg`. The platform package test should provide the following failure:

```
ok  	github.com/drud/ddev/pkg/ddevapp	0.020s
time="2017-05-26T13:34:50-06:00" level=fatal msg="Local plugin tests require no sites running. You have %v site(s) running.1"
FAIL	github.com/drud/ddev/pkg/plugins/platform	0.031s
```

The remaining package tests will proceed, but they only take a matter of seconds to complete. You should now be able to remove running sites, run the test again, and this time have the local tests fully perform and succeed.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

