### PR TITLE
validate sitenames, validate config during init, fixes #86

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -33,8 +33,8 @@ const DDevTLD = "ddev.local"
 // AllowedAppTypes lists the types of site/app that can be used.
 var AllowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}
 
-// Regexp pattern to match any non-alphanumeric characters (except dashes) so they can be replaced.
-var re = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
+// Regexp pattern to determine if a hostname is valid per RFC 1123.
+var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
 
 // Config defines the yaml config file format for ddev applications
 type Config struct {
@@ -133,9 +133,6 @@ func (c *Config) Read() error {
 		c.DBAImage = version.DBAImg + ":" + version.DBATag
 	}
 
-	// Ensure sitename is alphanumberic + dashes
-	c.Name = re.ReplaceAllString(c.Name, "")
-
 	log.WithFields(log.Fields{
 		"Active config": awsutil.Prettify(c),
 	}).Debug("Finished config set")
@@ -157,22 +154,12 @@ func (c *Config) Config() error {
 		"Existing config": awsutil.Prettify(c),
 	}).Debug("Configuring application")
 
-	namePrompt := "Project name"
-	if c.Name == "" {
-		dir, err := os.Getwd()
-		if err == nil {
-			c.Name = filepath.Base(dir)
-			c.Name = re.ReplaceAllString(c.Name, "")
-		}
+	err := c.namePrompt()
+	if err != nil {
+		return err
 	}
 
-	namePrompt = fmt.Sprintf("%s (%s)", namePrompt, c.Name)
-	// Define an application name.
-	fmt.Print(namePrompt + ": ")
-	c.Name = util.GetInput(c.Name)
-	c.Name = re.ReplaceAllString(c.Name, "")
-
-	err := c.docrootPrompt()
+	err = c.docrootPrompt()
 	if err != nil {
 		return err
 	}
@@ -186,6 +173,29 @@ func (c *Config) Config() error {
 	log.WithFields(log.Fields{
 		"Config": awsutil.Prettify(c),
 	}).Debug("Configuration completed")
+
+	return nil
+}
+
+// Validate ensures the configuraton meets ddev's requirements.
+func (c *Config) Validate() error {
+	// validate docroot
+	fullPath := filepath.Join(c.AppRoot, c.Docroot)
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		return fmt.Errorf("no directory could be found at %s. Please enter a valid docroot in your configuration", fullPath)
+	}
+
+	// validate hostname
+	match := hostRegex.MatchString(c.Hostname())
+	if !match {
+		return fmt.Errorf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", c.Hostname())
+	}
+
+	// validate apptype
+	match = IsAllowedAppType(c.AppType)
+	if !match {
+		return fmt.Errorf("%s is not a valid apptype", c.AppType)
+	}
 
 	return nil
 }
@@ -245,8 +255,33 @@ func (c *Config) RenderComposeYAML() (string, error) {
 	return doc.String(), err
 }
 
+// Define an application name.
+func (c *Config) namePrompt() error {
+	namePrompt := "Project name"
+	if c.Name == "" {
+		dir, err := os.Getwd()
+		// if working directory name is invalid for hostnames, we shouldn't suggest it
+		if err == nil && hostRegex.MatchString(filepath.Base(dir)) {
+			c.Name = filepath.Base(dir)
+		}
+	}
+
+	namePrompt = fmt.Sprintf("%s (%s)", namePrompt, c.Name)
+	fmt.Print(namePrompt + ": ")
+	c.Name = util.GetInput(c.Name)
+
+	match := hostRegex.MatchString(c.Hostname())
+	if !match {
+		fmt.Printf("%s is not a valid hostname. Please enter a site name that will allow for a valid hostname.\n See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements \n", c.Hostname())
+		c.Name = ""
+		return c.namePrompt()
+	}
+
+	return nil
+}
+
+// Determine the document root.
 func (c *Config) docrootPrompt() error {
-	// Determine the document root.
 	fmt.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your application root (%s)\n", c.AppRoot)
 	fmt.Println("You may leave this value blank if your site files are in the application root")
 	var docrootPrompt = "Docroot Location"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -33,7 +33,7 @@ const DDevTLD = "ddev.local"
 // AllowedAppTypes lists the types of site/app that can be used.
 var AllowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}
 
-// Regexp pattern for alphanumeric + dashes
+// Regexp pattern to match any non-alphanumeric characters (except dashes) so they can be replaced.
 var re = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 
 // Config defines the yaml config file format for ddev applications

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -38,7 +38,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(newConfig.DBImage, version.DBImg+":"+version.DBTag)
 	assert.Equal(newConfig.WebImage, version.WebImg+":"+version.WebTag)
 	assert.Equal(newConfig.DBAImage, version.DBAImg+":"+version.DBATag)
-	newConfig.Name = util.RandString(32)
+	newConfig.Name = util.RandString(32) + "-awesome!"
 	newConfig.AppType = "drupal8"
 
 	// Write the newConfig.
@@ -50,7 +50,8 @@ func TestNewConfig(t *testing.T) {
 	loadedConfig, err := NewConfig(testDir)
 	// There should be no error this time, since the config should be available for loading.
 	assert.NoError(err)
-	assert.Equal(newConfig.Name, loadedConfig.Name)
+	// Site name should only be alphanumeric + dashes
+	assert.Equal(strings.TrimSuffix(newConfig.Name, "!"), loadedConfig.Name)
 	assert.Equal(newConfig.AppType, loadedConfig.AppType)
 }
 
@@ -198,7 +199,7 @@ func TestRead(t *testing.T) {
 		AppRoot:    "testing",
 		APIVersion: CurrentAppVersion,
 		Platform:   DDevDefaultPlatform,
-		Name:       "TestRead",
+		Name:       "Test-Read!",
 		WebImage:   version.WebImg + ":" + version.WebTag,
 		DBImage:    version.DBImg + ":" + version.DBTag,
 		DBAImage:   version.DBAImg + ":" + version.DBATag,
@@ -208,7 +209,7 @@ func TestRead(t *testing.T) {
 	assert.NoError(err)
 
 	// Values not defined in file, we should still have default values
-	assert.Equal(c.Name, "TestRead")
+	assert.Equal(c.Name, "Test-Read")
 	assert.Equal(c.DBImage, version.DBImg+":"+version.DBTag)
 
 	// Values defined in file, we should have values from file

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -51,6 +51,11 @@ func (l *LocalApp) Init(basePath string) error {
 		return fmt.Errorf("could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
 	}
 
+	err = config.Validate()
+	if err != nil {
+		return err
+	}
+
 	l.AppConfig = config
 
 	web, err := l.FindContainerByType("web")


### PR DESCRIPTION
## The Problem:
#86 OP we currently accept site names allowing any/all characters. This doesn't work out so well for domain names, and attempting to start a site whose sitename contains invalid characters for a domain will result in the site failing to start.

## The Fix:
This PR introduces validation of the site name value. Site names will now be validated as hostnames per RFC 1123. If the working directory name does not validate, it will not be suggested to the user. If the user supplies an invalid site name during "ddev config", they will be re-prompted for the site name.

This also introduces a Validate() method for config that runs during App.Init(), which will validate hostname, docroot, and apptype. If any of these values are invalid, an error will be returned to the user instructing them to resolve the invalid configuration.

## The Test:
The case in OP should no longer be reproducible:
- mkdir invalid-drud-site\?
- cd invalid-drud-site\?
- ddev config, there should be no suggested site name
- Provide a sitename with invalid characters. You should be prompted to re-enter the sitename.
- ddev start. it should not fail

You can also test config validation on start by manually setting values in config.yaml and running "ddev start:
- Entering a sitename with invalid characters and running "ddev start" should result in an error saying the sitename is invalid.
- Entering a non-existent docroot path should result in an error saying the docroot path does not exist.
- Entering an invalid apptype should result in an error saying the apptype is invalid.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Introduced a test for the new config Validate() method.

## Related Issue Link(s):
#86 
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

