### PR TITLE
Add fix for nightly build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ testcmd: build setup
 	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
 
 testpkg:
-	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) DRUD_DEBUG=true go test  -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
+	PATH=$$PWD/bin/$(TESTOS):$$PATH CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) DRUD_DEBUG=true go test -p 1 -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
 
 setup:
 	@mkdir -p bin/darwin bin/linux

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -45,6 +45,9 @@ func TestServicesSetup(t *testing.T) {
 			return nil
 		})
 		assert.NoError(err)
+
+		err = dockerutil.EnsureNetwork(dockerutil.GetDockerClient(), dockerutil.NetName)
+		assert.NoError(err)
 	} else {
 		log.Info("services tests skipped in short mode")
 	}
@@ -90,6 +93,9 @@ func TestServices(t *testing.T) {
 
 				container, err := dockerutil.FindContainerByLabels(labels)
 				assert.NoError(err)
+				if err != nil {
+					t.Fatalf("Could not find running container for service %s. Skipping remainder of test.", serviceName)
+				}
 				name := dockerutil.ContainerName(container)
 				check, err := testcommon.ContainerCheck(name, "running")
 				assert.NoError(err)


### PR DESCRIPTION
## The Problem:
This is a fix for #365. The nightly build failed due to the docker network not being set up.

## The Fix:
This PR adds the "ddev_default" network before running the servicetest group. Additionally, it failed more gracefully in the event that the network is not set up.

