### PR TITLE
Remove volumes when removing containers Fixes #39

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -339,7 +339,7 @@ func (l *LocalApp) Start() error {
 		return err
 	}
 
-	StartDockerRouter()
+	StartDdevRouter()
 
 	return nil
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -540,7 +540,7 @@ func (l *LocalApp) Config() error {
 // Down stops the docker containers for the local project.
 func (l *LocalApp) Down() error {
 	l.DockerEnv()
-	err := dockerutil.ComposeCmd(l.ComposeFiles(), "down")
+	err := dockerutil.ComposeCmd(l.ComposeFiles(), "down", "-v")
 	if err != nil {
 		util.Warning("Could not stop site with docker-compose. Attempting manual cleanup.")
 		return Cleanup(l)

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -41,13 +41,13 @@ func StopRouter() error {
 
 	if !containersRunning {
 		dest := RouterComposeYAMLPath()
-		return dockerutil.ComposeCmd([]string{dest}, "-p", routerProjectName, "down")
+		return dockerutil.ComposeCmd([]string{dest}, "-p", routerProjectName, "down", "-v")
 	}
 	return nil
 }
 
-// StartDockerRouter ensures the router is running.
-func StartDockerRouter() {
+// StartDdevRouter ensures the router is running.
+func StartDdevRouter() {
 	exposedPorts := determineRouterPorts()
 
 	dest := RouterComposeYAMLPath()
@@ -65,7 +65,7 @@ func StartDockerRouter() {
 	defer util.CheckClose(f)
 
 	templ := template.New("compose template")
-	templ, err = templ.Parse(DrudRouterTemplate)
+	templ, err = templ.Parse(DdevRouterTemplate)
 	if err != nil {
 		log.Fatal(ferr)
 	}

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -62,8 +62,8 @@ var SequelproTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 </dict>
 </plist>`
 
-// DrudRouterTemplate is the template for the generic router container.
-const DrudRouterTemplate = `version: '2'
+// DdevRouterTemplate is the template for the generic router container.
+const DdevRouterTemplate = `version: '2'
 services:
   nginx-proxy:
     image: {{ .router_image }}:{{ .router_tag }}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -129,8 +129,9 @@ func Cleanup(app App) error {
 	for i := range containers {
 		containerName := containers[i].Names[0][1:len(containers[i].Names[0])]
 		removeOpts := docker.RemoveContainerOptions{
-			ID:    containers[i].ID,
-			Force: true,
+			ID:            containers[i].ID,
+			RemoveVolumes: true,
+			Force:         true,
 		}
 		fmt.Printf("Removing container: %s\n", containerName)
 		if err := client.RemoveContainer(removeOpts); err != nil {


### PR DESCRIPTION
## The Problem:

OP [#39 Remove associated docker volumes when ddev-removing a site/app](https://github.com/drud/ddev/issues/39)

## The Fix:

* Use -v argument with docker-compose
* Use RemoveVolumes in the failsafe cleanup

## The Test:

* Remove all your sites
* Remove volumes to start clean.  `docker volume ls`
* Start a site
* `docker volume ls` to see volumes
* `ddev rm -y` to kill your site
* `docker volume ls` to see that the volumes are gone now.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

