### PR TITLE
installs docker 17.05 edge for circle builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,11 @@ jobs:
             sudo apt-get update -qq &&
             sudo apt-get install -qq apt-transport-https ca-certificates  curl software-properties-common &&
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
+            # Per docker docs, you always need the stable repository, even if you want to install edge builds as well.
             sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
+            sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge" &&
             sudo apt-get update -qq &&
-            sudo apt-get install -qq docker-ce
+            sudo apt-get install -qq docker-ce=17.0.5~ce-0~ubuntu-$(lsb_release -cs)
           name: Install docker
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
             sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge" &&
             sudo apt-get update -qq &&
-            sudo apt-get install -qq docker-ce=17.0.5~ce-0~ubuntu-$(lsb_release -cs)
+            sudo apt-get install -qq docker-ce=17.05.0~ce-0~ubuntu-$(lsb_release -cs)
           name: Install docker
 
       - run:


### PR DESCRIPTION
## The Problem:
We need docker 17.05 running on CircleCI, since we're introducing that as the minimum required version for ddev in #289 

## The Fix:
This installs the 17.05 edge release for CircleCI

## The Test:
It either works or it doesn't.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

