### PR TITLE
adds restart policy to ddev-router, updates to docker-compose v3, fixes #300

### DIFF
--- a/docs/users/customization-extendibility.md
+++ b/docs/users/customization-extendibility.md
@@ -49,7 +49,7 @@ This file would be saved as `docker-compose.solr.yml` in your project's `.ddev` 
 # you would copy the solr-conf/5.x/ contents into .ddev/solr/conf. The configuration
 # files must be present before running `ddev start`.
 
-version: '2'
+version: '3'
 
 services:
   solr: # This is the service name used when running ddev commands accepting the --service flag

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -2,7 +2,7 @@ package ddevapp
 
 // DDevComposeTemplate is used to create the docker-compose.yaml for
 // legacy sites in the ddev env
-const DDevComposeTemplate = `version: '2'
+const DDevComposeTemplate = `version: '3'
 
 services:
   db:

--- a/pkg/plugins/platform/templates.go
+++ b/pkg/plugins/platform/templates.go
@@ -63,7 +63,7 @@ var SequelproTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>`
 
 // DdevRouterTemplate is the template for the generic router container.
-const DdevRouterTemplate = `version: '2'
+const DdevRouterTemplate = `version: '3'
 services:
   ddev-router:
     image: {{ .router_image }}:{{ .router_tag }}
@@ -73,6 +73,7 @@ services:
       {{ end }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+    restart: always
 networks:
    default:
      external:


### PR DESCRIPTION
## The Problem:
#300 OP. If the docker daemon gets restarted, previously running site containers come back, but ddev-router doesn't.

## The Fix:
We defined restart policies for site containers, but not for the router. This adds a restart policy of always to the router, matching policy for the site containers.

I also bumped the composer file versions to v3. I initially bumped to v3 to evaluate a restart policy option not available for v2 (unless-stopped), but decided against using that option. I went ahead and bumped the version anyways, since we don't have any incompatible usage, and we may as well upgrade sooner rather than later, potentially affecting more users.

## The Test:
#300 OP outlines how to reproduce the failure:
- Have ddev sites running
- Restart the docker daemon
- See no ddev-router in `docker ps`, no accessible site where there once was.

With this PR, you should be able to restart the docker daemon, the ddev-router should be present in docker ps, and the site should be accessible.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
I don't think there's a reasonable way to test this via automation, since we need to restart docker entirely in order to reproduce the case.

## Related Issue Link(s):
#300 OP

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

