### PR TITLE
Allows ddev describe, stop and rm to accept sitename argument, fixes #78

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -15,16 +15,14 @@ var DescribeCommand = &cobra.Command{
 	Short: "Get a detailed description of a running ddev site.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 1 {
-			log.Fatal("Too many arguments detected. Please use `ddev describe` or `ddev describe [appname]`")
+			util.Failed("Too many arguments provided. Please use `ddev describe` or `ddev describe [appname]`")
 		}
-
-		appName := ""
 
 		if len(args) == 1 {
-			appName = args[0]
+			siteName = args[0]
 		}
 
-		out, err := describeApp(appName)
+		out, err := describeApp(siteName)
 		if err != nil {
 			log.Fatalf("Could not describe app: %v", err)
 		}
@@ -37,38 +35,11 @@ func describeApp(appName string) (string, error) {
 	var app platform.App
 	var err error
 
-	if appName == "" {
-		app, err = getActiveApp()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		labels := map[string]string{
-			"com.ddev.site-name":         appName,
-			"com.docker.compose.service": "web",
-		}
-
-		webContainer, err := dockerutil.FindContainerByLabels(labels)
-		if err != nil {
-			return "", err
-		}
-
-		dir, ok := webContainer.Labels["com.ddev.approot"]
-		if !ok {
-			return "", fmt.Errorf("could not find webroot on container: %s", dockerutil.ContainerName(webContainer))
-		}
-
-		app, err = platform.GetPluginApp(plugin)
-		if err != nil {
-			log.Fatalf("Could not find application type %s: %v", plugin, err)
-		}
-
-		err = app.Init(dir)
-		if err != nil {
-			return "", err
-		}
-
+	app, err = getActiveApp(appName)
+	if err != nil {
+		return "", err
 	}
+
 	out, err := app.Describe()
 	return out, err
 }

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -14,6 +14,8 @@ var DescribeCommand = &cobra.Command{
 	Use:   "describe",
 	Short: "Get a detailed description of a running ddev site.",
 	Run: func(cmd *cobra.Command, args []string) {
+		var siteName string
+
 		if len(args) > 1 {
 			util.Failed("Too many arguments provided. Please use `ddev describe` or `ddev describe [appname]`")
 		}

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -11,8 +11,14 @@ import (
 
 // DescribeCommand represents the `ddev config` command
 var DescribeCommand = &cobra.Command{
-	Use:   "describe",
+	Use:   "describe [sitename]",
 	Short: "Get a detailed description of a running ddev site.",
+	Long: `Get a detailed description of a running ddev site. Describe provides basic
+information about a ddev site, including its name, location, url, and status.
+It also provides details for MySQL connections, and connection information for
+additional services like MailHog and phpMyAdmin. You can run 'ddev describe' from
+a site directory to stop that site, or you can specify a site to describe by
+running 'ddev stop <sitename>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var siteName string
 

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -33,7 +33,7 @@ func TestDescribeBadArgs(t *testing.T) {
 	args = []string{"describe", testcommon.RandString(16), testcommon.RandString(16)}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "Too many arguments detected")
+	assert.Contains(string(out), "Too many arguments provided")
 
 }
 
@@ -77,7 +77,7 @@ func TestDescribeAppFunction(t *testing.T) {
 	for _, v := range DevTestSites {
 		cleanup := v.Chdir()
 
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		assert.NoError(err)
 
 		out, err := describeApp("")

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -20,7 +20,7 @@ var LocalDevExecCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			util.Failed("Failed to exec command: %v", err)
 		}

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -16,7 +16,10 @@ var dbSource string
 var ImportDBCmd = &cobra.Command{
 	Use:   "import-db",
 	Short: "Import the database of an existing site to the local dev environment.",
-	Long:  "Import the database of an existing site to the local development environment. The database can be provided as a SQL dump in a .sql, .sql.gz, .zip, or .tar.gz format. For the .zip and .tar.gz formats, a SQL dump in .sql format must be present at the root of the archive.",
+	Long: `Import the database of an existing site to the local development environment.
+The database can be provided as a SQL dump in a .sql, .sql.gz, .zip, or .tar.gz
+format. For the .zip and .tar.gz formats, a SQL dump in .sql format must be
+present at the root of the archive.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -33,7 +33,7 @@ var ImportDBCmd = &cobra.Command{
 
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			util.Failed("Failed to import database: %v", app.GetName(), err)
 		}

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -15,7 +15,12 @@ var fileSource string
 var ImportFileCmd = &cobra.Command{
 	Use:   "import-files",
 	Short: "Import the uploaded files directory of an existing site to the default public upload directory of your application.",
-	Long:  "Import the uploaded files directory of an existing site to the default public upload directory of your application. The files can be provided as a directory path or an archive in .tar, .tar.gz, .tgz, or .zip format. The contents at the root of the archive or directory will be the contents of the default public upload directory of your application. If the destination directory exists, it will be replaced with the assets being imported.",
+	Long: `Import the uploaded files directory of an existing site to the default public
+upload directory of your application. The files can be provided as a directory
+path or an archive in .tar, .tar.gz, .tgz, or .zip format. The contents at the
+root of the archive or directory will be the contents of the default public
+upload directory of your application. If the destination directory exists, it
+will be replaced with the assets being imported.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -30,7 +30,7 @@ var ImportFileCmd = &cobra.Command{
 
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			util.Failed("Failed to import files: %v", err)
 		}

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -15,7 +15,7 @@ func TestDevList(t *testing.T) {
 	for _, v := range DevTestSites {
 		cleanup := v.Chdir()
 
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			assert.Fail("Could not find an active ddev configuration: %v", err)
 		}

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -17,7 +17,7 @@ var LocalDevLogsCmd = &cobra.Command{
 	Short: "Get the logs from your running services.",
 	Long:  `Uses 'docker logs' to display stdout from the running services.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			util.Failed("Failed to retrieve logs: %v", err)
 		}

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -13,7 +13,7 @@ var skipConfirmation bool
 
 // LocalDevRMCmd represents the stop command
 var LocalDevRMCmd = &cobra.Command{
-	Use:     "remove",
+	Use:     "remove [sitename]",
 	Aliases: []string{"rm"},
 	Short:   "Remove the local development environment for a site. (Destructive)",
 	Long: `Remove the local development environment for a site. You can run 'ddev remove'

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -15,8 +15,12 @@ var skipConfirmation bool
 var LocalDevRMCmd = &cobra.Command{
 	Use:     "remove",
 	Aliases: []string{"rm"},
-	Short:   "Remove an application's local services.",
-	Long:    `Remove will delete the local service containers from this machine.`,
+	Short:   "Remove the local development environment for a site. (Destructive)",
+	Long: `Remove the local development environment for a site. You can run 'ddev remove'
+from a site directory to remove that site, or you can specify a site to remove
+by running 'ddev stop <sitename>. Remove is a destructive operation. It will
+remove all containers for the site, destroying database contents in the process.
+Your project code base and files will not be affected.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var siteName string
 

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -18,6 +18,8 @@ var LocalDevRMCmd = &cobra.Command{
 	Short:   "Remove an application's local services.",
 	Long:    `Remove will delete the local service containers from this machine.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var siteName string
+
 		if len(args) > 1 {
 			util.Failed("Too many arguments provided. Please use `ddev remove` or `ddev remove [appname]`")
 		}

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -18,7 +18,15 @@ var LocalDevRMCmd = &cobra.Command{
 	Short:   "Remove an application's local services.",
 	Long:    `Remove will delete the local service containers from this machine.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getActiveApp()
+		if len(args) > 1 {
+			util.Failed("Too many arguments provided. Please use `ddev remove` or `ddev remove [appname]`")
+		}
+
+		if len(args) == 1 {
+			siteName = args[0]
+		}
+
+		app, err := getActiveApp(siteName)
 		if err != nil {
 			util.Failed("Failed to get active app: %v", err)
 		}

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/util"
@@ -15,6 +16,12 @@ var LocalDevReconfigCmd = &cobra.Command{
 	Short: "Restart the local development environment for a site.",
 	Long:  `Restart stops the containers for site's environment and starts them back up again.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			err := cmd.Usage()
+			util.CheckErr(err)
+			os.Exit(0)
+		}
+
 		client := dockerutil.GetDockerClient()
 
 		err := dockerutil.EnsureNetwork(client, netName)

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -24,7 +24,7 @@ var LocalDevReconfigCmd = &cobra.Command{
 
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			util.Failed("Failed to restart: %v", err)
 		}

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -18,7 +18,7 @@ func TestDevRestart(t *testing.T) {
 		out, err := exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
 
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			assert.Fail("Could not find an active ddev configuration: %v", err)
 		}

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -23,7 +23,11 @@ var (
 	plugin   = "local"
 	// 1 week
 	updateInterval = time.Hour * 24 * 7
+	siteName       string
+	serviceType    string
 )
+
+const netName = "ddev_default"
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -51,7 +55,7 @@ var RootCmd = &cobra.Command{
 
 		usr, err := homedir.Dir()
 		if err != nil {
-			log.Fatalf("Could not detect user's home directory: %v", err)
+			log.Fatal("Could not detect user's home directory: ", err)
 		}
 
 		updateFile := filepath.Join(usr, ".ddev", ".update")
@@ -108,13 +112,35 @@ func init() {
 }
 
 // getActiveAppRoot returns the fully rooted directory of the active app, or an error
-func getActiveAppRoot() (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("error determining the current directory: %s", err)
+func getActiveAppRoot(siteName string) (string, error) {
+	var siteDir string
+	var err error
+
+	if siteName == "" {
+		siteDir, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("error determining the current directory: %s", err)
+		}
+	} else {
+		var ok bool
+
+		labels := map[string]string{
+			"com.ddev.site-name":         siteName,
+			"com.docker.compose.service": "web",
+		}
+
+		webContainer, err := dockerutil.FindContainerByLabels(labels)
+		if err != nil {
+			return "", err
+		}
+
+		siteDir, ok = webContainer.Labels["com.ddev.approot"]
+		if !ok {
+			return "", fmt.Errorf("could not find webroot on container: %s", dockerutil.ContainerName(webContainer))
+		}
 	}
 
-	appRoot, err := platform.CheckForConf(cwd)
+	appRoot, err := platform.CheckForConf(siteDir)
 	if err != nil {
 		return "", fmt.Errorf("unable to determine the application for this command. Have you run 'ddev config'? Error: %s", err)
 	}
@@ -122,13 +148,13 @@ func getActiveAppRoot() (string, error) {
 	return appRoot, nil
 }
 
-// getActiveApp returns the active platform.App based on the current working directory.
-func getActiveApp() (platform.App, error) {
+// getActiveApp returns the active platform.App based on the current working directory or running siteName provided.
+func getActiveApp(siteName string) (platform.App, error) {
 	app, err := platform.GetPluginApp(plugin)
 	if err != nil {
 		return app, err
 	}
-	activeAppRoot, err := getActiveAppRoot()
+	activeAppRoot, err := getActiveAppRoot(siteName)
 	if err != nil {
 		return app, err
 	}

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -23,7 +23,6 @@ var (
 	plugin   = "local"
 	// 1 week
 	updateInterval = time.Hour * 24 * 7
-	siteName       string
 	serviceType    string
 )
 
@@ -55,7 +54,7 @@ var RootCmd = &cobra.Command{
 
 		usr, err := homedir.Dir()
 		if err != nil {
-			log.Fatal("Could not detect user's home directory: ", err)
+			util.Failed("Could not detect user's home directory: ", err)
 		}
 
 		updateFile := filepath.Join(usr, ".ddev", ".update")

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -130,12 +130,12 @@ func getActiveAppRoot(siteName string) (string, error) {
 
 		webContainer, err := dockerutil.FindContainerByLabels(labels)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("could not find a site named '%s'. Run 'ddev list' to see currently active sites", siteName)
 		}
 
 		siteDir, ok = webContainer.Labels["com.ddev.approot"]
 		if !ok {
-			return "", fmt.Errorf("could not find webroot on container: %s", dockerutil.ContainerName(webContainer))
+			return "", fmt.Errorf("could not determine the location of %s from container: %s", siteName, dockerutil.ContainerName(webContainer))
 		}
 	}
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/drud-go/utils/network"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -58,6 +59,28 @@ func TestMain(m *testing.M) {
 
 }
 
+func TestGetActiveAppRoot(t *testing.T) {
+	assert := assert.New(t)
+
+	appRoot, err := getActiveAppRoot("")
+	assert.Contains(err.Error(), "unable to determine the application for this command")
+
+	appRoot, err = getActiveAppRoot("potato")
+	assert.Error(err)
+
+	appRoot, err = getActiveAppRoot(DevTestSites[0].Name)
+	assert.NoError(err)
+	assert.Equal(DevTestSites[0].Dir, appRoot)
+
+	switchDir := DevTestSites[0].Chdir()
+
+	appRoot, err = getActiveAppRoot("")
+	assert.NoError(err)
+	assert.Equal(DevTestSites[0].Dir, appRoot)
+
+	switchDir()
+}
+
 // addSites runs `ddev start` on the test apps
 func addSites() {
 	for _, site := range DevTestSites {
@@ -70,7 +93,7 @@ func addSites() {
 			log.Fatalln("Error Output from ddev start:", out, "err:", err)
 		}
 
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			log.Fatalln("Could not find an active ddev configuration:", err)
 		}

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -62,13 +62,13 @@ func TestMain(m *testing.M) {
 func TestGetActiveAppRoot(t *testing.T) {
 	assert := assert.New(t)
 
-	appRoot, err := getActiveAppRoot("")
+	_, err := getActiveAppRoot("")
 	assert.Contains(err.Error(), "unable to determine the application for this command")
 
-	appRoot, err = getActiveAppRoot("potato")
+	_, err = getActiveAppRoot("potato")
 	assert.Error(err)
 
-	appRoot, err = getActiveAppRoot(DevTestSites[0].Name)
+	appRoot, err := getActiveAppRoot(DevTestSites[0].Name)
 	assert.NoError(err)
 	assert.Equal(DevTestSites[0].Dir, appRoot)
 

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -40,7 +40,7 @@ var localDevSequelproCmd = &cobra.Command{
 
 // handleSequelProCommand() is the "real" handler for the real command
 func handleSequelProCommand(appLocation string) (string, error) {
-	app, err := getActiveApp()
+	app, err := getActiveApp("")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/ddev/cmd/sequelpro_test.go
+++ b/cmd/ddev/cmd/sequelpro_test.go
@@ -19,14 +19,14 @@ func TestSequelproOperation(t *testing.T) {
 	v := DevTestSites[0]
 	cleanup := v.Chdir()
 
-	_, err := getActiveApp()
+	_, err := getActiveApp("")
 	assert.NoError(err)
 
 	out, err := handleSequelProCommand(SequelproLoc)
 	assert.NoError(err)
 	assert.Contains(string(out), "sequelpro command finished successfully")
 
-	dir, err := getActiveAppRoot()
+	dir, err := getActiveAppRoot("")
 	assert.NoError(err)
 	assert.Equal(true, fileutil.FileExists(filepath.Join(dir, ".ddev/sequelpro.spf")))
 

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -11,7 +11,7 @@ var LocalDevSSHCmd = &cobra.Command{
 	Short: "Starts a shell session in the container for a service. Uses web service by default.",
 	Long:  `Starts a shell session in the container for a service. Uses web service by default. To start a shell session for another service, run "ddev ssh --service <service>`,
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			util.Failed("Failed to ssh: %v", err)
 		}

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -10,16 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const netName = "ddev_default"
-
-var (
-	serviceType string
-	webImage    string
-	dbImage     string
-	webImageTag string
-	dbImageTag  string
-)
-
 // StartCmd represents the add command
 var StartCmd = &cobra.Command{
 	Use:     "start",
@@ -42,7 +32,7 @@ var StartCmd = &cobra.Command{
 
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getActiveApp()
+		app, err := getActiveApp("")
 		if err != nil {
 			util.Failed("Failed to start: %s", err)
 		}
@@ -67,10 +57,5 @@ var StartCmd = &cobra.Command{
 }
 
 func init() {
-	StartCmd.Flags().StringVarP(&webImage, "web-image", "", "", "Change the image used for the app's web server")
-	StartCmd.Flags().StringVarP(&dbImage, "db-image", "", "", "Change the image used for the app's database server")
-	StartCmd.Flags().StringVarP(&webImageTag, "web-image-tag", "", "", "Override the default web image tag")
-	StartCmd.Flags().StringVarP(&dbImageTag, "db-image-tag", "", "", "Override the default web image tag")
-
 	RootCmd.AddCommand(StartCmd)
 }

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -15,7 +15,8 @@ var StartCmd = &cobra.Command{
 	Use:     "start",
 	Aliases: []string{"add"},
 	Short:   "Start the local development environment for a site.",
-	Long:    `Start initializes and configures the web server and database containers to provide a working environment for development.`,
+	Long: `Start initializes and configures the web server and database containers to
+provide a working environment for development.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -7,14 +7,16 @@ import (
 
 // LocalDevStopCmd represents the stop command
 var LocalDevStopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stop an application's local services.",
-	Long:  `Stop will turn off the local containers and not remove them.`,
+	Use:   "stop [sitename]",
+	Short: "Stop the local development environment for a site.",
+	Long: `Stop the local development environment for a site. You can run 'ddev stop'
+from a site directory to stop that site, or you can specify a running site
+to stop by running 'ddev stop <sitename>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var siteName string
 
 		if len(args) > 1 {
-			util.Failed("Too many arguments provided. Please use `ddev stop` or `ddev stop [appname]`")
+			util.Failed("Too many arguments provided. Please use `ddev stop` or `ddev stop [sitename]`")
 		}
 
 		if len(args) == 1 {

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -11,7 +11,15 @@ var LocalDevStopCmd = &cobra.Command{
 	Short: "Stop an application's local services.",
 	Long:  `Stop will turn off the local containers and not remove them.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getActiveApp()
+		if len(args) > 1 {
+			util.Failed("Too many arguments provided. Please use `ddev stop` or `ddev stop [appname]`")
+		}
+
+		if len(args) == 1 {
+			siteName = args[0]
+		}
+
+		app, err := getActiveApp(siteName)
 		if err != nil {
 			util.Failed("Failed to stop: %v", err)
 		}

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -11,6 +11,8 @@ var LocalDevStopCmd = &cobra.Command{
 	Short: "Stop an application's local services.",
 	Long:  `Stop will turn off the local containers and not remove them.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var siteName string
+
 		if len(args) > 1 {
 			util.Failed("Too many arguments provided. Please use `ddev stop` or `ddev stop [appname]`")
 		}

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -147,4 +147,4 @@ Additional logging can be accessed by using `ddev ssh` to manually review the lo
 You can stop a site's containers without losing data by using `ddev stop` in the working directory of the site. You can also stop any running site's containers by providing the site name as an argument, e.g. `ddev stop <sitename>`.
 
 ## Removing a site
-You can remove a site's containers by running `ddev remove` in the working directory of the site. You can also remove any running site's containers by providing the site name as an argument, e.g. `ddev rm <sitename>`. **Note:** this operation is destructive. It will remove all containers for the site, destroying database contents in the process. Your project code base and files will not be affected.
+You can remove a site's containers by running `ddev remove` in the working directory of the site. You can also remove any running site's containers by providing the site name as an argument, e.g. `ddev remove <sitename>`. **Note:** `ddev remove` is destructive. It will remove all containers for the site, destroying database contents in the process. Your project code base and files will not be affected.

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -139,9 +139,12 @@ Commands can also be executed using the shorter `ddev . <cmd>` alias.
 The `ddev ssh` command will open a bash shell session to the container for a ddev service. The web service is connected to by default. To connect to another service, use the `--service` flag to specify the service you want to connect to. For example, to connect to the database container, you would run `ddev ssh --service db`.
 
 ### Log Access
-The `ddev logs` command allows you to easily retrieve error logs from the web server. To follow the webserver  error log (watch the lines in real time), run `ddev logs -f`. When you are done, press CTRL+C to exit from the log trail.
+The `ddev logs` command allows you to easily retrieve error logs from the web server. To follow the web server error log (watch the lines in real time), run `ddev logs -f`. When you are done, press CTRL+C to exit from the log trail.
 
 Additional logging can be accessed by using `ddev ssh` to manually review the log files you are after. The web server stores access logs at `/var/log/nginx/access.log`, and PHP-FPM logs at `/var/log/php7.0-fpm.log`.
 
+## Stopping a site
+You can stop a site's containers without losing data by using `ddev stop` in the working directory of the site. You can also stop any running site's containers by providing the site name as an argument, e.g. `ddev stop <sitename>`.
+
 ## Removing a site
-You can remove a site by going to the working directory for the site and running `ddev remove`. `ddev remove` destroys all data and containers associated with the site.
+You can remove a site's containers by running `ddev remove` in the working directory of the site. You can also remove any running site's containers by providing the site name as an argument, e.g. `ddev rm <sitename>`. **Note:** this operation is destructive. It will remove all containers for the site, destroying database contents in the process. Your project code base and files will not be affected.


### PR DESCRIPTION
## The Problem:
#78 OP. It's annoying to go hunt down running ddev sites, switching to their directories one at a time to describe/stop/remove them.

## The Fix:
This PR introduces the ability to provide the sitename as an argument for ddev stop and ddev rm. This allows you to stop and remove sites without having to navigate in the terminal to the working directories of those sites. This is done by extending the functionality of getActiveAppRoot() based on similar functionality originally introduced for the describe command. Some additional cleanup was done along the way, including the removal of dead db/web image/tag flags on ddev start.

## The Test:
Using the binary built from this PR, start up a couple of sites. Then, navigate away from those sites in your terminal. Run ddev list to see your sites. You should be able to run `ddev stop <sitename>` and `ddev rm <sitename>` successfully.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Existing tests were updated, and a new test was added for getActiveAppRoot.

## Related Issue Link(s):
#78 OP

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

