### PR TITLE
Reduce TestRun duration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
 
       - checkout
 
+      # The nightly build builds a ddev that can't be run elsewhere because the containers built in are not pushed.
+      # Therefore we build this full nightly first, and then throw it away.
       - run:
           command: |
             if [ -n "${RUN_NIGHTLY_BUILD}" ]; then
@@ -59,11 +61,12 @@ jobs:
           no_output_timeout: "20m"
           name: Run full nightly build  and tests if $RUN_NIGHTLY_BUILD
 
+      # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
       - run:
           command: make clean linux darwin windows
           name: Build the ddev executables
 
-      # Run the built-in ddev tests
+      # Run the built-in ddev tests with the executables just built.
       - run:
           command: |
             if [ ! -n "${RUN_NIGHTLY_BUILD}" ]; then
@@ -78,6 +81,7 @@ jobs:
           command: bin/linux/ddev version
           name: ddev version information
 
+      # Now we store the artifacts, which are the ones built by the *normal* build (not the nightly, in case of nightly)
       - store_artifacts:
           path: bin/darwin/darwin_amd64/ddev
           destination: darwin/ddev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,17 +45,9 @@ jobs:
       - checkout
 
       - run:
-          command: make linux darwin windows
+          command: make clean linux darwin windows
           name: Build the ddev executables
 
-      # Run the built-in ddev tests
-      - run:
-          command: |
-            if [ ! -n "${RUN_NIGHTLY_BUILD}" ]; then
-              make test
-            fi
-          name: ddev tests (not nightly build)
-          no_output_timeout: "20m"
 
       - run:
           command: |
@@ -71,10 +63,6 @@ jobs:
             fi
           no_output_timeout: "20m"
           name: Run full nightly build  and tests if $RUN_NIGHTLY_BUILD
-
-      - run:
-          command: make clean linux darwin windows
-          name: Build the ddev executables
 
       # Run the built-in ddev tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,6 @@ jobs:
       - checkout
 
       - run:
-          command: make clean linux darwin windows
-          name: Build the ddev executables
-
-
-      - run:
           command: |
             if [ -n "${RUN_NIGHTLY_BUILD}" ]; then
               make clean
@@ -63,6 +58,10 @@ jobs:
             fi
           no_output_timeout: "20m"
           name: Run full nightly build  and tests if $RUN_NIGHTLY_BUILD
+
+      - run:
+          command: make clean linux darwin windows
+          name: Build the ddev executables
 
       # Run the built-in ddev tests
       - run:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ RouterTag ?= v0.4.0
 DBAImg ?= drud/phpmyadmin
 DBATag ?= v0.2.0
 
+TESTLENGTH ?= -short
 # Optional to docker build
 #DOCKER_ARGS =
 
@@ -63,10 +64,10 @@ DDEV_BINARY_FULLPATH=$(shell pwd)/bin/$(TESTOS)/ddev
 test: testpkg testcmd
 
 testcmd: build setup
-	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
+	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 $(TESTLENGTH) -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
 
-testpkg: 
-	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) DRUD_DEBUG=true go test -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
+testpkg:
+	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) DRUD_DEBUG=true go test $(TESTLENGTH) -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
 
 setup:
 	@mkdir -p bin/darwin bin/linux

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ RouterTag ?= v0.4.0
 DBAImg ?= drud/phpmyadmin
 DBATag ?= v0.2.0
 
-TESTLENGTH ?= -short
 # Optional to docker build
 #DOCKER_ARGS =
 
@@ -40,6 +39,10 @@ TESTLENGTH ?= -short
 # This version-strategy uses git tags to set the version string
 # VERSION can be overridden on make commandline: make VERSION=0.9.1 push
 VERSION := $(shell git describe --tags --always --dirty)
+
+# Run tests with -short by default, for faster run times.
+TESTARGS ?= -short
+
 #
 # This version-strategy uses a manual value to set the version string
 #VERSION := 1.2.3
@@ -64,10 +67,10 @@ DDEV_BINARY_FULLPATH=$(shell pwd)/bin/$(TESTOS)/ddev
 test: testpkg testcmd
 
 testcmd: build setup
-	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 $(TESTLENGTH) -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
+	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
 
 testpkg:
-	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) DRUD_DEBUG=true go test $(TESTLENGTH) -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
+	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) DRUD_DEBUG=true go test  -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
 
 setup:
 	@mkdir -p bin/darwin bin/linux

--- a/nightly_build.mak
+++ b/nightly_build.mak
@@ -32,4 +32,4 @@ submodules:
 	git fetch --all && git submodule update --init && git submodule update --remote
 
 test:
-	$(MAKE) && TESTLENGTH="-v" $(MAKE) test
+	$(MAKE) && TESTARGS="" $(MAKE) test

--- a/nightly_build.mak
+++ b/nightly_build.mak
@@ -32,4 +32,4 @@ submodules:
 	git fetch --all && git submodule update --init && git submodule update --remote
 
 test:
-	$(MAKE) && $(MAKE) test
+	$(MAKE) && TESTLENGTH="-v" $(MAKE) test

--- a/nightly_build.mak
+++ b/nightly_build.mak
@@ -32,4 +32,4 @@ submodules:
 	git fetch --all && git submodule update --init && git submodule update --remote
 
 test:
-	$(MAKE) && TESTARGS="" $(MAKE) test
+	$(MAKE) && $(MAKE) TESTARGS="" test

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -28,24 +28,33 @@ var (
 			DBTarURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 			DBZipURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.zip",
 		},
-		{
-			Name:                          "TestMainPkgWordpress",
-			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
-			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
-		},
-		{
-			Name:                          "TestMainPkgDrupalKickstart",
-			SourceURL:                     "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-kickstart-0.4.0/",
-			FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
-		},
 	}
 )
 
 func TestMain(m *testing.M) {
+	// Allow tests to run in "short" mode, which will only test a single site. This keeps test runtimes low.
+	if !testing.Short() {
+		// If we're doing full tests, add additional sites to the TestSites slice.
+		additionalSites := []testcommon.TestSite{
+			{
+				Name:                          "TestMainPkgWordpress",
+				SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+				ArchiveInternalExtractionPath: "wordpress-0.4.0/",
+				FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+				DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+			},
+			{
+				Name:                          "TestMainPkgDrupalKickstart",
+				SourceURL:                     "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
+				ArchiveInternalExtractionPath: "drupal-kickstart-0.4.0/",
+				FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
+				DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
+			},
+		}
+
+		TestSites = append(TestSites, additionalSites...)
+	}
+
 	if len(GetApps()) > 0 {
 		log.Fatalf("Local plugin tests require no sites running. You have %v site(s) running.", len(GetApps()))
 	}

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -28,32 +28,24 @@ var (
 			DBTarURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 			DBZipURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.zip",
 		},
+		{
+			Name:                          "TestMainPkgWordpress",
+			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
+			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+		},
+		{
+			Name:                          "TestMainPkgDrupalKickstart",
+			SourceURL:                     "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-kickstart-0.4.0/",
+			FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
+		},
 	}
 )
 
 func TestMain(m *testing.M) {
-	// Allow tests to run in "short" mode, which will only test a single site. This keeps test runtimes low.
-	if !testing.Short() {
-		// If we're doing full tests, add additional sites to the TestSites slice.
-		additionalSites := []testcommon.TestSite{
-			{
-				Name:                          "TestMainPkgWordpress",
-				SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
-				ArchiveInternalExtractionPath: "wordpress-0.4.0/",
-				FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
-				DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
-			},
-			{
-				Name:                          "TestMainPkgDrupalKickstart",
-				SourceURL:                     "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
-				ArchiveInternalExtractionPath: "drupal-kickstart-0.4.0/",
-				FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
-				DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
-			},
-		}
-
-		TestSites = append(TestSites, additionalSites...)
-	}
 
 	if len(GetApps()) > 0 {
 		log.Fatalf("Local plugin tests require no sites running. You have %v site(s) running.", len(GetApps()))
@@ -74,6 +66,15 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(testRun)
+}
+
+// TestLocalSetup reduces the TestSite list on shorter test runs.
+func TestLocalSetup(t *testing.T) {
+	// Allow tests to run in "short" mode, which will only test a single site. This keeps test runtimes low.
+	// We would much prefer to do this in TestMain, but the Short() flag is not yet available at that point.
+	if testing.Short() {
+		TestSites = []testcommon.TestSite{TestSites[0]}
+	}
 }
 
 // TestLocalStart tests the functionality that is called when "ddev start" is executed


### PR DESCRIPTION
## The Problem:
Tests take a long time. It's good we have a lot of tests, but we probably don't need to check 3 sites for every single test run. 99% of things should be found by a single site.

## The Fix: 
- We're running "make test' twice. Removing the second run is a slam dunk for cutting out tests in half.
- We get a further reduction by using `-short` flag to reduce runtime for our normal tests, while still doing the full testing list on the nightly build. This is straight out of https://splice.com/blog/lesser-known-features-go-test/. This further reduces test times by an additional ~5 minutes (~21 to ~16).

Obviously doing step 1 is a no brainer. The usage of `-short` I could go either way on. I feel like it's probably worth it, though. We still maintain the full test list on our nightly builds so if anything does slip by we still have coverage. My preference is probably to give it a try and if more things slip by than we're comfortable with than it's an easy rollback.
