### PR TITLE
Build tools upgrade, circle followup

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -8,7 +8,7 @@ sudo apt-get install -qq mysql-client realpath zip
 
 # golang of the version we want
 sudo apt-get remove -qq golang &&
-wget -q -O /tmp/golang.tgz https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz &&
+wget -q -O /tmp/golang.tgz https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz &&
 cd /tmp && tar -xf golang.tgz &&
 sudo rm -rf /usr/local/go && sudo mv go /usr/local
 
@@ -26,4 +26,3 @@ sudo apt-get install -qq docker-ce=17.05.0~ce-0~ubuntu-$(lsb_release -cs)
 # docker-compose
 sudo curl -s -L "https://github.com/docker/compose/releases/download/1.12.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,11 @@ jobs:
       - run: make -s staticrequired
 
       # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
+      # Earlier process updated submodules so now we clean them up to continue.
       - run:
-          command: make -s clean linux darwin windows
+          command: |
+            git submodule update --init &&
+            make -s clean linux darwin windows
           name: Build the ddev executables
 
       # Run the built-in ddev tests with the clean binaries just built.

--- a/.circleci/tag_build.sh
+++ b/.circleci/tag_build.sh
@@ -3,7 +3,7 @@
 # from https://circleci.com/docs/1.0/nightly-builds/
 # See also https://circleci.com/docs/2.0/defining-multiple-jobs/
 
-# ag_build.sh $circle_token $tag $project_optional
+# tag_build.sh $circle_token $tag $project_optional
 
 CIRCLE_TOKEN=$1
 TAG=$2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Temporary build-tools artifacts to be ignored
 /.go/
+/.gotmp/
 /bin/
 /.container*
 /.push*

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -1,6 +1,6 @@
 # Build tools for standard makefile
 
-**These build tools live at https://github.com/drud/build-tools**. If you are viewing this README in any other repository, it's important to know that modifications should **never** be made directly, and instead should be made to the base repository and pulled in via the subtree merge instructions below.
+**These build tools live at https://github.com/drud/build-tools**. If you are viewing this README in any other repository, it's important to know that modifications should **never** be made directly, and instead should be made to the base repository and pulled in via the instructions below.
 
 These tools add standard components (sub-makefiles and build scripts) as well as example starters for the Makefile and .circleci/config.yml.
 

--- a/build-tools/gitignore.example
+++ b/build-tools/gitignore.example
@@ -2,6 +2,7 @@
 
 # Temporary build-tools artifacts to be ignored
 /.go/
+/.gotmp/
 /bin/
 /.container*
 /.push*

--- a/build-tools/makefile_components/base_build_python-docker.mak
+++ b/build-tools/makefile_components/base_build_python-docker.mak
@@ -30,4 +30,4 @@ container-clean:
 	rm -rf .container-* .dockerfile* .push-* linux darwin container VERSION.txt .docker_image
 
 bin-clean:
-	rm -rf .go bin .tmp
+	rm -rf .go $(GOTMP) bin .tmp

--- a/build-tools/makefile_components/base_test_go.mak
+++ b/build-tools/makefile_components/base_test_go.mak
@@ -8,14 +8,13 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 test: build
 	@mkdir -p bin/linux
-	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
+	@mkdir -p $(GOTMP)/{src/$(PKG),pkg,bin,std/linux}
 	@docker run -t --rm  -u $(shell id -u):$(shell id -g)                 \
-	    -v $$(pwd)/.go:/go                                                 \
+	    -v $$(pwd)/$(GOTMP):/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
-	    -v $$(pwd)/.go/std/linux:/usr/local/go/pkg/linux_amd64_static  \
+	    -v $$(pwd)/$(GOTMP)/std/linux:/usr/local/go/pkg/linux_amd64_static  \
 	    -e CGO_ENABLED=0	\
-	    -e GOOS=$$(uname -s |  tr "[:upper:]" "[:lower:]")
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
         go test -v -installsuffix static -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER)


### PR DESCRIPTION
## The Problem:

* Upgrade build-tools, moves us to golang 1.8.3
* Typo fix from https://github.com/drud/ddev/pull/295
