### PR TITLE
Mount full codebase to web container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm7-local
-WebTag ?= v0.6.1
+WebTag ?= template-site-config
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.4.1
 RouterImage ?= drud/ddev-router

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm7-local
-WebTag ?= template-site-config
+WebTag ?= v0.7.0
 DBImg ?= drud/mysql-docker-local-57
 DBTag ?= v0.4.1
 RouterImage ?= drud/ddev-router

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -29,7 +29,7 @@ func TestDevExec(t *testing.T) {
 		args := []string{"exec", "pwd"}
 		out, err := exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
-		assert.Contains(string(out), "/var/www/html/docroot")
+		assert.Contains(string(out), "/var/www/html")
 
 		args = []string{"-s", "db", "exec", "pwd"}
 		out, err = exec.RunCommand(DdevBin, args)

--- a/docs/users/customization-extendibility.md
+++ b/docs/users/customization-extendibility.md
@@ -84,7 +84,7 @@ The default web container for ddev uses NGINX as the web server. A default confi
 
 - Run `ddev config` for the site if it has not been used with ddev before.
 - Create a file named "nginx-site.conf" in the ".ddev" directory for your site.
-- Add your configurations to the "nginx-site.conf" file. You can optionally use the default ddev configuration as a reference or starting point.
+- Add your configurations to the "nginx-site.conf" file. You can optionally use the [default NGINX configuration provided by ddev](https://github.com/drud/docker.nginx-php-fpm-local/blob/master/files/etc/nginx/nginx-site.conf) as a reference or starting point. [Additional configuration examples](https://www.nginx.com/resources/wiki/start/#other-examples) and documentation are available at the [nginx wiki](https://www.nginx.com/resources/wiki/)
 - **NOTE:** The "root" statement in the server block must be `root $NGINX_DOCROOT;` in order to ensure the path for NGINX to serve the site from is correct.
 - Save your configuration file and run `dev start` to start the site environment. If you encounter issues with your configuration or the site fails to start, use `ddev logs` to inspect the logs for possible NGINX configuration errors.
 

--- a/docs/users/customization-extendibility.md
+++ b/docs/users/customization-extendibility.md
@@ -79,5 +79,14 @@ services:
       - solr:$DDEV_HOSTNAME
 ```
 
+## Providing custom nginx configuration
+The default web container for ddev uses NGINX as the web server. A default configuration is provided in the web container that should work for most Drupal 7+ and WordPress sites. Some sites may require custom configuration, for example to support a module or plugin requiring special rules. To accommodate these needs, ddev provides a way to replace the default configuration with a custom version.
+
+- Run `ddev config` for the site if it has not been used with ddev before.
+- Create a file named "nginx-site.conf" in the ".ddev" directory for your site.
+- Add your configurations to the "nginx-site.conf" file. You can optionally use the default ddev configuration as a reference or starting point.
+- **NOTE:** The "root" statement in the server block must be `root $NGINX_DOCROOT;` in order to ensure the path for NGINX to serve the site from is correct.
+- Save your configuration file and run `dev start` to start the site environment. If you encounter issues with your configuration or the site fails to start, use `ddev logs` to inspect the logs for possible NGINX configuration errors.
+
 ## Overriding default container images
 The default container images provided by ddev are defined in the `config.yaml` file in the `.ddev` folder of your project. This means that _defining_ an alternative image for default services is as simple as changing the image definition in `config.yaml`. In practice, however, ddev currently has certain expectations and assumptions for what the web and database containers provide. At this time, it is recommended that the default container projects be referenced or used as a starting point for developing an alternative image. If you encounter difficulties integrating alternative images, please [file an issue and let us know](https://github.com/drud/ddev/issues/new).

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -6,7 +6,6 @@ import (
 	"html/template"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -223,7 +222,6 @@ func (c *Config) RenderComposeYAML() (string, error) {
 		"name": c.Name,
 		// path.Join is desired over filepath.Join here,
 		// as we always want a unix-style path for the mount.
-		"docroot":     path.Join("../", c.Docroot),
 		"plugin":      "ddev",
 		"appType":     c.AppType,
 		"mailhogport": appports.GetPort("mailhog"),

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -114,7 +114,6 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	assert.Error(err)
 	config.Name = util.RandString(32)
 	config.AppType = AllowedAppTypes[0]
-	config.Docroot = util.RandString(16)
 
 	// Write a config to create/prep necessary directories.
 	err = config.Write()
@@ -133,7 +132,6 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	composeBytes, err := ioutil.ReadFile(config.DockerComposeYAMLPath())
 	assert.NoError(err)
 	contentString := string(composeBytes)
-	assert.Contains(contentString, config.Docroot)
 	assert.Contains(contentString, config.Platform)
 	assert.Contains(contentString, config.AppType)
 }

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -32,7 +32,7 @@ services:
     ports:
       - "80"
       - "{{ .mailhogport }}"
-    working_dir: "/var/www/html"
+    working_dir: /var/www/html/${DDEV_DOCROOT}
     environment:
       - DDEV_UID=$DDEV_UID
       - DDEV_GID=$DDEV_GID

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -1,7 +1,7 @@
 package ddevapp
 
-// DDevComposeTemplate is used to create the docker-compose.yaml for
-// legacy sites in the ddev env
+// DDevComposeTemplate is used to create the main docker-compose.yaml
+// file for a ddev site.
 const DDevComposeTemplate = `version: '3'
 
 services:
@@ -17,14 +17,13 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
-      com.ddev.docroot: $DDEV_DOCROOT
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
   web:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
     volumes:
-      - "{{ .docroot }}/:/var/www/html/docroot:cached"
+      - "./:/var/www/html/docroot:cached"
     restart: always
     depends_on:
       - db
@@ -33,10 +32,11 @@ services:
     ports:
       - "80"
       - "{{ .mailhogport }}"
-    working_dir: "/var/www/html/docroot"
+    working_dir: "/var/www/html"
     environment:
       - DDEV_UID=$DDEV_UID
       - DDEV_GID=$DDEV_GID
+      - DOCROOT=$DDEV_DOCROOT
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
@@ -46,7 +46,6 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
-      com.ddev.docroot: $DDEV_DOCROOT
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
   dba:
@@ -57,7 +56,6 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
-      com.ddev.docroot: $DDEV_DOCROOT
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
     depends_on:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -23,7 +23,7 @@ services:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
     volumes:
-      - "./:/var/www/html/docroot:cached"
+      - "../:/var/www/html:cached"
     restart: always
     depends_on:
       - db

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -469,7 +469,7 @@ func (l *LocalApp) DockerEnv() {
 		"DDEV_DBAIMAGE":        l.AppConfig.DBAImage,
 		"DDEV_WEBIMAGE":        l.AppConfig.WebImage,
 		"DDEV_APPROOT":         l.AppConfig.AppRoot,
-		"DDEV_DOCROOT":         filepath.Join(l.AppConfig.AppRoot, l.AppConfig.Docroot),
+		"DDEV_DOCROOT":         l.AppConfig.Docroot,
 		"DDEV_URL":             l.URL(),
 		"DDEV_HOSTNAME":        l.HostName(),
 		"DDEV_UID":             "",

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -312,7 +312,7 @@ func TestLocalExec(t *testing.T) {
 		err = app.Exec("web", true, "pwd")
 		assert.NoError(err)
 		out := stdout()
-		assert.Contains(out, "/var/www/html/docroot")
+		assert.Contains(out, "/var/www/html")
 
 		stdout = testcommon.CaptureStdOut()
 		switch app.GetType() {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,7 +17,7 @@ var DockerVersionConstraint = ">= 17.05.0-ce"
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.6.1" // Note that this is overridden by make
+var WebTag = "v0.7.0" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-docker-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:
#189 OP. Mounting only the docroot prevents code and assets above the docroot from being accessible to the web container. This can prevent a site from working entirely if it depends on code that resides above the docroot.

## The Fix:
This introduces changes to mount the full codebase of the project instead of the docroot. The docroot value becomes a relative path that is provided to the web container as an environment variable. This env var is then used to set the docroot for nginx in the web container.

This will also include documentation changes to support overriding the nginx configuration file with one the user provides.

## The Test:
**To test this, you need to remove any pre-existing .ddev directory (minimally the docker-compose.yml). This also requires the `template-site-config` tag of the web container be used for the test sites.**

To test this, you'll need a site that depends on code or assets that reside above the docroot. One way to get such a code base would be to create a drupal8 site using drupal-composer/drupal-project:

```
composer create-project drupal-composer/drupal-project:8.x-dev some-dir --stability dev --no-interaction
```

This creates as drupal8 site with a vendor directory above its docroot (named web). You should be able to ddev config/ddev start, and access a working drupal 8 installation. Previously, this project would produce fatal errors, as vendor dependencies would not be present on the web container. With this PR, it should work normally.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Existing tests have been updated for the mount volume / working directory change on the web container. I'm not sure there's a test for ddev, but I'm happy to consider suggestions. Most of the functionality change occurs with the web container, so I might look at a test over there.

## Related Issue Link(s):
#189 
#293 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
This will require a new web container tag before merge.

