### PR TITLE
Improve example mysql command in ddev describe, followup on #277

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -109,7 +109,7 @@ func (l *LocalApp) Describe() (string, error) {
 		dbTable.AddRow("Host:", "db")
 		dbTable.AddRow("Port:", appports.GetPort("db"))
 		output = output + fmt.Sprint(dbTable)
-		output = output + fmt.Sprintf("\nTo connect to mysql from your host machine, use port %[1]v on 127.0.0.1.\nFor example: mysql --host 127.0.0.1 --port %[1]v", dbPublishPort)
+		output = output + fmt.Sprintf("\nTo connect to mysql from your host machine, use port %[1]v on 127.0.0.1.\nFor example: mysql --host=127.0.0.1 --port=%[1]v --user=db --password=db --database=db", dbPublishPort)
 
 		output = output + "\n\nOther Services\n--------------\n"
 		other := uitable.New()


### PR DESCRIPTION
## The Problem:

The mysql example in ddev describe didn't have all the options needed to make the user successful.

## The Fix:

Give a full example.

```
$ ddev describe
NAME      TYPE     LOCATION              URL                         STATUS
randyfay  drupal7  ~/workspace/randyfay  http://randyfay.ddev.local  running

MySQL Credentials
-----------------
Username:     	db
Password:     	db
Database name:	db
Host:         	db
Port:         	3306
To connect to mysql from your host machine, use port 32868 on 127.0.0.1.
For example: mysql --host=127.0.0.1 --port=32868 --user=db --password=db --database=db

Other Services
--------------
MailHog:   	http://randyfay.ddev.local:8025
phpMyAdmin:	http://randyfay.ddev.local:8036
```

## The Test:

Do a `ddev describe` and then plug in the example mysql command.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

This is followup on comment on #277 - https://github.com/drud/ddev/issues/277#issuecomment-308177156

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

