### PR TITLE
Provides option for import to extract specific paths in archives, fixes #287

### DIFF
--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -19,8 +19,8 @@ var ImportDBCmd = &cobra.Command{
 	Short: "Import the database of an existing site to the local dev environment.",
 	Long: `Import the database of an existing site to the local development environment.
 The database can be provided as a SQL dump in a .sql, .sql.gz, .zip, or .tar.gz
-format. For the .zip and .tar.gz formats, a SQL dump in .sql format must be
-present at the root of the archive.`,
+format. For the .zip and .tar.gz formats, the path to a .sql file within the archive
+can be provided if it is not located at the top-level of the archive.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -11,6 +11,7 @@ import (
 )
 
 var dbSource string
+var dbExtPath string
 
 // ImportDBCmd represents the `ddev import-db` command.
 var ImportDBCmd = &cobra.Command{
@@ -41,7 +42,7 @@ present at the root of the archive.`,
 			util.Failed("Failed to import database: %v", app.GetName(), err)
 		}
 
-		err = app.ImportDB(dbSource)
+		err = app.ImportDB(dbSource, dbExtPath)
 		if err != nil {
 			util.Failed("Failed to import database for %s: %v", app.GetName(), err)
 		}
@@ -51,5 +52,6 @@ present at the root of the archive.`,
 
 func init() {
 	ImportDBCmd.Flags().StringVarP(&dbSource, "src", "", "", "Provide the path to a sql dump in .sql or .tar.gz format")
+	ImportDBCmd.Flags().StringVarP(&dbExtPath, "extract-path", "", "", "If provided asset is an archive, provide the path to extract within the archive.")
 	RootCmd.AddCommand(ImportDBCmd)
 }

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -10,6 +10,7 @@ import (
 )
 
 var fileSource string
+var fileExtPath string
 
 // ImportFileCmd represents the `ddev import-db` command.
 var ImportFileCmd = &cobra.Command{
@@ -40,7 +41,7 @@ will be replaced with the assets being imported.`,
 			util.Failed("Failed to import files: %v", err)
 		}
 
-		err = app.ImportFiles(fileSource)
+		err = app.ImportFiles(fileSource, fileExtPath)
 		if err != nil {
 			util.Failed("Failed to import files for %s: %v", app.GetName(), err)
 		}
@@ -50,5 +51,6 @@ will be replaced with the assets being imported.`,
 
 func init() {
 	ImportFileCmd.Flags().StringVarP(&fileSource, "src", "", "", "Provide the path to a directory or .tar.gz archive of files to import")
+	ImportFileCmd.Flags().StringVarP(&fileExtPath, "extract-path", "", "", "If provided asset is an archive, provide the path to extract within the archive.")
 	RootCmd.AddCommand(ImportFileCmd)
 }

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -18,10 +18,10 @@ var ImportFileCmd = &cobra.Command{
 	Short: "Import the uploaded files directory of an existing site to the default public upload directory of your application.",
 	Long: `Import the uploaded files directory of an existing site to the default public
 upload directory of your application. The files can be provided as a directory
-path or an archive in .tar, .tar.gz, .tgz, or .zip format. The contents at the
-root of the archive or directory will be the contents of the default public
-upload directory of your application. If the destination directory exists, it
-will be replaced with the assets being imported.`,
+path or an archive in .tar, .tar.gz, .tgz, or .zip format. For the .zip and .tar.gz formats,
+the path to a directory within the archive can be provided if it is not located at the
+top-level of the archive. If the destination directory exists, it will be replaced with
+the assets being imported.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -98,10 +98,11 @@ MailHog:   	http://drupal8.ddev.local:8025
 phpMyAdmin:	http://drupal8.ddev.local:8036
 ```
 
-## Importing an existing site
-Two commands are provided for importing assets from an existing site, `ddev import-db` and `ddev import-files`. Running either of these commands will provide a prompt to enter the location of the assets to import. You can also skip the prompt by specifying the location using the `--src` flag.
+## Importing assets for an existing site
+An important aspect of local web development is the ability to have a precise recreation of the site you are working on locally, including up-to-date database contents and static assets such as uploaded images and files. ddev provides functionality to help with importing assets to your local environment with two commands.
 
-### import-db
+### Importing a database
+The `ddev import-db` command is provided for importing the MySQL database for a site. Running this command will provide a prompt for you to specify the location of your database import.
 
 ```
 ➜  ddev import-db
@@ -113,10 +114,38 @@ Generating settings.php file for database connection.
 Successfully imported database for drupal8
 ```
 
-The `import-db` command allows you to specify the location of a SQL dump to be imported as the active database for your site. The database may be provided as a `.sql` file, `.sql.gz` or tar archive. The provided dump will be imported into the database named `data` in the database container for your site. A database connection file will be generated for your site if one does not exist (`settings.php` for Drupal, `wp-config.php` for WordPress). If you have already created a connection file, you will need to ensure your connection credentials match the ones provided in `ddev describe`.
+A database connection file will be generated for your site if one does not exist (`settings.php` for Drupal, `wp-config.php` for WordPress). If you have already created a connection file, you will need to ensure your connection credentials match the ones provided in `ddev describe`.
 
+<h4>Supported file types</h4>
 
-### import-files
+Database import supports the following file types:
+
+- Raw SQL Dump (.sql)
+- Gzipped SQL Dump (.sql.gz)
+- (Gzipped) Tarball Archive (.tar, .tar.gz, .tgz)
+- Zip Archive (.zip)
+
+If a Tarball Archive or Zip Archive is provided for the import, you will be provided an additional prompt, allowing you to specify a path within the archive to use for the import asset. The specified path should provide a Raw SQL Dump (.sql). In the following example, the database we want to import is named data.sql and resides at the top-level of the archive:
+
+```
+➜  ddev import-db
+Provide the path to the database you wish to import.
+Import path:
+~/Downloads/site-backup.tar.gz
+You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents
+Archive extraction path:
+data.sql
+Importing database...
+A settings file already exists for your application, so ddev did not generate one.
+Run 'ddev describe' to find the database credentials for this application.
+Successfully imported database for drupal8
+```
+
+<h4>Non-interactive usage</h4>
+If you want to use import-db without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag.
+
+### Importing static file assets
+The `ddev import-files` command is provided for importing the static file assets for a site, such as uploaded images and documents. Running this command will provide a prompt for you to specify the location of your asset import. The assets will then be imported to the default public upload directory of the platform for the site. For Drupal sites, this is the "sites/default/files" directory. For WordPress sites, this is the "wp-content/uploads" directory. 
 
 ```
 ➜  ddev import-files
@@ -126,7 +155,29 @@ Import path:
 Successfully imported files for drupal8
 ```
 
-The `import-files` command allows you to specify the location of uploaded file assets to import for your site. For Drupal, this is the public files directory, located at `sites/default/files` by default. For WordPress, this is the uploads directory, located at `wp-content/uploads` by default. The files may be provided as a directory or tar archive containing the contents of the uploads folder. The contents of the directory or archive provided will be copied to the default location of the upload directory for your site.
+<h4>Supported file types</h4>
+
+Static asset import supports the following file types:
+
+- A directory containing static assets
+- (Gzipped) Tarball Archive (.tar, .tar.gz, .tgz)
+- Zip Archive (.zip)
+
+If a Tarball Archive or Zip Archive is provided for the import, you will be provided an additional prompt, allowing you to specify a path within the archive to use for the import asset. In the following example, the assets we want to import reside at "docroot/sites/default/files":
+
+```
+➜  ddev import-files
+Provide the path to the directory or archive you wish to import. Please note, if the destination directory exists, it will be replaced with the import assets specified here.
+Import path:
+~/Downloads/site-backup.tar.gz
+You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents
+Archive extraction path:
+docroot/sites/default/files
+Successfully imported files for drupal8
+```
+
+<h4>Non-interactive usage</h4>
+If you want to use import-files without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag.
 
 ## Interacting with your Site
 ddev provides several commands to facilitate interacting with your site in the development environment. These commands can be run within the working directory of your project while the site is running in ddev. 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -102,8 +102,14 @@ func Untar(source string, dest string, extractionDir string) error {
 		if !strings.HasPrefix(file.Name, extractionDir) {
 			continue
 		}
-		// Now transform the filename to skip the extractionDir
-		file.Name = strings.TrimPrefix(file.Name, extractionDir)
+
+		// If extractionDir matches file name and isn't a directory, we should be extracting a specific file.
+		if file.Name == extractionDir && file.Typeflag != tar.TypeDir {
+			file.Name = filepath.Base(file.Name)
+		} else {
+			// Transform the filename to skip the extractionDir
+			file.Name = strings.TrimPrefix(file.Name, extractionDir)
+		}
 
 		// If file.Name is now empty this is the root directory we want to extract, and need not do anything.
 		if file.Name == "" && file.Typeflag == tar.TypeDir {
@@ -161,8 +167,15 @@ func Unzip(source string, dest string, extractionDir string) error {
 			continue
 		}
 
-		// Now transform the filename to skip the extractionDir
-		file.Name = strings.TrimPrefix(file.Name, extractionDir)
+		// If extractionDir matches file name and isn't a directory, we should be extracting a specific file.
+		fileInfo := file.FileInfo()
+		if file.Name == extractionDir && !fileInfo.IsDir() {
+			file.Name = filepath.Base(file.Name)
+		} else {
+			// Transform the filename to skip the extractionDir
+			file.Name = strings.TrimPrefix(file.Name, extractionDir)
+		}
+
 		fullPath := filepath.Join(dest, file.Name)
 
 		if strings.HasSuffix(file.Name, "/") {

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -127,7 +127,7 @@ func Untar(source string, dest string, extractionDir string) error {
 				continue
 			}
 
-			err = os.Mkdir(fullPath, 0755)
+			err = os.MkdirAll(fullPath, 0755)
 			if err != nil {
 				return err
 			}

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -114,3 +114,31 @@ func FileExists(name string) bool {
 	}
 	return true
 }
+
+// PurgeDirectory removes all of the contents of a given
+// directory, leaving the directory itself intact.
+func PurgeDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	defer util.CheckClose(dir)
+
+	files, err := dir.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		err = os.Chmod(filepath.Join(path, file), 0777)
+		if err != nil {
+			return err
+		}
+		err = os.RemoveAll(filepath.Join(path, file))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -75,3 +75,31 @@ func TestCopyFile(t *testing.T) {
 	err = os.RemoveAll(tmpTargetDir)
 	assert.NoError(err)
 }
+
+// TestPurgeDirectory tests removal of directory contents without removing
+// the directory itself.
+func TestPurgeDirectory(t *testing.T) {
+	assert := assert.New(t)
+	tmpPurgeDir := testcommon.CreateTmpDir("TestPurgeDirectory")
+	tmpPurgeFile := filepath.Join(tmpPurgeDir, "regular_file")
+	tmpPurgeSubFile := filepath.Join(tmpPurgeDir, "subdir", "regular_file")
+
+	err := fileutil.CopyFile(testFileLocation, tmpPurgeFile)
+	assert.NoError(err)
+
+	err = os.Mkdir(filepath.Join(tmpPurgeDir, "subdir"), 0755)
+	assert.NoError(err)
+
+	err = fileutil.CopyFile(testFileLocation, tmpPurgeSubFile)
+	assert.NoError(err)
+
+	err = os.Chmod(tmpPurgeSubFile, 0444)
+	assert.NoError(err)
+
+	err = fileutil.PurgeDirectory(tmpPurgeDir)
+	assert.NoError(err)
+
+	assert.True(fileutil.FileExists(tmpPurgeDir))
+	assert.False(fileutil.FileExists(tmpPurgeFile))
+	assert.False(fileutil.FileExists(tmpPurgeSubFile))
+}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -159,15 +159,15 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 	}
 
 	importPath, err := appimport.ValidateAsset(imPath, "db")
-	if err != nil && err.Error() != "is archive" {
-		return err
-	}
+	if err != nil {
+		if err.Error() == "is archive" && extPathPrompt {
+			fmt.Println("You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents")
+			fmt.Println("Archive extraction path:")
 
-	if err.Error() == "is archive" && extPathPrompt {
-		fmt.Println("You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents")
-		fmt.Println("Archive extraction path:")
-
-		extPath = util.GetInput("")
+			extPath = util.GetInput("")
+		} else {
+			return err
+		}
 	}
 
 	switch {
@@ -288,15 +288,15 @@ func (l *LocalApp) ImportFiles(imPath string, extPath string) error {
 	}
 
 	importPath, err := appimport.ValidateAsset(imPath, "files")
-	if err != nil && err.Error() != "is archive" {
-		return err
-	}
+	if err != nil {
+		if err.Error() == "is archive" && extPathPrompt {
+			fmt.Println("You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents")
+			fmt.Println("Archive extraction path:")
 
-	if err.Error() == "is archive" && extPathPrompt {
-		fmt.Println("You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents")
-		fmt.Println("Archive extraction path:")
-
-		extPath = util.GetInput("")
+			extPath = util.GetInput("")
+		} else {
+			return err
+		}
 	}
 
 	switch {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -165,7 +165,8 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 			fmt.Println("Archive extraction path:")
 
 			extPath = util.GetInput("")
-		} else {
+		}
+		if err.Error() != "is archive" {
 			return err
 		}
 	}
@@ -294,7 +295,8 @@ func (l *LocalApp) ImportFiles(imPath string, extPath string) error {
 			fmt.Println("Archive extraction path:")
 
 			extPath = util.GetInput("")
-		} else {
+		}
+		if err.Error() != "is archive" {
 			return err
 		}
 	}

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -222,6 +222,7 @@ func TestLocalImportDB(t *testing.T) {
 			err = app.ImportDB(siteTarPath, "data.sql")
 			assert.NoError(err)
 			err = os.Remove(siteTarPath)
+			assert.NoError(err)
 		}
 
 		runTime()
@@ -270,6 +271,7 @@ func TestLocalImportFiles(t *testing.T) {
 			err = app.ImportFiles(siteTarPath, "docroot/sites/default/files")
 			assert.NoError(err)
 			err = os.Remove(siteTarPath)
+			assert.NoError(err)
 		}
 
 		runTime()

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -42,6 +42,7 @@ var (
 			ArchiveInternalExtractionPath: "drupal-kickstart-0.4.0/",
 			FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
+			FullSiteTarballURL:            "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/site.tar.gz",
 		},
 	}
 )
@@ -172,7 +173,7 @@ func TestLocalImportDB(t *testing.T) {
 		// Test simple db loads.
 		for _, file := range []string{"users.sql", "users.sql.gz", "users.sql.tar.gz", "users.sql.tgz", "users.sql.zip"} {
 			path := filepath.Join(testDir, "testing", file)
-			err = app.ImportDB(path)
+			err = app.ImportDB(path, "")
 			assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", path, err)
 		}
 
@@ -180,8 +181,7 @@ func TestLocalImportDB(t *testing.T) {
 			dbPath := filepath.Join(testcommon.CreateTmpDir("local-db"), "db.tar.gz")
 			err := util.DownloadFile(dbPath, site.DBTarURL)
 			assert.NoError(err)
-
-			err = app.ImportDB(dbPath)
+			err = app.ImportDB(dbPath, "")
 			assert.NoError(err)
 
 			stdout := testcommon.CaptureStdOut()
@@ -200,8 +200,7 @@ func TestLocalImportDB(t *testing.T) {
 			dbZipPath := filepath.Join(testcommon.CreateTmpDir("local-db-zip"), "db.zip")
 			err = util.DownloadFile(dbZipPath, site.DBZipURL)
 			assert.NoError(err)
-
-			err = app.ImportDB(dbZipPath)
+			err = app.ImportDB(dbZipPath, "")
 			assert.NoError(err)
 
 			stdout := testcommon.CaptureStdOut()
@@ -214,6 +213,15 @@ func TestLocalImportDB(t *testing.T) {
 
 			err = os.Remove(dbZipPath)
 			assert.NoError(err)
+		}
+
+		if site.FullSiteTarballURL != "" {
+			siteTarPath := filepath.Join(testcommon.CreateTmpDir("local-site-tar"), "site.tar.gz")
+			err = util.DownloadFile(siteTarPath, site.FullSiteTarballURL)
+			assert.NoError(err)
+			err = app.ImportDB(siteTarPath, "data.sql")
+			assert.NoError(err)
+			err = os.Remove(siteTarPath)
 		}
 
 		runTime()
@@ -239,7 +247,7 @@ func TestLocalImportFiles(t *testing.T) {
 			filePath := filepath.Join(testcommon.CreateTmpDir("local-tarball-files"), "files.tar.gz")
 			err := util.DownloadFile(filePath, site.FilesTarballURL)
 			assert.NoError(err)
-			err = app.ImportFiles(filePath)
+			err = app.ImportFiles(filePath, "")
 			assert.NoError(err)
 			err = os.Remove(filePath)
 			assert.NoError(err)
@@ -249,10 +257,19 @@ func TestLocalImportFiles(t *testing.T) {
 			filePath := filepath.Join(testcommon.CreateTmpDir("local-zipball-files"), "files.zip")
 			err := util.DownloadFile(filePath, site.FilesZipballURL)
 			assert.NoError(err)
-			err = app.ImportFiles(filePath)
+			err = app.ImportFiles(filePath, "")
 			assert.NoError(err)
 			err = os.Remove(filePath)
 			assert.NoError(err)
+		}
+
+		if site.FullSiteTarballURL != "" {
+			siteTarPath := filepath.Join(testcommon.CreateTmpDir("local-site-tar"), "site.tar.gz")
+			err = util.DownloadFile(siteTarPath, site.FullSiteTarballURL)
+			assert.NoError(err)
+			err = app.ImportFiles(siteTarPath, "docroot/sites/default/files")
+			assert.NoError(err)
+			err = os.Remove(siteTarPath)
 		}
 
 		runTime()

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -179,6 +179,11 @@ func TestLocalImportDB(t *testing.T) {
 		}
 
 		if site.DBTarURL != "" {
+			err = app.Exec("db", true, "mysql", "-e", "DROP DATABASE db;")
+			assert.NoError(err)
+			err = app.Exec("db", true, "mysql", "information_schema", "-e", "CREATE DATABASE db;")
+			assert.NoError(err)
+
 			dbPath := filepath.Join(testcommon.CreateTmpDir("local-db"), "db.tar.gz")
 			err := util.DownloadFile(dbPath, site.DBTarURL)
 			assert.NoError(err)
@@ -198,6 +203,11 @@ func TestLocalImportDB(t *testing.T) {
 		}
 
 		if site.DBZipURL != "" {
+			err = app.Exec("db", true, "mysql", "-e", "DROP DATABASE db;")
+			assert.NoError(err)
+			err = app.Exec("db", true, "mysql", "information_schema", "-e", "CREATE DATABASE db;")
+			assert.NoError(err)
+
 			dbZipPath := filepath.Join(testcommon.CreateTmpDir("local-db-zip"), "db.zip")
 			err = util.DownloadFile(dbZipPath, site.DBZipURL)
 			assert.NoError(err)
@@ -217,6 +227,11 @@ func TestLocalImportDB(t *testing.T) {
 		}
 
 		if site.FullSiteTarballURL != "" {
+			err = app.Exec("db", true, "mysql", "-e", "DROP DATABASE db;")
+			assert.NoError(err)
+			err = app.Exec("db", true, "mysql", "information_schema", "-e", "CREATE DATABASE db;")
+			assert.NoError(err)
+
 			siteTarPath := filepath.Join(testcommon.CreateTmpDir("local-site-tar"), "site.tar.gz")
 			err = util.DownloadFile(siteTarPath, site.FullSiteTarballURL)
 			assert.NoError(err)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -28,6 +28,7 @@ var (
 			FilesZipballURL:               "https://github.com/drud/drupal8/releases/download/v0.6.0/files.zip",
 			DBTarURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 			DBZipURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.zip",
+			FullSiteTarballURL:            "https://github.com/drud/drupal8/releases/download/v0.6.0/site.tar.gz",
 		},
 		{
 			Name:                          "TestMainPkgWordpress",

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -32,8 +32,8 @@ type App interface {
 	Wait(string) error
 	HostName() string
 	URL() string
-	ImportDB(string) error
-	ImportFiles(string) error
+	ImportDB(imPath string, extPath string) error
+	ImportFiles(imPath string, extPath string) error
 	SiteStatus() string
 	FindContainerByType(containerType string) (docker.APIContainers, error)
 	Exec(service string, tty bool, cmd ...string) error

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -26,6 +26,8 @@ type TestSite struct {
 	SourceURL string
 	// ArchiveExtractionPath is the relative path within the tarball which should be extracted, ending with /
 	ArchiveInternalExtractionPath string
+	// FullSiteTarballURL is the URL of the tarball of a full site archive used for testing import.
+	FullSiteTarballURL string
 	// FilesTarballURL is the URL of the tarball of file uploads used for testing file import.
 	FilesTarballURL string
 	// FilesZipballURL is the URL of the zipball of file uploads used for testing file import.


### PR DESCRIPTION
## The Problem:
#287 OP. If your stuff isn't at the root of your archive, your archive is no good to us!

## The Fix:
This PR introduces options for import-db and import-files to specify a path in an archive to extract, rather than extracting the whole archive. The extraction path can be specified with the --extract-path flag. If no flags are provided, the user gets the prompt for import asset path. If the provided asset is an archive, an additional prompt is provided, asking the user if they want to specify a location in the directory to extract.

## The Test:
This PR should generally let you use an archive structured in any way, so long as 1) if importing a db, you provide a path to a sql asset 2) if importing site files, you provide a path to site files.

I have added a full drush-generated archive for the kickstart test site: https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/site.tar.gz

To test extracting from the drush archive:
- Clone the kickstart repo
- Download the drush archive
- ddev config / ddev start the kickstart repo
- Drush archives put the sql dump at the root of the repo. To get just the sql asset using flags, run `ddev import-db --src path/to/site.tar.gz --extract-path data.sql`. You should also be able to run `ddev import-db` with no flags, provide the path to the archive in the first prompt, then provide the path to extract in the second prompt.
- To test import-files, `ddev import-db --src path/to/site.tar.gz --extract-path docroot/sites/default/files`. Same with import-db, you should be able to provide no flags and follow the prompts to the same result.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Local import tests expanded to test extracting from the drush-generated archive.

## Related Issue Link(s):
#287 OP

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

