### PR TITLE
Use named volumes for MySQL volume

### DIFF
--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var removeData bool
+
 // LocalDevRMCmd represents the stop command
 var LocalDevRMCmd = &cobra.Command{
 	Use:     "remove [sitename]",
@@ -13,9 +15,10 @@ var LocalDevRMCmd = &cobra.Command{
 	Short:   "Remove the local development environment for a site. (Destructive)",
 	Long: `Remove the local development environment for a site. You can run 'ddev remove'
 from a site directory to remove that site, or you can specify a site to remove
-by running 'ddev stop <sitename>. Remove is a destructive operation. It will
-remove all containers for the site, destroying database contents in the process.
-Your project code base and files will not be affected.`,
+by running 'ddev rm <sitename>. By default, remove is a non-destructive operation and will
+leave database contents intact.
+
+To remove database contents, you may use the --remove-data flag with remove.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var siteName string
 
@@ -36,7 +39,7 @@ Your project code base and files will not be affected.`,
 			util.Failed("App not running locally. Try `ddev start`.")
 		}
 
-		err = app.Down()
+		err = app.Down(removeData)
 		if err != nil {
 			util.Failed("Failed to remove %s: %s", app.GetName(), err)
 		}
@@ -46,5 +49,6 @@ Your project code base and files will not be affected.`,
 }
 
 func init() {
+	LocalDevRMCmd.Flags().BoolVarP(&removeData, "remove-data", "R", false, "Remove stored application data (MySQL, logs, etc.)")
 	RootCmd.AddCommand(LocalDevRMCmd)
 }

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -1,16 +1,10 @@
 package cmd
 
 import (
-	"fmt"
-
-	"os"
-
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
-
-var skipConfirmation bool
 
 // LocalDevRMCmd represents the stop command
 var LocalDevRMCmd = &cobra.Command{
@@ -42,13 +36,6 @@ Your project code base and files will not be affected.`,
 			util.Failed("App not running locally. Try `ddev start`.")
 		}
 
-		if !skipConfirmation {
-			fmt.Printf("Is it ok to remove the site %s with all of its containers? All data will be lost. (y/N): ", app.GetName())
-			if !util.AskForConfirmation() {
-				util.Warning("App removal canceled by user.")
-				os.Exit(2)
-			}
-		}
 		err = app.Down()
 		if err != nil {
 			util.Failed("Failed to remove %s: %s", app.GetName(), err)
@@ -59,6 +46,5 @@ Your project code base and files will not be affected.`,
 }
 
 func init() {
-	LocalDevRMCmd.Flags().BoolVarP(&skipConfirmation, "skip-confirmation", "y", false, "Skip confirmation step.")
 	RootCmd.AddCommand(LocalDevRMCmd)
 }

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -12,7 +12,7 @@ var removeData bool
 var LocalDevRMCmd = &cobra.Command{
 	Use:     "remove [sitename]",
 	Aliases: []string{"rm"},
-	Short:   "Remove the local development environment for a site. (Destructive)",
+	Short:   "Remove the local development environment for a site.",
 	Long: `Remove the local development environment for a site. You can run 'ddev remove'
 from a site directory to remove that site, or you can specify a site to remove
 by running 'ddev rm <sitename>. By default, remove is a non-destructive operation and will

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/drud/ddev/pkg/exec"
@@ -17,21 +16,7 @@ func TestDevRemove(t *testing.T) {
 
 	for _, site := range DevTestSites {
 		cleanup := site.Chdir()
-
-		// Note that the "ddev remove -y" case use used in the TestMain, so that should cover that option.
-
-		cmd := fmt.Sprintf("echo n | %s remove", DdevBin)
-		out, err := exec.RunCommand("sh", []string{"-c", cmd})
-		assert.Error(err, "ddev remove should fail and instead succeeded ('n' response to prompt)")
-		assert.Contains(out, "App removal canceled")
-
-		cmd = fmt.Sprintf("echo so silly to expect this to work | %s remove", DdevBin)
-		out, err = exec.RunCommand("sh", []string{"-c", cmd})
-		assert.Error(err, "ddev remove should fail and instead succeeded (silly response to prompt)")
-		assert.Contains(out, "App removal canceled")
-
-		cmd = fmt.Sprintf("echo y | %s remove", DdevBin)
-		out, err = exec.RunCommand("sh", []string{"-c", cmd})
+		out, err := exec.RunCommand("ddev", []string{"remove"})
 		assert.NoError(err, "ddev remove should succeed but failed, err: %v, output: %s", err, out)
 		assert.Contains(out, "Successfully removed")
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -124,7 +124,7 @@ func removeSites() {
 	for _, site := range DevTestSites {
 		_ = site.Chdir()
 
-		args := []string{"remove", "-y"}
+		args := []string{"remove"}
 		out, err := exec.RunCommand(DdevBin, args)
 		if err != nil {
 			log.Fatalln("Failed to run ddev remove -y command, err: %v, output: %s", err, out)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 
@@ -124,10 +125,28 @@ func removeSites() {
 	for _, site := range DevTestSites {
 		_ = site.Chdir()
 
-		args := []string{"remove"}
+		args := []string{"remove", "--remove-data"}
 		out, err := exec.RunCommand(DdevBin, args)
 		if err != nil {
 			log.Fatalln("Failed to run ddev remove -y command, err: %v, output: %s", err, out)
+		}
+
+		allVolumes, err := dockerutil.GetVolumes()
+		if err != nil {
+			log.Fatalf("Could not ensure volumes are empty for site %s during teardown", site.Name)
+		}
+
+		removedNames := []string{
+			fmt.Sprintf("ddev%s_mysql", site.Name),
+			fmt.Sprintf("ddev%s_nginx-logs", site.Name),
+		}
+
+		for _, remainingVolume := range allVolumes {
+			for _, removedName := range removedNames {
+				if removedName == remainingVolume.Name {
+					log.Fatalf("Volume %s still remaining after site removal", remainingVolume.Name)
+				}
+			}
 		}
 	}
 }

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -18,12 +18,12 @@ Available Commands:
   import-files Import the uploaded files directory of an existing site to the default public upload directory of your application.
   list         List applications that exist locally
   logs         Get the logs from your running services.
+  remove       Remove the local development environment for a site.
   restart      Restart the local development environment for a site.
-  remove       Remove an application's local services.
   sequelpro    Easily connect local site to sequelpro
-  ssh          Starts a shell session in the container for a service. Uses the web service by default.
+  ssh          Starts a shell session in the container for a service. Uses web service by default.
   start        Start the local development environment for a site.
-  stop         Stop an application's local services.
+  stop         Stop the local development environment for a site.
   version      print ddev version and component versions
 
 Use "ddev [command] --help" for more information about a command.
@@ -145,7 +145,7 @@ Successfully imported database for drupal8
 If you want to use import-db without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag.
 
 ### Importing static file assets
-The `ddev import-files` command is provided for importing the static file assets for a site, such as uploaded images and documents. Running this command will provide a prompt for you to specify the location of your asset import. The assets will then be imported to the default public upload directory of the platform for the site. For Drupal sites, this is the "sites/default/files" directory. For WordPress sites, this is the "wp-content/uploads" directory. 
+The `ddev import-files` command is provided for importing the static file assets for a site, such as uploaded images and documents. Running this command will provide a prompt for you to specify the location of your asset import. The assets will then be imported to the default public upload directory of the platform for the site. For Drupal sites, this is the "sites/default/files" directory. For WordPress sites, this is the "wp-content/uploads" directory.
 
 ```
 ➜  ddev import-files
@@ -180,7 +180,7 @@ Successfully imported files for drupal8
 If you want to use import-files without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag.
 
 ## Interacting with your Site
-ddev provides several commands to facilitate interacting with your site in the development environment. These commands can be run within the working directory of your project while the site is running in ddev. 
+ddev provides several commands to facilitate interacting with your site in the development environment. These commands can be run within the working directory of your project while the site is running in ddev.
 
 ### Executing Commands in Containers
 The `ddev exec` command allows you to run shell commands in the container for a ddev service. By default, commands are executed on the web service container, in the docroot path of your site. This allows you to use [the developer tools included in the web container](developer-tools.md). For example, to run the Drush CLI in the web container, you would run `ddev exec drush status`.
@@ -201,7 +201,7 @@ Additional logging can be accessed by using `ddev ssh` to manually review the lo
 You can stop a site's containers without losing data by using `ddev stop` in the working directory of the site. You can also stop any running site's containers by providing the site name as an argument, e.g. `ddev stop <sitename>`.
 
 ## Removing a site
-You can remove a site's containers by running `ddev remove` in the working directory of the site. You can also remove any running site's containers by providing the site name as an argument, e.g. `ddev remove <sitename>`. **Note:** `ddev remove` is destructive. It will remove all containers for the site, destroying database contents in the process. Your project code base and files will not be affected.
+You can remove a site's containers by running `ddev remove` in the working directory of the site. You can also remove any running site's containers by providing the site name as an argument, e.g. `ddev remove <sitename>`. **Note:** `ddev remove` is non-destructive. It will remove all containers for the site, but will retain the database contents unless the `--remove-data` flag is used. Your project code base and files will not be affected.
 
 ## ddev Command Auto-Completion
 ddev bash auto-completion is available. If you have installed ddev via homebrew (on OSX) it will already be installed. Otherwise, you can download the [latest release](https://github.com/drud/ddev/releases) tarball for your platform and the ddev_bash_completions.sh inside it can be installed wherever your bash_completions.d is. For example, `cp ddev_bash_completions.sh /etc/bash_completion.d/ddev`

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -33,16 +33,17 @@ var AllowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}
 
 // Config defines the yaml config file format for ddev applications
 type Config struct {
-	APIVersion string `yaml:"APIVersion"`
-	Name       string `yaml:"name"`
-	AppType    string `yaml:"type"`
-	Docroot    string `yaml:"docroot"`
-	WebImage   string `yaml:"webimage"`
-	DBImage    string `yaml:"dbimage"`
-	DBAImage   string `yaml:"dbaimage"`
-	ConfigPath string `yaml:"-"`
-	AppRoot    string `yaml:"-"`
-	Platform   string `yaml:"-"`
+	APIVersion       string `yaml:"APIVersion"`
+	Name             string `yaml:"name"`
+	AppType          string `yaml:"type"`
+	Docroot          string `yaml:"docroot"`
+	WebImage         string `yaml:"webimage"`
+	DBImage          string `yaml:"dbimage"`
+	DBAImage         string `yaml:"dbaimage"`
+	ConfigPath       string `yaml:"-"`
+	AppRoot          string `yaml:"-"`
+	Platform         string `yaml:"-"`
+	SiteSettingsPath string `yaml:"-"`
 }
 
 // NewConfig creates a new Config struct with defaults set. It is preferred to using new() directly.
@@ -127,6 +128,8 @@ func (c *Config) Read() error {
 	if c.DBAImage == "" {
 		c.DBAImage = version.DBAImg + ":" + version.DBATag
 	}
+
+	c.setSiteSettingsPath(c.AppType)
 
 	log.WithFields(log.Fields{
 		"Active config": awsutil.Prettify(c),
@@ -372,4 +375,20 @@ func prepLocalSiteDirs(base string) error {
 	}
 
 	return nil
+}
+
+// setSiteSettingsPath determines the location for site's db settings file based on apptype.
+func (c *Config) setSiteSettingsPath(appType string) {
+	settingsFilePath := filepath.Join(c.AppRoot, c.Docroot)
+
+	switch appType {
+	case "drupal8":
+		fallthrough
+	case "drupal7":
+		settingsFilePath = filepath.Join(settingsFilePath, "sites", "default", "settings.php")
+	case "wordpress":
+		settingsFilePath = filepath.Join(settingsFilePath, "wp-config.php")
+	}
+
+	c.SiteSettingsPath = settingsFilePath
 }

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -25,6 +25,7 @@ services:
     image: $DDEV_WEBIMAGE
     volumes:
       - "../:/var/www/html:cached"
+      - "nginx-logs:/var/log/nginx"
     restart: always
     depends_on:
       - db
@@ -77,4 +78,5 @@ networks:
       name: ddev_default
 volumes:
   mysql:
+  nginx-logs:
 `

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -10,6 +10,7 @@ services:
     image: $DDEV_DBIMAGE
     volumes:
       - "./data:/db"
+      - mysql:/var/lib/mysql
     restart: always
     ports:
       - "3306"
@@ -74,4 +75,6 @@ networks:
   default:
     external:
       name: ddev_default
+volumes:
+  mysql:
 `

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -276,6 +276,7 @@ func GetPublishedPort(privatePort int64, container docker.APIContainers) int64 {
 	return 0
 }
 
+// GetVolumes returns a list of all docker volumes on the host.
 func GetVolumes() ([]docker.Volume, error) {
 	client := GetDockerClient()
 	return client.ListVolumes(docker.ListVolumesOptions{})

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -275,3 +275,8 @@ func GetPublishedPort(privatePort int64, container docker.APIContainers) int64 {
 	}
 	return 0
 }
+
+func GetVolumes() ([]docker.Volume, error) {
+	client := GetDockerClient()
+	return client.ListVolumes(docker.ListVolumesOptions{})
+}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -650,7 +650,7 @@ func (l *LocalApp) Config() error {
 // Down stops the docker containers for the local project.
 func (l *LocalApp) Down() error {
 	l.DockerEnv()
-	err := dockerutil.ComposeCmd(l.ComposeFiles(), "down", "-v")
+	err := dockerutil.ComposeCmd(l.ComposeFiles(), "down")
 	if err != nil {
 		util.Warning("Could not stop site with docker-compose. Attempting manual cleanup.")
 		return Cleanup(l)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -572,25 +572,23 @@ func (l *LocalApp) Wait(containerTypes ...string) error {
 // Config creates the apps config file adding things like database host, name, and password
 // as well as other sensitive data like salts.
 func (l *LocalApp) Config() error {
-	basePath := l.AppRoot()
-	docroot := l.Docroot()
-	settingsFilePath := filepath.Join(basePath, docroot)
+	settingsFilePath := l.AppConfig.SiteSettingsPath
+
+	if fileutil.FileExists(settingsFilePath) {
+		signatureFound, err := fileutil.FgrepStringInFile(settingsFilePath, model.DdevSettingsFileSignature)
+		util.CheckErr(err) // Really can't happen as we already checked for the file existence
+		if !signatureFound {
+			return errors.New("app config exists")
+		}
+		// Otherwise we'll go on our way and recreate the settings file.
+	}
 
 	switch l.GetType() {
 	case "drupal8":
 		fallthrough
 	case "drupal7":
-		settingsFilePath = filepath.Join(settingsFilePath, "sites", "default", "settings.php")
-		if fileutil.FileExists(settingsFilePath) {
-			signatureFound, err := fileutil.FgrepStringInFile(settingsFilePath, model.DdevSettingsFileSignature)
-			util.CheckErr(err) // Really can't happen as we already checked for the file existence
-			if !signatureFound {
-				return errors.New("app config exists")
-			}
-			// Otherwise we'll go on our way and recreate the settings file.
-		}
-
-		drushSettingsPath := filepath.Join(basePath, "drush.settings.php")
+		fmt.Println("Generating settings.php file for database connection.")
+		drushSettingsPath := filepath.Join(l.AppRoot(), "drush.settings.php")
 
 		// Retrieve published mysql port for drush settings file.
 		db, err := l.FindContainerByType("db")
@@ -603,8 +601,6 @@ func (l *LocalApp) Config() error {
 			return err
 		}
 		dbPublishPort := dockerutil.GetPublishedPort(dbPrivatePort, db)
-
-		fmt.Println("Generating settings.php file for database connection.")
 
 		drupalConfig := model.NewDrupalConfig()
 		drushConfig := model.NewDrushConfig()
@@ -626,16 +622,6 @@ func (l *LocalApp) Config() error {
 			return err
 		}
 	case "wordpress":
-		settingsFilePath = filepath.Join(settingsFilePath, "wp-config.php")
-		if fileutil.FileExists(settingsFilePath) {
-			signatureFound, err := fileutil.FgrepStringInFile(settingsFilePath, model.DdevSettingsFileSignature)
-			util.CheckErr(err) // Really can't happen as we already checked for the file existence
-			if !signatureFound {
-				return errors.New("app config exists")
-			}
-			// Otherwise we'll go on our way and recreate the settings file.
-		}
-
 		fmt.Println("Generating wp-config.php file for database connection.")
 		wpConfig := model.NewWordpressConfig()
 		wpConfig.DeployURL = l.URL()
@@ -650,10 +636,26 @@ func (l *LocalApp) Config() error {
 // Down stops the docker containers for the local project.
 func (l *LocalApp) Down(removeData bool) error {
 	l.DockerEnv()
+	settingsFilePath := l.AppConfig.SiteSettingsPath
 
 	args := []string{"down"}
 	if removeData {
 		args = append(args, "-v")
+		if fileutil.FileExists(settingsFilePath) {
+			signatureFound, err := fileutil.FgrepStringInFile(settingsFilePath, model.DdevSettingsFileSignature)
+			util.CheckErr(err) // Really can't happen as we already checked for the file existence
+			if signatureFound {
+				err = os.Chmod(settingsFilePath, 0644)
+				if err != nil {
+					return err
+				}
+				err = os.Remove(settingsFilePath)
+				if err != nil {
+					return err
+				}
+			}
+			// Otherwise we'll go on our way and recreate the settings file.
+		}
 	}
 
 	err := dockerutil.ComposeCmd(l.ComposeFiles(), args...)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -648,9 +648,15 @@ func (l *LocalApp) Config() error {
 }
 
 // Down stops the docker containers for the local project.
-func (l *LocalApp) Down() error {
+func (l *LocalApp) Down(removeData bool) error {
 	l.DockerEnv()
-	err := dockerutil.ComposeCmd(l.ComposeFiles(), "down")
+
+	args := []string{"down"}
+	if removeData {
+		args = append(args, "-v")
+	}
+
+	err := dockerutil.ComposeCmd(l.ComposeFiles(), args...)
 	if err != nil {
 		util.Warning("Could not stop site with docker-compose. Attempting manual cleanup.")
 		return Cleanup(l)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -443,7 +443,7 @@ func TestLocalRemove(t *testing.T) {
 		assert.NoError(err)
 
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s LocalRemove", site.Name))
-		err = app.Down()
+		err = app.Down(true)
 		assert.NoError(err)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -27,7 +27,7 @@ type App interface {
 	Stop() error
 	DockerEnv()
 	DockerComposeYAMLPath() string
-	Down() error
+	Down(removeData bool) error
 	Config() error
 	HostName() string
 	URL() string

--- a/pkg/util/prompt.go
+++ b/pkg/util/prompt.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 )
@@ -26,37 +25,4 @@ func GetInput(defaultValue string) string {
 	}
 
 	return value
-}
-
-// AskForConfirmation requests a y/n from user.
-func AskForConfirmation() bool {
-	response := GetInput("")
-	okayResponses := []string{"y", "yes"}
-	nokayResponses := []string{"n", "no", ""}
-	responseLower := strings.ToLower(response)
-
-	if containsString(okayResponses, responseLower) {
-		return true
-	} else if containsString(nokayResponses, responseLower) {
-		return false
-	} else {
-		fmt.Println("Please type yes or no and then press enter:")
-		return AskForConfirmation()
-	}
-}
-
-// containsString returns true if slice contains element
-func containsString(slice []string, element string) bool {
-	return !(posString(slice, element) == -1)
-}
-
-// posString returns the first index of element in slice.
-// If slice does not contain element, returns -1.
-func posString(slice []string, element string) int {
-	for index, elem := range slice {
-		if elem == element {
-			return index
-		}
-	}
-	return -1
 }


### PR DESCRIPTION
## The Problem:
This is an alternative approach to #337 which uses named volumes instead of host mounted directories.

It allows MySQL data to persist even when a site is removed using `ddev rm`, but rather than host mounting the files, it uses the native docker volume functionality, https://docs.docker.com/compose/compose-file/#volume-configuration-reference. Personally, I think it will be easier to maintain in the long run if we just rely on what docker is giving us. That being said, I can also understand the potential UX benefits of exposing the volume as a directory.

I mostly put this together to prove to myself it would work as I expected and from there the changes were small enough that it made sense to just open a PR to compare the approaches.

## The Test:
- Start a site
- Install drupal/wordpress
- Remove the site
- Start the site again
- Observe previously installed Drupal/WP site still active.

you should also be able to change MySQL container versions without any data loss.

If we stick with this method, it might make sense to expand the `ddev rm` command to have an option for cleaning up the volume as well, in case users really want to start completely from scratch

## Automation Overview:
I removed the previous tests around the `-y` flag, as ddev rm is no longer a destructive operation.

## Related Issue Link(s):
#208 #337 


