### PR TITLE
Make sure that ~/.ddev exists very early, fixes #358

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -51,12 +51,21 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		usr, err := homedir.Dir()
+		homedir, err := homedir.Dir()
 		if err != nil {
 			util.Failed("Could not detect user's home directory: ", err)
 		}
 
-		updateFile := filepath.Join(usr, ".ddev", ".update")
+		// Verify that the ~/.ddev exists
+		homeddev := filepath.Join(homedir, ".ddev")
+		if _, err := os.Stat(homeddev); os.IsNotExist(err) {
+			err = os.MkdirAll(homeddev, 0700)
+			if err != nil {
+				util.Failed("Failed to create required directory %s, err: %v", homeddev, err)
+			}
+		}
+
+		updateFile := filepath.Join(homeddev, ".update")
 		// Do periodic detection of whether an update is available for ddev users.
 		timeToCheckForUpdates, err := updatecheck.IsUpdateNeeded(updateFile, updateInterval)
 		if err != nil {

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -102,7 +102,7 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	err = os.Setenv("HOME", tmpDir)
 	assert.NoError(t, err)
 
-	args := []string{}
+	args := []string{"list"}
 	_, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
## The Problem:

We have a couple of ways that ~/.ddev might not get created at the right time and it's absolutely essential for both mounts (mysql health) and updatecheck. 

## The Fix:

Create ~/.ddev in root.go at the very beginning before the updatecheck.

## The Test:

rm -r ~/.ddev and then `ddev start`

This should be tested explicitly on windows.

## Automation Overview:

Adds TestCreateGlobalDdev as a test - it changes the $HOME environment variable in order to much with ~/.ddev without breaking the user's system.

## Related Issue Link(s):

OP #358 

## Release/Deployment notes:
