### PR TITLE
Pantheon Provider plugin

### DIFF
--- a/cmd/ddev/cmd/auth_pantheon.go
+++ b/cmd/ddev/cmd/auth_pantheon.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"path/filepath"
+
+	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/go-pantheon/pkg/pantheon"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+)
+
+// PantheonAuthCommand represents the `ddev auth-pantheon` command
+var PantheonAuthCommand = &cobra.Command{
+	Use:   "auth-pantheon [token]",
+	Short: "Provide a machine token for the global pantheon auth.",
+	Long:  "Configure global machine token for pantheon authentication. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if len(args) == 0 {
+			util.Failed("You must provide a Pantheon machine token, e.g. `ddev auth-pantheon [token]`. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.")
+		}
+		if len(args) != 1 {
+			util.Failed("Too many arguments detected. Please provide only your Pantheon Machine token., e.g. `ddev auth-pantheon [token]`. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.")
+		}
+		userDir, err := homedir.Dir()
+		util.CheckErr(err)
+		sessionLocation := filepath.Join(userDir, ".ddev", "pantheonconfig.json")
+
+		session := pantheon.NewAuthSession(args[0])
+		err = session.Auth()
+		if err != nil {
+			util.Failed("Could not authenticate with pantheon: %v", err)
+		}
+
+		err = session.Write(sessionLocation)
+		util.Success("Authentication successful!\nYou may now use the `ddev config pantheon` command when configuring sites!")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(PantheonAuthCommand)
+}

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -21,7 +21,7 @@ var ConfigCommand = &cobra.Command{
 
 		}
 
-		provider := ""
+		provider := ddevapp.DefaultProviderName
 
 		if len(args) > 1 {
 			log.Fatal("Invalid argument detected. Please use 'ddev config' or 'ddev config [provider]' to configure a site.")
@@ -39,6 +39,10 @@ var ConfigCommand = &cobra.Command{
 				util.Failed("Could not read config: %v", err)
 			}
 		}
+
+		// Set the provider value after load so we can ensure we use the passed in provider value
+		// for this configuration.
+		c.Provider = provider
 
 		err = c.Config()
 		if err != nil {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"log"
 	"os"
 
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -10,15 +11,27 @@ import (
 
 // ConfigCommand represents the `ddev config` command
 var ConfigCommand = &cobra.Command{
-	Use:   "config",
+	Use:   "config [provider]",
 	Short: "Create or modify a ddev application config in the current directory",
 	Run: func(cmd *cobra.Command, args []string) {
+
 		appRoot, err := os.Getwd()
 		if err != nil {
 			util.Failed("Could not determine current working directory: %v\n", err)
+
 		}
 
-		c, err := ddevapp.NewConfig(appRoot)
+		provider := ""
+
+		if len(args) > 1 {
+			log.Fatal("Invalid argument detected. Please use 'ddev config' or 'ddev config [provider]' to configure a site.")
+		}
+
+		if len(args) == 1 {
+			provider = args[0]
+		}
+
+		c, err := ddevapp.NewConfig(appRoot, provider)
 		if err != nil {
 			// If there is an error reading the config and the file exists, we're not sure
 			// how to proceed.
@@ -35,6 +48,12 @@ var ConfigCommand = &cobra.Command{
 		err = c.Write()
 		if err != nil {
 			util.Failed("Could not write ddev config file: %v\n", err)
+
+		}
+
+		// If a provider is specified, prompt about whether to do an import after config.
+		if provider != "" {
+			util.Success("Configuration complete. You may now run `ddev start` or `ddev pull`")
 		}
 		util.Success("Initial configuration file written successfully. See the configuration file for additional configuration options.")
 	},

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"log"
-
 	"os"
 
-	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -28,14 +25,7 @@ can be provided if it is not located at the top-level of the archive.`,
 			util.CheckErr(err)
 			os.Exit(0)
 		}
-
-		client := dockerutil.GetDockerClient()
-
-		err := dockerutil.EnsureNetwork(client, netName)
-		if err != nil {
-			log.Fatal(err)
-		}
-
+		dockerNetworkPreRun()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := platform.GetActiveApp("")

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"log"
 	"os"
 
-	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -29,12 +27,7 @@ the assets being imported.`,
 			util.CheckErr(err)
 			os.Exit(0)
 		}
-		client := dockerutil.GetDockerClient()
-		err := dockerutil.EnsureNetwork(client, netName)
-		if err != nil {
-			log.Fatal(err)
-		}
-
+		dockerNetworkPreRun()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := platform.GetActiveApp("")

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -41,7 +41,8 @@ func appImport(skipConfirmation bool) {
 	if !skipConfirmation {
 		// Unfortunately we cannot use util.Warning here as it automatically adds a newline, which is awkward when dealing with prompts.
 		d := color.New(color.FgYellow)
-		d.Printf("You're about to delete the current database and files and replace with a fresh import. Would you like to continue (y/N): ")
+		_, err := d.Printf("You're about to delete the current database and files and replace with a fresh import. Would you like to continue (y/N): ")
+		util.CheckErr(err)
 		if !util.AskForConfirmation() {
 			util.Warning("Import cancelled.")
 			os.Exit(2)

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +39,9 @@ func appImport(skipConfirmation bool) {
 	}
 
 	if !skipConfirmation {
-		util.Warning("You're about to delete the current database and files and replace with a fresh import. Would you like to continue (y/N): ")
+		// Unfortunately we cannot use util.Warning here as it automatically adds a newline, which is awkward when dealing with prompts.
+		d := color.New(color.FgYellow)
+		d.Printf("You're about to delete the current database and files and replace with a fresh import. Would you like to continue (y/N): ")
 		if !util.AskForConfirmation() {
 			util.Warning("Import cancelled.")
 			os.Exit(2)

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/drud/ddev/pkg/plugins/platform"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var skipConfirmation bool
+
+// PullCmd represents the `ddev pull` command.
+var PullCmd = &cobra.Command{
+	Use:   "pull",
+	Short: "Import files and database using a configured provider plugin.",
+	Long: `Import files and databased using a configured provider plugin.
+	Running pull will connect to the configured provider and download + import the
+	latest backups.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			err := cmd.Usage()
+			util.CheckErr(err)
+			os.Exit(0)
+		}
+		dockerNetworkPreRun()
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		appImport(skipConfirmation)
+	},
+}
+
+func appImport(skipConfirmation bool) {
+	app, err := platform.GetActiveApp("")
+
+	if err != nil {
+		util.Failed("%v", err)
+	}
+
+	if !skipConfirmation {
+		util.Warning("You're about to delete the current database and files and replace with a fresh import. Would you like to continue (y/N): ")
+		if !util.AskForConfirmation() {
+			util.Warning("Import cancelled.")
+			os.Exit(2)
+		}
+	}
+
+	err = app.Import()
+	if err != nil {
+		util.Failed("Could not perform import: %v", err)
+	}
+
+	util.Success("Successfully Imported.")
+	util.Success("Your application can be reached at: %s", app.URL())
+}
+
+func init() {
+	PullCmd.Flags().BoolVarP(&skipConfirmation, "skip-confirmation", "y", false, "Skip confirmation step.")
+	RootCmd.AddCommand(PullCmd)
+}

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -14,7 +14,7 @@ var skipConfirmation bool
 var PullCmd = &cobra.Command{
 	Use:   "pull",
 	Short: "Import files and database using a configured provider plugin.",
-	Long: `Import files and databased using a configured provider plugin.
+	Long: `Import files and database using a configured provider plugin.
 	Running pull will connect to the configured provider and download + import the
 	latest backups.`,
 	PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
-	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -23,13 +21,7 @@ var LocalDevReconfigCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		client := dockerutil.GetDockerClient()
-
-		err := dockerutil.EnsureNetwork(client, netName)
-		if err != nil {
-			log.Fatal(err)
-		}
-
+		dockerNetworkPreRun()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := platform.GetActiveApp("")

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -52,12 +52,6 @@ var RootCmd = &cobra.Command{
 
 		// Verify that the ~/.ddev exists
 		userDdevDir := util.GetGlobalDdevDir()
-		if _, err := os.Stat(userDdevDir); os.IsNotExist(err) {
-			err = os.MkdirAll(userDdevDir, 0700)
-			if err != nil {
-				util.Failed("Failed to create required directory %s, err: %v", userDdevDir, err)
-			}
-		}
 
 		updateFile := filepath.Join(userDdevDir, ".update")
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -118,3 +118,12 @@ func init() {
 
 	log.SetLevel(logLevel)
 }
+
+func dockerNetworkPreRun() {
+	client := dockerutil.GetDockerClient()
+
+	err := dockerutil.EnsureNetwork(client, netName)
+	if err != nil {
+		util.Failed("Unable to create/ensure docker network %s, error: %v", netName, err)
+	}
+}

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
-	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -25,33 +23,30 @@ provide a working environment for development.`,
 			os.Exit(0)
 		}
 
-		client := dockerutil.GetDockerClient()
-
-		err := dockerutil.EnsureNetwork(client, netName)
-		if err != nil {
-			log.Fatalf("Unable to create/ensure docker network %s, error: %v", netName, err)
-		}
-
+		dockerNetworkPreRun()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := platform.GetActiveApp("")
-		if err != nil {
-			util.Failed("Failed to start: %s", err)
-		}
-
-		fmt.Printf("Starting environment for %s...\n", app.GetName())
-
-		err = app.Start()
-		if err != nil {
-			util.Failed("Failed to start %s: %v", app.GetName(), err)
-		}
-
-		util.Success("Successfully started %s", app.GetName())
-		util.Success("Your application can be reached at: %s", app.URL())
-
+		appStart()
 	},
 }
 
+func appStart() {
+	app, err := platform.GetActiveApp("")
+	if err != nil {
+		util.Failed("Failed to start: %s", err)
+	}
+
+	fmt.Printf("Starting environment for %s...\n", app.GetName())
+
+	err = app.Start()
+	if err != nil {
+		util.Failed("Failed to start %s: %v", app.GetName(), err)
+	}
+
+	util.Success("Successfully started %s", app.GetName())
+	util.Success("Your application can be reached at: %s", app.URL())
+
+}
 func init() {
 	RootCmd.AddCommand(StartCmd)
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -138,7 +138,7 @@ func Untar(source string, dest string, extractionDir string) error {
 			fullPathDir := filepath.Dir(fullPath)
 			err = os.MkdirAll(fullPathDir, 0755)
 			if err != nil {
-				return err
+				return fmt.Errorf("Failed to create the directory %s, err: %v", fullPathDir, err)
 			}
 
 			// For a regular file, create and copy the file.

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -134,6 +134,13 @@ func Untar(source string, dest string, extractionDir string) error {
 		case tar.TypeReg:
 			fallthrough
 		case tar.TypeRegA:
+			// Always ensure the directory is created before trying to move the file.
+			fullPathDir := filepath.Dir(fullPath)
+			err = os.MkdirAll(fullPathDir, 0755)
+			if err != nil {
+				return err
+			}
+
 			// For a regular file, create and copy the file.
 			exFile, err := os.Create(fullPath)
 			if err != nil {

--- a/pkg/cms/config/drupal.go
+++ b/pkg/cms/config/drupal.go
@@ -16,7 +16,7 @@ const (
 {{ $config := . }}
 /**
  {{ $config.Signature }}: Automatically generated Drupal settings.php file.
- ddev manages this file and may delete the file unless this comment is removed.
+ ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
 
 $databases['default']['default'] = array(

--- a/pkg/cms/config/wordpress.go
+++ b/pkg/cms/config/wordpress.go
@@ -16,7 +16,7 @@ const (
 {{ $config := . }}
 /**
  {{ $config.Signature }}: Automatically generated WordPress wp-config.php file.
- ddev manages this file and may delete the file unless this comment is removed.
+ ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
 
 // ** MySQL settings - You can get this info from your web host ** //
@@ -66,8 +66,15 @@ define( 'NONCE_SALT',       '{{ $config.NonceSalt }}' );
 if ( !defined('ABSPATH') )
 	define('ABSPATH', dirname(__FILE__) . '/');
 
-/** Sets up WordPress vars and included files. */
-require_once(ABSPATH . '/wp-settings.php');
+/**
+Sets up WordPress vars and included files.
+
+wp-settings.php is typically included in wp-config.php. This check ensures it is not
+included again if this file is written to wp-config-local.php.
+*/
+if (__FILE__ == "wp-config.php") {
+	require_once(ABSPATH . '/wp-settings.php');
+}
 `
 )
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -95,11 +95,8 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	c.WebImage = version.WebImg + ":" + version.WebTag
 	c.DBImage = version.DBImg + ":" + version.DBTag
 	c.DBAImage = version.DBAImg + ":" + version.DBATag
-
 	c.Provider = provider
-	if c.Provider == "" {
-		c.Provider = DefaultProviderName
-	}
+
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
 	err := c.Read()
@@ -117,7 +114,7 @@ func (c *Config) GetProvider() (Provider, error) {
 	}
 
 	var provider Provider
-	err := fmt.Errorf("unknown provider type: %s", provider)
+	err := fmt.Errorf("unknown provider type: %s", c.Provider)
 
 	switch c.Provider {
 	case "pantheon":
@@ -226,8 +223,6 @@ func (c *Config) Read() error {
 	log.WithFields(log.Fields{
 		"Active config": awsutil.Prettify(c),
 	}).Debug("Finished config set")
-
-	_, err = c.GetProvider()
 
 	return err
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -96,15 +96,16 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	c.DBImage = version.DBImg + ":" + version.DBTag
 	c.DBAImage = version.DBAImg + ":" + version.DBATag
 
+	c.Provider = provider
+
+	if c.Provider == "" {
+		c.Provider = DefaultProviderName
+	}
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
 	err := c.Read()
 	if err != nil {
 		return c, err
-	}
-
-	if c.Provider == "" {
-		c.Provider = DefaultProviderName
 	}
 
 	return c, err

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -14,11 +14,15 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/drud/ddev/pkg/appports"
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
+
+// DefaultProviderName contains the name of the default provider which will be used if one is not otherwise specified.
+const DefaultProviderName = "default"
 
 // CurrentAppVersion sets the current YAML config file version.
 // We're not doing anything with AppVersion, so just default it to 1 for now.
@@ -38,20 +42,23 @@ var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-z
 
 // Config defines the yaml config file format for ddev applications
 type Config struct {
-	APIVersion       string               `yaml:"APIVersion"`
-	Name             string               `yaml:"name"`
-	AppType          string               `yaml:"type"`
-	Docroot          string               `yaml:"docroot"`
-	WebImage         string               `yaml:"webimage"`
-	DBImage          string               `yaml:"dbimage"`
-	DBAImage         string               `yaml:"dbaimage"`
-	ConfigPath       string               `yaml:"-"`
-	AppRoot          string               `yaml:"-"`
-	Platform         string               `yaml:"-"`
-	DataDir          string               `yaml:"-"`
-	ImportDir        string               `yaml:"-"`
-	SiteSettingsPath string               `yaml:"-"`
-	Commands         map[string][]Command `yaml:"hooks,omitempty"`
+	APIVersion            string               `yaml:"APIVersion"`
+	Name                  string               `yaml:"name"`
+	AppType               string               `yaml:"type"`
+	Docroot               string               `yaml:"docroot"`
+	WebImage              string               `yaml:"webimage"`
+	DBImage               string               `yaml:"dbimage"`
+	DBAImage              string               `yaml:"dbaimage"`
+	ConfigPath            string               `yaml:"-"`
+	AppRoot               string               `yaml:"-"`
+	Platform              string               `yaml:"-"`
+	Provider              string               `yaml:"provider,omitempty"`
+	DataDir               string               `yaml:"-"`
+	ImportDir             string               `yaml:"-"`
+	SiteSettingsPath      string               `yaml:"-"`
+	SiteLocalSettingsPath string               `yaml:"-"`
+	providerInstance      Provider             `yaml:"-"`
+	Commands              map[string][]Command `yaml:"hooks,omitempty"`
 }
 
 // Command defines commands to be run as pre/post hooks
@@ -60,12 +67,25 @@ type Command struct {
 	ExecHost string `yaml:"exec-host,omitempty"`
 }
 
+// Provider in the interface which all provider plugins must implement.
+type Provider interface {
+	Init(*Config) error
+	ValidateField(string, string) error
+	Config() error
+	Write(string) error
+	Read(string) error
+	Validate() error
+	GetBackup(string) (fileLocation string, importPath string, err error)
+}
+
 // NewConfig creates a new Config struct with defaults set. It is preferred to using new() directly.
-func NewConfig(AppRoot string) (*Config, error) {
+func NewConfig(AppRoot string, provider string) (*Config, error) {
 	// Set defaults.
 	c := &Config{}
 	c.ConfigPath = filepath.Join(AppRoot, ".ddev", "config.yaml")
+
 	c.AppRoot = AppRoot
+	c.ConfigPath = c.GetPath("config.yaml")
 	c.APIVersion = CurrentAppVersion
 
 	// Default platform for now.
@@ -76,6 +96,10 @@ func NewConfig(AppRoot string) (*Config, error) {
 	c.DBImage = version.DBImg + ":" + version.DBTag
 	c.DBAImage = version.DBAImg + ":" + version.DBATag
 
+	c.Provider = provider
+	if c.Provider == "" {
+		c.Provider = DefaultProviderName
+	}
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
 	err := c.Read()
@@ -83,11 +107,41 @@ func NewConfig(AppRoot string) (*Config, error) {
 		return c, err
 	}
 
-	return c, nil
+	return c, err
+}
+
+// GetProvider returns a pointer to the provider instance interface.
+func (c *Config) GetProvider() (Provider, error) {
+	if c.providerInstance != nil {
+		return c.providerInstance, nil
+	}
+
+	var provider Provider
+	err := fmt.Errorf("unknown provider type: %s", provider)
+
+	switch c.Provider {
+	case "pantheon":
+		provider = &PantheonProvider{}
+		err = provider.Init(c)
+	case DefaultProviderName:
+		provider = &DefaultProvider{}
+		err = nil
+	default:
+		provider = &DefaultProvider{}
+		// Use the default error from above.
+	}
+	c.providerInstance = provider
+	return c.providerInstance, err
+}
+
+// GetPath returns the path to an application config file specified by filename.
+func (c *Config) GetPath(filename string) string {
+	return filepath.Join(c.AppRoot, ".ddev", filename)
 }
 
 // Write the app configuration to the .ddev folder.
 func (c *Config) Write() error {
+
 	err := PrepDdevDirectory(filepath.Dir(c.ConfigPath))
 	if err != nil {
 		return err
@@ -116,12 +170,18 @@ func (c *Config) Write() error {
 		return err
 	}
 
-	return nil
+	provider, err := c.GetProvider()
+	if err != nil {
+		return err
+	}
+
+	return provider.Write(c.GetPath("import.yaml"))
 }
 
 // Read app configuration from a specified location on disk, falling back to defaults for config
 // values not defined in the read config file.
 func (c *Config) Read() error {
+
 	source, err := ioutil.ReadFile(c.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("could not find an active ddev configuration, have you run 'ddev config'? %v", err)
@@ -161,13 +221,15 @@ func (c *Config) Read() error {
 	c.DataDir = filepath.Join(dirPath, "mysql")
 	c.ImportDir = filepath.Join(dirPath, "import-db")
 
-	c.setSiteSettingsPath(c.AppType)
+	c.setSiteSettingsPaths(c.AppType)
 
 	log.WithFields(log.Fields{
 		"Active config": awsutil.Prettify(c),
 	}).Debug("Finished config set")
 
-	return nil
+	_, err = c.GetProvider()
+
+	return err
 }
 
 // Config goes through a set of prompts to receive user input and generate an Config struct.
@@ -185,27 +247,39 @@ func (c *Config) Config() error {
 		"Existing config": awsutil.Prettify(c),
 	}).Debug("Configuring application")
 
-	err := c.namePrompt()
+	for {
+		err := c.namePrompt()
+
+		if err == nil {
+			break
+		}
+
+		fmt.Printf("%v\n", err)
+	}
+
+	for {
+		err := c.docrootPrompt()
+
+		if err == nil {
+			break
+		}
+
+		fmt.Printf("%v\n", err)
+	}
+
+	err := c.appTypePrompt()
 	if err != nil {
 		return err
 	}
 
-	err = c.docrootPrompt()
-	if err != nil {
-		return err
-	}
-
-	err = c.appTypePrompt()
-	if err != nil {
-		return err
-	}
+	err = c.providerInstance.Config()
 
 	// Log the resulting config, for debugging purposes.
 	log.WithFields(log.Fields{
 		"Config": awsutil.Prettify(c),
 	}).Debug("Configuration completed")
 
-	return nil
+	return err
 }
 
 // Validate ensures the configuraton meets ddev's requirements.
@@ -233,7 +307,7 @@ func (c *Config) Validate() error {
 
 // DockerComposeYAMLPath returns the absolute path to where the docker-compose.yaml should exist for this app configuration.
 func (c *Config) DockerComposeYAMLPath() string {
-	return filepath.Join(c.AppRoot, ".ddev", "docker-compose.yaml")
+	return c.GetPath("docker-compose.yaml")
 }
 
 // Hostname returns the hostname to the app controlled by this config.
@@ -243,22 +317,28 @@ func (c *Config) Hostname() string {
 
 // WriteDockerComposeConfig writes a docker-compose.yaml to the app configuration directory.
 func (c *Config) WriteDockerComposeConfig() error {
-	log.WithFields(log.Fields{
-		"Location": c.DockerComposeYAMLPath(),
-	}).Debug("Writing docker-compose.yaml")
+	var err error
 
-	f, err := os.Create(c.DockerComposeYAMLPath())
-	if err != nil {
-		return err
+	if !fileutil.FileExists(c.DockerComposeYAMLPath()) {
+		log.WithFields(log.Fields{
+			"Location": c.DockerComposeYAMLPath(),
+		}).Debug("Writing docker-compose.yaml")
+
+		f, err := os.Create(c.DockerComposeYAMLPath())
+		if err != nil {
+			return err
+		}
+		defer util.CheckClose(f)
+
+		rendered, err := c.RenderComposeYAML()
+		if err != nil {
+			return err
+		}
+		_, err = f.WriteString(rendered)
+		if err != nil {
+			return err
+		}
 	}
-	defer util.CheckClose(f)
-
-	rendered, err := c.RenderComposeYAML()
-	if err != nil {
-		return err
-	}
-	_, err = f.WriteString(rendered)
-
 	return err
 }
 
@@ -286,11 +366,17 @@ func (c *Config) RenderComposeYAML() (string, error) {
 
 // Define an application name.
 func (c *Config) namePrompt() error {
+	provider, err := c.GetProvider()
+	if err != nil {
+		return err
+	}
+
 	namePrompt := "Project name"
 	if c.Name == "" {
 		dir, err := os.Getwd()
 		// if working directory name is invalid for hostnames, we shouldn't suggest it
 		if err == nil && hostRegex.MatchString(filepath.Base(dir)) {
+
 			c.Name = filepath.Base(dir)
 		}
 	}
@@ -298,19 +384,17 @@ func (c *Config) namePrompt() error {
 	namePrompt = fmt.Sprintf("%s (%s)", namePrompt, c.Name)
 	fmt.Print(namePrompt + ": ")
 	c.Name = util.GetInput(c.Name)
-
-	match := hostRegex.MatchString(c.Hostname())
-	if !match {
-		fmt.Printf("%s is not a valid hostname. Please enter a site name that will allow for a valid hostname.\n See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements \n", c.Hostname())
-		c.Name = ""
-		return c.namePrompt()
-	}
-
-	return nil
+	return provider.ValidateField("Name", c.Name)
 }
 
 // Determine the document root.
 func (c *Config) docrootPrompt() error {
+	provider, err := c.GetProvider()
+	if err != nil {
+		return err
+	}
+
+	// Determine the document root.
 	fmt.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your application root (%s)\n", c.AppRoot)
 	fmt.Println("You may leave this value blank if your site files are in the application root")
 	var docrootPrompt = "Docroot Location"
@@ -324,11 +408,11 @@ func (c *Config) docrootPrompt() error {
 	// Ensure the docroot exists. If it doesn't, prompt the user to verify they entered it correctly.
 	fullPath := filepath.Join(c.AppRoot, c.Docroot)
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		fmt.Printf("No directory could be found at %s. Please enter a valid docroot", fullPath)
+		fmt.Printf("No directory could be found at %s. Please enter a valid docroot\n", fullPath)
 		c.Docroot = ""
 		return c.docrootPrompt()
 	}
-	return nil
+	return provider.ValidateField("Docroot", c.Docroot)
 }
 
 // ConfigExists determines if a ddev config file exists for this application.
@@ -341,6 +425,10 @@ func (c *Config) ConfigExists() bool {
 
 // appTypePrompt handles the AppType workflow.
 func (c *Config) appTypePrompt() error {
+	provider, err := c.GetProvider()
+	if err != nil {
+		return err
+	}
 	var appType string
 	typePrompt := fmt.Sprintf("Application Type [%s]", strings.Join(AllowedAppTypes, ", "))
 
@@ -350,12 +438,12 @@ func (c *Config) appTypePrompt() error {
 		"Location": absDocroot,
 	}).Debug("Attempting to auto-determine application type")
 
-	appType, err := determineAppType(absDocroot)
+	appType, err = determineAppType(absDocroot)
 	if err == nil {
 		// If we found an application type just set it and inform the user.
-		fmt.Printf("Found a %s codebase at %s\n", appType, filepath.Join(c.AppRoot, c.Docroot))
+		util.Success("Found a %s codebase at %s\n", appType, filepath.Join(c.AppRoot, c.Docroot))
 		c.AppType = appType
-		return nil
+		return provider.ValidateField("AppType", c.AppType)
 	}
 	typePrompt = fmt.Sprintf("%s (%s)", typePrompt, c.AppType)
 
@@ -368,7 +456,7 @@ func (c *Config) appTypePrompt() error {
 		}
 		c.AppType = appType
 	}
-	return nil
+	return provider.ValidateField("AppType", c.AppType)
 }
 
 // IsAllowedAppType determines if a given string exists in the AllowedAppTypes slice.
@@ -426,19 +514,22 @@ func determineAppType(basePath string) (string, error) {
 }
 
 // setSiteSettingsPath determines the location for site's db settings file based on apptype.
-func (c *Config) setSiteSettingsPath(appType string) {
-	settingsFilePath := filepath.Join(c.AppRoot, c.Docroot)
-
+func (c *Config) setSiteSettingsPaths(appType string) {
+	settingsFileBasePath := filepath.Join(c.AppRoot, c.Docroot)
+	var settingsFilePath, localSettingsFilePath string
 	switch appType {
 	case "drupal8":
 		fallthrough
 	case "drupal7":
-		settingsFilePath = filepath.Join(settingsFilePath, "sites", "default", "settings.php")
+		settingsFilePath = filepath.Join(settingsFileBasePath, "sites", "default", "settings.php")
+		localSettingsFilePath = filepath.Join(settingsFileBasePath, "sites", "default", "settings.local.php")
 	case "wordpress":
-		settingsFilePath = filepath.Join(settingsFilePath, "wp-config.php")
+		settingsFilePath = filepath.Join(settingsFileBasePath, "wp-config.php")
+		localSettingsFilePath = filepath.Join(settingsFileBasePath, "wp-config-local.php")
 	}
 
 	c.SiteSettingsPath = settingsFilePath
+	c.SiteLocalSettingsPath = localSettingsFilePath
 }
 
 // validateCommandYaml validates command hooks and tasks defined in hooks for config.yaml

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -95,13 +95,16 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	c.WebImage = version.WebImg + ":" + version.WebTag
 	c.DBImage = version.DBImg + ":" + version.DBTag
 	c.DBAImage = version.DBAImg + ":" + version.DBATag
-	c.Provider = provider
 
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
 	err := c.Read()
 	if err != nil {
 		return c, err
+	}
+
+	if c.Provider == "" {
+		c.Provider = DefaultProviderName
 	}
 
 	return c, err

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -271,6 +271,7 @@ func TestWrite(t *testing.T) {
 		DBImage:    version.DBImg + ":" + version.DBTag,
 		DBAImage:   version.DBAImg + ":" + version.DBATag,
 		AppType:    "drupal8",
+		Provider:   DefaultProviderName,
 	}
 
 	err := c.Write()

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -13,24 +13,12 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
-	homedir, err := homedir.Dir()
-	if err != nil {
-		util.Failed("Could not detect user's home directory: ", err)
-	}
-
-	// Verify that the ~/.ddev exists
-	homeddev := filepath.Join(homedir, ".ddev")
-	if _, err := os.Stat(homeddev); os.IsNotExist(err) {
-		err = os.MkdirAll(homeddev, 0700)
-		if err != nil {
-			util.Failed("Failed to create required directory %s, err: %v", homeddev, err)
-		}
-	}
+	// Ensure the ddev directory is created before tests run.
+	_ = util.GetGlobalDdevDir()
 }
 
 // TestNewConfig tests functionality around creating a new config, writing it to disk, and reading the resulting config.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -19,6 +19,7 @@ import (
 func TestMain(m *testing.M) {
 	// Ensure the ddev directory is created before tests run.
 	_ = util.GetGlobalDdevDir()
+	os.Exit(m.Run())
 }
 
 // TestNewConfig tests functionality around creating a new config, writing it to disk, and reading the resulting config.

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+/**
+ * These tests rely on an external test account managed by DRUD. To run them, you'll
+ * need to set an environment variable called "PANTHEON_API_KEY" with credentials for
+ * this account. If no such environment variable is present, these tests will be skipped.
+ */
+
 var pantheonTestSiteName = "ddev-test-site-do-not-delete"
 var pantheonTestEnvName = "bbowman"
 

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -1,0 +1,124 @@
+package ddevapp_test
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+var pantheonTestSiteName = "ddev-test-site-do-not-delete"
+var pantheonTestEnvName = "bbowman"
+
+// TestConfigCommand tests the interactive config options.
+func TestPantheonConfigCommand(t *testing.T) {
+	if os.Getenv("PANTHEON_API_KEY") == "" {
+		t.Skip("No PANTHEON_API_KEY env var has been set. Skipping Pantheon specific test.")
+	}
+
+	// Set up tests and give ourselves a working directory.
+	assert := assert.New(t)
+	testDir := testcommon.CreateTmpDir("TestPantheonConfigCommand")
+
+	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+	defer testcommon.Chdir(testDir)()
+	defer testcommon.CleanupDir(testDir)
+
+	// Create a docroot folder.
+	err := os.Mkdir(filepath.Join(testDir, "docroot"), 0644)
+	if err != nil {
+		t.Errorf("Could not create docroot directory under %s", testDir)
+	}
+
+	// Create the ddevapp we'll use for testing.
+	// This should return an error, since no existing config can be read.
+	config, err := NewConfig(testDir, "pantheon")
+	assert.Error(err)
+
+	// Randomize some values to use for Stdin during testing.
+	invalidName := strings.ToLower(util.RandString(16))
+	docroot := "docroot"
+	invalidEnvironment := strings.ToLower(util.RandString(8))
+
+	/**
+	 * Do a full interactive configuration for a pantheon environment.
+	 *
+	 * 1. Provide an invalid site name, ensure there is an error.
+	 * 2. Provide a valid site name. Ensure there is no error.
+	 * 3. Provide a valid docroot (already tested elsewhere)
+	 * 4. Provide a valid app type (drupal8)
+	 * 5. Provide an invalid pantheon environment name, ensure an error is triggered.
+	 * 6. Provide a valid environment name.
+	 **/
+	input := fmt.Sprintf("%s\n%s\n%s\ndocroot\ndrupal8\n%s\n%s", invalidName, pantheonTestSiteName, docroot, invalidEnvironment, pantheonTestEnvName)
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	util.SetInputScanner(scanner)
+
+	restoreOutput := testcommon.CaptureStdOut()
+	err = config.Config()
+	assert.NoError(err, t)
+	out := restoreOutput()
+
+	// Get the provider interface and ensure it validates.
+	provider, err := config.GetProvider()
+	assert.NoError(err)
+	err = provider.Validate()
+	assert.NoError(err)
+
+	// Ensure we have expected string values in output.
+	assert.Contains(out, "Creating a new ddev project")
+	assert.Contains(out, testDir)
+	assert.Contains(out, fmt.Sprintf("could not find a pantheon site named %s", invalidName))
+	assert.Contains(out, fmt.Sprintf("could not find an environment named '%s'", invalidEnvironment))
+
+	// Ensure values were properly set on the config struct.
+	assert.Equal(pantheonTestSiteName, config.Name)
+	assert.Equal("drupal8", config.AppType)
+	assert.Equal("docroot", config.Docroot)
+	err = PrepDdevDirectory(testDir)
+	assert.NoError(err)
+}
+
+func TestPantheonBackupLinks(t *testing.T) {
+	if os.Getenv("PANTHEON_API_KEY") == "" {
+		t.Skip("No PANTHEON_API_KEY env var has been set. Skipping Pantheon specific test.")
+	}
+
+	// Set up tests and give ourselves a working directory.
+	assert := assert.New(t)
+	testDir := testcommon.CreateTmpDir("TestPantheonBackupLinks")
+
+	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+	defer testcommon.Chdir(testDir)()
+	defer testcommon.CleanupDir(testDir)
+
+	config, err := NewConfig(testDir, "pantheon")
+	// No config should exist so this will result in an error
+	assert.Error(err)
+	config.Name = pantheonTestSiteName
+
+	provider := PantheonProvider{}
+	err = provider.Init(config)
+	assert.NoError(err)
+
+	provider.Sitename = pantheonTestSiteName
+	provider.Environment = pantheonTestEnvName
+
+	// Ensure GetBackup triggers an error for unknown backup types.
+	_, _, err = provider.GetBackup(util.RandString(8))
+	assert.Error(err)
+
+	// Ensure we can get a
+	backupLink, importPath, err := provider.GetBackup("database")
+
+	assert.Equal(importPath, "")
+	assert.Contains(backupLink, "database.sql.gz")
+	assert.NoError(err)
+}

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -16,17 +16,19 @@ import (
 
 /**
  * These tests rely on an external test account managed by DRUD. To run them, you'll
- * need to set an environment variable called "PANTHEON_API_KEY" with credentials for
+ * need to set an environment variable called "DDEV_PANTHEON_API_TOKEN" with credentials for
  * this account. If no such environment variable is present, these tests will be skipped.
+ *
+ * A valid site (with backups) must be present which matches the test site and environment name
+ * defined in the constants below.
  */
-
-var pantheonTestSiteName = "ddev-test-site-do-not-delete"
-var pantheonTestEnvName = "bbowman"
+const pantheonTestSiteName = "ddev-test-site-do-not-delete"
+const pantheonTestEnvName = "bbowman"
 
 // TestConfigCommand tests the interactive config options.
 func TestPantheonConfigCommand(t *testing.T) {
-	if os.Getenv("PANTHEON_API_KEY") == "" {
-		t.Skip("No PANTHEON_API_KEY env var has been set. Skipping Pantheon specific test.")
+	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
+		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
 
 	// Set up tests and give ourselves a working directory.
@@ -94,8 +96,8 @@ func TestPantheonConfigCommand(t *testing.T) {
 
 // TestPantheonBackupLinks ensures we can get backups from pantheon for a configured environment.
 func TestPantheonBackupLinks(t *testing.T) {
-	if os.Getenv("PANTHEON_API_KEY") == "" {
-		t.Skip("No PANTHEON_API_KEY env var has been set. Skipping Pantheon specific test.")
+	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
+		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
 
 	// Set up tests and give ourselves a working directory.

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -34,8 +34,8 @@ func TestPantheonConfigCommand(t *testing.T) {
 	testDir := testcommon.CreateTmpDir("TestPantheonConfigCommand")
 
 	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
-	defer testcommon.Chdir(testDir)()
 	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
 
 	// Create a docroot folder.
 	err := os.Mkdir(filepath.Join(testDir, "docroot"), 0644)
@@ -92,6 +92,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	assert.NoError(err)
 }
 
+// TestPantheonBackupLinks ensures we can get backups from pantheon for a configured environment.
 func TestPantheonBackupLinks(t *testing.T) {
 	if os.Getenv("PANTHEON_API_KEY") == "" {
 		t.Skip("No PANTHEON_API_KEY env var has been set. Skipping Pantheon specific test.")
@@ -102,8 +103,8 @@ func TestPantheonBackupLinks(t *testing.T) {
 	testDir := testcommon.CreateTmpDir("TestPantheonBackupLinks")
 
 	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
-	defer testcommon.Chdir(testDir)()
 	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
 
 	config, err := NewConfig(testDir, "pantheon")
 	// No config should exist so this will result in an error

--- a/pkg/ddevapp/providerDefault.go
+++ b/pkg/ddevapp/providerDefault.go
@@ -1,0 +1,41 @@
+package ddevapp
+
+import "errors"
+
+// DefaultProvider provides a no-op for the provider plugin interface methods.
+type DefaultProvider struct{}
+
+// Init provides a no-op for the Init operation.
+func (p *DefaultProvider) Init(config *Config) error {
+	return nil
+}
+
+// ValidateField provides a no-op for the ValidateField operation.
+func (p *DefaultProvider) ValidateField(field, value string) error {
+	return nil
+}
+
+// Config provides a no-op for the Config operation.
+func (p *DefaultProvider) Config() error {
+	return nil
+}
+
+// Write provides a no-op for the Write operation.
+func (p *DefaultProvider) Write(configPath string) error {
+	return nil
+}
+
+// Read provides a no-op for the Read operation.
+func (p *DefaultProvider) Read(configPath string) error {
+	return nil
+}
+
+// Validate always returns an error from the default provider, as we have no provider to import data from.
+func (p *DefaultProvider) Validate() error {
+	return errors.New("could not perform import because there is no configured provider for this application. please see `ddev config` documentation")
+}
+
+// GetBackup provides a no-op for the GetBackup operation.
+func (p *DefaultProvider) GetBackup(backupType string) (fileLocation string, importPath string, err error) {
+	return "", "", nil
+}

--- a/pkg/ddevapp/providerDefault.go
+++ b/pkg/ddevapp/providerDefault.go
@@ -1,6 +1,7 @@
 package ddevapp
 
 import "errors"
+import "os"
 
 // DefaultProvider provides a no-op for the provider plugin interface methods.
 type DefaultProvider struct{}
@@ -22,7 +23,14 @@ func (p *DefaultProvider) Config() error {
 
 // Write provides a no-op for the Write operation.
 func (p *DefaultProvider) Write(configPath string) error {
-	return nil
+	// Check if the file exists and can be read and just return nil if it doesn't.
+	_, err := os.Stat(configPath)
+	if err != nil {
+		return nil
+	}
+
+	// Attempt to remove any import config for another provider which may be present.
+	return os.Remove(configPath)
 }
 
 // Read provides a no-op for the Read operation.

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -1,0 +1,329 @@
+package ddevapp
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/mitchellh/go-homedir"
+
+	"fmt"
+
+	"github.com/drud/go-pantheon/pkg/pantheon"
+	"gopkg.in/yaml.v2"
+)
+
+// PantheonProvider provides pantheon-specific import functionality.
+type PantheonProvider struct {
+	ProviderType     string                   `yaml:"provider"`
+	config           *Config                  `yaml:"-"`
+	Sitename         string                   `yaml:"site"`
+	site             pantheon.Site            `yaml:"-"`
+	siteEnvironments pantheon.EnvironmentList `yaml:"-"`
+	Environment      string                   `yaml:"environment"`
+	environment      pantheon.Environment     `yaml:"-"`
+}
+
+// Init handles loading data from saved config.
+func (p *PantheonProvider) Init(config *Config) error {
+	var err error
+	p.config = config
+
+	configPath := config.GetPath("import.yaml")
+	if fileutil.FileExists(configPath) {
+		err = p.Read(configPath)
+	}
+
+	p.ProviderType = "pantheon"
+	return err
+}
+
+// ValidateField provides field level validation for config settings. This is used any time a field is set via `ddev config` on the primary app config, and allows
+// provider plugins to have additional validation for top level config settings.
+func (p *PantheonProvider) ValidateField(field, value string) error {
+	switch field {
+	case "Name":
+		_, err := findPantheonSite(value)
+		if err != nil {
+			p.Sitename = value
+		}
+		return err
+	}
+	return nil
+}
+
+// Config provides interactive configuration prompts when running `ddev config pantheon`
+func (p *PantheonProvider) Config() error {
+	p.Sitename = p.config.Name
+	for {
+		err := p.environmentPrompt()
+
+		if err == nil {
+			break
+		}
+
+		fmt.Printf("%v\n", err)
+	}
+
+	return nil
+}
+
+// GetBackup will download the most recent backup specified by backupType. Valid values for backupType are "database" or "files".
+func (p *PantheonProvider) GetBackup(backupType string) (fileLocation string, importPath string, err error) {
+	if backupType != "database" && backupType != "files" {
+		return "", "", fmt.Errorf("could not get backup: %s is not a valid backup type", backupType)
+	}
+
+	// Set the import path blank, to use the root of the archive by default.
+	importPath = ""
+	err = p.environmentExists()
+	if err != nil {
+		return "", "", err
+	}
+
+	session := getPantheonSession()
+
+	// Find either a files or database backup, depending on what was asked for.
+	bl := pantheon.NewBackupList(p.site.ID, p.Environment)
+	err = session.Request("GET", bl)
+	if err != nil {
+		return "", "", err
+	}
+
+	backup, err := p.getPantheonBackupLink(backupType, bl, session)
+	if err != nil {
+		return "", "", err
+	}
+
+	p.prepDownloadDir()
+	destFile := filepath.Join(p.getDownloadDir(), backup.FileName)
+
+	// Check to see if this file has been downloaded previously.
+	// Attempt a new download If we can't stat the file or we get a mismatch on the filesize.
+	stat, err := os.Stat(destFile)
+	if err != nil || stat.Size() != int64(backup.Size) {
+		err = util.DownloadFile(destFile, backup.DownloadURL, true)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	if backupType == "files" {
+		importPath = fmt.Sprintf("files_%s", p.Environment)
+	}
+
+	return destFile, importPath, nil
+}
+
+// prepDownloadDir ensures the local download cache directories are created and writeable.
+func (p *PantheonProvider) prepDownloadDir() {
+	destDir := p.getDownloadDir()
+	err := os.MkdirAll(destDir, 0755)
+	util.CheckErr(err)
+}
+
+func (p *PantheonProvider) getDownloadDir() string {
+	userDir, err := homedir.Dir()
+	util.CheckErr(err)
+	destDir := filepath.Join(userDir, ".ddev", "pantheon", p.config.Name)
+	return destDir
+}
+
+// getPantheonBackupLink will return a URL for the most recent backyp of archiveType that exist with the BackupList specified.
+func (p *PantheonProvider) getPantheonBackupLink(archiveType string, bl *pantheon.BackupList, session *pantheon.AuthSession) (*pantheon.Backup, error) {
+	latestBackup := pantheon.Backup{}
+	for i, backup := range bl.Backups {
+		if backup.ArchiveType == archiveType && backup.Timestamp > latestBackup.Timestamp {
+			latestBackup = bl.Backups[i]
+		}
+	}
+
+	if latestBackup.Timestamp != 0 {
+		// Get a time-limited backup URL from Pantheon. This requires a POST of the backup type to their API.
+		err := session.Request("POST", &latestBackup)
+		if err != nil {
+			return &pantheon.Backup{}, fmt.Errorf("could not get backup URL: %v", err)
+		}
+
+		return &latestBackup, nil
+	}
+
+	// If no matches were found, just return an empty backup along with an error.
+	return &pantheon.Backup{}, fmt.Errorf("could not find a backup of type %s. please visit your pantheon dashboard and ensure the '%s' environment has a backup available", archiveType, p.Environment)
+}
+
+// environmentPrompt contains the user prompts for interactive configuration of the pantheon environment.
+func (p *PantheonProvider) environmentPrompt() error {
+	_, err := p.GetEnvironments()
+	if err != nil {
+		return err
+	}
+
+	if p.Environment == "" {
+		p.Environment = "dev"
+	}
+
+	fmt.Println("\nConfigure import environment:")
+
+	keys := make([]string, 0, len(p.siteEnvironments.Environments))
+	for k := range p.siteEnvironments.Environments {
+		keys = append(keys, k)
+	}
+	fmt.Println("\n\t- " + strings.Join(keys, "\n\t- ") + "\n")
+	var environmentPrompt = "Type the name to select an environment to import from"
+	if p.Environment != "" {
+		environmentPrompt = fmt.Sprintf("%s (%s)", environmentPrompt, p.Environment)
+	}
+
+	fmt.Print(environmentPrompt + ": ")
+	p.Environment = util.GetInput(p.Environment)
+
+	environment, ok := p.siteEnvironments.Environments[p.Environment]
+	p.environment = environment
+
+	if !ok {
+		return fmt.Errorf("could not find an environment named '%s'", p.Environment)
+	}
+	return nil
+}
+
+// Write the pantheon provider configuration to a spcified location on disk.
+func (p *PantheonProvider) Write(configPath string) error {
+	err := PrepDdevDirectory(filepath.Dir(configPath))
+	if err != nil {
+		return err
+	}
+
+	cfgbytes, err := yaml.Marshal(p)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(configPath, cfgbytes, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Read pantheon provider configuration from a specified location on disk.
+func (p *PantheonProvider) Read(configPath string) error {
+	source, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	// Read config values from file.
+	err = yaml.Unmarshal(source, p)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetEnvironments will return a list of environments for the currently configured upstream pantheon site.
+func (p *PantheonProvider) GetEnvironments() (pantheon.EnvironmentList, error) {
+	var el *pantheon.EnvironmentList
+	// If we've got an already populated environment list, then just use that.
+	if len(p.siteEnvironments.Environments) > 0 {
+		return p.siteEnvironments, nil
+	}
+
+	// Otherwise we need to find our environments.
+	session := getPantheonSession()
+
+	if p.site.ID == "" {
+		site, err := findPantheonSite(p.Sitename)
+		if err != nil {
+			return p.siteEnvironments, err
+		}
+
+		p.site = site
+	}
+
+	// Get a list of all active environments for the current site.
+	el = pantheon.NewEnvironmentList(p.site.ID)
+	err := session.Request("GET", el)
+	p.siteEnvironments = *el
+	return *el, err
+}
+
+// Validate ensures that the current configuration is valid (i.e. the configured pantheon site/environment exists)
+func (p *PantheonProvider) Validate() error {
+	return p.environmentExists()
+}
+
+// environmentExists ensures the currently configured pantheon site & environment exists.
+func (p *PantheonProvider) environmentExists() error {
+	_, err := p.GetEnvironments()
+	if err != nil {
+		return err
+	}
+
+	_, ok := p.siteEnvironments.Environments[p.Environment]
+
+	if !ok {
+		return fmt.Errorf("could not find an environment named '%s'", p.Environment)
+	}
+
+	return nil
+}
+
+// findPantheonSite ensures the pantheon site specified by name exists, and the current user has access to it.
+func findPantheonSite(name string) (pantheon.Site, error) {
+	session := getPantheonSession()
+
+	// Get a list of all sites the current user has access to. Ensure we can find the site which was used in the CLI arguments in that list.
+	sl := &pantheon.SiteList{}
+	err := session.Request("GET", sl)
+	if err != nil {
+		return pantheon.Site{}, err
+	}
+
+	// Get a list of environments for a given site.
+	for i, site := range sl.Sites {
+		if site.Site.Name == name {
+			return sl.Sites[i], nil
+		}
+	}
+
+	return pantheon.Site{}, fmt.Errorf("could not find a pantheon site named %s", name)
+}
+
+// getPantheonSession loads the pantheon API config from disk and returns a pantheon session struct.
+func getPantheonSession() *pantheon.AuthSession {
+	userDir, err := homedir.Dir()
+	util.CheckErr(err)
+	sessionLocation := filepath.Join(userDir, ".ddev", "pantheonconfig.json")
+
+	// Generate a session object based on the PANTHEON_API_TOKEN environment var.
+	session := &pantheon.AuthSession{}
+
+	// Read a previously saved session.
+	err = session.Read(sessionLocation)
+
+	if err != nil {
+		// If we can't read a previous session fall back to using the API token.
+		apiToken := os.Getenv("PANTHEON_API_TOKEN")
+		if apiToken == "" {
+			util.Failed("No saved session could be found and the environment variable PANTHEON_API_TOKEN is not set. Please use ddev auth-pantheon or set a PANTHEON_API_TOKEN. https://pantheon.io/docs/machine-tokens/ provides instructions on creating a token.")
+		}
+		session = pantheon.NewAuthSession(os.Getenv("PANTHEON_API_TOKEN"))
+	}
+
+	err = session.Auth()
+	if err != nil {
+		log.Fatalf("Could not authenticate with pantheon: %v", err)
+	}
+
+	err = session.Write(sessionLocation)
+	util.CheckErr(err)
+
+	return session
+}

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -302,7 +302,7 @@ func getPantheonSession() *pantheon.AuthSession {
 	util.CheckErr(err)
 	sessionLocation := filepath.Join(userDir, ".ddev", "pantheonconfig.json")
 
-	// Generate a session object based on the PANTHEON_API_TOKEN environment var.
+	// Generate a session object based on the DDEV_PANTHEON_API_TOKEN environment var.
 	session := &pantheon.AuthSession{}
 
 	// Read a previously saved session.
@@ -310,11 +310,11 @@ func getPantheonSession() *pantheon.AuthSession {
 
 	if err != nil {
 		// If we can't read a previous session fall back to using the API token.
-		apiToken := os.Getenv("PANTHEON_API_TOKEN")
+		apiToken := os.Getenv("DDEV_PANTHEON_API_TOKEN")
 		if apiToken == "" {
-			util.Failed("No saved session could be found and the environment variable PANTHEON_API_TOKEN is not set. Please use ddev auth-pantheon or set a PANTHEON_API_TOKEN. https://pantheon.io/docs/machine-tokens/ provides instructions on creating a token.")
+			util.Failed("No saved session could be found and the environment variable DDEV_PANTHEON_API_TOKEN is not set. Please use ddev auth-pantheon or set a DDEV_PANTHEON_API_TOKEN. https://pantheon.io/docs/machine-tokens/ provides instructions on creating a token.")
 		}
-		session = pantheon.NewAuthSession(os.Getenv("PANTHEON_API_TOKEN"))
+		session = pantheon.NewAuthSession(os.Getenv("DDEV_PANTHEON_API_TOKEN"))
 	}
 
 	err = session.Auth()

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -40,6 +40,7 @@ services:
     environment:
       - DDEV_UID=$DDEV_UID
       - DDEV_GID=$DDEV_GID
+      - DDEV_URL=$DDEV_URL
       - DOCROOT=$DDEV_DOCROOT
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -2,6 +2,7 @@ package dockerutil_test
 
 import (
 	"log"
+	"os"
 	"testing"
 
 	"path/filepath"
@@ -44,7 +45,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal("failed to create/start docker container ", err)
 	}
-
+	os.Exit(m.Run())
 	// teardown docker container from docker util tests
 	err = client.RemoveContainer(docker.RemoveContainerOptions{
 		ID:    container.ID,

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal("failed to create/start docker container ", err)
 	}
-	os.Exit(m.Run())
+	exitStatus := m.Run()
 	// teardown docker container from docker util tests
 	err = client.RemoveContainer(docker.RemoveContainerOptions{
 		ID:    container.ID,
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 		log.Fatal("failed to remove test container: ", err)
 	}
 
+	os.Exit(exitStatus)
 }
 
 // TestGetContainerHealth tests the function for processing container readiness.

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -741,7 +741,10 @@ func (l *LocalApp) Config() error {
 				perms = 0755
 			}
 
-			os.Chmod(fp, os.FileMode(perms))
+			err = os.Chmod(fp, os.FileMode(perms))
+			if err != nil {
+				return fmt.Errorf("could not change permissions on %s to make the file writeable", fp)
+			}
 		}
 	}
 

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -731,6 +731,20 @@ func (l *LocalApp) Config() error {
 		return err
 	}
 
+	// Drupal and WordPress love to change settings files to be unwriteable. Chmod them to something we can work with
+	// in the event that they already exist.
+	chmodTargets := []string{filepath.Dir(settingsFilePath), settingsFilePath}
+	for _, fp := range chmodTargets {
+		if fileInfo, err := os.Stat(fp); !os.IsNotExist(err) {
+			perms := 0644
+			if fileInfo.IsDir() {
+				perms = 0755
+			}
+
+			os.Chmod(fp, os.FileMode(perms))
+		}
+	}
+
 	fileName := filepath.Base(settingsFilePath)
 
 	switch l.GetType() {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -299,7 +299,7 @@ func (l *LocalApp) SiteStatus() string {
 	return siteStatus
 }
 
-// Import performs an import from a local
+// Import performs an import from the a configured provider plugin, if one exists.
 func (l *LocalApp) Import() error {
 	provider, err := l.AppConfig.GetProvider()
 	if err != nil {
@@ -312,7 +312,7 @@ func (l *LocalApp) Import() error {
 	}
 
 	if l.SiteStatus() != SiteRunning {
-		util.Warning("Site is not currently running. Starting site before performing import.")
+		fmt.Println("Site is not currently running. Starting site before performing import.")
 		err := l.Start()
 		if err != nil {
 			return err
@@ -341,7 +341,6 @@ func (l *LocalApp) Import() error {
 		return err
 	}
 
-	util.Success("\nImport successful, restarting application.\n")
 	return nil
 }
 

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -14,8 +14,6 @@ import (
 	"os/user"
 	"runtime"
 
-	"errors"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/appimport"
 	"github.com/drud/ddev/pkg/appports"
@@ -47,7 +45,7 @@ func (l *LocalApp) GetType() string {
 
 // Init populates LocalApp settings based on the current working directory.
 func (l *LocalApp) Init(basePath string) error {
-	config, err := ddevapp.NewConfig(basePath)
+	config, err := ddevapp.NewConfig(basePath, "")
 	if err != nil {
 		return err
 	}
@@ -232,7 +230,6 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 		return fmt.Errorf("no .sql files found to import")
 	}
 
-	fmt.Println("Importing database...")
 	err = l.Exec("db", true, "bash", "-c", "cat /db/*.sql | mysql")
 	if err != nil {
 		return err
@@ -300,6 +297,52 @@ func (l *LocalApp) SiteStatus() string {
 	}
 
 	return siteStatus
+}
+
+// Import performs an import from a local
+func (l *LocalApp) Import() error {
+	provider, err := l.AppConfig.GetProvider()
+	if err != nil {
+		return err
+	}
+
+	err = provider.Validate()
+	if err != nil {
+		return err
+	}
+
+	if l.SiteStatus() != SiteRunning {
+		util.Warning("Site is not currently running. Starting site before performing import.")
+		err := l.Start()
+		if err != nil {
+			return err
+		}
+	}
+
+	fileLocation, importPath, err := provider.GetBackup("database")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Importing database...")
+	err = l.ImportDB(fileLocation, importPath)
+	if err != nil {
+		return err
+	}
+
+	fileLocation, importPath, err = provider.GetBackup("files")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Importing files...")
+	err = l.ImportFiles(fileLocation, importPath)
+	if err != nil {
+		return err
+	}
+
+	util.Success("\nImport successful, restarting application.\n")
+	return nil
 }
 
 // ImportFiles takes a source directory or archive and copies to the uploaded files directory of a given app.
@@ -495,11 +538,9 @@ func (l *LocalApp) Start() error {
 	// Write docker-compose.yaml (if it doesn't exist).
 	// If the user went through the `ddev config` process it will be written already, but
 	// we also do it here in the case of a manually created `.ddev/config.yaml` file.
-	if !fileutil.FileExists(l.AppConfig.DockerComposeYAMLPath()) {
-		err := l.AppConfig.WriteDockerComposeConfig()
-		if err != nil {
-			return err
-		}
+	err = l.AppConfig.WriteDockerComposeConfig()
+	if err != nil {
+		return err
 	}
 
 	err = l.prepSiteDirs()
@@ -658,25 +699,46 @@ func (l *LocalApp) Wait(containerTypes ...string) error {
 	return nil
 }
 
+func (l *LocalApp) determineConfigLocation() (string, error) {
+	possibleLocations := []string{l.AppConfig.SiteSettingsPath, l.AppConfig.SiteLocalSettingsPath}
+	for _, loc := range possibleLocations {
+		// If the file is found we need to check for a signature to determine if it's safe to use.
+		if fileutil.FileExists(loc) {
+			signatureFound, err := fileutil.FgrepStringInFile(loc, model.DdevSettingsFileSignature)
+			util.CheckErr(err) // Really can't happen as we already checked for the file existence
+
+			if signatureFound {
+				return loc, nil
+			}
+		} else {
+			// If the file is not found it's safe to use.
+			return loc, nil
+		}
+	}
+
+	return "", fmt.Errorf("settings files already exist and are being manged by the user")
+}
+
 // Config creates the apps config file adding things like database host, name, and password
 // as well as other sensitive data like salts.
 func (l *LocalApp) Config() error {
-	settingsFilePath := l.AppConfig.SiteSettingsPath
-
-	if fileutil.FileExists(settingsFilePath) {
-		signatureFound, err := fileutil.FgrepStringInFile(settingsFilePath, model.DdevSettingsFileSignature)
-		util.CheckErr(err) // Really can't happen as we already checked for the file existence
-		if !signatureFound {
-			return errors.New("app config exists")
-		}
-		// Otherwise we'll go on our way and recreate the settings file.
+	// If neither settings file options are set, then
+	if l.AppConfig.SiteLocalSettingsPath == "" && l.AppConfig.SiteSettingsPath == "" {
+		return nil
 	}
+
+	settingsFilePath, err := l.determineConfigLocation()
+	if err != nil {
+		return err
+	}
+
+	fileName := filepath.Base(settingsFilePath)
 
 	switch l.GetType() {
 	case "drupal8":
 		fallthrough
 	case "drupal7":
-		fmt.Println("Generating settings.php file for database connection.")
+		fmt.Printf("Generating %s file for database connection.\n", fileName)
 		drushSettingsPath := filepath.Join(l.AppRoot(), "drush.settings.php")
 
 		// Retrieve published mysql port for drush settings file.
@@ -711,7 +773,7 @@ func (l *LocalApp) Config() error {
 			return err
 		}
 	case "wordpress":
-		fmt.Println("Generating wp-config.php file for database connection.")
+		fmt.Printf("Generating %s file for database connection.\n", fileName)
 		wpConfig := model.NewWordpressConfig()
 		wpConfig.DeployURL = l.URL()
 		err := config.WriteWordpressConfig(wpConfig, settingsFilePath)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -277,7 +277,7 @@ func TestLocalImportFiles(t *testing.T) {
 
 		if site.FilesTarballURL != "" {
 			filePath := filepath.Join(testcommon.CreateTmpDir("local-tarball-files"), "files.tar.gz")
-			err := util.DownloadFile(filePath, site.FilesTarballURL)
+			err := util.DownloadFile(filePath, site.FilesTarballURL, false)
 			assert.NoError(err)
 			err = app.ImportFiles(filePath, "")
 			assert.NoError(err)
@@ -287,7 +287,7 @@ func TestLocalImportFiles(t *testing.T) {
 
 		if site.FilesZipballURL != "" {
 			filePath := filepath.Join(testcommon.CreateTmpDir("local-zipball-files"), "files.zip")
-			err := util.DownloadFile(filePath, site.FilesZipballURL)
+			err := util.DownloadFile(filePath, site.FilesZipballURL, false)
 			assert.NoError(err)
 			err = app.ImportFiles(filePath, "")
 			assert.NoError(err)
@@ -297,7 +297,7 @@ func TestLocalImportFiles(t *testing.T) {
 
 		if site.FullSiteTarballURL != "" {
 			siteTarPath := filepath.Join(testcommon.CreateTmpDir("local-site-tar"), "site.tar.gz")
-			err = util.DownloadFile(siteTarPath, site.FullSiteTarballURL)
+			err = util.DownloadFile(siteTarPath, site.FullSiteTarballURL, false)
 			assert.NoError(err)
 			err = app.ImportFiles(siteTarPath, "docroot/sites/default/files")
 			assert.NoError(err)
@@ -406,7 +406,7 @@ func TestProcessHooks(t *testing.T) {
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ProcessHooks", site.Name))
 
 		testcommon.ClearDockerEnv()
-		conf, err := ddevapp.NewConfig(site.Dir)
+		conf, err := ddevapp.NewConfig(site.Dir, ddevapp.DDevDefaultPlatform)
 		assert.NoError(err)
 
 		conf.Commands = map[string][]ddevapp.Command{

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -31,6 +31,7 @@ type App interface {
 	Config() error
 	HostName() string
 	URL() string
+	Import() error
 	ImportDB(imPath string, extPath string) error
 	ImportFiles(imPath string, extPath string) error
 	SiteStatus() string

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -57,6 +57,7 @@ func (site *TestSite) Prepare() error {
 	util.CheckErr(err)
 
 	cachedSrcDir, _, err := GetCachedArchive(site.Name, site.Name+"_siteArchive", site.ArchiveInternalExtractionPath, site.SourceURL)
+
 	if err != nil {
 		site.Cleanup()
 		return fmt.Errorf("Failed to GetCachedArchive, err=%v", err)
@@ -73,7 +74,7 @@ func (site *TestSite) Prepare() error {
 
 	// If our test site has a Name: then update the config file to reflect that.
 	if site.Name != "" {
-		config, err := ddevapp.NewConfig(site.Dir)
+		config, err := ddevapp.NewConfig(site.Dir, "")
 		if err != nil {
 			return errors.Errorf("Failed to read site config for site %s, dir %s, err:%v", site.Name, site.Dir, err)
 		}
@@ -264,7 +265,7 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 	}
 
 	_ = os.MkdirAll(extractPath, 0777)
-	err := util.DownloadFile(fileNameFullPath, sourceURL)
+	err := util.DownloadFile(fileNameFullPath, sourceURL, false)
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to download url=%s into %s, err=%v", sourceURL, fileNameFullPath, err)
 	}

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -14,9 +14,9 @@ import (
 )
 
 // DownloadFile retreives a file.
-func DownloadFile(filepath string, url string, progressBar bool) (err error) {
+func DownloadFile(fp string, url string, progressBar bool) (err error) {
 	// Create the file
-	out, err := os.Create(filepath)
+	out, err := os.Create(fp)
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,8 @@ func DownloadFile(filepath string, url string, progressBar bool) (err error) {
 	}
 	reader := resp.Body
 	if progressBar {
-		bar := pb.New(int(resp.ContentLength)).SetUnits(pb.U_BYTES).Prefix(path.Base(filepath))
+
+		bar := pb.New(int(resp.ContentLength)).SetUnits(pb.U_BYTES).Prefix(filepath.Base(fp))
 		bar.Start()
 
 		// create proxy reader

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"path"
 
-	"github.com/drud/ddev/pkg/util"
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
 )
@@ -77,7 +76,7 @@ func GetGlobalDdevDir() string {
 	if _, err := os.Stat(ddevDir); os.IsNotExist(err) {
 		err = os.MkdirAll(ddevDir, 0700)
 		if err != nil {
-			util.Failed("Failed to create required directory %s, err: %v", ddevDir, err)
+			Failed("Failed to create required directory %s, err: %v", ddevDir, err)
 		}
 	}
 	return ddevDir

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -7,11 +7,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
-	"github.com/mitchellh/go-homedir"
 	"log"
 	"path"
+
+	"github.com/drud/ddev/pkg/util"
+	"github.com/fatih/color"
+	"github.com/mitchellh/go-homedir"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 // Failed will print an red error message and exit with failure.
 func Failed(format string, a ...interface{}) {
@@ -66,11 +72,15 @@ func GetGlobalDdevDir() string {
 		log.Fatal("could not get home directory for current user. is it set?")
 	}
 	ddevDir := path.Join(userHome, ".ddev")
-	return ddevDir
-}
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
+	// Create the directory if it is not already present.
+	if _, err := os.Stat(ddevDir); os.IsNotExist(err) {
+		err = os.MkdirAll(ddevDir, 0700)
+		if err != nil {
+			util.Failed("Failed to create required directory %s, err: %v", ddevDir, err)
+		}
+	}
+	return ddevDir
 }
 
 // AskForConfirmation requests a y/n from user.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,8 +1,10 @@
 package util
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -13,8 +15,13 @@ import (
 
 // Failed will print an red error message and exit with failure.
 func Failed(format string, a ...interface{}) {
-	color.Red(format, a...)
+	Error(format, a...)
 	os.Exit(1)
+}
+
+// Error will print an red error message but will not exit.
+func Error(format string, a ...interface{}) {
+	color.Red(format, a...)
 }
 
 // Warning will present the user with warning text.
@@ -64,4 +71,37 @@ func GetGlobalDdevDir() string {
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
+}
+
+// AskForConfirmation requests a y/n from user.
+func AskForConfirmation() bool {
+	response := GetInput("")
+	okayResponses := []string{"y", "yes"}
+	nokayResponses := []string{"n", "no", ""}
+	responseLower := strings.ToLower(response)
+
+	if containsString(okayResponses, responseLower) {
+		return true
+	} else if containsString(nokayResponses, responseLower) {
+		return false
+	} else {
+		fmt.Println("Please type yes or no and then press enter:")
+		return AskForConfirmation()
+	}
+}
+
+// containsString returns true if slice contains element
+func containsString(slice []string, element string) bool {
+	return !(posString(slice, element) == -1)
+}
+
+// posString returns the first index of element in slice.
+// If slice does not contain element, returns -1.
+func posString(slice []string, element string) int {
+	for index, elem := range slice {
+		if elem == element {
+			return index
+		}
+	}
+	return -1
 }

--- a/vendor/github.com/cheggaaa/pb/LICENSE
+++ b/vendor/github.com/cheggaaa/pb/LICENSE
@@ -1,0 +1,12 @@
+Copyright (c) 2012-2015, Sergey Cherepanov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/cheggaaa/pb/README.md
+++ b/vendor/github.com/cheggaaa/pb/README.md
@@ -1,0 +1,178 @@
+# Terminal progress bar for Go  
+
+[![Join the chat at https://gitter.im/cheggaaa/pb](https://badges.gitter.im/cheggaaa/pb.svg)](https://gitter.im/cheggaaa/pb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Simple progress bar for console programs. 
+    
+
+## Installation
+
+```
+go get gopkg.in/cheggaaa/pb.v1
+```   
+
+## Usage   
+
+```Go
+package main
+
+import (
+	"gopkg.in/cheggaaa/pb.v1"
+	"time"
+)
+
+func main() {
+	count := 100000
+	bar := pb.StartNew(count)
+	for i := 0; i < count; i++ {
+		bar.Increment()
+		time.Sleep(time.Millisecond)
+	}
+	bar.FinishPrint("The End!")
+}
+
+```
+
+Result will be like this:
+
+```
+> go run test.go
+37158 / 100000 [================>_______________________________] 37.16% 1m11s
+```
+
+## Customization
+
+```Go  
+// create bar
+bar := pb.New(count)
+
+// refresh info every second (default 200ms)
+bar.SetRefreshRate(time.Second)
+
+// show percents (by default already true)
+bar.ShowPercent = true
+
+// show bar (by default already true)
+bar.ShowBar = true
+
+// no counters
+bar.ShowCounters = false
+
+// show "time left"
+bar.ShowTimeLeft = true
+
+// show average speed
+bar.ShowSpeed = true
+
+// sets the width of the progress bar
+bar.SetWidth(80)
+
+// sets the width of the progress bar, but if terminal size smaller will be ignored
+bar.SetMaxWidth(80)
+
+// convert output to readable format (like KB, MB)
+bar.SetUnits(pb.U_BYTES)
+
+// and start
+bar.Start()
+``` 
+
+## Progress bar for IO Operations
+
+```go
+// create and start bar
+bar := pb.New(myDataLen).SetUnits(pb.U_BYTES)
+bar.Start()
+
+// my io.Reader
+r := myReader
+
+// my io.Writer
+w := myWriter
+
+// create proxy reader
+reader := bar.NewProxyReader(r)
+
+// and copy from pb reader
+io.Copy(w, reader)
+
+```
+
+```go
+// create and start bar
+bar := pb.New(myDataLen).SetUnits(pb.U_BYTES)
+bar.Start()
+
+// my io.Reader
+r := myReader
+
+// my io.Writer
+w := myWriter
+
+// create multi writer
+writer := io.MultiWriter(w, bar)
+
+// and copy
+io.Copy(writer, r)
+
+bar.Finish()
+```
+
+## Custom Progress Bar Look-and-feel
+
+```go
+bar.Format("<.- >")
+```
+
+## Multiple Progress Bars (experimental and unstable)
+
+Do not print to terminal while pool is active.
+
+```go
+package main
+
+import (
+    "math/rand"
+    "sync"
+    "time"
+
+    "gopkg.in/cheggaaa/pb.v1"
+)
+
+func main() {
+    // create bars
+    first := pb.New(200).Prefix("First ")
+    second := pb.New(200).Prefix("Second ")
+    third := pb.New(200).Prefix("Third ")
+    // start pool
+    pool, err := pb.StartPool(first, second, third)
+    if err != nil {
+        panic(err)
+    }
+    // update bars
+    wg := new(sync.WaitGroup)
+    for _, bar := range []*pb.ProgressBar{first, second, third} {
+        wg.Add(1)
+        go func(cb *pb.ProgressBar) {
+            for n := 0; n < 200; n++ {
+                cb.Increment()
+                time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
+            }
+            cb.Finish()
+            wg.Done()
+        }(bar)
+    }
+    wg.Wait()
+    // close pool
+    pool.Stop()
+}
+```
+
+The result will be as follows:
+
+```
+$ go run example/multiple.go 
+First 141 / 1000 [===============>---------------------------------------] 14.10 % 44s
+Second 139 / 1000 [==============>---------------------------------------] 13.90 % 44s
+Third 152 / 1000 [================>--------------------------------------] 15.20 % 40s
+```

--- a/vendor/github.com/cheggaaa/pb/format.go
+++ b/vendor/github.com/cheggaaa/pb/format.go
@@ -1,0 +1,92 @@
+package pb
+
+import (
+	"fmt"
+	"time"
+)
+
+type Units int
+
+const (
+	// U_NO are default units, they represent a simple value and are not formatted at all.
+	U_NO Units = iota
+	// U_BYTES units are formatted in a human readable way (b, Bb, Mb, ...)
+	U_BYTES
+	// U_DURATION units are formatted in a human readable way (3h14m15s)
+	U_DURATION
+)
+
+const (
+	KiB = 1024
+	MiB = 1048576
+	GiB = 1073741824
+	TiB = 1099511627776
+)
+
+func Format(i int64) *formatter {
+	return &formatter{n: i}
+}
+
+type formatter struct {
+	n      int64
+	unit   Units
+	width  int
+	perSec bool
+}
+
+func (f *formatter) To(unit Units) *formatter {
+	f.unit = unit
+	return f
+}
+
+func (f *formatter) Width(width int) *formatter {
+	f.width = width
+	return f
+}
+
+func (f *formatter) PerSec() *formatter {
+	f.perSec = true
+	return f
+}
+
+func (f *formatter) String() (out string) {
+	switch f.unit {
+	case U_BYTES:
+		out = formatBytes(f.n)
+	case U_DURATION:
+		out = formatDuration(f.n)
+	default:
+		out = fmt.Sprintf(fmt.Sprintf("%%%dd", f.width), f.n)
+	}
+	if f.perSec {
+		out += "/s"
+	}
+	return
+}
+
+// Convert bytes to human readable string. Like a 2 MiB, 64.2 KiB, 52 B
+func formatBytes(i int64) (result string) {
+	switch {
+	case i >= TiB:
+		result = fmt.Sprintf("%.02f TiB", float64(i)/TiB)
+	case i >= GiB:
+		result = fmt.Sprintf("%.02f GiB", float64(i)/GiB)
+	case i >= MiB:
+		result = fmt.Sprintf("%.02f MiB", float64(i)/MiB)
+	case i >= KiB:
+		result = fmt.Sprintf("%.02f KiB", float64(i)/KiB)
+	default:
+		result = fmt.Sprintf("%d B", i)
+	}
+	return
+}
+
+func formatDuration(n int64) (result string) {
+	d := time.Duration(n)
+	if d > time.Hour*24 {
+		result = fmt.Sprintf("%dd", d/24/time.Hour)
+		d -= (d / time.Hour / 24) * (time.Hour * 24)
+	}
+	result = fmt.Sprintf("%s%v", result, d)
+	return
+}

--- a/vendor/github.com/cheggaaa/pb/pb.go
+++ b/vendor/github.com/cheggaaa/pb/pb.go
@@ -1,0 +1,451 @@
+// Simple console progress bars
+package pb
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+)
+
+// Current version
+const Version = "1.0.15"
+
+const (
+	// Default refresh rate - 200ms
+	DEFAULT_REFRESH_RATE = time.Millisecond * 200
+	FORMAT               = "[=>-]"
+)
+
+// DEPRECATED
+// variables for backward compatibility, from now do not work
+// use pb.Format and pb.SetRefreshRate
+var (
+	DefaultRefreshRate                         = DEFAULT_REFRESH_RATE
+	BarStart, BarEnd, Empty, Current, CurrentN string
+)
+
+// Create new progress bar object
+func New(total int) *ProgressBar {
+	return New64(int64(total))
+}
+
+// Create new progress bar object using int64 as total
+func New64(total int64) *ProgressBar {
+	pb := &ProgressBar{
+		Total:         total,
+		RefreshRate:   DEFAULT_REFRESH_RATE,
+		ShowPercent:   true,
+		ShowCounters:  true,
+		ShowBar:       true,
+		ShowTimeLeft:  true,
+		ShowFinalTime: true,
+		Units:         U_NO,
+		ManualUpdate:  false,
+		finish:        make(chan struct{}),
+	}
+	return pb.Format(FORMAT)
+}
+
+// Create new object and start
+func StartNew(total int) *ProgressBar {
+	return New(total).Start()
+}
+
+// Callback for custom output
+// For example:
+// bar.Callback = func(s string) {
+//     mySuperPrint(s)
+// }
+//
+type Callback func(out string)
+
+type ProgressBar struct {
+	current int64 // current must be first member of struct (https://code.google.com/p/go/issues/detail?id=5278)
+
+	Total                            int64
+	RefreshRate                      time.Duration
+	ShowPercent, ShowCounters        bool
+	ShowSpeed, ShowTimeLeft, ShowBar bool
+	ShowFinalTime                    bool
+	Output                           io.Writer
+	Callback                         Callback
+	NotPrint                         bool
+	Units                            Units
+	Width                            int
+	ForceWidth                       bool
+	ManualUpdate                     bool
+	AutoStat                         bool
+
+	// Default width for the time box.
+	UnitsWidth   int
+	TimeBoxWidth int
+
+	finishOnce sync.Once //Guards isFinish
+	finish     chan struct{}
+	isFinish   bool
+
+	startTime  time.Time
+	startValue int64
+
+	prefix, postfix string
+
+	mu        sync.Mutex
+	lastPrint string
+
+	BarStart string
+	BarEnd   string
+	Empty    string
+	Current  string
+	CurrentN string
+
+	AlwaysUpdate bool
+}
+
+// Start print
+func (pb *ProgressBar) Start() *ProgressBar {
+	pb.startTime = time.Now()
+	pb.startValue = atomic.LoadInt64(&pb.current)
+	if pb.Total == 0 {
+		pb.ShowTimeLeft = false
+		pb.ShowPercent = false
+		pb.AutoStat = false
+	}
+	if !pb.ManualUpdate {
+		pb.Update() // Initial printing of the bar before running the bar refresher.
+		go pb.refresher()
+	}
+	return pb
+}
+
+// Increment current value
+func (pb *ProgressBar) Increment() int {
+	return pb.Add(1)
+}
+
+// Get current value
+func (pb *ProgressBar) Get() int64 {
+	c := atomic.LoadInt64(&pb.current)
+	return c
+}
+
+// Set current value
+func (pb *ProgressBar) Set(current int) *ProgressBar {
+	return pb.Set64(int64(current))
+}
+
+// Set64 sets the current value as int64
+func (pb *ProgressBar) Set64(current int64) *ProgressBar {
+	atomic.StoreInt64(&pb.current, current)
+	return pb
+}
+
+// Add to current value
+func (pb *ProgressBar) Add(add int) int {
+	return int(pb.Add64(int64(add)))
+}
+
+func (pb *ProgressBar) Add64(add int64) int64 {
+	return atomic.AddInt64(&pb.current, add)
+}
+
+// Set prefix string
+func (pb *ProgressBar) Prefix(prefix string) *ProgressBar {
+	pb.prefix = prefix
+	return pb
+}
+
+// Set postfix string
+func (pb *ProgressBar) Postfix(postfix string) *ProgressBar {
+	pb.postfix = postfix
+	return pb
+}
+
+// Set custom format for bar
+// Example: bar.Format("[=>_]")
+// Example: bar.Format("[\x00=\x00>\x00-\x00]") // \x00 is the delimiter
+func (pb *ProgressBar) Format(format string) *ProgressBar {
+	var formatEntries []string
+	if utf8.RuneCountInString(format) == 5 {
+		formatEntries = strings.Split(format, "")
+	} else {
+		formatEntries = strings.Split(format, "\x00")
+	}
+	if len(formatEntries) == 5 {
+		pb.BarStart = formatEntries[0]
+		pb.BarEnd = formatEntries[4]
+		pb.Empty = formatEntries[3]
+		pb.Current = formatEntries[1]
+		pb.CurrentN = formatEntries[2]
+	}
+	return pb
+}
+
+// Set bar refresh rate
+func (pb *ProgressBar) SetRefreshRate(rate time.Duration) *ProgressBar {
+	pb.RefreshRate = rate
+	return pb
+}
+
+// Set units
+// bar.SetUnits(U_NO) - by default
+// bar.SetUnits(U_BYTES) - for Mb, Kb, etc
+func (pb *ProgressBar) SetUnits(units Units) *ProgressBar {
+	pb.Units = units
+	return pb
+}
+
+// Set max width, if width is bigger than terminal width, will be ignored
+func (pb *ProgressBar) SetMaxWidth(width int) *ProgressBar {
+	pb.Width = width
+	pb.ForceWidth = false
+	return pb
+}
+
+// Set bar width
+func (pb *ProgressBar) SetWidth(width int) *ProgressBar {
+	pb.Width = width
+	pb.ForceWidth = true
+	return pb
+}
+
+// End print
+func (pb *ProgressBar) Finish() {
+	//Protect multiple calls
+	pb.finishOnce.Do(func() {
+		close(pb.finish)
+		pb.write(atomic.LoadInt64(&pb.current))
+		pb.mu.Lock()
+		defer pb.mu.Unlock()
+		switch {
+		case pb.Output != nil:
+			fmt.Fprintln(pb.Output)
+		case !pb.NotPrint:
+			fmt.Println()
+		}
+		pb.isFinish = true
+	})
+}
+
+// IsFinished return boolean
+func (pb *ProgressBar) IsFinished() bool {
+	pb.mu.Lock()
+	defer pb.mu.Unlock()
+	return pb.isFinish
+}
+
+// End print and write string 'str'
+func (pb *ProgressBar) FinishPrint(str string) {
+	pb.Finish()
+	if pb.Output != nil {
+		fmt.Fprintln(pb.Output, str)
+	} else {
+		fmt.Println(str)
+	}
+}
+
+// implement io.Writer
+func (pb *ProgressBar) Write(p []byte) (n int, err error) {
+	n = len(p)
+	pb.Add(n)
+	return
+}
+
+// implement io.Reader
+func (pb *ProgressBar) Read(p []byte) (n int, err error) {
+	n = len(p)
+	pb.Add(n)
+	return
+}
+
+// Create new proxy reader over bar
+// Takes io.Reader or io.ReadCloser
+func (pb *ProgressBar) NewProxyReader(r io.Reader) *Reader {
+	return &Reader{r, pb}
+}
+
+func (pb *ProgressBar) write(current int64) {
+	width := pb.GetWidth()
+
+	var percentBox, countersBox, timeLeftBox, speedBox, barBox, end, out string
+
+	// percents
+	if pb.ShowPercent {
+		var percent float64
+		if pb.Total > 0 {
+			percent = float64(current) / (float64(pb.Total) / float64(100))
+		} else {
+			percent = float64(current) / float64(100)
+		}
+		percentBox = fmt.Sprintf(" %6.02f%%", percent)
+	}
+
+	// counters
+	if pb.ShowCounters {
+		current := Format(current).To(pb.Units).Width(pb.UnitsWidth)
+		if pb.Total > 0 {
+			total := Format(pb.Total).To(pb.Units).Width(pb.UnitsWidth)
+			countersBox = fmt.Sprintf(" %s / %s ", current, total)
+		} else {
+			countersBox = fmt.Sprintf(" %s / ? ", current)
+		}
+	}
+
+	// time left
+	fromStart := time.Now().Sub(pb.startTime)
+	currentFromStart := current - pb.startValue
+	select {
+	case <-pb.finish:
+		if pb.ShowFinalTime {
+			var left time.Duration
+			left = (fromStart / time.Second) * time.Second
+			timeLeftBox = fmt.Sprintf(" %s", left.String())
+		}
+	default:
+		if pb.ShowTimeLeft && currentFromStart > 0 {
+			perEntry := fromStart / time.Duration(currentFromStart)
+			var left time.Duration
+			if pb.Total > 0 {
+				left = time.Duration(pb.Total-currentFromStart) * perEntry
+				left = (left / time.Second) * time.Second
+			} else {
+				left = time.Duration(currentFromStart) * perEntry
+				left = (left / time.Second) * time.Second
+			}
+			timeLeft := Format(int64(left)).To(U_DURATION).String()
+			timeLeftBox = fmt.Sprintf(" %s", timeLeft)
+		}
+	}
+
+	if len(timeLeftBox) < pb.TimeBoxWidth {
+		timeLeftBox = fmt.Sprintf("%s%s", strings.Repeat(" ", pb.TimeBoxWidth-len(timeLeftBox)), timeLeftBox)
+	}
+
+	// speed
+	if pb.ShowSpeed && currentFromStart > 0 {
+		fromStart := time.Now().Sub(pb.startTime)
+		speed := float64(currentFromStart) / (float64(fromStart) / float64(time.Second))
+		speedBox = " " + Format(int64(speed)).To(pb.Units).Width(pb.UnitsWidth).PerSec().String()
+	}
+
+	barWidth := escapeAwareRuneCountInString(countersBox + pb.BarStart + pb.BarEnd + percentBox + timeLeftBox + speedBox + pb.prefix + pb.postfix)
+	// bar
+	if pb.ShowBar {
+		size := width - barWidth
+		if size > 0 {
+			if pb.Total > 0 {
+				curCount := int(math.Ceil((float64(current) / float64(pb.Total)) * float64(size)))
+				emptCount := size - curCount
+				barBox = pb.BarStart
+				if emptCount < 0 {
+					emptCount = 0
+				}
+				if curCount > size {
+					curCount = size
+				}
+				if emptCount <= 0 {
+					barBox += strings.Repeat(pb.Current, curCount)
+				} else if curCount > 0 {
+					barBox += strings.Repeat(pb.Current, curCount-1) + pb.CurrentN
+				}
+				barBox += strings.Repeat(pb.Empty, emptCount) + pb.BarEnd
+			} else {
+				barBox = pb.BarStart
+				pos := size - int(current)%int(size)
+				if pos-1 > 0 {
+					barBox += strings.Repeat(pb.Empty, pos-1)
+				}
+				barBox += pb.Current
+				if size-pos-1 > 0 {
+					barBox += strings.Repeat(pb.Empty, size-pos-1)
+				}
+				barBox += pb.BarEnd
+			}
+		}
+	}
+
+	// check len
+	out = pb.prefix + countersBox + barBox + percentBox + speedBox + timeLeftBox + pb.postfix
+	if cl := escapeAwareRuneCountInString(out); cl < width {
+		end = strings.Repeat(" ", width-cl)
+	}
+
+	// and print!
+	pb.mu.Lock()
+	pb.lastPrint = out + end
+	isFinish := pb.isFinish
+	pb.mu.Unlock()
+	switch {
+	case isFinish:
+		return
+	case pb.Output != nil:
+		fmt.Fprint(pb.Output, "\r"+out+end)
+	case pb.Callback != nil:
+		pb.Callback(out + end)
+	case !pb.NotPrint:
+		fmt.Print("\r" + out + end)
+	}
+}
+
+// GetTerminalWidth - returns terminal width for all platforms.
+func GetTerminalWidth() (int, error) {
+	return terminalWidth()
+}
+
+func (pb *ProgressBar) GetWidth() int {
+	if pb.ForceWidth {
+		return pb.Width
+	}
+
+	width := pb.Width
+	termWidth, _ := terminalWidth()
+	if width == 0 || termWidth <= width {
+		width = termWidth
+	}
+
+	return width
+}
+
+// Write the current state of the progressbar
+func (pb *ProgressBar) Update() {
+	c := atomic.LoadInt64(&pb.current)
+	pb.write(c)
+	if pb.AutoStat {
+		if c == 0 {
+			pb.startTime = time.Now()
+			pb.startValue = 0
+		} else if c >= pb.Total && pb.isFinish != true {
+			pb.Finish()
+		}
+	}
+}
+
+// String return the last bar print
+func (pb *ProgressBar) String() string {
+	pb.mu.Lock()
+	defer pb.mu.Unlock()
+	return pb.lastPrint
+}
+
+// Internal loop for refreshing the progressbar
+func (pb *ProgressBar) refresher() {
+	for {
+		select {
+		case <-pb.finish:
+			return
+		case <-time.After(pb.RefreshRate):
+			pb.Update()
+		}
+	}
+}
+
+type window struct {
+	Row    uint16
+	Col    uint16
+	Xpixel uint16
+	Ypixel uint16
+}

--- a/vendor/github.com/cheggaaa/pb/pb_nix.go
+++ b/vendor/github.com/cheggaaa/pb/pb_nix.go
@@ -1,0 +1,8 @@
+// +build linux darwin freebsd netbsd openbsd dragonfly
+// +build !appengine
+
+package pb
+
+import "syscall"
+
+const sysIoctl = syscall.SYS_IOCTL

--- a/vendor/github.com/cheggaaa/pb/pb_solaris.go
+++ b/vendor/github.com/cheggaaa/pb/pb_solaris.go
@@ -1,0 +1,6 @@
+// +build solaris
+// +build !appengine
+
+package pb
+
+const sysIoctl = 54

--- a/vendor/github.com/cheggaaa/pb/pb_win.go
+++ b/vendor/github.com/cheggaaa/pb/pb_win.go
@@ -1,0 +1,141 @@
+// +build windows
+
+package pb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+var tty = os.Stdin
+
+var (
+	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+	// GetConsoleScreenBufferInfo retrieves information about the
+	// specified console screen buffer.
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms683171(v=vs.85).aspx
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+
+	// GetConsoleMode retrieves the current input mode of a console's
+	// input buffer or the current output mode of a console screen buffer.
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms683167(v=vs.85).aspx
+	getConsoleMode = kernel32.NewProc("GetConsoleMode")
+
+	// SetConsoleMode sets the input mode of a console's input buffer
+	// or the output mode of a console screen buffer.
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
+	setConsoleMode = kernel32.NewProc("SetConsoleMode")
+
+	// SetConsoleCursorPosition sets the cursor position in the
+	// specified console screen buffer.
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms686025(v=vs.85).aspx
+	setConsoleCursorPosition = kernel32.NewProc("SetConsoleCursorPosition")
+)
+
+type (
+	// Defines the coordinates of the upper left and lower right corners
+	// of a rectangle.
+	// See
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms686311(v=vs.85).aspx
+	smallRect struct {
+		Left, Top, Right, Bottom int16
+	}
+
+	// Defines the coordinates of a character cell in a console screen
+	// buffer. The origin of the coordinate system (0,0) is at the top, left cell
+	// of the buffer.
+	// See
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms682119(v=vs.85).aspx
+	coordinates struct {
+		X, Y int16
+	}
+
+	word int16
+
+	// Contains information about a console screen buffer.
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms682093(v=vs.85).aspx
+	consoleScreenBufferInfo struct {
+		dwSize              coordinates
+		dwCursorPosition    coordinates
+		wAttributes         word
+		srWindow            smallRect
+		dwMaximumWindowSize coordinates
+	}
+)
+
+// terminalWidth returns width of the terminal.
+func terminalWidth() (width int, err error) {
+	var info consoleScreenBufferInfo
+	_, _, e := syscall.Syscall(procGetConsoleScreenBufferInfo.Addr(), 2, uintptr(syscall.Stdout), uintptr(unsafe.Pointer(&info)), 0)
+	if e != 0 {
+		return 0, error(e)
+	}
+	return int(info.dwSize.X) - 1, nil
+}
+
+func getCursorPos() (pos coordinates, err error) {
+	var info consoleScreenBufferInfo
+	_, _, e := syscall.Syscall(procGetConsoleScreenBufferInfo.Addr(), 2, uintptr(syscall.Stdout), uintptr(unsafe.Pointer(&info)), 0)
+	if e != 0 {
+		return info.dwCursorPosition, error(e)
+	}
+	return info.dwCursorPosition, nil
+}
+
+func setCursorPos(pos coordinates) error {
+	_, _, e := syscall.Syscall(setConsoleCursorPosition.Addr(), 2, uintptr(syscall.Stdout), uintptr(uint32(uint16(pos.Y))<<16|uint32(uint16(pos.X))), 0)
+	if e != 0 {
+		return error(e)
+	}
+	return nil
+}
+
+var ErrPoolWasStarted = errors.New("Bar pool was started")
+
+var echoLocked bool
+var echoLockMutex sync.Mutex
+
+var oldState word
+
+func lockEcho() (quit chan int, err error) {
+	echoLockMutex.Lock()
+	defer echoLockMutex.Unlock()
+	if echoLocked {
+		err = ErrPoolWasStarted
+		return
+	}
+	echoLocked = true
+
+	if _, _, e := syscall.Syscall(getConsoleMode.Addr(), 2, uintptr(syscall.Stdout), uintptr(unsafe.Pointer(&oldState)), 0); e != 0 {
+		err = fmt.Errorf("Can't get terminal settings: %v", e)
+		return
+	}
+
+	newState := oldState
+	const ENABLE_ECHO_INPUT = 0x0004
+	const ENABLE_LINE_INPUT = 0x0002
+	newState = newState & (^(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT))
+	if _, _, e := syscall.Syscall(setConsoleMode.Addr(), 2, uintptr(syscall.Stdout), uintptr(newState), 0); e != 0 {
+		err = fmt.Errorf("Can't set terminal settings: %v", e)
+		return
+	}
+	return
+}
+
+func unlockEcho() (err error) {
+	echoLockMutex.Lock()
+	defer echoLockMutex.Unlock()
+	if !echoLocked {
+		return
+	}
+	echoLocked = false
+	if _, _, e := syscall.Syscall(setConsoleMode.Addr(), 2, uintptr(syscall.Stdout), uintptr(oldState), 0); e != 0 {
+		err = fmt.Errorf("Can't set terminal settings")
+	}
+	return
+}

--- a/vendor/github.com/cheggaaa/pb/pb_x.go
+++ b/vendor/github.com/cheggaaa/pb/pb_x.go
@@ -1,0 +1,110 @@
+// +build linux darwin freebsd netbsd openbsd solaris dragonfly
+// +build !appengine
+
+package pb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	TIOCGWINSZ     = 0x5413
+	TIOCGWINSZ_OSX = 1074295912
+)
+
+var tty *os.File
+
+var ErrPoolWasStarted = errors.New("Bar pool was started")
+
+var echoLocked bool
+var echoLockMutex sync.Mutex
+
+func init() {
+	var err error
+	tty, err = os.Open("/dev/tty")
+	if err != nil {
+		tty = os.Stdin
+	}
+}
+
+// terminalWidth returns width of the terminal.
+func terminalWidth() (int, error) {
+	w := new(window)
+	tio := syscall.TIOCGWINSZ
+	if runtime.GOOS == "darwin" {
+		tio = TIOCGWINSZ_OSX
+	}
+	res, _, err := syscall.Syscall(sysIoctl,
+		tty.Fd(),
+		uintptr(tio),
+		uintptr(unsafe.Pointer(w)),
+	)
+	if int(res) == -1 {
+		return 0, err
+	}
+	return int(w.Col), nil
+}
+
+var oldState syscall.Termios
+
+func lockEcho() (quit chan int, err error) {
+	echoLockMutex.Lock()
+	defer echoLockMutex.Unlock()
+	if echoLocked {
+		err = ErrPoolWasStarted
+		return
+	}
+	echoLocked = true
+
+	fd := tty.Fd()
+	if _, _, e := syscall.Syscall6(sysIoctl, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0); e != 0 {
+		err = fmt.Errorf("Can't get terminal settings: %v", e)
+		return
+	}
+
+	newState := oldState
+	newState.Lflag &^= syscall.ECHO
+	newState.Lflag |= syscall.ICANON | syscall.ISIG
+	newState.Iflag |= syscall.ICRNL
+	if _, _, e := syscall.Syscall6(sysIoctl, fd, ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); e != 0 {
+		err = fmt.Errorf("Can't set terminal settings: %v", e)
+		return
+	}
+	quit = make(chan int, 1)
+	go catchTerminate(quit)
+	return
+}
+
+func unlockEcho() (err error) {
+	echoLockMutex.Lock()
+	defer echoLockMutex.Unlock()
+	if !echoLocked {
+		return
+	}
+	echoLocked = false
+	fd := tty.Fd()
+	if _, _, e := syscall.Syscall6(sysIoctl, fd, ioctlWriteTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0); e != 0 {
+		err = fmt.Errorf("Can't set terminal settings")
+	}
+	return
+}
+
+// listen exit signals and restore terminal state
+func catchTerminate(quit chan int) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGKILL)
+	defer signal.Stop(sig)
+	select {
+	case <-quit:
+		unlockEcho()
+	case <-sig:
+		unlockEcho()
+	}
+}

--- a/vendor/github.com/cheggaaa/pb/pool.go
+++ b/vendor/github.com/cheggaaa/pb/pool.go
@@ -1,0 +1,82 @@
+// +build linux darwin freebsd netbsd openbsd solaris dragonfly windows
+
+package pb
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+// Create and start new pool with given bars
+// You need call pool.Stop() after work
+func StartPool(pbs ...*ProgressBar) (pool *Pool, err error) {
+	pool = new(Pool)
+	if err = pool.start(); err != nil {
+		return
+	}
+	pool.Add(pbs...)
+	return
+}
+
+type Pool struct {
+	Output        io.Writer
+	RefreshRate   time.Duration
+	bars          []*ProgressBar
+	lastBarsCount int
+	quit          chan int
+	m             sync.Mutex
+	finishOnce    sync.Once
+}
+
+// Add progress bars.
+func (p *Pool) Add(pbs ...*ProgressBar) {
+	p.m.Lock()
+	defer p.m.Unlock()
+	for _, bar := range pbs {
+		bar.ManualUpdate = true
+		bar.NotPrint = true
+		bar.Start()
+		p.bars = append(p.bars, bar)
+	}
+}
+
+func (p *Pool) start() (err error) {
+	p.RefreshRate = DefaultRefreshRate
+	quit, err := lockEcho()
+	if err != nil {
+		return
+	}
+	p.quit = make(chan int)
+	go p.writer(quit)
+	return
+}
+
+func (p *Pool) writer(finish chan int) {
+	var first = true
+	for {
+		select {
+		case <-time.After(p.RefreshRate):
+			if p.print(first) {
+				p.print(false)
+				finish <- 1
+				return
+			}
+			first = false
+		case <-p.quit:
+			finish <- 1
+			return
+		}
+	}
+}
+
+// Restore terminal state and close pool
+func (p *Pool) Stop() error {
+	// Wait until one final refresh has passed.
+	time.Sleep(p.RefreshRate)
+
+	p.finishOnce.Do(func() {
+		close(p.quit)
+	})
+	return unlockEcho()
+}

--- a/vendor/github.com/cheggaaa/pb/pool_win.go
+++ b/vendor/github.com/cheggaaa/pb/pool_win.go
@@ -1,0 +1,45 @@
+// +build windows
+
+package pb
+
+import (
+	"fmt"
+	"log"
+)
+
+func (p *Pool) print(first bool) bool {
+	p.m.Lock()
+	defer p.m.Unlock()
+	var out string
+	if !first {
+		coords, err := getCursorPos()
+		if err != nil {
+			log.Panic(err)
+		}
+		coords.Y -= int16(p.lastBarsCount)
+		if coords.Y < 0 {
+			coords.Y = 0
+		}
+		coords.X = 0
+
+		err = setCursorPos(coords)
+		if err != nil {
+			log.Panic(err)
+		}
+	}
+	isFinished := true
+	for _, bar := range p.bars {
+		if !bar.IsFinished() {
+			isFinished = false
+		}
+		bar.Update()
+		out += fmt.Sprintf("\r%s\n", bar.String())
+	}
+	if p.Output != nil {
+		fmt.Fprint(p.Output, out)
+	} else {
+		fmt.Print(out)
+	}
+	p.lastBarsCount = len(p.bars)
+	return isFinished
+}

--- a/vendor/github.com/cheggaaa/pb/pool_x.go
+++ b/vendor/github.com/cheggaaa/pb/pool_x.go
@@ -1,0 +1,29 @@
+// +build linux darwin freebsd netbsd openbsd solaris dragonfly
+
+package pb
+
+import "fmt"
+
+func (p *Pool) print(first bool) bool {
+	p.m.Lock()
+	defer p.m.Unlock()
+	var out string
+	if !first {
+		out = fmt.Sprintf("\033[%dA", p.lastBarsCount)
+	}
+	isFinished := true
+	for _, bar := range p.bars {
+		if !bar.IsFinished() {
+			isFinished = false
+		}
+		bar.Update()
+		out += fmt.Sprintf("\r%s\n", bar.String())
+	}
+	if p.Output != nil {
+		fmt.Fprint(p.Output, out)
+	} else {
+		fmt.Print(out)
+	}
+	p.lastBarsCount = len(p.bars)
+	return isFinished
+}

--- a/vendor/github.com/cheggaaa/pb/reader.go
+++ b/vendor/github.com/cheggaaa/pb/reader.go
@@ -1,0 +1,25 @@
+package pb
+
+import (
+	"io"
+)
+
+// It's proxy reader, implement io.Reader
+type Reader struct {
+	io.Reader
+	bar *ProgressBar
+}
+
+func (r *Reader) Read(p []byte) (n int, err error) {
+	n, err = r.Reader.Read(p)
+	r.bar.Add(n)
+	return
+}
+
+// Close the reader when it implements io.Closer
+func (r *Reader) Close() (err error) {
+	if closer, ok := r.Reader.(io.Closer); ok {
+		return closer.Close()
+	}
+	return
+}

--- a/vendor/github.com/cheggaaa/pb/runecount.go
+++ b/vendor/github.com/cheggaaa/pb/runecount.go
@@ -1,0 +1,17 @@
+package pb
+
+import (
+	"github.com/mattn/go-runewidth"
+	"regexp"
+)
+
+// Finds the control character sequences (like colors)
+var ctrlFinder = regexp.MustCompile("\x1b\x5b[0-9]+\x6d")
+
+func escapeAwareRuneCountInString(s string) int {
+	n := runewidth.StringWidth(s)
+	for _, sm := range ctrlFinder.FindAllString(s, -1) {
+		n -= runewidth.StringWidth(sm)
+	}
+	return n
+}

--- a/vendor/github.com/cheggaaa/pb/termios_bsd.go
+++ b/vendor/github.com/cheggaaa/pb/termios_bsd.go
@@ -1,0 +1,9 @@
+// +build darwin freebsd netbsd openbsd dragonfly
+// +build !appengine
+
+package pb
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+const ioctlWriteTermios = syscall.TIOCSETA

--- a/vendor/github.com/cheggaaa/pb/termios_nix.go
+++ b/vendor/github.com/cheggaaa/pb/termios_nix.go
@@ -1,0 +1,7 @@
+// +build linux solaris
+// +build !appengine
+
+package pb
+
+const ioctlReadTermios = 0x5401  // syscall.TCGETS
+const ioctlWriteTermios = 0x5402 // syscall.TCSETS

--- a/vendor/github.com/drud/go-pantheon/LICENSE
+++ b/vendor/github.com/drud/go-pantheon/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 DRUD
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/backup.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/backup.go
@@ -11,23 +11,23 @@ import (
 
 // Backup represents a single backup in the pantheon system.
 type Backup struct {
-	ID              string `json:"-"`
-	ArchiveType     string `json:"-"`
-	DownloadURL     string `json:"url,omitempty"`
-	SiteID          string `json:"-"`
-	FileName        string `json:"filename,omitempty"`
-	EnvironmentName string `json:"-"`
-	BuildTag        string `json:"BUILD_TAG"`
-	BuildURL        string `json:"BUILD_URL"`
-	EndpointUUID    string `json:"endpoint_uuid"`
-	Folder          string `json:"folder"`
-	Size            int64  `json:"size"`
-	Timestamp       int64  `json:"timestamp"`
-	TotalDirs       int64  `json:"total_dirs"`
-	TotalEntries    int64  `json:"total_entries"`
-	TotalFiles      int64  `json:"total_files"`
-	TotalSize       int64  `json:"total_size"`
-	TTL             int64  `json:"ttl"`
+	ID              string    `json:"-"`
+	ArchiveType     string    `json:"-"`
+	DownloadURL     string    `json:"url,omitempty"`
+	SiteID          string    `json:"-"`
+	FileName        string    `json:"filename,omitempty"`
+	EnvironmentName string    `json:"-"`
+	BuildTag        string    `json:"BUILD_TAG"`
+	BuildURL        string    `json:"BUILD_URL"`
+	EndpointUUID    string    `json:"endpoint_uuid"`
+	Folder          string    `json:"folder"`
+	Size            jsonInt64 `json:"size"`
+	Timestamp       jsonInt64 `json:"timestamp"`
+	TotalDirs       jsonInt64 `json:"total_dirs"`
+	TotalEntries    jsonInt64 `json:"total_entries"`
+	TotalFiles      jsonInt64 `json:"total_files"`
+	TotalSize       jsonInt64 `json:"total_size"`
+	TTL             jsonInt64 `json:"ttl"`
 }
 
 // BackupList represents a list of all backups taken for a given site and environment combination.

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/backup.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/backup.go
@@ -1,0 +1,132 @@
+package pantheon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// Backup represents a single backup in the pantheon system.
+type Backup struct {
+	ID              string `json:"-"`
+	ArchiveType     string `json:"-"`
+	DownloadURL     string `json:"url,omitempty"`
+	SiteID          string `json:"-"`
+	FileName        string `json:"filename,omitempty"`
+	EnvironmentName string `json:"-"`
+	BuildTag        string `json:"BUILD_TAG"`
+	BuildURL        string `json:"BUILD_URL"`
+	EndpointUUID    string `json:"endpoint_uuid"`
+	Folder          string `json:"folder"`
+	Size            int64  `json:"size"`
+	Timestamp       int64  `json:"timestamp"`
+	TotalDirs       int64  `json:"total_dirs"`
+	TotalEntries    int64  `json:"total_entries"`
+	TotalFiles      int64  `json:"total_files"`
+	TotalSize       int64  `json:"total_size"`
+	TTL             int64  `json:"ttl"`
+}
+
+// BackupList represents a list of all backups taken for a given site and environment combination.
+type BackupList struct {
+	EnvironmentName string
+	SiteID          string
+	Backups         map[string]Backup
+}
+
+// NewBackupList creates an BackupList for a given site. You are responsible for making the HTTP request.
+func NewBackupList(siteID string, environmentName string) *BackupList {
+	return &BackupList{
+		SiteID:          siteID,
+		EnvironmentName: environmentName,
+		Backups:         make(map[string]Backup),
+	}
+}
+
+// Path returns the API endpoint which can be used to get a BackupList for the current user.
+func (bl BackupList) Path(method string, auth AuthSession) string {
+	return fmt.Sprintf("/sites/%s/environments/%s/backups/catalog", bl.SiteID, bl.EnvironmentName)
+}
+
+// JSON prepares the BackupList for HTTP transport.
+func (bl BackupList) JSON() ([]byte, error) {
+	return json.Marshal(bl.Backups)
+}
+
+// Unmarshal is responsible for converting a HTTP response into a BackupList struct.
+func (bl *BackupList) Unmarshal(data []byte) error {
+	err := json.Unmarshal(data, &bl.Backups)
+	if err != nil {
+		return err
+	}
+
+	if len(bl.Backups) > 0 {
+		for name, backup := range bl.Backups {
+			backup.ID = name
+			backup.SiteID = bl.SiteID
+			backup.EnvironmentName = bl.EnvironmentName
+
+			/**
+			 * The name field is always in the following forms:
+			 * - 1489769609_backup_files
+			 * - 1489769609_backup_database
+			 * - 1489769609_backup_code
+			 *
+			 * Based on code in terminus, the canonical way to determine 'type' for backup is to parse the name.
+			 **/
+			nameParts := strings.Split(name, "_")
+			backup.ArchiveType = nameParts[2]
+
+			bl.Backups[name] = backup
+		}
+	}
+
+	return nil
+}
+
+// Path returns the API endpoint which can be used to get a BackupList for the current user.
+func (b Backup) Path(method string, auth AuthSession) string {
+	return fmt.Sprintf("/sites/%s/environments/%s/backups/catalog/%s/%s/s3token", b.SiteID, b.EnvironmentName, b.Folder, b.ArchiveType)
+}
+
+// JSON prepares the BackupList for HTTP transport.
+func (b Backup) JSON() ([]byte, error) {
+	return []byte("{\"method\": \"get\"}"), nil
+}
+
+// Unmarshal is responsible for converting a HTTP response into a BackupList struct.
+func (b *Backup) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, &b)
+}
+
+// Download will download the backup to the location specified by downloadLocation.
+func (b *Backup) Download(downloadLocation string) error {
+	if b.DownloadURL == "" {
+		return fmt.Errorf("download URL is unknown. Have you performed an HTTP GET on the backup entity?")
+	}
+
+	// Create the file
+	out, err := os.Create(downloadLocation)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Get the data
+	resp, err := http.Get(b.DownloadURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Writer the body to file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/environment.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/environment.go
@@ -7,9 +7,9 @@ import (
 
 // Environment contains meta-data about a specific environment
 type Environment struct {
-	Name               string `json:"-"`
-	DNSZone            string `json:"dns_zone"`
-	EnvironmentCreated int64  `json:"environment_created"`
+	Name               string    `json:"-"`
+	DNSZone            string    `json:"dns_zone"`
+	EnvironmentCreated jsonInt64 `json:"environment_created"`
 	Lock               struct {
 		Locked   bool        `json:"locked"`
 		Password interface{} `json:"password"`

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/environment.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/environment.go
@@ -1,0 +1,66 @@
+package pantheon
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Environment contains meta-data about a specific environment
+type Environment struct {
+	Name               string `json:"-"`
+	DNSZone            string `json:"dns_zone"`
+	EnvironmentCreated int64  `json:"environment_created"`
+	Lock               struct {
+		Locked   bool        `json:"locked"`
+		Password interface{} `json:"password"`
+		Username interface{} `json:"username"`
+	} `json:"lock"`
+	Maintenance struct {
+		Enabled bool `json:"enabled"`
+	} `json:"maintenance"`
+	Randseed     string `json:"randseed"`
+	StyxCluster  string `json:"styx_cluster"`
+	TargetCommit string `json:"target_commit"`
+	TargetRef    string `json:"target_ref"`
+}
+
+// EnvironmentList provides a list of environments for a given site.
+type EnvironmentList struct {
+	SiteID       string
+	Environments map[string]Environment
+}
+
+// NewEnvironmentList creates an EnvironmentList for a given site. You are responsible for making the HTTP request.
+func NewEnvironmentList(siteID string) *EnvironmentList {
+	return &EnvironmentList{
+		SiteID:       siteID,
+		Environments: make(map[string]Environment),
+	}
+}
+
+// Path returns the API endpoint which can be used to get a SiteList for the current user.
+func (el EnvironmentList) Path(method string, auth AuthSession) string {
+	return fmt.Sprintf("/sites/%s/environments", el.SiteID)
+}
+
+// JSON prepares the EnvironmentList for HTTP transport.
+func (el EnvironmentList) JSON() ([]byte, error) {
+	return json.Marshal(el.Environments)
+}
+
+// Unmarshal is responsible for converting a HTTP response into a EnvironmentList struct.
+func (el *EnvironmentList) Unmarshal(data []byte) error {
+	err := json.Unmarshal(data, &el.Environments)
+	if err != nil {
+		return err
+	}
+
+	if len(el.Environments) > 0 {
+		for name, env := range el.Environments {
+			env.Name = name
+			el.Environments[name] = env
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/jsonInt64.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/jsonInt64.go
@@ -1,0 +1,31 @@
+package pantheon
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// jsonFloat is an int64 which unmarshals from JSON
+// as either unquoted or quoted (with any amount
+// of internal leading/trailing whitespace).
+// it is based off of https://play.golang.org/p/KNPxDL1yqL
+type jsonInt64 int64
+
+func (f jsonInt64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(int64(f))
+}
+
+func (f *jsonInt64) UnmarshalJSON(data []byte) error {
+	var v int64
+
+	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
+		// Remove single set of matching quotes
+		data = data[1 : len(data)-1]
+	}
+	// And remove any whitespace:
+	data = bytes.TrimSpace(data)
+
+	err := json.Unmarshal(data, &v)
+	*f = jsonInt64(v)
+	return err
+}

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/request.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/request.go
@@ -1,0 +1,69 @@
+package pantheon
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// APIHost in the Hostname + basepath for the pantheon API endpoint.
+var APIHost = "https://terminus.pantheon.io:443/api"
+
+// RequestEntity provides an interface for making requests to the Pantheon API and marshaling/unmarshaling JSON data. Any object which
+// wishes to use the Request type must implement this interface.
+type RequestEntity interface {
+	Path(method string, auth AuthSession) string // Path returns the request path of the entity for a given HTTP method.
+	Unmarshal(data []byte) error                 // Unmarshal is responsible for converting the []byte response back into the struct.
+	JSON() ([]byte, error)                       // JSON() is responsible for preparing the struct for HTTP transport. It is responsible for removing any fields which should not be included in the request.
+}
+
+// setRequestHeaders sets default headers that should be used for all HTTP requests.
+func setRequestHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Terminus/1.3.1-dev (php_version=7.1.5&script=bin/terminus)")
+}
+
+// httpRequest performs a HTTP request for a given resource.
+func httpRequest(requestType string, requestPath string, body []byte, headers map[string]string) ([]byte, error) {
+	var req *http.Request
+	var err error
+	u, err := url.Parse(APIHost)
+	if err != nil {
+		return nil, err
+	}
+
+	u.Path = path.Join(u.Path, requestPath)
+	req, err = http.NewRequest(strings.ToUpper(requestType), u.String(), bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+
+	setRequestHeaders(req)
+
+	if len(headers) > 0 {
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode-200 > 100 {
+		return nil, fmt.Errorf("%s: %d", resp.Status, resp.StatusCode)
+	}
+
+	return respBody, nil
+}

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/session.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/session.go
@@ -1,0 +1,135 @@
+package pantheon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+)
+
+// AuthSession is responsible for authentication and session management with the pantheon API.
+type AuthSession struct {
+	Token   string `json:"machine_token"`
+	Email   string `json:"email,omitempty"`
+	Client  string `json:"client"`
+	Expires int64  `json:"expires_at"`
+	Session string `json:"session,omitempty"`
+	UserID  string `json:"user_id,omitempty"`
+}
+
+// NewAuthSession creates a new authentication session using a given token. It is the preferred method for creating a new AuthSession.
+func NewAuthSession(token string) *AuthSession {
+	return &AuthSession{
+		Token:  token,
+		Client: "terminus",
+	}
+}
+
+// Request performs the HTTP request. You must provide it a request type and the entity the result should be stored in.
+func (a *AuthSession) Request(requestType string, entity RequestEntity) error {
+	var json []byte
+	var err error
+
+	requestType = strings.ToUpper(requestType)
+	if requestType != "GET" {
+		json, err = entity.JSON()
+		if err != nil {
+			return err
+		}
+	}
+
+	headers, err := a.Headers()
+	if err != nil {
+		return err
+	}
+
+	bytes, err := httpRequest(requestType, entity.Path(requestType, *a), json, headers)
+
+	if err != nil {
+		return err
+	}
+
+	return entity.Unmarshal(bytes)
+}
+
+// Auth checks the expiration time of the current session (if there is one) and re-authenticates as necessary.
+func (a *AuthSession) Auth() error {
+	now := time.Now().UTC().Unix()
+	// Determine if an expiration has happened.
+	if a.Expires <= now {
+
+		// If so, re-authenticate.
+		json, err := a.JSON()
+		if err != nil {
+			return err
+		}
+
+		bytes, err := httpRequest("POST", a.Path("POST"), json, make(map[string]string))
+		if err != nil {
+			return err
+		}
+
+		return a.Unmarshal(bytes)
+	}
+	return nil
+}
+
+// Headers returns authentication headers needed for accessing the pantheon API. It should be used on all authenticated requests.
+func (a *AuthSession) Headers() (map[string]string, error) {
+	err := a.Auth()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{"Authorization": fmt.Sprintf("Bearer %s", a.Session)}, nil
+}
+
+// Path returns the API endpoint for authenticating.
+func (a *AuthSession) Path(method string) string {
+	return "/authorize/machine-token"
+}
+
+// JSON prepares the AuthSession struct for an HTTP request by stripping out fields which should not be sent, and returning the JSON representation of the struct as byte array.
+func (a AuthSession) JSON() ([]byte, error) {
+	a.Email = ""
+	a.UserID = ""
+	a.Session = ""
+	a.Expires = 0
+	return json.Marshal(a)
+}
+
+// Unmarshal converts the byte array from an HTTP response back into the AuthSession struct.
+func (a *AuthSession) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, a)
+}
+
+// GetUser returns the UserID for the current AuthSession.
+func (a *AuthSession) GetUser() (string, error) {
+	err := a.Auth()
+	if err != nil {
+		return "", err
+	}
+
+	return a.UserID, nil
+}
+
+// Write converts the current AuthSession to JSON and writes persists result to the specified location.
+func (a *AuthSession) Write(location string) error {
+	contents, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(location, contents, 0644)
+}
+
+// Read loads the JSON representation of the AuthSession from the specified location.
+func (a *AuthSession) Read(location string) error {
+	bytes, err := ioutil.ReadFile(location)
+	if err != nil {
+		return err
+	}
+
+	return a.Unmarshal(bytes)
+}

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/site.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/site.go
@@ -17,10 +17,10 @@ type Site struct {
 		Attributes struct {
 			Label string `json:"label"`
 		} `json:"attributes"`
-		Created         int64  `json:"created"`
-		CreatedByUserID string `json:"created_by_user_id"`
-		Framework       string `json:"framework"`
-		Frozen          bool   `json:"frozen"`
+		Created         jsonInt64 `json:"created"`
+		CreatedByUserID string    `json:"created_by_user_id"`
+		Framework       string    `json:"framework"`
+		Frozen          bool      `json:"frozen"`
 		Holder          struct {
 			Email   string `json:"email"`
 			ID      string `json:"id"`
@@ -34,28 +34,28 @@ type Site struct {
 				Experiments                 struct{}    `json:"experiments"`
 				Firstname                   string      `json:"firstname"`
 				FullName                    string      `json:"full_name"`
-				GoogleAdwordsPushedCodeSent int64       `json:"google_adwords_pushed_code_sent"`
+				GoogleAdwordsPushedCodeSent jsonInt64   `json:"google_adwords_pushed_code_sent"`
 				GuiltyOfAbuse               interface{} `json:"guilty_of_abuse"`
 				InitialIdentityName         interface{} `json:"initial_identity_name"`
 				InitialIdentityStrategy     interface{} `json:"initial_identity_strategy"`
-				InvitesSent                 int64       `json:"invites_sent"`
-				InvitesToSite               int64       `json:"invites_to_site"`
-				InvitesToUser               int64       `json:"invites_to_user"`
+				InvitesSent                 jsonInt64   `json:"invites_sent"`
+				InvitesToSite               jsonInt64   `json:"invites_to_site"`
+				InvitesToUser               jsonInt64   `json:"invites_to_user"`
 				LastOrgSpinup               string      `json:"last-org-spinup"`
 				Lastname                    string      `json:"lastname"`
-				Maxdevsites                 int64       `json:"maxdevsites"`
+				Maxdevsites                 jsonInt64   `json:"maxdevsites"`
 				MinimizeJitDocs             bool        `json:"minimize_jit_docs"`
-				Modified                    int64       `json:"modified"`
+				Modified                    jsonInt64   `json:"modified"`
 				Organization                string      `json:"organization"`
 				Seens                       struct {
 					NewSiteSupportInterface bool `json:"new-site-support-interface"`
 				} `json:"seens"`
-				TrackingFirstCodePush       int64 `json:"tracking_first_code_push"`
-				TrackingFirstSiteCreate     int64 `json:"tracking_first_site_create"`
-				TrackingFirstTeamInvite     int64 `json:"tracking_first_team_invite"`
-				TrackingFirstWorkflowInLive int64 `json:"tracking_first_workflow_in_live"`
-				Verify                      int64 `json:"verify"`
-				WebServicesBusiness         bool  `json:"web_services_business"`
+				TrackingFirstCodePush       jsonInt64 `json:"tracking_first_code_push"`
+				TrackingFirstSiteCreate     jsonInt64 `json:"tracking_first_site_create"`
+				TrackingFirstTeamInvite     jsonInt64 `json:"tracking_first_team_invite"`
+				TrackingFirstWorkflowInLive jsonInt64 `json:"tracking_first_workflow_in_live"`
+				Verify                      jsonInt64 `json:"verify"`
+				WebServicesBusiness         bool      `json:"web_services_business"`
 			} `json:"profile"`
 		} `json:"holder"`
 		HolderID     string `json:"holder_id"`
@@ -65,10 +65,11 @@ type Site struct {
 			Timestamp string      `json:"timestamp"`
 			UserUUID  interface{} `json:"user_uuid"`
 		} `json:"last_code_push"`
-		LastFrozenAt  int64  `json:"last_frozen_at"`
-		Name          string `json:"name"`
-		Owner         string `json:"owner"`
-		PreferredZone string `json:"preferred_zone"`
+		LastFrozenAt  jsonInt64 `json:"last_frozen_at"`
+		Name          string    `json:"name"`
+		Owner         string    `json:"owner"`
+		PhpVersion    jsonInt64 `json:"php_version"`
+		PreferredZone string    `json:"preferred_zone"`
 		Product       struct {
 			ID       string `json:"id"`
 			Longname string `json:"longname"`
@@ -96,28 +97,28 @@ type Site struct {
 				Experiments                 struct{}    `json:"experiments"`
 				Firstname                   string      `json:"firstname"`
 				FullName                    string      `json:"full_name"`
-				GoogleAdwordsPushedCodeSent int64       `json:"google_adwords_pushed_code_sent"`
+				GoogleAdwordsPushedCodeSent jsonInt64   `json:"google_adwords_pushed_code_sent"`
 				GuiltyOfAbuse               interface{} `json:"guilty_of_abuse"`
 				InitialIdentityName         interface{} `json:"initial_identity_name"`
 				InitialIdentityStrategy     interface{} `json:"initial_identity_strategy"`
-				InvitesSent                 int64       `json:"invites_sent"`
-				InvitesToSite               int64       `json:"invites_to_site"`
-				InvitesToUser               int64       `json:"invites_to_user"`
+				InvitesSent                 jsonInt64   `json:"invites_sent"`
+				InvitesToSite               jsonInt64   `json:"invites_to_site"`
+				InvitesToUser               jsonInt64   `json:"invites_to_user"`
 				LastOrgSpinup               string      `json:"last-org-spinup"`
 				Lastname                    string      `json:"lastname"`
-				Maxdevsites                 int64       `json:"maxdevsites"`
+				Maxdevsites                 jsonInt64   `json:"maxdevsites"`
 				MinimizeJitDocs             bool        `json:"minimize_jit_docs"`
-				Modified                    int64       `json:"modified"`
+				Modified                    jsonInt64   `json:"modified"`
 				Organization                string      `json:"organization"`
 				Seens                       struct {
 					NewSiteSupportInterface bool `json:"new-site-support-interface"`
 				} `json:"seens"`
-				TrackingFirstCodePush       int64 `json:"tracking_first_code_push"`
-				TrackingFirstSiteCreate     int64 `json:"tracking_first_site_create"`
-				TrackingFirstTeamInvite     int64 `json:"tracking_first_team_invite"`
-				TrackingFirstWorkflowInLive int64 `json:"tracking_first_workflow_in_live"`
-				Verify                      int64 `json:"verify"`
-				WebServicesBusiness         bool  `json:"web_services_business"`
+				TrackingFirstCodePush       jsonInt64 `json:"tracking_first_code_push"`
+				TrackingFirstSiteCreate     jsonInt64 `json:"tracking_first_site_create"`
+				TrackingFirstTeamInvite     jsonInt64 `json:"tracking_first_team_invite"`
+				TrackingFirstWorkflowInLive jsonInt64 `json:"tracking_first_workflow_in_live"`
+				Verify                      jsonInt64 `json:"verify"`
+				WebServicesBusiness         bool      `json:"web_services_business"`
 			} `json:"profile"`
 		} `json:"user_in_charge"`
 		UserInChargeID string `json:"user_in_charge_id"`

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/site.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/site.go
@@ -1,0 +1,157 @@
+package pantheon
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+// Site is a representation of a deployed pantheon site.
+type Site struct {
+	Archived    bool   `json:"archived"`
+	ID          string `json:"id"`
+	InvitedByID string `json:"invited_by_id"`
+	Key         string `json:"key"`
+	Role        string `json:"role"`
+	Site        struct {
+		Attributes struct {
+			Label string `json:"label"`
+		} `json:"attributes"`
+		Created         int64  `json:"created"`
+		CreatedByUserID string `json:"created_by_user_id"`
+		Framework       string `json:"framework"`
+		Frozen          bool   `json:"frozen"`
+		Holder          struct {
+			Email   string `json:"email"`
+			ID      string `json:"id"`
+			Profile struct {
+				ActivityLevel   string `json:"activity_level"`
+				Code            string `json:"code"`
+				DashboardVisits []struct {
+					Date string `json:"date"`
+					Site string `json:"site"`
+				} `json:"dashboard_visits"`
+				Experiments                 struct{}    `json:"experiments"`
+				Firstname                   string      `json:"firstname"`
+				FullName                    string      `json:"full_name"`
+				GoogleAdwordsPushedCodeSent int64       `json:"google_adwords_pushed_code_sent"`
+				GuiltyOfAbuse               interface{} `json:"guilty_of_abuse"`
+				InitialIdentityName         interface{} `json:"initial_identity_name"`
+				InitialIdentityStrategy     interface{} `json:"initial_identity_strategy"`
+				InvitesSent                 int64       `json:"invites_sent"`
+				InvitesToSite               int64       `json:"invites_to_site"`
+				InvitesToUser               int64       `json:"invites_to_user"`
+				LastOrgSpinup               string      `json:"last-org-spinup"`
+				Lastname                    string      `json:"lastname"`
+				Maxdevsites                 int64       `json:"maxdevsites"`
+				MinimizeJitDocs             bool        `json:"minimize_jit_docs"`
+				Modified                    int64       `json:"modified"`
+				Organization                string      `json:"organization"`
+				Seens                       struct {
+					NewSiteSupportInterface bool `json:"new-site-support-interface"`
+				} `json:"seens"`
+				TrackingFirstCodePush       int64 `json:"tracking_first_code_push"`
+				TrackingFirstSiteCreate     int64 `json:"tracking_first_site_create"`
+				TrackingFirstTeamInvite     int64 `json:"tracking_first_team_invite"`
+				TrackingFirstWorkflowInLive int64 `json:"tracking_first_workflow_in_live"`
+				Verify                      int64 `json:"verify"`
+				WebServicesBusiness         bool  `json:"web_services_business"`
+			} `json:"profile"`
+		} `json:"holder"`
+		HolderID     string `json:"holder_id"`
+		HolderType   string `json:"holder_type"`
+		ID           string `json:"id"`
+		LastCodePush struct {
+			Timestamp string      `json:"timestamp"`
+			UserUUID  interface{} `json:"user_uuid"`
+		} `json:"last_code_push"`
+		LastFrozenAt  int64  `json:"last_frozen_at"`
+		Name          string `json:"name"`
+		Owner         string `json:"owner"`
+		PreferredZone string `json:"preferred_zone"`
+		Product       struct {
+			ID       string `json:"id"`
+			Longname string `json:"longname"`
+		} `json:"product"`
+		ProductID    string `json:"product_id"`
+		ServiceLevel string `json:"service_level"`
+		Upstream     struct {
+			Branch    string `json:"branch"`
+			ProductID string `json:"product_id"`
+			URL       string `json:"url"`
+		} `json:"upstream"`
+		UpstreamUpdatesByEnvironment struct {
+			HasCode bool `json:"has_code"`
+		} `json:"upstream_updates_by_environment"`
+		UserInCharge struct {
+			Email   string `json:"email"`
+			ID      string `json:"id"`
+			Profile struct {
+				ActivityLevel   string `json:"activity_level"`
+				Code            string `json:"code"`
+				DashboardVisits []struct {
+					Date string `json:"date"`
+					Site string `json:"site"`
+				} `json:"dashboard_visits"`
+				Experiments                 struct{}    `json:"experiments"`
+				Firstname                   string      `json:"firstname"`
+				FullName                    string      `json:"full_name"`
+				GoogleAdwordsPushedCodeSent int64       `json:"google_adwords_pushed_code_sent"`
+				GuiltyOfAbuse               interface{} `json:"guilty_of_abuse"`
+				InitialIdentityName         interface{} `json:"initial_identity_name"`
+				InitialIdentityStrategy     interface{} `json:"initial_identity_strategy"`
+				InvitesSent                 int64       `json:"invites_sent"`
+				InvitesToSite               int64       `json:"invites_to_site"`
+				InvitesToUser               int64       `json:"invites_to_user"`
+				LastOrgSpinup               string      `json:"last-org-spinup"`
+				Lastname                    string      `json:"lastname"`
+				Maxdevsites                 int64       `json:"maxdevsites"`
+				MinimizeJitDocs             bool        `json:"minimize_jit_docs"`
+				Modified                    int64       `json:"modified"`
+				Organization                string      `json:"organization"`
+				Seens                       struct {
+					NewSiteSupportInterface bool `json:"new-site-support-interface"`
+				} `json:"seens"`
+				TrackingFirstCodePush       int64 `json:"tracking_first_code_push"`
+				TrackingFirstSiteCreate     int64 `json:"tracking_first_site_create"`
+				TrackingFirstTeamInvite     int64 `json:"tracking_first_team_invite"`
+				TrackingFirstWorkflowInLive int64 `json:"tracking_first_workflow_in_live"`
+				Verify                      int64 `json:"verify"`
+				WebServicesBusiness         bool  `json:"web_services_business"`
+			} `json:"profile"`
+		} `json:"user_in_charge"`
+		UserInChargeID string `json:"user_in_charge_id"`
+	} `json:"site"`
+	SiteID string `json:"site_id"`
+	UserID string `json:"user_id"`
+}
+
+// SiteList represents a grouping of deployed Pantheon sites.
+type SiteList struct {
+	Sites []Site
+}
+
+// NewSiteList creates an SiteList. The user will be specified by which session you use to make the GET request. You are responsible for making the HTTP request.
+func NewSiteList() *SiteList {
+	return &SiteList{}
+}
+
+// Path returns the API endpoint which can be used to get a SiteList for the current user.
+func (sl SiteList) Path(method string, auth AuthSession) string {
+	userid, err := auth.GetUser()
+	if err != nil {
+		log.Fatalf("Could not determine user for request: %v", err)
+	}
+
+	return fmt.Sprintf("/users/%s/memberships/sites", userid)
+}
+
+// JSON prepares the SiteList for HTTP transport.
+func (sl SiteList) JSON() ([]byte, error) {
+	return json.Marshal(sl.Sites)
+}
+
+// Unmarshal is responsible for converting a HTTP response into a SiteList struct.
+func (sl *SiteList) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, &sl.Sites)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -152,11 +152,10 @@
 			"revisionTime": "2016-09-08T21:06:52Z"
 		},
 		{
-
-			"checksumSHA1": "auQ/Akiflnn0kozpOD3cdilBQd8=",
+			"checksumSHA1": "CyDrvckSL+RTYvT4PAkySbyjuHA=",
 			"path": "github.com/drud/go-pantheon/pkg/pantheon",
-			"revision": "202f5416371ef6c522c49beae17a8d41e8841b7f",
-			"revisionTime": "2017-06-20T12:57:25Z"
+			"revision": "82b298bb9e4699cbc698f33b11dfbdcd6408aeda",
+			"revisionTime": "2017-06-30T17:10:26Z"
 		},
 		{
 			"checksumSHA1": "Yn+Uxp0Vz4WiGdrYLLwYX9lzD5I=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -44,6 +44,12 @@
 			"revision": ""
 		},
 		{
+			"checksumSHA1": "/Jr7LzqFpllFtHsm90PCwdjQvc4=",
+			"path": "github.com/cheggaaa/pb",
+			"revision": "f6ccf2184de4dd34495277e38dc19b6e7fbe0ea2",
+			"revisionTime": "2017-05-08T13:24:47Z"
+		},
+		{
 			"checksumSHA1": "BJXHEdzHxRPmVnt6GFaPpwgns2c=",
 			"path": "github.com/coreos/go-etcd/etcd",
 			"revision": "003851be7bb0694fe3cc457a49529a19388ee7cf",
@@ -146,7 +152,14 @@
 			"revisionTime": "2016-09-08T21:06:52Z"
 		},
 		{
-			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
+
+			"checksumSHA1": "auQ/Akiflnn0kozpOD3cdilBQd8=",
+			"path": "github.com/drud/go-pantheon/pkg/pantheon",
+			"revision": "202f5416371ef6c522c49beae17a8d41e8841b7f",
+			"revisionTime": "2017-06-20T12:57:25Z"
+		},
+		{
+			"checksumSHA1": "Yn+Uxp0Vz4WiGdrYLLwYX9lzD5I=",
 			"path": "github.com/fatih/color",
 			"revision": "62e9147c64a1ed519147b62a56a14e83e2be02c1",
 			"revisionTime": "2017-05-23T20:24:04Z"
@@ -498,6 +511,11 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "a3f3340b5840cee44f372bddb5880fcbc419b46a",
 			"revisionTime": "2017-02-08T14:18:51Z"
+		},
+		{
+			"path": "https://github.com/cheggaaa/pb",
+			"revision": "f6ccf2184de4dd34495277e38dc19b6e7fbe0ea2",
+			"version": "f6ccf2184de4dd34495277e38dc19b6e7fbe0ea2"
 		}
 	],
 	"rootPath": "github.com/drud/ddev"


### PR DESCRIPTION
## What happened (or feature request):
As per #216 we need pantheon integration. This PR introduces the integration.

At this point, it is feature complete enough to take it for a test drive.

There are three new commands which will be needed:
- `ddev config-pantheon [token]` sets global configuration for talking to the pantheon API. Please see https://pantheon.io/docs/machine-tokens/ for documentation on creating a machine token.
- `ddev config pantheon` extends standard ddev config to account for pantheon specific data.
- `ddev import` imports from a provider. It prints an error if no external provider has been configured.


There are also two new files which get added to the `.ddev` folder:

- import.yaml - This contains pantheon provider-specific data. The goal is that all providers would use this same import.YAML (although with different fields).
- provider.env - This is an environment file included by default in docker-compose. It includes provider specific environment variables. In the case of pantheon, Pressflow allows for various configuration options using environment variables, and those get written to provider.env.

## How to reproduce it (as minimally and precisely as possible):

1. Deploy a new site to pantheon. Either Drupal or WordPress will do.
2. After installation, switch the site to "git" mode and create a backup of the site.
3. Git clone the repository.
4. Run `ddev config pantheon` from the git root directory. Follow configuration prompts.
5. Run `ddev import`

## Related source links or issues:
#216 is the parent issue.