### PR TITLE
Bash autocompletion for ddev, fixes #125

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,23 +39,7 @@ jobs:
           name: ddev version information
 
       - run:
-          command: |
-            BASE_DIR=$PWD
-            sudo mkdir $ARTIFACTS && sudo chmod 777 $ARTIFACTS
-            export VERSION=$(git describe --tags --always --dirty)
-            cd $BASE_DIR/bin/darwin/darwin_amd64
-            tar -czf $ARTIFACTS/ddev_osx.$VERSION.tar.gz ddev
-            zip $ARTIFACTS/ddev_osx.$VERSION.zip ddev
-            cd $BASE_DIR/bin/linux
-            tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev
-            zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev
-            cd $BASE_DIR/bin/windows/windows_amd64
-            tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe
-            zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe
-            cd $ARTIFACTS
-            for item in *.tar.gz *.zip; do
-              sha256sum $item > $item.sha256.txt
-            done
+          command: ./.circleci/generate_artifacts.sh $ARTIFACTS
           name: tar/zip up artifacts and make hashes
 
       - store_artifacts:
@@ -71,8 +55,6 @@ jobs:
       GOPATH: /home/circleci/go
       ARTIFACTS: /artifacts
     steps:
-#      - run: mkdir -p ~/go/{lib,pkg,src/github.com/drud/ddev}
-
       - checkout
 
       - run:
@@ -128,37 +110,7 @@ jobs:
           name: ddev version information (clean binaries, not nightlies)
 
       - run:
-          command: |
-            BASE_DIR=$PWD
-            sudo mkdir $ARTIFACTS && sudo chmod 777 $ARTIFACTS
-            export VERSION=$(git describe --tags --always --dirty)
-
-            # Generate and place the autocomplete
-            bin/linux/ddev_gen_autocomplete
-            for dir in bin/darwin/darwin_amd64 bin/linux bin/windows/windows_amd64; do
-              cp bin/ddev_bash_completion.sh $dir
-            done
-
-            # Generate OSX tarball/zipball
-            cd $BASE_DIR/bin/darwin/darwin_amd64
-            tar -czf $ARTIFACTS/ddev_osx.$VERSION.tar.gz ddev ddev_bash_completion.sh
-            zip $ARTIFACTS/ddev_osx.$VERSION.zip ddev ddev_bash_completion.sh
-
-            # Generate linux tarball/zipball
-            cd $BASE_DIR/bin/linux
-            tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev ddev_bash_completion.sh
-            zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev ddev_bash_completion.sh
-
-            # generate windows tarball/zipball
-            cd $BASE_DIR/bin/windows/windows_amd64
-            tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe ddev_bash_completion.sh
-            zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
-
-            # Create the sha256 files
-            cd $ARTIFACTS
-            for item in *.tar.gz *.zip; do
-              sha256sum $item > $item.sha256.txt
-            done
+          command: ./.circleci/generate_artifacts.sh $ARTIFACTS
           name: tar/zip up artifacts and make hashes
 
       - store_artifacts:
@@ -192,23 +144,7 @@ jobs:
           name: ddev version information
 
       - run:
-          command: |
-            BASE_DIR=$PWD
-            sudo mkdir $ARTIFACTS && sudo chmod 777 $ARTIFACTS
-            export VERSION=$(git describe --tags --always --dirty)
-            cd $BASE_DIR/bin/darwin/darwin_amd64
-            tar -czf $ARTIFACTS/ddev_osx.$VERSION.tar.gz ddev
-            zip $ARTIFACTS/ddev_osx.$VERSION.zip ddev
-            cd $BASE_DIR/bin/linux
-            tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev
-            zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev
-            cd $BASE_DIR/bin/windows/windows_amd64
-            tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe
-            zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe
-            cd $ARTIFACTS
-            for item in *.tar.gz *.zip; do
-              sha256sum $item > $item.sha256.txt
-            done
+          command: ./.circleci/generate_artifacts.sh $ARTIFACTS
           name: tar/zip up artifacts and make hashes
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,15 +132,29 @@ jobs:
             BASE_DIR=$PWD
             sudo mkdir $ARTIFACTS && sudo chmod 777 $ARTIFACTS
             export VERSION=$(git describe --tags --always --dirty)
+
+            # Generate and place the autocomplete
+            bin/linux/ddev_gen_autocomplete
+            for dir in bin/darwin/darwin_amd64 bin/linux bin/windows/windows_amd64; do
+              cp bin/ddev_bash_completion.sh $dir
+            done
+
+            # Generate OSX tarball/zipball
             cd $BASE_DIR/bin/darwin/darwin_amd64
-            tar -czf $ARTIFACTS/ddev_osx.$VERSION.tar.gz ddev
-            zip $ARTIFACTS/ddev_osx.$VERSION.zip ddev
+            tar -czf $ARTIFACTS/ddev_osx.$VERSION.tar.gz ddev ddev_bash_completion.sh
+            zip $ARTIFACTS/ddev_osx.$VERSION.zip ddev ddev_bash_completion.sh
+
+            # Generate linux tarball/zipball
             cd $BASE_DIR/bin/linux
-            tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev
-            zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev
+            tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev ddev_bash_completion.sh
+            zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev ddev_bash_completion.sh
+
+            # generate windows tarball/zipball
             cd $BASE_DIR/bin/windows/windows_amd64
-            tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe
-            zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe
+            tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe ddev_bash_completion.sh
+            zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
+
+            # Create the sha256 files
             cd $ARTIFACTS
             for item in *.tar.gz *.zip; do
               sha256sum $item > $item.sha256.txt

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -o errexit
+
+ARTIFACTS=$1
+BASE_DIR=$PWD
+
+sudo mkdir $ARTIFACTS && sudo chmod 777 $ARTIFACTS
+export VERSION=$(git describe --tags --always --dirty)
+
+# Generate and place the autocomplete
+bin/linux/ddev_gen_autocomplete
+for dir in bin/darwin/darwin_amd64 bin/linux bin/windows/windows_amd64; do
+  cp bin/ddev_bash_completion.sh $dir
+done
+
+# Generate OSX tarball/zipball
+cd $BASE_DIR/bin/darwin/darwin_amd64
+tar -czf $ARTIFACTS/ddev_osx.$VERSION.tar.gz ddev ddev_bash_completion.sh
+zip $ARTIFACTS/ddev_osx.$VERSION.zip ddev ddev_bash_completion.sh
+
+# Generate linux tarball/zipball
+cd $BASE_DIR/bin/linux
+tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev ddev_bash_completion.sh
+zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev ddev_bash_completion.sh
+
+# generate windows tarball/zipball
+cd $BASE_DIR/bin/windows/windows_amd64
+tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe ddev_bash_completion.sh
+zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
+
+# Create the sha256 files
+cd $ARTIFACTS
+for item in *.tar.gz *.zip; do
+  sha256sum $item > $item.sha256.txt
+done

--- a/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
+++ b/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"github.com/drud/ddev/cmd/ddev/cmd"
-	"github.com/drud/ddev/pkg/util"
 	"os"
 	"path/filepath"
+
+	"github.com/drud/ddev/cmd/ddev/cmd"
+	"github.com/drud/ddev/pkg/util"
 )
 
-var targetDir string = "bin"
+var targetDir = "bin"
 
 func main() {
 	if _, err := os.Stat(targetDir); os.IsNotExist(err) {

--- a/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
+++ b/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/drud/ddev/cmd/ddev/cmd"
+	"github.com/drud/ddev/pkg/util"
+	"os"
+	"path/filepath"
+)
+
+var targetDir string = "bin"
+
+func main() {
+	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
+		err = os.MkdirAll(targetDir, 0755)
+		util.CheckErr(err)
+	}
+	err := cmd.RootCmd.GenBashCompletionFile(filepath.Join(targetDir, "ddev_bash_completion.sh"))
+	util.CheckErr(err)
+}

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -202,3 +202,6 @@ You can stop a site's containers without losing data by using `ddev stop` in the
 
 ## Removing a site
 You can remove a site's containers by running `ddev remove` in the working directory of the site. You can also remove any running site's containers by providing the site name as an argument, e.g. `ddev remove <sitename>`. **Note:** `ddev remove` is destructive. It will remove all containers for the site, destroying database contents in the process. Your project code base and files will not be affected.
+
+## ddev Command Auto-Completion
+ddev bash auto-completion is available. If you have installed ddev via homebrew (on OSX) it will already be installed. Otherwise, you can download the [latest release](https://github.com/drud/ddev/releases) tarball for your platform and the ddev_bash_completions.sh inside it can be installed wherever your bash_completions.d is. For example, `cp ddev_bash_completions.sh /etc/bash_completion.d/ddev`

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -51,6 +51,15 @@ else
     sudo mv /tmp/ddev /usr/local/bin/
 fi
 
+if which brew &&  [ -f `brew --prefix`/etc/bash_completion ]; then
+	bash_completion_dir=$(brew --prefix)/etc/bash_completion.d
+    cp /tmp/ddev_bash_completion.sh $bash_completion_dir/ddev
+    echo "$(GREEN)Installed ddev bash completions in $bash_completion_dir$(RESET)"
+    rm /tmp/ddev_bash_completion.sh
+else
+	echo "$(YELLOW)Bash completion for ddev was not installed. You may manually install /tmp/ddev_bash_completions.sh in your bash_completions.d directory.$(RESET)"
+fi
+
 rm /tmp/$TARBALL /tmp/$SHAFILE
 
 echo "${GREEN}ddev is now installed. Run \"ddev\" to verify your installation and see usage.${RESET}"


### PR DESCRIPTION
## The Problem:

Some of us are dependent on autocompletion. OP #125 

## The Fix:

Cobra supports bash completion, although it does not yet support (directly) zsh completion. The implementation is fairly straightforward into a separate binary.

## The Test:

* build for your platform
* The completions generator will be in bin/.../ddev_gen_autocomplete, for example bin/darwin/darwin_amd64/ddev_gen_autocomplete
* run the generator, `bin/darwin/darwin_amd64/ddev_gen_autocomplete` and it will create bin/ddev_bash_completion.sh 
* ddev_bash_completion.sh can be installed as `ddev` in /usr/local/etc/bash_completion.d/ddev or wherever you keep your bash completions.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

After a new release (v0.8) is created, the homebrew recipe should support automatically installing the completions.