### PR TITLE
Remove -short default in makefile, fixes #354

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,6 @@ DBATag ?= v0.2.0
 # VERSION can be overridden on make commandline: make VERSION=0.9.1 push
 VERSION := $(shell git describe --tags --always --dirty)
 
-# Run tests with -short by default, for faster run times.
-TESTARGS ?= -short
-
 #
 # This version-strategy uses a manual value to set the version string
 #VERSION := 1.2.3


### PR DESCRIPTION
## The Problem:

We introduced -short in #292 in order to reduce test run duration. However, at least twice we've missed regressions until after pull because we don't test multiple sites without it. It's time to bring it back. There are a number of ways we could make things faster.

It's still easy to build with -short: `make testpkg TESTARGS="-short"`

## The Fix:

Remove the default -short from the Makefile. If it comes back it would probably be better to put it in the circleci config.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

#354 OP
#292 was the introduction of -short as default. We're not reverting anything but the default usage of -short in the build.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

