### PR TITLE
use unique folder for testing ValidateAsset, fixes #203

### DIFF
--- a/pkg/appimport/appimport_test.go
+++ b/pkg/appimport/appimport_test.go
@@ -38,12 +38,13 @@ func TestValidateAsset(t *testing.T) {
 
 	// test tilde expansion
 	userDir, err := homedir.Dir()
-	testDir := filepath.Join(userDir, "testpath")
+	testDirName := "testpath-" + util.RandString(4)
+	testDir := filepath.Join(userDir, testDirName)
 	assert.NoError(err)
 	err = os.Mkdir(testDir, 0755)
 	assert.NoError(err)
 
-	testPath, err := ValidateAsset("~/testpath", "files")
+	testPath, err := ValidateAsset("~/"+testDirName, "files")
 	assert.NoError(err)
 	assert.Contains(testPath, userDir)
 	assert.False(strings.Contains(testPath, "~"))

--- a/pkg/appimport/appimport_test.go
+++ b/pkg/appimport/appimport_test.go
@@ -38,7 +38,7 @@ func TestValidateAsset(t *testing.T) {
 
 	// test tilde expansion
 	userDir, err := homedir.Dir()
-	testDirName := "testpath-" + util.RandString(4)
+	testDirName := "tmp.ddev.testpath-" + util.RandString(4)
 	testDir := filepath.Join(userDir, testDirName)
 	assert.NoError(err)
 	err = os.Mkdir(testDir, 0755)


### PR DESCRIPTION
## The Problem:
#203 created test folder should be unique to avoid collision
## The Fix:
This makes the folder created in user's home directory uniquely named to prevent collision. 

## The Test:
This only affects tests, and there should be no discernible difference in the test. The OP identified an error that was originally showing up in our tests, but it does not appear to be present in recent builds. I'm not sure if the issue is still valid at this point, but it doesn't hurt to make the test directory unique.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#203
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

