### PR TITLE
improve error message for no docker connection, fixes #357

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -67,7 +67,7 @@ var RootCmd = &cobra.Command{
 			updateNeeded, updateURL, err := updatecheck.AvailableUpdates("drud", "ddev", version.DdevVersion)
 
 			if err != nil {
-				util.Warning("Could not check for updates. this is most often caused by a networking issue.")
+				util.Warning("Could not check for updates. This is most often caused by a networking issue.")
 				log.Debug(err)
 				return
 			}
@@ -83,7 +83,13 @@ var RootCmd = &cobra.Command{
 
 		err = dockerutil.CheckDockerVersion(version.DockerVersionConstraint)
 		if err != nil {
-			util.Failed("The docker version currently installed does not meet ddev's requirements: %v", err)
+			if err.Error() == "no docker" {
+				if os.Args[1] != "version" && os.Args[1] != "config" {
+					util.Failed("Could not connect to docker. Please ensure Docker is installed and running.")
+				}
+			} else {
+				util.Failed("The docker version currently installed does not meet ddev's requirements: %v", err)
+			}
 		}
 	},
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -236,7 +236,7 @@ func CheckDockerVersion(versionConstraint string) error {
 	client := GetDockerClient()
 	version, err := client.Version()
 	if err != nil {
-		return err
+		return fmt.Errorf("no docker")
 	}
 
 	currentVersion := version.Get("Version")


### PR DESCRIPTION
## The Problem:
OP #357 Our error message is not very good if we can't connect to the docker client.

## The Fix:
This improves the error message if we can't connect to docker. It also allows the "version" and "config" commands to be run regardless of docker's state or version.

## The Test:
- Stop your Docker daemon
- Run a ddev command that's not version or config. You should get a clear error message that we can't connect to Docker.
- Run ddev version and ddev config. These commands should work normally without docker running.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

