### PR TITLE
Local test refactor, fixes #371, fixes #381

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
 {
     "go.testTimeout": "360s",
     "go.testEnvVars": {
-        "DRUD_DEBUG": "true"
+        "DRUD_DEBUG": "true",
+        "GOTEST_SHORT": "true"
     }
 }

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -552,8 +552,8 @@ func (l *LocalApp) DockerEnv() {
 func (l *LocalApp) Stop() error {
 	l.DockerEnv()
 
-	if l.SiteStatus() != SiteRunning {
-		return fmt.Errorf("site does not appear to be running - web container %s", l.SiteStatus())
+	if l.SiteStatus() == SiteNotFound {
+		return fmt.Errorf("no site to remove")
 	}
 
 	err := dockerutil.ComposeCmd(l.ComposeFiles(), "stop")

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -668,16 +668,20 @@ func (l *LocalApp) Down(removeData bool) error {
 		dir := filepath.Dir(l.AppConfig.DataDir)
 		// mysql data can be set to read-only on linux hosts. PurgeDirectory ensures files
 		// are writable before we attempt to remove them.
-		err := fileutil.PurgeDirectory(dir)
-		if err != nil {
-			return fmt.Errorf("failed to remove data directories: %v", err)
+		if !fileutil.FileExists(dir) {
+			util.Warning("No application data to remove")
+		} else {
+			err := fileutil.PurgeDirectory(dir)
+			if err != nil {
+				return fmt.Errorf("failed to remove data directories: %v", err)
+			}
+			// PurgeDirectory leaves the directory itself in place, so we remove it here.
+			err = os.RemoveAll(dir)
+			if err != nil {
+				return fmt.Errorf("failed to remove data directories: %v", err)
+			}
+			util.Success("Application data removed")
 		}
-		// PurgeDirectory leaves the directory itself in place, so we remove it here.
-		err = os.RemoveAll(dir)
-		if err != nil {
-			return fmt.Errorf("failed to remove data directories: %v", err)
-		}
-		util.Success("Application data removed")
 	}
 
 	err := dockerutil.ComposeCmd(l.ComposeFiles(), "down", "-v")

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -216,11 +216,6 @@ func TestLocalImportDB(t *testing.T) {
 		}
 
 		if site.DBTarURL != "" {
-			err = app.Exec("db", true, "mysql", "-e", "DROP DATABASE db;")
-			assert.NoError(err)
-			err = app.Exec("db", true, "mysql", "information_schema", "-e", "CREATE DATABASE db;")
-			assert.NoError(err)
-
 			dbPath := filepath.Join(testcommon.CreateTmpDir("local-db"), "db.tar.gz")
 			err := util.DownloadFile(dbPath, site.DBTarURL)
 			assert.NoError(err)
@@ -240,11 +235,6 @@ func TestLocalImportDB(t *testing.T) {
 		}
 
 		if site.DBZipURL != "" {
-			err = app.Exec("db", true, "mysql", "-e", "DROP DATABASE db;")
-			assert.NoError(err)
-			err = app.Exec("db", true, "mysql", "information_schema", "-e", "CREATE DATABASE db;")
-			assert.NoError(err)
-
 			dbZipPath := filepath.Join(testcommon.CreateTmpDir("local-db-zip"), "db.zip")
 			err = util.DownloadFile(dbZipPath, site.DBZipURL)
 			assert.NoError(err)
@@ -264,11 +254,6 @@ func TestLocalImportDB(t *testing.T) {
 		}
 
 		if site.FullSiteTarballURL != "" {
-			err = app.Exec("db", true, "mysql", "-e", "DROP DATABASE db;")
-			assert.NoError(err)
-			err = app.Exec("db", true, "mysql", "information_schema", "-e", "CREATE DATABASE db;")
-			assert.NoError(err)
-
 			siteTarPath := filepath.Join(testcommon.CreateTmpDir("local-site-tar"), "site.tar.gz")
 			err = util.DownloadFile(siteTarPath, site.FullSiteTarballURL)
 			assert.NoError(err)
@@ -350,6 +335,20 @@ func TestLocalExec(t *testing.T) {
 		assert.NoError(err)
 		out := stdout()
 		assert.Contains(out, "/var/www/html")
+
+		err = app.Exec("db", true, "mysql", "-e", "DROP DATABASE db;")
+		assert.NoError(err)
+		err = app.Exec("db", true, "mysql", "information_schema", "-e", "CREATE DATABASE db;")
+		assert.NoError(err)
+
+		dbPath := filepath.Join(testcommon.CreateTmpDir("local-db"), "db.tar.gz")
+		err = util.DownloadFile(dbPath, site.DBTarURL)
+		assert.NoError(err)
+		err = app.ImportDB(dbPath, "")
+		assert.NoError(err)
+
+		err = os.Remove(dbPath)
+		assert.NoError(err)
 
 		stdout = testcommon.CaptureStdOut()
 		switch app.GetType() {
@@ -453,6 +452,9 @@ func TestDescribeStopped(t *testing.T) {
 
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
+		assert.NoError(err)
+
+		err = app.Stop()
 		assert.NoError(err)
 
 		out, err := app.Describe()

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -30,13 +30,12 @@ var (
 	ServiceDir   string
 )
 
-func TestServicesSetup(t *testing.T) {
-	if !testing.Short() {
+func TestMain(m *testing.M) {
+	if os.Getenv("GOTEST_SHORT") != "" {
 		var err error
-		assert := assert.New(t)
 
 		ServiceDir, err = filepath.Abs("../../services")
-		assert.NoError(err)
+		util.CheckErr(err)
 
 		err = filepath.Walk(ServiceDir, func(path string, f os.FileInfo, _ error) error {
 			if !f.IsDir() && strings.HasPrefix(f.Name(), "docker-compose") {
@@ -44,13 +43,18 @@ func TestServicesSetup(t *testing.T) {
 			}
 			return nil
 		})
-		assert.NoError(err)
+		util.CheckErr(err)
 
 		err = dockerutil.EnsureNetwork(dockerutil.GetDockerClient(), dockerutil.NetName)
-		assert.NoError(err)
+		util.CheckErr(err)
 	} else {
 		log.Info("services tests skipped in short mode")
 	}
+
+	log.Debugln("Running tests.")
+	testRun := m.Run()
+
+	os.Exit(testRun)
 }
 
 // TestServices tests each service compose file in the services folder.

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	homedir "github.com/mitchellh/go-homedir"
 
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/pkg/errors"
 )
@@ -102,6 +104,14 @@ func (site *TestSite) Cleanup() {
 	util.CheckErr(err)
 	// CleanupDir checks its own errors.
 	CleanupDir(site.Dir)
+
+	home, err := homedir.Dir()
+	util.CheckErr(err)
+
+	siteData := filepath.Join(home, ".ddev", site.Name)
+	if fileutil.FileExists(siteData) {
+		CleanupDir(siteData)
+	}
 }
 
 // CleanupDir removes a directory specified by string.


### PR DESCRIPTION
## The Problem:
OP #371. Our tests in the platform package are interdependent, requiring the full package tests to be run in order to run a given individual test.

## The Fix:
This PR breaks most of the test interdependencies. It moves start and remove functionality to the provision/cleanup handled in TestMain, so that individual tests can run without having to test the whole package. It also updates a couple tests, notably TestLocalExec, so that they can run without dependency on tests previous.

This also resolves #381, allowing ddev stop to run successfully unless there are no containers found.

There are a couple smaller tests I did not update to run independently, TestGetAppsEmpty and TestRouterNotRunning. These tests both validate a state in which no applications are running. I can update them if there's a strong desire, but I figured there's not much value in running these tests individually. 

## The Test:

Aside from TestGetAppsEmpty and TestRouterNotRunning, you should be able to pick an individual test out of local_test.go and run it. Sites should spin up for the test, it should pass, and then sites should tear down.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
This is largely an automation-specific improvement.

## Related Issue Link(s):
#371 OP for test refactor
#381 - ddev stop only works if site is in running state. 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

