### PR TITLE
Expands status checks to account for router and db, fixes #313, fixes #318

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ WebTag ?= v0.7.3
 DBImg ?= drud/mysql-local-57
 DBTag ?= v0.5.0
 RouterImage ?= drud/ddev-router
-RouterTag ?= v0.4.2
+RouterTag ?= v0.4.3
 DBAImg ?= drud/phpmyadmin
 DBATag ?= v0.2.0
 

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
@@ -32,7 +31,7 @@ running 'ddev stop <sitename>.`,
 
 		out, err := describeApp(siteName)
 		if err != nil {
-			log.Fatalf("Could not describe app: %v", err)
+			util.Failed("Could not describe app: %v", err)
 		}
 		fmt.Println(out)
 	},

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -87,13 +88,13 @@ func TestDescribeAppFunction(t *testing.T) {
 		assert.Contains(string(out), app.GetName())
 		assert.Contains(string(out), "running")
 		assert.Contains(string(out), v.Dir)
-		assert.Contains(string(out), "DDEV ROUTER STATUS: running")
+		assert.Contains(string(out), "DDEV ROUTER STATUS: "+color.CyanString("running"))
 
 		_, err = exec.RunCommand("docker", []string{"stop", "ddev-router"})
 		assert.NoError(err)
 		out, err = describeApp("")
 		assert.NoError(err)
-		assert.Contains(string(out), "DDEV ROUTER STATUS: stopped")
+		assert.Contains(string(out), "DDEV ROUTER STATUS: "+color.YellowString("stopped"))
 		assert.Contains(string(out), "The router is not currently running")
 		_, err = exec.RunCommand("docker", []string{"start", "ddev-router"})
 		assert.NoError(err)

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -87,6 +87,16 @@ func TestDescribeAppFunction(t *testing.T) {
 		assert.Contains(string(out), app.GetName())
 		assert.Contains(string(out), "running")
 		assert.Contains(string(out), v.Dir)
+		assert.Contains(string(out), "DDEV ROUTER STATUS: running")
+
+		_, err = exec.RunCommand("docker", []string{"stop", "ddev-router"})
+		assert.NoError(err)
+		out, err = describeApp("")
+		assert.NoError(err)
+		assert.Contains(string(out), "DDEV ROUTER STATUS: stopped")
+		assert.Contains(string(out), "The router is not currently running")
+		_, err = exec.RunCommand("docker", []string{"start", "ddev-router"})
+		assert.NoError(err)
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -94,7 +94,7 @@ func TestDescribeAppFunction(t *testing.T) {
 		assert.NoError(err)
 		out, err = describeApp("")
 		assert.NoError(err)
-		assert.Contains(string(out), "DDEV ROUTER STATUS: "+color.YellowString("stopped"))
+		assert.Contains(string(out), "DDEV ROUTER STATUS: "+color.RedString("stopped"))
 		assert.Contains(string(out), "The router is not currently running")
 		_, err = exec.RunCommand("docker", []string{"start", "ddev-router"})
 		assert.NoError(err)

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"os"
 
+	"strings"
+
+	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -25,8 +28,12 @@ var LocalDevExecCmd = &cobra.Command{
 			util.Failed("Failed to exec command: %v", err)
 		}
 
-		if app.SiteStatus() != "running" {
+		if strings.Contains(app.SiteStatus(), platform.SiteNotFound) {
 			util.Failed("App not running locally. Try `ddev start`.")
+		}
+
+		if strings.Contains(app.SiteStatus(), platform.SiteStopped) {
+			util.Failed("App is stopped. Run `ddev start` to start the environment.")
 		}
 
 		app.DockerEnv()

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +41,10 @@ can be provided if it is not located at the top-level of the archive.`,
 		app, err := getActiveApp("")
 		if err != nil {
 			util.Failed("Failed to find active app to import database to: %v", app.GetName(), err)
+		}
+
+		if app.SiteStatus() != platform.SiteRunning {
+			util.Failed("App not running locally. Try `ddev start`.")
 		}
 
 		err = app.ImportDB(dbSource, dbExtPath)

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -44,7 +44,7 @@ can be provided if it is not located at the top-level of the archive.`,
 		}
 
 		if app.SiteStatus() != platform.SiteRunning {
-			util.Failed("App not running locally. Try `ddev start`.")
+			util.Failed("The site is not running. The site must be running in order to import a database.")
 		}
 
 		err = app.ImportDB(dbSource, dbExtPath)

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"strings"
+
+	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -22,8 +25,12 @@ var LocalDevLogsCmd = &cobra.Command{
 			util.Failed("Failed to retrieve logs: %v", err)
 		}
 
-		if app.SiteStatus() != "running" {
+		if strings.Contains(app.SiteStatus(), platform.SiteNotFound) {
 			util.Failed("App not running locally. Try `ddev start`.")
+		}
+
+		if strings.Contains(app.SiteStatus(), platform.SiteStopped) {
+			util.Failed("App is stopped. Run `ddev start` to start the environment.")
 		}
 
 		err = app.Logs(serviceType, follow, timestamp, tail)

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -5,6 +5,7 @@ import (
 
 	"os"
 
+	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -37,7 +38,7 @@ Your project code base and files will not be affected.`,
 			util.Failed("Failed to get active app: %v", err)
 		}
 
-		if app.SiteStatus() == "not found" {
+		if app.SiteStatus() == platform.SiteNotFound {
 			util.Failed("App not running locally. Try `ddev start`.")
 		}
 

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -47,12 +47,6 @@ var LocalDevReconfigCmd = &cobra.Command{
 			util.Failed("Failed to restart %s: %v", app.GetName(), err)
 		}
 
-		fmt.Println("Waiting for the environment to become ready. This may take a couple of minutes...")
-		err = app.Wait("web")
-		if err != nil {
-			util.Failed("Failed to restart %s: %v", app.GetName(), err)
-		}
-
 		util.Success("Successfully restarted %s", app.GetName())
 		util.Success("Your application can be reached at: %s", app.URL())
 	},

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -47,8 +47,8 @@ func handleSequelProCommand(appLocation string) (string, error) {
 		return "", err
 	}
 
-	if app.SiteStatus() != "running" {
-		return "", errors.New("app not running locally. Try `ddev start`")
+	if app.SiteStatus() != platform.SiteRunning {
+		return "", errors.New("App not running locally. Try `ddev start`")
 	}
 
 	db, err := app.FindContainerByType("db")

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -48,7 +48,7 @@ func handleSequelProCommand(appLocation string) (string, error) {
 	}
 
 	if app.SiteStatus() != platform.SiteRunning {
-		return "", errors.New("App not running locally. Try `ddev start`")
+		return "", errors.New("site is not running. The site must be running to create a Sequel Pro connection")
 	}
 
 	db, err := app.FindContainerByType("db")

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"strings"
+
+	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -16,8 +19,12 @@ var LocalDevSSHCmd = &cobra.Command{
 			util.Failed("Failed to ssh: %v", err)
 		}
 
-		if app.SiteStatus() != "running" {
+		if strings.Contains(app.SiteStatus(), platform.SiteNotFound) {
 			util.Failed("App not running locally. Try `ddev start`.")
+		}
+
+		if strings.Contains(app.SiteStatus(), platform.SiteStopped) {
+			util.Failed("App is stopped. Run `ddev start` to start the environment.")
 		}
 
 		app.DockerEnv()

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -45,12 +45,6 @@ provide a working environment for development.`,
 			util.Failed("Failed to start %s: %v", app.GetName(), err)
 		}
 
-		fmt.Println("Waiting for the environment to become ready. This may take a couple of minutes...")
-		err = app.Wait("web")
-		if err != nil {
-			util.Failed("The environment for %s never became ready: %v", app.GetName(), err)
-		}
-
 		util.Success("Successfully started %s", app.GetName())
 		util.Success("Your application can be reached at: %s", app.URL())
 

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -246,22 +246,42 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 	return nil
 }
 
-// SiteStatus returns the current status of an application based on the web container.
+// SiteStatus returns the current status of an application determined from web and db service health.
 func (l *LocalApp) SiteStatus() string {
-	webContainer, err := l.FindContainerByType("web")
-	if err != nil {
-		return SiteNotFound
+	var siteStatus string
+	services := map[string]string{"web": "", "db": ""}
+
+	for service := range services {
+		container, err := l.FindContainerByType(service)
+		if err != nil {
+			services[service] = SiteNotFound
+			siteStatus = service + " service " + SiteNotFound
+		}
+
+		status := dockerutil.GetContainerHealth(container)
+
+		switch status {
+		case "exited":
+			services[service] = SiteStopped
+			siteStatus = service + " service " + SiteStopped
+		case "healthy":
+			services[service] = SiteRunning
+		default:
+			services[service] = status
+		}
 	}
 
-	status := dockerutil.GetContainerHealth(webContainer)
-	if status == "exited" {
-		return SiteStopped
-	}
-	if status == "healthy" {
-		return SiteRunning
+	if services["web"] == services["db"] {
+		siteStatus = services["web"]
+	} else {
+		for service, status := range services {
+			if status != SiteRunning {
+				siteStatus = service + " service " + status
+			}
+		}
 	}
 
-	return status
+	return siteStatus
 }
 
 // ImportFiles takes a source directory or archive and copies to the uploaded files directory of a given app.
@@ -418,6 +438,11 @@ func (l *LocalApp) Start() error {
 		return err
 	}
 
+	err = l.Wait("web", "db")
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -526,15 +551,17 @@ func (l *LocalApp) Stop() error {
 	return StopRouter()
 }
 
-// Wait ensures that the app appears to be read before returning
-func (l *LocalApp) Wait(containerType string) error {
-	labels := map[string]string{
-		"com.ddev.site-name":         l.GetName(),
-		"com.docker.compose.service": containerType,
-	}
-	err := dockerutil.ContainerWait(35, labels)
-	if err != nil {
-		return err
+// Wait ensures that the app service containers are healthy.
+func (l *LocalApp) Wait(containerTypes ...string) error {
+	for _, containerType := range containerTypes {
+		labels := map[string]string{
+			"com.ddev.site-name":         l.GetName(),
+			"com.docker.compose.service": containerType,
+		}
+		err := dockerutil.ContainerWait(35, labels)
+		if err != nil {
+			return fmt.Errorf("%s service %v", containerType, err)
+		}
 	}
 
 	return nil

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -118,6 +118,9 @@ func (l *LocalApp) Describe() (string, error) {
 		other.AddRow("phpMyAdmin:", l.URL()+":"+appports.GetPort("dba"))
 		output = output + fmt.Sprint(other)
 	}
+
+	output = output + "\n" + PrintRouterStatus()
+
 	return output, nil
 }
 
@@ -529,7 +532,7 @@ func (l *LocalApp) Wait(containerType string) error {
 		"com.ddev.site-name":         l.GetName(),
 		"com.docker.compose.service": containerType,
 	}
-	err := dockerutil.ContainerWait(90, labels)
+	err := dockerutil.ContainerWait(35, labels)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -32,6 +32,8 @@ import (
 	"github.com/lextoumbourou/goodhosts"
 )
 
+const containerWaitTimeout = 35
+
 // LocalApp implements the AppBase interface local development apps
 type LocalApp struct {
 	AppConfig *ddevapp.Config
@@ -558,7 +560,7 @@ func (l *LocalApp) Wait(containerTypes ...string) error {
 			"com.ddev.site-name":         l.GetName(),
 			"com.docker.compose.service": containerType,
 		}
-		err := dockerutil.ContainerWait(35, labels)
+		err := dockerutil.ContainerWait(containerWaitTimeout, labels)
 		if err != nil {
 			return fmt.Errorf("%s service %v", containerType, err)
 		}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -410,7 +410,10 @@ func (l *LocalApp) Start() error {
 		return err
 	}
 
-	StartDdevRouter()
+	err = StartDdevRouter()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -256,18 +256,18 @@ func (l *LocalApp) SiteStatus() string {
 		if err != nil {
 			services[service] = SiteNotFound
 			siteStatus = service + " service " + SiteNotFound
-		}
+		} else {
+			status := dockerutil.GetContainerHealth(container)
 
-		status := dockerutil.GetContainerHealth(container)
-
-		switch status {
-		case "exited":
-			services[service] = SiteStopped
-			siteStatus = service + " service " + SiteStopped
-		case "healthy":
-			services[service] = SiteRunning
-		default:
-			services[service] = status
+			switch status {
+			case "exited":
+				services[service] = SiteStopped
+				siteStatus = service + " service " + SiteStopped
+			case "healthy":
+				services[service] = SiteRunning
+			default:
+				services[service] = status
+			}
 		}
 	}
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -105,9 +105,6 @@ func TestLocalStart(t *testing.T) {
 		err = app.Start()
 		assert.NoError(err)
 
-		err = app.Wait("web")
-		assert.NoError(err)
-
 		// ensure docker-compose.yaml exists inside .ddev site folder
 		composeFile := fileutil.FileExists(app.DockerComposeYAMLPath())
 		assert.True(composeFile)
@@ -445,9 +442,6 @@ func TestLocalRemove(t *testing.T) {
 		err = app.Start()
 		assert.NoError(err)
 
-		err = app.Wait("web")
-		assert.NoError(err)
-
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalRemove", site.Name))
 		err = app.Down()
 		assert.NoError(err)
@@ -477,9 +471,6 @@ func TestCleanupWithoutCompose(t *testing.T) {
 
 	// Start a site so we have something to cleanup
 	err = app.Start()
-	assert.NoError(err)
-
-	err = app.Wait("web")
 	assert.NoError(err)
 
 	// Call the Cleanup command()

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -89,6 +89,8 @@ func StartDdevRouter() error {
 		return fmt.Errorf("failed to start ddev-router: %v", err)
 	}
 
+	fmt.Println("Starting service health checks...")
+
 	// ensure we have a happy router
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
 	err = dockerutil.ContainerWait(35, label)

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -112,10 +112,10 @@ func PrintRouterStatus() string {
 	container, err := dockerutil.FindContainerByLabels(label)
 
 	if err != nil {
-		status = color.RedString("not running") + badRouter
+		status = color.RedString(SiteNotFound) + badRouter
+	} else {
+		status = dockerutil.GetContainerHealth(container)
 	}
-
-	status = dockerutil.GetContainerHealth(container)
 
 	switch status {
 	case "exited":

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -93,7 +93,7 @@ func StartDdevRouter() error {
 
 	// ensure we have a happy router
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
-	err = dockerutil.ContainerWait(35, label)
+	err = dockerutil.ContainerWait(containerWaitTimeout, label)
 	if err != nil {
 		return fmt.Errorf("ddev-router failed to become ready: %v", err)
 	}

--- a/pkg/plugins/platform/router.go
+++ b/pkg/plugins/platform/router.go
@@ -118,14 +118,12 @@ func PrintRouterStatus() string {
 	}
 
 	switch status {
-	case "exited":
-		status = color.YellowString(SiteStopped) + badRouter
-	case "restarting":
-		status = color.RedString(status) + badRouter
 	case "healthy":
 		status = color.CyanString(SiteRunning)
+	case "exited":
+		status = color.RedString(SiteStopped) + badRouter
 	default:
-		status = color.CyanString(status)
+		status = color.RedString(status) + badRouter
 	}
 
 	return fmt.Sprintf("\nDDEV ROUTER STATUS: %v", status)

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -29,7 +29,6 @@ type App interface {
 	DockerComposeYAMLPath() string
 	Down() error
 	Config() error
-	Wait(string) error
 	HostName() string
 	URL() string
 	ImportDB(imPath string, extPath string) error

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -64,6 +64,7 @@ func RenderAppTable(platform string, apps []App) {
 			RenderAppRow(table, site)
 		}
 		fmt.Println(table)
+		fmt.Println(PrintRouterStatus())
 	}
 
 }

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -87,11 +87,16 @@ func RenderAppRow(table *uitable.Table, site App) {
 		appRoot = strings.Replace(appRoot, userDir, "~", 1)
 	}
 	status := site.SiteStatus()
-	if status == "stopped" {
+
+	switch {
+	case strings.Contains(status, SiteStopped):
 		status = color.YellowString(status)
-	} else {
+	case strings.Contains(status, SiteNotFound):
+		status = color.RedString(status)
+	default:
 		status = color.CyanString(status)
 	}
+
 	table.AddRow(
 		site.GetName(),
 		site.GetType(),

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -35,7 +35,7 @@ var DBATag = "v0.2.0"
 var RouterImage = "drud/ddev-router" // Note that this is overridden by make
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.4.2" // Note that this is overridden by make
+var RouterTag = "v0.4.3" // Note that this is overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem:
OPs #313 & #318 surface issues with our current approach for determining site status, which only checks the web container's health. The router and the db service are also important and need to be running healthily, otherwise the site environment is not truly running, and this is not accurately reflected in ddev list or describe output.

## The Fix:
This PR introduces a number of fixes related to improving site status checks:

- Adds status check of ddev-router to StartDDevRouter() to ensure the router is healthy running. If the router fails to report running, "ddev start" will provide a failure error message.
- Adds router status messaging to "ddev list" and "ddev describe". If the router is not running, an additional message will be provided to inform the user that sites are not likely to be accessible.
- Updates l.Wait() to support checking status of multiple container types.
- Updates app.SiteStatus() to reflect the site status based on status of both web and db containers. If one of the two containers is not running, status should indicate as "<type> service <status>"
- Updates status checks for exec, ssh, and logs to prevent use only if the status is stopped or not found. This should allow the commands to still be used in the event the site is not in a fully running state, which can be useful for debugging.
- Updates container tags to new versions with reduced health check intervals, and reduces timeout on l.Wait() to 35s, since all containers should succeed or hit unhealthy within this range. 

## The Test:
- "ddev start" a site.
- Run "ddev list". You should see router status output. Router should be running.
- Run "ddev describe". You should see same router status output.
- Run "docker stop ddev-router" and then run list or describe. Router status should report "stopped" and provide a warning that your sites are not accessible. Restart the router with "docker start ddev-router"
- Stop the db container for a site, run describe or list. Status should report "db service stopped".

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Tests updated, with addition to describe tests for outputting router status.

## Related Issue Link(s):
#313
#318 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

