### PR TITLE
Adds support for pre-/post- ddev command tasks

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"log"
 	"os"
 
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +15,7 @@ var ConfigCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		appRoot, err := os.Getwd()
 		if err != nil {
-			log.Fatalf("Could not determine current working directory: %v\n", err)
+			util.Failed("Could not determine current working directory: %v\n", err)
 		}
 
 		c, err := ddevapp.NewConfig(appRoot)
@@ -23,19 +23,20 @@ var ConfigCommand = &cobra.Command{
 			// If there is an error reading the config and the file exists, we're not sure
 			// how to proceed.
 			if c.ConfigExists() {
-				log.Fatalf("Could not read config: %v", err)
+				util.Failed("Could not read config: %v", err)
 			}
 		}
 
 		err = c.Config()
 		if err != nil {
-			log.Fatalf("There was a problem configuring your application: %v\n", err)
+			util.Failed("There was a problem configuring your application: %v\n", err)
 		}
 
 		err = c.Write()
 		if err != nil {
-			log.Fatalf("Could not write ddev config file: %v\n", err)
+			util.Failed("Could not write ddev config file: %v\n", err)
 		}
+		util.Success("Initial configuration file written successfully. See the configuration file for additional configuration options.")
 	},
 }
 

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -40,7 +40,7 @@ can be provided if it is not located at the top-level of the archive.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := platform.GetActiveApp("")
 		if err != nil {
-			util.Failed("Failed to find active app to import database to: %v", err)
+			util.Failed("Failed to import database: %v", err)
 		}
 
 		if app.SiteStatus() != platform.SiteRunning {

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -40,7 +40,7 @@ can be provided if it is not located at the top-level of the archive.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := platform.GetActiveApp("")
 		if err != nil {
-			util.Failed("Failed to find active app to import database to: %v", app.GetName(), err)
+			util.Failed("Failed to find active app to import database to: %v", err)
 		}
 
 		if app.SiteStatus() != platform.SiteRunning {

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -32,7 +32,7 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 
 		app, err := platform.GetActiveApp(siteName)
 		if err != nil {
-			util.Failed("Failed to get active app: %v", err)
+			util.Failed("Failed to remove: %v", err)
 		}
 
 		if app.SiteStatus() == platform.SiteNotFound {

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -12,7 +12,7 @@ extend-commands:
 
 ## Supported Command Hooks
 
-- `pre-start`: Hooks into "ddev start". Execute tasks before the site environment starts.
+- `pre-start`: Hooks into "ddev start". Execute tasks before the site environment starts. **Note:** Only `exec-host` tasks can be run successfully for pre-start. See Supported Tasks below for more info.
 - `post-start`: Hooks into "ddev start". Execute tasks after the site environment has started
 - `pre-import-db`: Hooks into "ddev import-db". Execute tasks before database import
 - `post-import-db`: Hooks into "ddev import-db". Execute tasks after database import
@@ -33,6 +33,20 @@ _Use drush to clear the drupal cache after database import_
 extend-commands:
   post-import-db:
     - exec: "drush cc all"
+```
+
+- `exec-host`: Execute a shell command on your system.
+
+Value: string providing the command to run.
+
+Example:
+
+_Run a git pull before starting the site_
+
+```
+extend-commands:
+  pre-start:
+    - exec: "git pull origin master"
 ```
 
 - `import-db`: Import the database of an existing site to the local environment.

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -23,7 +23,7 @@ extend-commands:
 
 - `exec`: Execute a shell command in the web service container.
 
-Value: string providing the command to run.
+Value: string providing the command to run. Commands requiring user interaction are not supported.
 
 Example:
 
@@ -37,7 +37,7 @@ extend-commands:
 
 - `exec-host`: Execute a shell command on your system.
 
-Value: string providing the command to run.
+Value: string providing the command to run. Commands requiring user interaction are not supported.
 
 Example:
 

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -1,4 +1,4 @@
-<h1>Extending ddev Commands<h1>
+<h1>Extending ddev Commands</h1>
 
 Certain ddev commands provide hooks to run tasks before or after the main command executes. These tasks can be defined in the config.yml for your site, and allow for you to automate setup tasks specific to your site. To define command tasks in your configuration, specify the desired command hook as a subfield to `extend-commands`, then provide a list of tasks to run.
 

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -1,0 +1,89 @@
+<h1>Extending ddev Commands<h1>
+
+Certain ddev commands provide hooks to run tasks before or after the main command executes. These tasks can be defined in the config.yml for your site, and allow for you to automate setup tasks specific to your site. To define command tasks in your configuration, specify the desired command hook as a subfield to `extend-commands`, then provide a list of tasks to run.
+
+Example:
+
+```
+extend-commands:
+  $command-hook:
+    - task: value
+```
+
+## Supported Command Hooks
+
+- `pre-start`: Hooks into "ddev start". Execute tasks before the site environment starts.
+- `post-start`: Hooks into "ddev start". Execute tasks after the site environment has started
+- `pre-import-db`: Hooks into "ddev import-db". Execute tasks before database import
+- `post-import-db`: Hooks into "ddev import-db". Execute tasks after database import
+- `pre-import-files`: Hooks into "ddev import-files". Execute tasks before files are imported
+- `post-import-files`: Hooks into "ddev import-files". Execute tasks after files are imported.
+
+## Supported Tasks
+
+- `exec`: Execute a shell command in the web service container.
+
+Value: string providing the command to run.
+
+Example:
+
+_Use drush to clear the drupal cache after database import_
+
+```
+extend-commands:
+  post-import-db:
+    - exec: "drush cc all"
+```
+
+- `import-db`: Import the database of an existing site to the local environment.
+
+Values:
+- `src`: Required. Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format
+- `extract-path`: Optional. If provided asset is an archive, provide the path to extract within the archive.
+
+Example:
+
+_Import a database after environment starts_
+
+```
+extend-commands:
+  post-start:
+    - import-db:
+        src: "~/Downloads/site-archive.tar.gz"
+        extract-path: "data.sql"
+```
+
+- `import-files`: Import the uploaded files directory of an existing site to the default public
+upload directory of your application.
+
+Values:
+- `src`: Required. Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format
+- `extract-path`: Optional. If provided asset is an archive, provide the path to extract within the archive.
+
+Example:
+
+_Import files after importing database_
+
+```
+extend-commands:
+  post-import-db:
+    - import-files:
+        src: "~/Downloads/site-archive.tar.gz"
+        extract-path: "docroot/sites/default/files"
+```
+
+## Full Example
+
+The following example would import database and files from a full site archive, and clear the cache for a drupal site when "ddev start" is run.
+
+```
+extend-commands:
+  post-start:
+    - import-db:
+        src: "~/Downloads/site-archive.tar.gz"
+        extract-path: "data.sql"
+    - import-files:
+        src: "~/Downloads/site-archive.tar.gz"
+        extract-path: "docroot/sites/default/files"
+    - exec: "drush cc all"
+```

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -41,12 +41,12 @@ Value: string providing the command to run. Commands requiring user interaction 
 
 Example:
 
-_Run a git pull before starting the site_
+_Run "composer install" from your system before starting the site (composer would nee to be installed on your system)_
 
 ```
 extend-commands:
   pre-start:
-    - exec: "git pull origin master"
+    - exec: "composer install"
 ```
 
 - `import-db`: Import the database of an existing site to the local environment.
@@ -76,14 +76,12 @@ Values:
 
 Example:
 
-_Import files after importing database_
+_Perform a search-replace on the database of a WordPress site after import to update its URL_
 
 ```
 extend-commands:
   post-import-db:
-    - import-files:
-        src: "~/Downloads/site-archive.tar.gz"
-        extract-path: "docroot/sites/default/files"
+    - exec: "wp search-replace https://www.myproductionsite.com http://mylocalsite.ddev.local"
 ```
 
 ## Full Example

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -49,41 +49,6 @@ extend-commands:
     - exec: "composer install"
 ```
 
-- `import-db`: Import the database of an existing site to the local environment.
-
-Values:
-- `src`: Required. Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format
-- `extract-path`: Optional. If provided asset is an archive, provide the path to extract within the archive.
-
-Example:
-
-_Import a database after environment starts_
-
-```
-extend-commands:
-  post-start:
-    - import-db:
-        src: "~/Downloads/site-archive.tar.gz"
-        extract-path: "data.sql"
-```
-
-- `import-files`: Import the uploaded files directory of an existing site to the default public
-upload directory of your application.
-
-Values:
-- `src`: Required. Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format
-- `extract-path`: Optional. If provided asset is an archive, provide the path to extract within the archive.
-
-Example:
-
-_Perform a search-replace on the database of a WordPress site after import to update its URL_
-
-```
-extend-commands:
-  post-import-db:
-    - exec: "wp search-replace https://www.myproductionsite.com http://mylocalsite.ddev.local"
-```
-
 ## Full Example
 
 The following example would import database and files from a full site archive, and clear the cache for a drupal site when "ddev start" is run.

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -1,11 +1,11 @@
 <h1>Extending ddev Commands</h1>
 
-Certain ddev commands provide hooks to run tasks before or after the main command executes. These tasks can be defined in the config.yaml for your site, and allow for you to automate setup tasks specific to your site. To define command tasks in your configuration, specify the desired command hook as a subfield to `extend-commands`, then provide a list of tasks to run.
+Certain ddev commands provide hooks to run tasks before or after the main command executes. These tasks can be defined in the config.yaml for your site, and allow for you to automate setup tasks specific to your site. To define command tasks in your configuration, specify the desired command hook as a subfield to `hooks`, then provide a list of tasks to run.
 
 Example:
 
 ```
-extend-commands:
+hooks:
   $command-hook:
     - task: value
 ```
@@ -30,7 +30,7 @@ Example:
 _Use drush to clear the Drupal cache after database import_
 
 ```
-extend-commands:
+hooks:
   post-import-db:
     - exec: "drush cc all"
 ```
@@ -40,7 +40,7 @@ Example:
 _Use wp-cli to replace the production URL with development URL in the database of a WordPress site_
 
 ```
-extend-commands:
+hooks:
   post-import-db:
     - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
 ```
@@ -54,15 +54,28 @@ Example:
 _Run "composer install" from your system before starting the site (composer would nee to be installed on your system)_
 
 ```
-extend-commands:
+hooks:
   pre-start:
     - exec: "composer install"
+```
+
+## WordPress Example
+
+```
+hooks:
+  post-start:
+    # Install WordPress after start
+    - exec: "wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db"
+    - exec: "wp core install --url=http://mysite.ddev.local --title=MySite --admin_user=admin --admin_email=admin@mail.test"
+  post-import-db:
+    # Update the URL of your site throughout your database after import
+    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
 ```
 
 ## Drupal 7 Example
 
 ```
-extend-commands:
+hooks:
   post-start:
     # Install Drupal after start
     - exec: "drush site-install -y --db-url=db:db@db/db"
@@ -80,7 +93,7 @@ extend-commands:
 ## Drupal 8 Example
 
 ```
-extend-commands:
+hooks:
   pre-start:
     # Install composer dependencies using composer on host system
     - exec-host: "composer install"
@@ -96,17 +109,4 @@ extend-commands:
     - exec: "drush en -y environment_indicator"
     # Clear the cache
     - exec: "drush cr"
-```
-
-## WordPress Example
-
-```
-extend-commands:
-  post-start:
-    # Install WordPress after start
-    - exec: "wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db"
-    - exec: "wp core install --url=http://mysite.ddev.local --title=MySite --admin_user=admin --admin_email=admin@mail.test"
-  post-import-db:
-    # Update the URL of your site throughout your database after import
-    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ pages:
   - 'Home': 'index.md'
   - 'User Documentation':
     - 'Using the CLI': 'users/cli-usage.md'
+    - 'Extending ddev Commands': 'users/extending-commands.md'
     - 'Using Developer Tools with ddev': 'users/developer-tools.md'
     - 'PHP Step Debugging': 'users/step-debugging.md'
     - 'Extending ddev':

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	DataDir          string               `yaml:"-"`
 	ImportDir        string               `yaml:"-"`
 	SiteSettingsPath string               `yaml:"-"`
-	Commands         map[string][]Command `yaml:"extend-commands,omitempty"`
+	Commands         map[string][]Command `yaml:"hooks,omitempty"`
 }
 
 // Command defines commands to be run as pre/post hooks
@@ -447,7 +447,7 @@ func (c *Config) setSiteSettingsPath(appType string) {
 	c.SiteSettingsPath = settingsFilePath
 }
 
-// validateCommandYaml validates command hooks and tasks defined in extend-commands for config.yaml
+// validateCommandYaml validates command hooks and tasks defined in hooks for config.yaml
 func validateCommandYaml(source []byte) error {
 	validHooks := []string{
 		"pre-start",
@@ -464,7 +464,7 @@ func validateCommandYaml(source []byte) error {
 	}
 
 	type Validate struct {
-		Commands map[string][]map[string]interface{} `yaml:"extend-commands,omitempty"`
+		Commands map[string][]map[string]interface{} `yaml:"hooks,omitempty"`
 	}
 	val := &Validate{}
 
@@ -481,7 +481,7 @@ func validateCommandYaml(source []byte) error {
 			}
 		}
 		if !match {
-			return fmt.Errorf("invalid command hook %s defined for extend-commands in config.yaml", command)
+			return fmt.Errorf("invalid command hook %s defined in config.yaml", command)
 		}
 
 		for _, taskSet := range tasks {
@@ -493,7 +493,7 @@ func validateCommandYaml(source []byte) error {
 					}
 				}
 				if !match {
-					return fmt.Errorf("invalid task '%s' defined for %s extend-commands in config.yaml", taskName, command)
+					return fmt.Errorf("invalid task '%s' defined for %s hook in config.yaml", taskName, command)
 				}
 			}
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -493,9 +493,10 @@ func validateCommandYaml(source []byte) error {
 		if !match {
 			return fmt.Errorf("invalid command hook %s defined for extend-commands in config.yaml", command)
 		}
-		match = false
+
 		for _, taskSet := range tasks {
 			for taskName := range taskSet {
+				var match bool
 				for _, validTask := range validTasks {
 					if taskName == validTask {
 						match = true

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -131,7 +131,7 @@ func (c *Config) Read() error {
 	// validate extend command keys
 	err = validateCommandYaml(source)
 	if err != nil {
-		return fmt.Errorf("invalid configuration: %v", err)
+		return fmt.Errorf("invalid configuration in %s: %v", c.ConfigPath, err)
 	}
 
 	// Read config values from file.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	DataDir          string               `yaml:"-"`
 	ImportDir        string               `yaml:"-"`
 	SiteSettingsPath string               `yaml:"-"`
-	Commands         map[string][]Command `yaml:"extend-commands"`
+	Commands         map[string][]Command `yaml:"extend-commands,omitempty"`
 }
 
 // Command defines commands to be run as pre/post hooks

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	DataDir          string               `yaml:"-"`
 	ImportDir        string               `yaml:"-"`
 	SiteSettingsPath string               `yaml:"-"`
-	Commands         map[string][]Command `yaml:"extend_commands"`
+	Commands         map[string][]Command `yaml:"extend-commands"`
 }
 
 // Command defines commands to be run as pre/post hooks
@@ -104,6 +104,16 @@ func (c *Config) Write() error {
 	cfgbytes, err := yaml.Marshal(c)
 	if err != nil {
 		return err
+	}
+
+	cfgbytes = append(cfgbytes, []byte(HookTemplate)...)
+	switch c.AppType {
+	case "drupal8":
+		cfgbytes = append(cfgbytes, []byte(Drupal8Hooks)...)
+	case "drupal7":
+		cfgbytes = append(cfgbytes, []byte(Drupal7Hooks)...)
+	case "wordpress":
+		cfgbytes = append(cfgbytes, []byte(WordPressHooks)...)
 	}
 
 	log.WithFields(log.Fields{

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -57,14 +57,6 @@ type Config struct {
 
 // Command defines commands to be run as pre/post hooks
 type Command struct {
-	ImportDB struct {
-		Src         string `yaml:"src"`
-		ExtractPath string `yaml:"extract-path"`
-	} `yaml:"import-db,omitempty"`
-	ImportFiles struct {
-		Src         string `yaml:"src"`
-		ExtractPath string `yaml:"extract-path"`
-	} `yaml:"import-files,omitempty"`
 	Exec     string `yaml:"exec,omitempty"`
 	ExecHost string `yaml:"exec-host,omitempty"`
 }
@@ -469,8 +461,6 @@ func validateCommandYaml(source []byte) error {
 	validTasks := []string{
 		"exec",
 		"exec-host",
-		"import-db",
-		"import-files",
 	}
 
 	type Validate struct {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -181,7 +181,7 @@ func (c *Config) Read() error {
 func (c *Config) Config() error {
 
 	if c.ConfigExists() {
-		fmt.Printf("Editing existing ddev project at %s\n\n", c.AppRoot)
+		util.Warning("You are re-configuring %s. The existing configuration will be replaced.\n\n", c.AppRoot)
 	} else {
 		fmt.Printf("Creating a new ddev project config in the current directory (%s)\n", c.AppRoot)
 		fmt.Printf("Once completed, your configuration will be written to %s\n\n\n", c.ConfigPath)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -39,19 +39,28 @@ var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-z
 
 // Config defines the yaml config file format for ddev applications
 type Config struct {
-	APIVersion       string `yaml:"APIVersion"`
-	Name             string `yaml:"name"`
-	AppType          string `yaml:"type"`
-	Docroot          string `yaml:"docroot"`
-	WebImage         string `yaml:"webimage"`
-	DBImage          string `yaml:"dbimage"`
-	DBAImage         string `yaml:"dbaimage"`
-	ConfigPath       string `yaml:"-"`
-	AppRoot          string `yaml:"-"`
-	Platform         string `yaml:"-"`
-	DataDir          string `yaml:"-"`
-	ImportDir        string `yaml:"-"`
-	SiteSettingsPath string `yaml:"-"`
+	APIVersion       string               `yaml:"APIVersion"`
+	Name             string               `yaml:"name"`
+	AppType          string               `yaml:"type"`
+	Docroot          string               `yaml:"docroot"`
+	WebImage         string               `yaml:"webimage"`
+	DBImage          string               `yaml:"dbimage"`
+	DBAImage         string               `yaml:"dbaimage"`
+	ConfigPath       string               `yaml:"-"`
+	AppRoot          string               `yaml:"-"`
+	Platform         string               `yaml:"-"`
+	DataDir          string               `yaml:"-"`
+	ImportDir        string               `yaml:"-"`
+	SiteSettingsPath string               `yaml:"-"`
+	Commands         map[string][]Command `yaml:"extend_commands"`
+}
+
+// Command defines commands to be run as pre/post hooks
+type Command struct {
+	ImportDB struct {
+		Src string `yaml:"src"`
+	} `yaml:"import-db,omitempty"`
+	Exec string `yaml:"exec,omitempty"`
 }
 
 // NewConfig creates a new Config struct with defaults set. It is preferred to using new() directly.
@@ -149,6 +158,7 @@ func (c *Config) Read() error {
 	log.WithFields(log.Fields{
 		"Active config": awsutil.Prettify(c),
 	}).Debug("Finished config set")
+
 	return nil
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -133,13 +133,13 @@ func (c *Config) Write() error {
 func (c *Config) Read() error {
 	source, err := ioutil.ReadFile(c.ConfigPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not find an active ddev configuration, have you run 'ddev config'? %v", err)
 	}
 
 	// validate extend command keys
 	err = validateCommandYaml(source)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid configuration: %v", err)
 	}
 
 	// Read config values from file.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -65,7 +65,8 @@ type Command struct {
 		Src         string `yaml:"src"`
 		ExtractPath string `yaml:"extract-path"`
 	} `yaml:"import-files,omitempty"`
-	Exec string `yaml:"exec,omitempty"`
+	Exec     string `yaml:"exec,omitempty"`
+	ExecHost string `yaml:"exec-host,omitempty"`
 }
 
 // NewConfig creates a new Config struct with defaults set. It is preferred to using new() directly.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -58,8 +58,13 @@ type Config struct {
 // Command defines commands to be run as pre/post hooks
 type Command struct {
 	ImportDB struct {
-		Src string `yaml:"src"`
+		Src         string `yaml:"src"`
+		ExtractPath string `yaml:"extract-path"`
 	} `yaml:"import-db,omitempty"`
+	ImportFiles struct {
+		Src         string `yaml:"src"`
+		ExtractPath string `yaml:"extract-path"`
+	} `yaml:"import-files,omitempty"`
 	Exec string `yaml:"exec,omitempty"`
 }
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -272,7 +272,7 @@ func TestWrite(t *testing.T) {
 	out, err := ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))
 	assert.NoError(err)
 	assert.Contains(string(out), "TestWrite")
-	assert.Contains(string(out), "exec: drush cr")
+	assert.Contains(string(out), `exec: "drush cr"`)
 
 	c.AppType = "wordpress"
 	err = c.Write()
@@ -280,7 +280,7 @@ func TestWrite(t *testing.T) {
 
 	out, err = ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))
 	assert.NoError(err)
-	assert.Contains(string(out), "exec: wp search-replace")
+	assert.Contains(string(out), `exec: "wp search-replace`)
 
 	err = os.RemoveAll(testDir)
 	assert.NoError(err)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -247,3 +247,41 @@ func TestValidate(t *testing.T) {
 	err = c.Validate()
 	assert.EqualError(err, fmt.Sprintf("%s is not a valid apptype", c.AppType))
 }
+
+// TestWrite tests writing config values to file
+func TestWrite(t *testing.T) {
+	assert := assert.New(t)
+	testDir := testcommon.CreateTmpDir("TestConfigWrite")
+
+	// This closely resembles the values one would have from NewConfig()
+	c := &Config{
+		ConfigPath: filepath.Join(testDir, "config.yaml"),
+		AppRoot:    testDir,
+		APIVersion: CurrentAppVersion,
+		Platform:   DDevDefaultPlatform,
+		Name:       "TestWrite",
+		WebImage:   version.WebImg + ":" + version.WebTag,
+		DBImage:    version.DBImg + ":" + version.DBTag,
+		DBAImage:   version.DBAImg + ":" + version.DBATag,
+		AppType:    "drupal8",
+	}
+
+	err := c.Write()
+	assert.NoError(err)
+
+	out, err := ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))
+	assert.NoError(err)
+	assert.Contains(string(out), "TestWrite")
+	assert.Contains(string(out), "exec: drush cr")
+
+	c.AppType = "wordpress"
+	err = c.Write()
+	assert.NoError(err)
+
+	out, err = ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))
+	assert.NoError(err)
+	assert.Contains(string(out), "exec: wp search-replace")
+
+	err = os.RemoveAll(testDir)
+	assert.NoError(err)
+}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -80,25 +80,25 @@ networks:
       name: ddev_default
 `
 
-// HookTemplate is used to add example extend-commands usage
+// HookTemplate is used to add example hooks usage
 const HookTemplate = `
 # Certain ddev commands can be extended to run tasks before or after the ddev
 # command is executed.
 # See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them.
-# extend-commands:
+# hooks:
 #   post-import-db:`
 
-// Drupal8Hooks adds a d8-specific extend-commands example for post-import-db
+// Drupal8Hooks adds a d8-specific hooks example for post-import-db
 const Drupal8Hooks = `
 #     - exec: "drush cr"`
 
-// Drupal7Hooks adds a d7-specific extend-commands example for post-import-db
+// Drupal7Hooks adds a d7-specific hooks example for post-import-db
 const Drupal7Hooks = `
 #     - exec: "drush cc all"`
 
-// WordPressHooks adds a wp-specific extend-commands example for post-import-db
+// WordPressHooks adds a wp-specific hooks example for post-import-db
 const WordPressHooks = `
     # Un-comment and enter the production url and local url
     # to replace in your database after import.

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -82,8 +82,8 @@ networks:
 
 // HookTemplate is used to add example extend-commands usage
 const HookTemplate = `
-# Certain ddev commands can be extended to run tasks before or after the
-# the ddev command is executed. See <docurl> for more information on the
+# Certain ddev commands can be extended to run tasks before or after the ddev command is executed.
+# See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more information on the
 # commands that can be extended and the tasks you can define for them.
 extend-commands:
   post-import-db:`

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -83,9 +83,10 @@ networks:
 // HookTemplate is used to add example extend-commands usage
 const HookTemplate = `
 # Certain ddev commands can be extended to run tasks before or after the ddev
-# command is executed. See https://ddev.readthedocs.io/en/latest/users/extending-commands/
-# for more information on the commands that can be extended and the tasks you
-# can define for them.
+# command is executed.
+# See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them.
 # extend-commands:
 #   post-import-db:`
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -85,16 +85,16 @@ const HookTemplate = `
 # Certain ddev commands can be extended to run tasks before or after the ddev command is executed.
 # See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more information on the
 # commands that can be extended and the tasks you can define for them.
-extend-commands:
-  post-import-db:`
+# extend-commands:
+#   post-import-db:`
 
 // Drupal8Hooks adds a d8-specific extend-commands example for post-import-db
 const Drupal8Hooks = `
-    - exec: drush cr`
+#     - exec: drush cr`
 
 // Drupal7Hooks adds a d7-specific extend-commands example for post-import-db
 const Drupal7Hooks = `
-    - exec: drush cc all`
+#     - exec: drush cc all`
 
 // WordPressHooks adds a wp-specific extend-commands example for post-import-db
 const WordPressHooks = `

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -82,22 +82,23 @@ networks:
 
 // HookTemplate is used to add example extend-commands usage
 const HookTemplate = `
-# Certain ddev commands can be extended to run tasks before or after the ddev command is executed.
-# See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more information on the
-# commands that can be extended and the tasks you can define for them.
+# Certain ddev commands can be extended to run tasks before or after the ddev
+# command is executed. See https://ddev.readthedocs.io/en/latest/users/extending-commands/
+# for more information on the commands that can be extended and the tasks you
+# can define for them.
 # extend-commands:
 #   post-import-db:`
 
 // Drupal8Hooks adds a d8-specific extend-commands example for post-import-db
 const Drupal8Hooks = `
-#     - exec: drush cr`
+#     - exec: "drush cr"`
 
 // Drupal7Hooks adds a d7-specific extend-commands example for post-import-db
 const Drupal7Hooks = `
-#     - exec: drush cc all`
+#     - exec: "drush cc all"`
 
 // WordPressHooks adds a wp-specific extend-commands example for post-import-db
 const WordPressHooks = `
     # Un-comment and enter the production url and local url
     # to replace in your database after import.
-    # - exec: wp search-replace <production-url> <local-url>`
+    # - exec: "wp search-replace <production-url> <local-url>"`

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -79,3 +79,25 @@ networks:
     external:
       name: ddev_default
 `
+
+// HookTemplate is used to add example extend-commands usage
+const HookTemplate = `
+# Certain ddev commands can be extended to run tasks before or after the
+# the ddev command is executed. See <docurl> for more information on the
+# commands that can be extended and the tasks you can define for them.
+extend-commands:
+  post-import-db:`
+
+// Drupal8Hooks adds a d8-specific extend-commands example for post-import-db
+const Drupal8Hooks = `
+    - exec: drush cr`
+
+// Drupal7Hooks adds a d7-specific extend-commands example for post-import-db
+const Drupal7Hooks = `
+    - exec: drush cc all`
+
+// WordPressHooks adds a wp-specific extend-commands example for post-import-db
+const WordPressHooks = `
+    # Un-comment and enter the production url and local url
+    # to replace in your database after import.
+    # - exec: wp search-replace <production-url> <local-url>`

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -457,29 +457,49 @@ func (l *LocalApp) ProcessHooks(commands []ddevapp.Command) error {
 	var err error
 	for _, c := range commands {
 		if c.ImportDB.Src != "" {
-			fmt.Println("--Importing database from ", c.ImportDB.Src, "--")
+			fmt.Printf("--- Importing database from %s ---\n", c.ImportDB.Src)
 			err = l.ImportDB(c.ImportDB.Src, c.ImportDB.ExtractPath)
 			if err != nil {
 				return fmt.Errorf("Database import failed: %v", err)
 			}
-			util.Success("--Database import succeeded--")
+			util.Success("--- Database import succeeded ---")
 		}
 		if c.ImportFiles.Src != "" {
-			fmt.Println("--Importing files from ", c.ImportFiles.Src, "--")
+			fmt.Printf("--- Importing files from %s ---\n", c.ImportFiles.Src)
 			err = l.ImportFiles(c.ImportFiles.Src, c.ImportFiles.ExtractPath)
 			if err != nil {
 				return fmt.Errorf("File import failed: %v", err)
 			}
-			util.Success("--File import succeeded--")
+			util.Success("--- File import succeeded ---\n")
 		}
 		if c.Exec != "" {
-			fmt.Println("--Runing exec: ", c.Exec, "--")
+			fmt.Printf("--- Runing exec command: %s ---\n", c.Exec)
 			args := strings.Split(c.Exec, " ")
 			err = l.Exec("web", true, args...)
 			if err != nil {
 				return fmt.Errorf("Exec failed: %v", err)
 			}
-			util.Success("--Exec command succeeded--")
+			util.Success("--- Exec command succeeded ---")
+		}
+		if c.ExecHost != "" {
+			fmt.Printf("--- Runing host command: %s ---\n", c.ExecHost)
+			args := strings.Split(c.ExecHost, " ")
+			cmd := args[0]
+			args = append(args[:0], args[1:]...)
+
+			// ensure exec-host runs from consistent location
+			cwd, err := os.Getwd()
+			util.CheckErr(err)
+			err = os.Chdir(l.AppRoot())
+			util.CheckErr(err)
+
+			err = exec.RunCommandPipe(cmd, args)
+			dirErr := os.Chdir(cwd)
+			util.CheckErr(dirErr)
+			if err != nil {
+				return fmt.Errorf("Host command failed: %v", err)
+			}
+			util.Success("--- Host command succeeded ---")
 		}
 	}
 

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -452,7 +452,7 @@ func (l *LocalApp) ComposeFiles() []string {
 	return files
 }
 
-// ProcessHook executes commands defined in a ddevapp.Command
+// ProcessHooks executes commands defined in a ddevapp.Command
 func (l *LocalApp) ProcessHooks(commands []ddevapp.Command) error {
 	var err error
 	for _, c := range commands {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -48,7 +48,7 @@ func (l *LocalApp) GetType() string {
 func (l *LocalApp) Init(basePath string) error {
 	config, err := ddevapp.NewConfig(basePath)
 	if err != nil {
-		return fmt.Errorf("could not find an active ddev configuration, have you run 'ddev config'?: %v", err)
+		return err
 	}
 
 	err = config.Validate()

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -460,7 +460,7 @@ func (l *LocalApp) ProcessHooks(commands []ddevapp.Command) error {
 			fmt.Println("--Importing database from ", c.ImportDB.Src, "--")
 			err = l.ImportDB(c.ImportDB.Src, c.ImportDB.ExtractPath)
 			if err != nil {
-				return err
+				return fmt.Errorf("Database import failed: %v", err)
 			}
 			util.Success("--Database import succeeded--")
 		}
@@ -468,7 +468,7 @@ func (l *LocalApp) ProcessHooks(commands []ddevapp.Command) error {
 			fmt.Println("--Importing files from ", c.ImportFiles.Src, "--")
 			err = l.ImportFiles(c.ImportFiles.Src, c.ImportFiles.ExtractPath)
 			if err != nil {
-				return err
+				return fmt.Errorf("File import failed: %v", err)
 			}
 			util.Success("--File import succeeded--")
 		}
@@ -477,7 +477,7 @@ func (l *LocalApp) ProcessHooks(commands []ddevapp.Command) error {
 			args := strings.Split(c.Exec, " ")
 			err = l.Exec("web", true, args...)
 			if err != nil {
-				return err
+				return fmt.Errorf("Exec failed: %v", err)
 			}
 			util.Success("--Exec command succeeded--")
 		}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -160,7 +160,7 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 	preCmds := l.AppConfig.Commands["pre-import-db"]
 	if len(preCmds) > 0 {
 		fmt.Println("Executing pre-import commands...")
-		err := l.ProcessHook(preCmds)
+		err := l.ProcessHooks(preCmds)
 		if err != nil {
 			return err
 		}
@@ -262,7 +262,7 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 	postCmds := l.AppConfig.Commands["post-import-db"]
 	if len(postCmds) > 0 {
 		fmt.Println("Executing post-import commands...")
-		err := l.ProcessHook(postCmds)
+		err := l.ProcessHooks(postCmds)
 		if err != nil {
 			return err
 		}
@@ -319,7 +319,7 @@ func (l *LocalApp) ImportFiles(imPath string, extPath string) error {
 	preCmds := l.AppConfig.Commands["pre-import-files"]
 	if len(preCmds) > 0 {
 		fmt.Println("Executing pre-start commands...")
-		err := l.ProcessHook(preCmds)
+		err := l.ProcessHooks(preCmds)
 		if err != nil {
 			return err
 		}
@@ -412,7 +412,7 @@ func (l *LocalApp) ImportFiles(imPath string, extPath string) error {
 	postCmds := l.AppConfig.Commands["post-import-files"]
 	if len(postCmds) > 0 {
 		fmt.Println("Executing post-import commands...")
-		err := l.ProcessHook(postCmds)
+		err := l.ProcessHooks(postCmds)
 		if err != nil {
 			return err
 		}
@@ -453,16 +453,24 @@ func (l *LocalApp) ComposeFiles() []string {
 }
 
 // ProcessHook executes commands defined in a ddevapp.Command
-func (l *LocalApp) ProcessHook(commands []ddevapp.Command) error {
+func (l *LocalApp) ProcessHooks(commands []ddevapp.Command) error {
 	var err error
 	for _, c := range commands {
 		if c.ImportDB.Src != "" {
 			fmt.Println("--Importing database from ", c.ImportDB.Src, "--")
-			err = l.ImportDB(c.ImportDB.Src, "")
+			err = l.ImportDB(c.ImportDB.Src, c.ImportDB.ExtractPath)
 			if err != nil {
 				return err
 			}
 			util.Success("--Database import succeeded--")
+		}
+		if c.ImportFiles.Src != "" {
+			fmt.Println("--Importing files from ", c.ImportFiles.Src, "--")
+			err = l.ImportFiles(c.ImportFiles.Src, c.ImportFiles.ExtractPath)
+			if err != nil {
+				return err
+			}
+			util.Success("--File import succeeded--")
 		}
 		if c.Exec != "" {
 			fmt.Println("--Runing exec: ", c.Exec, "--")
@@ -485,7 +493,7 @@ func (l *LocalApp) Start() error {
 	preCmds := l.AppConfig.Commands["pre-start"]
 	if len(preCmds) > 0 {
 		fmt.Println("Executing pre-start commands...")
-		err := l.ProcessHook(preCmds)
+		err := l.ProcessHooks(preCmds)
 		if err != nil {
 			return err
 		}
@@ -529,7 +537,7 @@ func (l *LocalApp) Start() error {
 	postCmds := l.AppConfig.Commands["post-start"]
 	if len(postCmds) > 0 {
 		fmt.Println("Executing post-start commands...")
-		err := l.ProcessHook(postCmds)
+		err := l.ProcessHooks(postCmds)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gosuri/uitable"
 	"github.com/lextoumbourou/goodhosts"
+	shellwords "github.com/mattn/go-shellwords"
 )
 
 const containerWaitTimeout = 35
@@ -463,7 +464,12 @@ func (l *LocalApp) ProcessHooks(hookName string) error {
 		}
 		if c.Exec != "" {
 			fmt.Printf("--- Running exec command: %s ---\n", c.Exec)
-			args := strings.Split(c.Exec, " ")
+
+			args, err := shellwords.Parse(c.Exec)
+			if err != nil {
+				return fmt.Errorf("%s exec failed: %v", hookName, err)
+			}
+
 			err = l.Exec("web", true, args...)
 			if err != nil {
 				return fmt.Errorf("%s exec failed: %v", hookName, err)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -439,29 +439,11 @@ func (l *LocalApp) ComposeFiles() []string {
 
 // ProcessHooks executes commands defined in a ddevapp.Command
 func (l *LocalApp) ProcessHooks(hookName string) error {
-	var err error
-
 	if cmds := l.AppConfig.Commands[hookName]; len(cmds) > 0 {
 		fmt.Printf("Executing %s commands...\n", hookName)
 	}
 
 	for _, c := range l.AppConfig.Commands[hookName] {
-		if c.ImportDB.Src != "" {
-			fmt.Printf("--- Importing database from %s ---\n", c.ImportDB.Src)
-			err = l.ImportDB(c.ImportDB.Src, c.ImportDB.ExtractPath)
-			if err != nil {
-				return fmt.Errorf("%s database import failed: %v", hookName, err)
-			}
-			util.Success("--- %s database import succeeded ---", hookName)
-		}
-		if c.ImportFiles.Src != "" {
-			fmt.Printf("--- Importing files from %s ---\n", c.ImportFiles.Src)
-			err = l.ImportFiles(c.ImportFiles.Src, c.ImportFiles.ExtractPath)
-			if err != nil {
-				return fmt.Errorf("%s file import failed: %v", hookName, err)
-			}
-			util.Success("--- %s file import succeeded ---\n", hookName)
-		}
 		if c.Exec != "" {
 			fmt.Printf("--- Running exec command: %s ---\n", c.Exec)
 

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -157,15 +157,12 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 	var extPathPrompt bool
 	dbPath := l.AppConfig.ImportDir
 
-	if preCmds := l.AppConfig.Commands["pre-import-db"]; len(preCmds) > 0 {
-		fmt.Println("Executing pre-import commands...")
-		err := l.ProcessHooks("pre-import-db")
-		if err != nil {
-			return err
-		}
+	err := l.ProcessHooks("pre-import-db")
+	if err != nil {
+		return err
 	}
 
-	err := fileutil.PurgeDirectory(dbPath)
+	err = fileutil.PurgeDirectory(dbPath)
 	if err != nil {
 		return fmt.Errorf("failed to cleanup %s before import: %v", dbPath, err)
 	}
@@ -258,12 +255,9 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 		return fmt.Errorf("failed to clean up %s after import: %v", dbPath, err)
 	}
 
-	if postCmds := l.AppConfig.Commands["post-import-db"]; len(postCmds) > 0 {
-		fmt.Println("Executing post-import commands...")
-		err := l.ProcessHooks("post-import-db")
-		if err != nil {
-			return err
-		}
+	err = l.ProcessHooks("post-import-db")
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -314,12 +308,9 @@ func (l *LocalApp) ImportFiles(imPath string, extPath string) error {
 
 	l.DockerEnv()
 
-	if preCmds := l.AppConfig.Commands["pre-import-files"]; len(preCmds) > 0 {
-		fmt.Println("Executing pre-import-files commands...")
-		err := l.ProcessHooks("pre-import-files")
-		if err != nil {
-			return err
-		}
+	err := l.ProcessHooks("pre-import-files")
+	if err != nil {
+		return err
 	}
 
 	if imPath == "" {
@@ -350,7 +341,7 @@ func (l *LocalApp) ImportFiles(imPath string, extPath string) error {
 	}
 
 	// parent of destination dir should be writable
-	err := os.Chmod(filepath.Dir(destPath), 0755)
+	err = os.Chmod(filepath.Dir(destPath), 0755)
 	if err != nil {
 		return err
 	}
@@ -406,12 +397,9 @@ func (l *LocalApp) ImportFiles(imPath string, extPath string) error {
 		}
 	}
 
-	if postCmds := l.AppConfig.Commands["post-import-files"]; len(postCmds) > 0 {
-		fmt.Println("Executing post-import commands...")
-		err := l.ProcessHooks("post-import-files")
-		if err != nil {
-			return err
-		}
+	err = l.ProcessHooks("post-import-files")
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -452,6 +440,10 @@ func (l *LocalApp) ComposeFiles() []string {
 func (l *LocalApp) ProcessHooks(hookName string) error {
 	var err error
 
+	if cmds := l.AppConfig.Commands[hookName]; len(cmds) > 0 {
+		fmt.Printf("Executing %s commands...\n", hookName)
+	}
+
 	for _, c := range l.AppConfig.Commands[hookName] {
 		if c.ImportDB.Src != "" {
 			fmt.Printf("--- Importing database from %s ---\n", c.ImportDB.Src)
@@ -470,7 +462,7 @@ func (l *LocalApp) ProcessHooks(hookName string) error {
 			util.Success("--- %s file import succeeded ---\n", hookName)
 		}
 		if c.Exec != "" {
-			fmt.Printf("--- Runing exec command: %s ---\n", c.Exec)
+			fmt.Printf("--- Running exec command: %s ---\n", c.Exec)
 			args := strings.Split(c.Exec, " ")
 			err = l.Exec("web", true, args...)
 			if err != nil {
@@ -479,7 +471,7 @@ func (l *LocalApp) ProcessHooks(hookName string) error {
 			util.Success("--- %s exec command succeeded ---", hookName)
 		}
 		if c.ExecHost != "" {
-			fmt.Printf("--- Runing host command: %s ---\n", c.ExecHost)
+			fmt.Printf("--- Running host command: %s ---\n", c.ExecHost)
 			args := strings.Split(c.ExecHost, " ")
 			cmd := args[0]
 			args = append(args[:0], args[1:]...)
@@ -507,12 +499,9 @@ func (l *LocalApp) ProcessHooks(hookName string) error {
 func (l *LocalApp) Start() error {
 	l.DockerEnv()
 
-	if preCmds := l.AppConfig.Commands["pre-start"]; len(preCmds) > 0 {
-		fmt.Println("Executing pre-start commands...")
-		err := l.ProcessHooks("pre-start")
-		if err != nil {
-			return err
-		}
+	err := l.ProcessHooks("pre-start")
+	if err != nil {
+		return err
 	}
 
 	// Write docker-compose.yaml (if it doesn't exist).
@@ -525,7 +514,7 @@ func (l *LocalApp) Start() error {
 		}
 	}
 
-	err := l.prepSiteDirs()
+	err = l.prepSiteDirs()
 	if err != nil {
 		return err
 	}
@@ -550,12 +539,9 @@ func (l *LocalApp) Start() error {
 		return err
 	}
 
-	if postCmds := l.AppConfig.Commands["post-start"]; len(postCmds) > 0 {
-		fmt.Println("Executing post-start commands...")
-		err := l.ProcessHooks("post-start")
-		if err != nil {
-			return err
-		}
+	err = l.ProcessHooks("post-start")
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -416,8 +416,8 @@ func TestProcessHooks(t *testing.T) {
 		assert.NoError(err)
 		out := stdout()
 
-		assert.Contains(out, "--- Runing exec command: pwd ---")
-		assert.Contains(out, "--- Runing host command: pwd ---")
+		assert.Contains(out, "--- Running exec command: pwd ---")
+		assert.Contains(out, "--- Running host command: pwd ---")
 		assert.Contains(out, fmt.Sprintf("--- Importing database from %s ---", testImport))
 		assert.Contains(out, fmt.Sprintf("--- Importing files from %s ---", testImport))
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -378,7 +378,6 @@ func TestLocalLogs(t *testing.T) {
 // TestProcessHooks tests execution of commands defined in config
 func TestProcessHooks(t *testing.T) {
 	assert := assert.New(t)
-	testDir, _ := os.Getwd()
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
@@ -390,22 +389,14 @@ func TestProcessHooks(t *testing.T) {
 
 		conf.Commands = map[string][]ddevapp.Command{
 			"hook-test": []ddevapp.Command{
-				ddevapp.Command{},
-				ddevapp.Command{},
-				ddevapp.Command{},
-				ddevapp.Command{},
+				ddevapp.Command{
+					Exec: "pwd",
+				},
+				ddevapp.Command{
+					ExecHost: "pwd",
+				},
 			},
 		}
-
-		testImport := filepath.Join(testDir, "testdata", "users.sql.tar.gz")
-		log.Debug(testImport)
-		testImport, err = filepath.Abs(testImport)
-		assert.NoError(err)
-		assert.True(fileutil.FileExists(testImport))
-		conf.Commands["hook-test"][0].Exec = "pwd"
-		conf.Commands["hook-test"][1].ExecHost = "pwd"
-		conf.Commands["hook-test"][2].ImportDB.Src = testImport
-		conf.Commands["hook-test"][3].ImportFiles.Src = testImport
 
 		l := &platform.LocalApp{
 			AppConfig: conf,
@@ -418,8 +409,6 @@ func TestProcessHooks(t *testing.T) {
 
 		assert.Contains(out, "--- Running exec command: pwd ---")
 		assert.Contains(out, "--- Running host command: pwd ---")
-		assert.Contains(out, fmt.Sprintf("--- Importing database from %s ---", testImport))
-		assert.Contains(out, fmt.Sprintf("--- Importing files from %s ---", testImport))
 
 		runTime()
 		cleanup()

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -374,6 +374,19 @@ func TestLocalLogs(t *testing.T) {
 	}
 }
 
+// TestProcessHooks tests execution of commands defined in config
+func TestProcessHooks(t *testing.T) {
+	assert := assert.New(t)
+
+	app, err := GetPluginApp("local")
+	assert.NoError(err)
+
+	for _, site := range TestSites {
+		cleanup := site.Chdir()
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ProcessHooks", site.Name))
+	}
+}
+
 // TestLocalStop tests the functionality that is called when "ddev stop" is executed
 func TestLocalStop(t *testing.T) {
 	assert := assert.New(t)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -407,7 +407,7 @@ func TestProcessHooks(t *testing.T) {
 		conf.Commands["hook-test"][2].ImportDB.Src = testImport
 		conf.Commands["hook-test"][3].ImportFiles.Src = testImport
 
-		l := &LocalApp{
+		l := &platform.LocalApp{
 			AppConfig: conf,
 		}
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -412,7 +412,7 @@ func TestProcessHooks(t *testing.T) {
 		}
 
 		stdout := testcommon.CaptureStdOut()
-		err = l.ProcessHooks(l.AppConfig.Commands["hook-test"])
+		err = l.ProcessHooks("hook-test")
 		assert.NoError(err)
 		out := stdout()
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -390,9 +390,8 @@ func TestProcessHooks(t *testing.T) {
 
 		conf.Commands = map[string][]ddevapp.Command{
 			"hook-test": []ddevapp.Command{
-				ddevapp.Command{
-					Exec: "pwd",
-				},
+				ddevapp.Command{},
+				ddevapp.Command{},
 				ddevapp.Command{},
 				ddevapp.Command{},
 			},
@@ -403,8 +402,10 @@ func TestProcessHooks(t *testing.T) {
 		testImport, err = filepath.Abs(testImport)
 		assert.NoError(err)
 		assert.True(fileutil.FileExists(testImport))
-		conf.Commands["hook-test"][1].ImportDB.Src = testImport
-		conf.Commands["hook-test"][2].ImportFiles.Src = testImport
+		conf.Commands["hook-test"][0].Exec = "pwd"
+		conf.Commands["hook-test"][1].ExecHost = "pwd"
+		conf.Commands["hook-test"][2].ImportDB.Src = testImport
+		conf.Commands["hook-test"][3].ImportFiles.Src = testImport
 
 		l := &LocalApp{
 			AppConfig: conf,
@@ -415,9 +416,10 @@ func TestProcessHooks(t *testing.T) {
 		assert.NoError(err)
 		out := stdout()
 
-		assert.Contains(out, "--Runing exec:  pwd --")
-		assert.Contains(out, fmt.Sprintf("--Importing database from  %s --", testImport))
-		assert.Contains(out, fmt.Sprintf("--Importing files from  %s --", testImport))
+		assert.Contains(out, "--- Runing exec command: pwd ---")
+		assert.Contains(out, "--- Runing host command: pwd ---")
+		assert.Contains(out, fmt.Sprintf("--- Importing database from %s ---", testImport))
+		assert.Contains(out, fmt.Sprintf("--- Importing files from %s ---", testImport))
 
 		runTime()
 		cleanup()

--- a/vendor/github.com/mattn/go-shellwords/LICENSE
+++ b/vendor/github.com/mattn/go-shellwords/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mattn/go-shellwords/README.md
+++ b/vendor/github.com/mattn/go-shellwords/README.md
@@ -1,0 +1,47 @@
+# go-shellwords
+
+[![Coverage Status](https://coveralls.io/repos/mattn/go-shellwords/badge.png?branch=master)](https://coveralls.io/r/mattn/go-shellwords?branch=master)
+[![Build Status](https://travis-ci.org/mattn/go-shellwords.svg?branch=master)](https://travis-ci.org/mattn/go-shellwords)
+
+Parse line as shell words.
+
+## Usage
+
+```go
+args, err := shellwords.Parse("./foo --bar=baz")
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
+os.Setenv("FOO", "bar")
+p := shellwords.NewParser()
+p.ParseEnv = true
+args, err := p.Parse("./foo $FOO")
+// args should be ["./foo", "bar"]
+```
+
+```go
+p := shellwords.NewParser()
+p.ParseBacktick = true
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+```go
+shellwords.ParseBacktick = true
+p := shellwords.NewParser()
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+# Thanks
+
+This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).
+
+# License
+
+under the MIT License: http://mattn.mit-license.org/2017
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/vendor/github.com/mattn/go-shellwords/shellwords.go
+++ b/vendor/github.com/mattn/go-shellwords/shellwords.go
@@ -1,0 +1,145 @@
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"regexp"
+)
+
+var (
+	ParseEnv      bool = false
+	ParseBacktick bool = false
+)
+
+var envRe = regexp.MustCompile(`\$({[a-zA-Z0-9_]+}|[a-zA-Z0-9_]+)`)
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\r', '\n':
+		return true
+	}
+	return false
+}
+
+func replaceEnv(s string) string {
+	return envRe.ReplaceAllStringFunc(s, func(s string) string {
+		s = s[1:]
+		if s[0] == '{' {
+			s = s[1 : len(s)-1]
+		}
+		return os.Getenv(s)
+	})
+}
+
+type Parser struct {
+	ParseEnv      bool
+	ParseBacktick bool
+	Position      int
+}
+
+func NewParser() *Parser {
+	return &Parser{ParseEnv, ParseBacktick, 0}
+}
+
+func (p *Parser) Parse(line string) ([]string, error) {
+	args := []string{}
+	buf := ""
+	var escaped, doubleQuoted, singleQuoted, backQuote bool
+	backtick := ""
+
+	pos := -1
+	got := false
+
+loop:
+	for i, r := range line {
+		if escaped {
+			buf += string(r)
+			escaped = false
+			continue
+		}
+
+		if r == '\\' {
+			if singleQuoted {
+				buf += string(r)
+			} else {
+				escaped = true
+			}
+			continue
+		}
+
+		if isSpace(r) {
+			if singleQuoted || doubleQuoted || backQuote {
+				buf += string(r)
+				backtick += string(r)
+			} else if got {
+				if p.ParseEnv {
+					buf = replaceEnv(buf)
+				}
+				args = append(args, buf)
+				buf = ""
+				got = false
+			}
+			continue
+		}
+
+		switch r {
+		case '`':
+			if !singleQuoted && !doubleQuoted {
+				if p.ParseBacktick {
+					if backQuote {
+						out, err := shellRun(backtick)
+						if err != nil {
+							return nil, err
+						}
+						buf = out
+					}
+					backtick = ""
+					backQuote = !backQuote
+					continue
+				}
+				backtick = ""
+				backQuote = !backQuote
+			}
+		case '"':
+			if !singleQuoted {
+				doubleQuoted = !doubleQuoted
+				continue
+			}
+		case '\'':
+			if !doubleQuoted {
+				singleQuoted = !singleQuoted
+				continue
+			}
+		case ';', '&', '|', '<', '>':
+			if !(escaped || singleQuoted || doubleQuoted || backQuote) {
+				pos = i
+				break loop
+			}
+		}
+
+		got = true
+		buf += string(r)
+		if backQuote {
+			backtick += string(r)
+		}
+	}
+
+	if got {
+		if p.ParseEnv {
+			buf = replaceEnv(buf)
+		}
+		args = append(args, buf)
+	}
+
+	if escaped || singleQuoted || doubleQuoted || backQuote {
+		return nil, errors.New("invalid command line string")
+	}
+
+	p.Position = pos
+
+	return args, nil
+}
+
+func Parse(line string) ([]string, error) {
+	return NewParser().Parse(line)
+}

--- a/vendor/github.com/mattn/go-shellwords/util_posix.go
+++ b/vendor/github.com/mattn/go-shellwords/util_posix.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	shell := os.Getenv("SHELL")
+	b, err := exec.Command(shell, "-c", line).Output()
+	if err != nil {
+		return "", errors.New(err.Error() + ":" + string(b))
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/github.com/mattn/go-shellwords/util_windows.go
+++ b/vendor/github.com/mattn/go-shellwords/util_windows.go
@@ -1,0 +1,17 @@
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	shell := os.Getenv("COMSPEC")
+	b, err := exec.Command(shell, "/c", line).Output()
+	if err != nil {
+		return "", errors.New(err.Error() + ":" + string(b))
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -268,6 +268,12 @@
 			"revisionTime": "2016-03-15T04:07:12Z"
 		},
 		{
+			"checksumSHA1": "3yckDt/xIreJZ/spvI+MvHOCmcY=",
+			"path": "github.com/mattn/go-shellwords",
+			"revision": "02e3cf038dcea8290e44424da473dd12be796a8a",
+			"revisionTime": "2017-04-11T07:14:55Z"
+		},
+		{
 			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",
 			"path": "github.com/mitchellh/go-homedir",
 			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",


### PR DESCRIPTION
## The Problem:
OP #183 We would like to provide support for running tasks before or after some ddev commands. These tasks should be defined in the config.yml for a site.

## The Fix:
This PR makes that happen. It adds support for an `extend-commands` key to be defined in the config.yml of a site, that then defines command hooks, with a list of tasks to run. For example:

```
extend-commands:
  post-import-db:
    - exec: "drush cc all"
```

The following command hooks can be defined:
- `pre-start`: Hooks into "ddev start". Execute tasks before the site environment starts.
- `post-start`: Hooks into "ddev start". Execute tasks after the site environment has started
- `pre-import-db`: Hooks into "ddev import-db". Execute tasks before database import
- `post-import-db`: Hooks into "ddev import-db". Execute tasks after database import
- `pre-import-files`: Hooks into "ddev import-files". Execute tasks before files are imported
- `post-import-files`: Hooks into "ddev import-files". Execute tasks after files are imported.

The following tasks can be defined:
- exec: Run a command in the web container
- import-db: Import a database
- import-files: Import files

An example configuration relevant to the apptype of the site is provided in config.yml when "ddev config" is run.

## The Test:
- "ddev config" a new site. Your config.yml should provide an example extend-commands.
- Run a "ddev import-db" to test the example extend-commands. Note: for Wordpress, you'll need to uncomment and provide URLs to replace. The output of import-db should indicate that it is executing post-import commands.
- Review documentation, and test out various configurations.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Tests have been introduced to validate example config is written to config.yml, and to test execution of commands defined in config.

## Related Issue Link(s):
#183 OP

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

