### PR TITLE
Update apt key for mysql to avoid errors on circleci

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -3,6 +3,9 @@
 set -o errexit
 
 # Basic tools
+
+# mysql - old key is expired, so get the new one
+sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5 >/dev/null 2>&1
 sudo apt-get update -qq
 sudo apt-get install -qq mysql-client realpath zip
 


### PR DESCRIPTION
## The Problem:

Mysql signing key for debian expired.

## The Fix:

Update to the new key - affects only our circleci build.

## The Test:

Look at circleci build and see if this has disappeared:

```
W: GPG error: http://repo.mysql.com trusty InRelease: The following signatures were invalid: KEYEXPIRED 1487236823 KEYEXPIRED 1487236823 KEYEXPIRED 1487236823
WARNING: The following packages cannot be authenticated!
  mysql-server mysql-community-server mysql-client mysql-community-client
  mysql-common

```

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

