### PR TITLE
Update install script to work with new tarball naming technique, fixes #296

### DIFF
--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+# Download and install latest ddev release
+
 RED=$(tput setaf 1)
 GREEN=$(tput setaf 2)
 YELLOW=$(tput setaf 3)
@@ -9,7 +11,7 @@ OS=$(uname)
 BINOWNER=$(ls -ld /usr/local/bin | awk '{print $3}')
 USER=$(whoami)
 SHACMD=""
-FILE=""
+FILEBASE=""
 LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/drud/ddev/releases/latest)
 # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
 LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
@@ -17,12 +19,12 @@ URL="https://github.com/drud/ddev/releases/download/$LATEST_VERSION"
 
 if [[ "$OS" == "Darwin" ]]; then
     SHACMD="shasum -a 256"
-    FILE="ddev_darwin_64"
+    FILEBASE="ddev_osx"
 elif [[ "$OS" == "Linux" ]]; then
     SHACMD="sha256sum"
-    FILE="ddev_linux"
+    FILEBASE="ddev_linux"
 else
-    echo "${RED}Sorry, your platform is not supported at this time.${RESET}"
+    echo "${RED}Sorry, this installer does not support your platform at this time.${RESET}"
     exit 1
 fi
 
@@ -30,11 +32,14 @@ if ! docker --version >/dev/null 2>&1; then
     echo "${YELLOW}Docker is required for ddev. Download and install docker at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}"
 fi
 
-curl -sSL "$URL/$FILE.tar.gz" -o "/tmp/$FILE.tar.gz"
-curl -sSL "$URL/$FILE.sha256" -o "/tmp/$FILE.sha256"
+TARBALL="$FILEBASE.$LATEST_VERSION.tar.gz"
+SHAFILE="$TARBALL.sha256.txt"
 
-cd /tmp; $SHACMD -c "$FILE.sha256"; cd -;
-tar -xzf "/tmp/$FILE.tar.gz" -C /tmp
+curl -sSL "$URL/$TARBALL" -o "/tmp/$TARBALL"
+curl -sSL "$URL/$SHAFILE" -o "/tmp/$SHAFILE"
+
+cd /tmp; $SHACMD -c "$SHAFILE"
+tar -xzf $TARBALL -C /tmp
 chmod ugo+x /tmp/ddev
 
 echo "Download verified. Ready to place ddev in your /usr/local/bin."
@@ -46,7 +51,6 @@ else
     sudo mv /tmp/ddev /usr/local/bin/
 fi
 
-rm "/tmp/$FILE.tar.gz"
-rm "/tmp/$FILE.sha256"
+rm /tmp/$TARBALL /tmp/$SHAFILE
 
 echo "${GREEN}ddev is now installed. Run \"ddev\" to verify your installation and see usage.${RESET}"


### PR DESCRIPTION
## The Problem:

We changed to versioning the tarball filenames in https://github.com/drud/ddev/pull/295, so the install script needs to support that.

## The Fix:

Minor fixes to the install script. 

## The Test:

Try it - run the script and make sure it updates correctly. 

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

#296 is the OP

## Release/Deployment notes:

Nothing should need to be done as the docs have people use master to obtain this script.
