### PR TITLE
Implement user-guided caching, check docker version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We use the longer-term roadmap to prioritize short-term sprints. Please review t
 
 ## System Requirements
 
-- [docker](https://www.docker.com/community-edition)
+- [Docker](https://www.docker.com/community-edition) version 17.05 or greater
 - OS Support
   - macOS Sierra
   - Linux

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -80,7 +80,7 @@ var RootCmd = &cobra.Command{
 
 		err = util.CheckDockerVersion(version.DockerVersionConstraint)
 		if err != nil {
-			util.Failed("The docker version currently installed does not meet ddev's requirements: ", err)
+			util.Failed("The docker version currently installed does not meet ddev's requirements: %v", err)
 		}
 	},
 }

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -77,6 +77,11 @@ var RootCmd = &cobra.Command{
 				}
 			}
 		}
+
+		err = util.CheckDockerVersion(version.DockerVersionConstraint)
+		if err != nil {
+			util.Failed("The docker version currently installed does not meet ddev's requirements: ", err)
+		}
 	},
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 ## System Requirements
 
-- [docker](https://www.docker.com/community-edition)
+- [Docker](https://www.docker.com/community-edition) version 17.05 or greater
 - OS Support
   - macOS Sierra
   - Linux (See [Linux notes](users/linux_notes.md))

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -29,7 +29,7 @@ services:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
     volumes:
-      - "{{ .docroot }}/:/var/www/html/docroot"
+      - "{{ .docroot }}/:/var/www/html/docroot:cached"
     restart: always
     depends_on:
       - db

--- a/pkg/util/dockerutils.go
+++ b/pkg/util/dockerutils.go
@@ -295,10 +295,15 @@ func CheckDockerVersion(versionConstraint string) error {
 
 	match, errs := constraint.Validate(dockerVersion)
 	if !match {
-		var msgs string
+		if len(errs) <= 1 {
+			return errs[0]
+		}
+
+		msgs := "\n"
 		for _, err := range errs {
 			msgs = fmt.Sprint(msgs, err, "\n")
 		}
+		return fmt.Errorf(msgs)
 	}
 	return nil
 }

--- a/pkg/util/dockerutils_test.go
+++ b/pkg/util/dockerutils_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/drud/ddev/pkg/testcommon"
 	. "github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/version"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -104,4 +105,15 @@ func TestGetContainerEnv(t *testing.T) {
 	assert.Equal("future-fry", env)
 	env = GetContainerEnv("NONEXISTENT", container)
 	assert.Equal("", env)
+}
+
+func TestCheckDockerVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	err := CheckDockerVersion(">= 50.0.0")
+	assert.Error(err)
+	assert.Contains(err.Error(), "is less than 50.0.0")
+
+	err = CheckDockerVersion(version.DockerVersionConstraint)
+	assert.NoError(err)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,6 +8,11 @@ var VERSION = ""
 // DdevVersion is the current version of ddev, by default the git committish (should be current git tag)
 var DdevVersion = "v0.3.0-dev" // Note that this is overridden by make
 
+// DockerVersionConstraint is the current minimum version of docker required for ddev.
+// See https://godoc.org/github.com/Masterminds/semver#hdr-Checking_Version_Constraints
+// for examples defining version constraints.
+var DockerVersionConstraint = ">= 17.05.0-ce"
+
 // WebImg defines the default web image used for applications.
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make
 


### PR DESCRIPTION
## The Problem:
#253 OP, we want to add the new :cached option to the web container mount so that we can realize the performance improvements provided by it. This option was introduced in 17.04 Edge, and is targeted for the upcoming 17.06 Stable release. The option is not understood by previous versions, so we need to ensure users are running versions that understand the new option.

## The Fix:
This PR introduces the :cached option to the web container mount.

It also introduces functionality to check the current running docker version, and see if it meets our version constraints. Currently, this constraint is defined as `>= 17.05-ce`. I chose 17.05 since none of us tested in 17.04, and it is an edge release with a shorter release cycle. We will be able to define different constraints in the future as needed, should we need to impose minimum and/or maximum versions in the future.

The new Docker version requirements are added to the README and index of the docs site.

## The Test:

- Try to run "ddev version" on a system with a docker release less than 17.05. You should receive an error similar to below:

```
The docker version currently installed does not meed ddev's requirements: 17.3.1-ce is less than 17.05.0-ce
```
- Try to run "ddev version" on a system with Docker 17.05. This should succeed
- You can evaluate the performance improvements gained from the :cached option, but many metrics have already been gathered in #253 at this point.


## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#253 OP

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

We will need to update the docker installation for CircleCI to the 17.05 Edge release in order for tests to succeed with this PR. I will be introducing that update as a separate PR, so expect this PR to fail tests currently.
