### PR TITLE
Adding GitHub specific packaging for releases to the Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /.docker_image
 /debug
 /debug.test
+/release/v*

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,15 @@ setup:
 # Required static analysis targets used in circleci - these cause fail if they don't work
 staticrequired: gofmt govet golint errcheck staticcheck codecoroner
 
+# Pulls down windows, mac and linux artifacts from a CircleCI build that should
+# be triggered after tagging a release.  In order to run this you will need to 
+# log into CircleCI and obtain the root url for the artifacts that are generated.
+# A successful call would look something like:
+#
+# make ddevrelease DDEV_CIRCLE_BUILD=https://900-80669528-gh.circle-artifacts.com/0
+#
+# You will be left with a versioned folder in the release directory that 
+# contains the assets that should be uploaded to GitHub to accompany the
+# release.
+ddevrelease:
+	./release/ddevrelease.sh $(DDEV_CIRCLE_BUILD)

--- a/release/ddevrelease.sh
+++ b/release/ddevrelease.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -ex
+# This script downloads artifacts from CircleCI and prepares them for upload to
+# accopany a GitHub release.  See the ddevrelease component of this projects
+# Makefile for additional information.
+function package {
+    dir=${PWD##*/}
+    for filename in "`pwd`/*"
+    do
+        echo $filename
+    if [ "$dir" == "windows" ]
+    then
+        zip ddev_"$dir".zip `basename $filename`
+        shasum -a 256 ddev_"$dir".zip > ddev_"$dir".sha256
+    else
+        tar -cvzf ddev_"$dir".tar.gz `basename $filename`
+        shasum -a 256 ddev_"$dir".tar.gz > ddev_"$dir".sha256
+    fi
+    done;
+}
+function setup {
+    mkdir -p $1/release/$3/darwin
+    cd $1/release/$3/darwin
+    curl -O "$2/darwin/ddev"
+    chmod +x ddev
+
+    mkdir -p $1/release/$3/linux
+    cd $1/release/$3/linux
+    curl -O "$2/linux/ddev"
+    chmod +x ddev
+
+    mkdir -p $1/release/$3/windows
+    cd $1/release/$3/windows
+    curl -O "$2/windows/ddev.exe"
+}
+function cleanup {
+    mv $1/release/$2/*/*.sha256 $1/release/$2
+    mv $1/release/$2/*/*.tar.gz $1/release/$2
+    mv $1/release/$2/*/*.zip $1/release/$2
+    rm -rf $1/release/$2/darwin
+    rm -rf $1/release/$2/linux
+    rm -rf $1/release/$2/windows
+}
+
+DIR=`pwd`
+TAG=$(git describe --tags)
+setup $DIR $1 $TAG
+for d in $DIR/release/$TAG/*/ ; do (cd "$d" && package); done
+cleanup $DIR $TAG


### PR DESCRIPTION
## The Problem:
The problem is outlined a bit more in https://github.com/drud/ddev/issues/278.

## The Fix:
This introduces a modification to the Makefile that will pull artifacts from CircleCI and package them in a way that is conducive to uploading to GitHub for a release.

## The Test:
Follow the instructions in the Makefile.  You will end up with a versioned folder inside of releases that contains the assets to match one of our releases.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/278

