### PR TITLE
Update fatih/color and related repos in vendor (Trying for #363)

### DIFF
--- a/vendor/github.com/fatih/color/README.md
+++ b/vendor/github.com/fatih/color/README.md
@@ -8,7 +8,6 @@ has support for Windows too! The API can be used in several ways, pick one that
 suits you.
 
 
-
 ![Color](http://i.imgur.com/c1JI0lA.png)
 
 
@@ -17,6 +16,9 @@ suits you.
 ```bash
 go get github.com/fatih/color
 ```
+
+Note that the `vendor` folder is here for stability. Remove the folder if you
+already have the dependencies in your GOPATH.
 
 ## Examples
 
@@ -56,6 +58,16 @@ whiteBackground := red.Add(color.BgWhite)
 whiteBackground.Println("Red text with white background.")
 ```
 
+### Use your own output (io.Writer)
+
+```go
+// Use your own io.Writer output
+color.New(color.FgBlue).Fprintln(myWriter, "blue color!")
+
+blue := color.New(color.FgBlue)
+blue.Fprint(writer, "This will print text in blue.")
+```
+
 ### Custom print functions (PrintFunc)
 
 ```go
@@ -67,6 +79,17 @@ red("Error: %s", err)
 // Mix up multiple attributes
 notice := color.New(color.Bold, color.FgGreen).PrintlnFunc()
 notice("Don't forget this...")
+```
+
+### Custom fprint functions (FprintFunc)
+
+```go
+blue := color.New(FgBlue).FprintfFunc()
+blue(myWriter, "important notice: %s", stars)
+
+// Mix up with multiple attributes
+success := color.New(color.Bold, color.FgGreen).FprintlnFunc()
+success(myWriter, "Don't forget this...")
 ```
 
 ### Insert into noncolor strings (SprintFunc)

--- a/vendor/github.com/fatih/color/color.go
+++ b/vendor/github.com/fatih/color/color.go
@@ -2,6 +2,7 @@ package color
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -11,11 +12,23 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-// NoColor defines if the output is colorized or not. It's dynamically set to
-// false or true based on the stdout's file descriptor referring to a terminal
-// or not. This is a global option and affects all colors. For more control
-// over each color block use the methods DisableColor() individually.
-var NoColor = !isatty.IsTerminal(os.Stdout.Fd())
+var (
+	// NoColor defines if the output is colorized or not. It's dynamically set to
+	// false or true based on the stdout's file descriptor referring to a terminal
+	// or not. This is a global option and affects all colors. For more control
+	// over each color block use the methods DisableColor() individually.
+	NoColor = os.Getenv("TERM") == "dumb" ||
+		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))
+
+	// Output defines the standard output of the print functions. By default
+	// os.Stdout is used.
+	Output = colorable.NewColorableStdout()
+
+	// colorsCache is used to reduce the count of created Color objects and
+	// allows to reuse already created objects with required Attribute.
+	colorsCache   = make(map[Attribute]*Color)
+	colorsCacheMu sync.Mutex // protects colorsCache
+)
 
 // Color defines a custom color object which is defined by SGR parameters.
 type Color struct {
@@ -133,6 +146,27 @@ func (c *Color) unset() {
 	Unset()
 }
 
+func (c *Color) setWriter(w io.Writer) *Color {
+	if c.isNoColorSet() {
+		return c
+	}
+
+	fmt.Fprintf(w, c.format())
+	return c
+}
+
+func (c *Color) unsetWriter(w io.Writer) {
+	if c.isNoColorSet() {
+		return
+	}
+
+	if NoColor {
+		return
+	}
+
+	fmt.Fprintf(w, "%s[%dm", escape, Reset)
+}
+
 // Add is used to chain SGR parameters. Use as many as parameters to combine
 // and create custom color objects. Example: Add(color.FgRed, color.Underline).
 func (c *Color) Add(value ...Attribute) *Color {
@@ -146,9 +180,17 @@ func (c *Color) prepend(value Attribute) {
 	c.params[0] = value
 }
 
-// Output defines the standard output of the print functions. By default
-// os.Stdout is used.
-var Output = colorable.NewColorableStdout()
+// Fprint formats using the default formats for its operands and writes to w.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+// On Windows, users should wrap w with colorable.NewColorable() if w is of
+// type *os.File.
+func (c *Color) Fprint(w io.Writer, a ...interface{}) (n int, err error) {
+	c.setWriter(w)
+	defer c.unsetWriter(w)
+
+	return fmt.Fprint(w, a...)
+}
 
 // Print formats using the default formats for its operands and writes to
 // standard output. Spaces are added between operands when neither is a
@@ -162,6 +204,17 @@ func (c *Color) Print(a ...interface{}) (n int, err error) {
 	return fmt.Fprint(Output, a...)
 }
 
+// Fprintf formats according to a format specifier and writes to w.
+// It returns the number of bytes written and any write error encountered.
+// On Windows, users should wrap w with colorable.NewColorable() if w is of
+// type *os.File.
+func (c *Color) Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+	c.setWriter(w)
+	defer c.unsetWriter(w)
+
+	return fmt.Fprintf(w, format, a...)
+}
+
 // Printf formats according to a format specifier and writes to standard output.
 // It returns the number of bytes written and any write error encountered.
 // This is the standard fmt.Printf() method wrapped with the given color.
@@ -170,6 +223,17 @@ func (c *Color) Printf(format string, a ...interface{}) (n int, err error) {
 	defer c.unset()
 
 	return fmt.Fprintf(Output, format, a...)
+}
+
+// Fprintln formats using the default formats for its operands and writes to w.
+// Spaces are always added between operands and a newline is appended.
+// On Windows, users should wrap w with colorable.NewColorable() if w is of
+// type *os.File.
+func (c *Color) Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
+	c.setWriter(w)
+	defer c.unsetWriter(w)
+
+	return fmt.Fprintln(w, a...)
 }
 
 // Println formats using the default formats for its operands and writes to
@@ -184,27 +248,72 @@ func (c *Color) Println(a ...interface{}) (n int, err error) {
 	return fmt.Fprintln(Output, a...)
 }
 
+// Sprint is just like Print, but returns a string instead of printing it.
+func (c *Color) Sprint(a ...interface{}) string {
+	return c.wrap(fmt.Sprint(a...))
+}
+
+// Sprintln is just like Println, but returns a string instead of printing it.
+func (c *Color) Sprintln(a ...interface{}) string {
+	return c.wrap(fmt.Sprintln(a...))
+}
+
+// Sprintf is just like Printf, but returns a string instead of printing it.
+func (c *Color) Sprintf(format string, a ...interface{}) string {
+	return c.wrap(fmt.Sprintf(format, a...))
+}
+
+// FprintFunc returns a new function that prints the passed arguments as
+// colorized with color.Fprint().
+func (c *Color) FprintFunc() func(w io.Writer, a ...interface{}) {
+	return func(w io.Writer, a ...interface{}) {
+		c.Fprint(w, a...)
+	}
+}
+
 // PrintFunc returns a new function that prints the passed arguments as
 // colorized with color.Print().
 func (c *Color) PrintFunc() func(a ...interface{}) {
-	return func(a ...interface{}) { c.Print(a...) }
+	return func(a ...interface{}) {
+		c.Print(a...)
+	}
+}
+
+// FprintfFunc returns a new function that prints the passed arguments as
+// colorized with color.Fprintf().
+func (c *Color) FprintfFunc() func(w io.Writer, format string, a ...interface{}) {
+	return func(w io.Writer, format string, a ...interface{}) {
+		c.Fprintf(w, format, a...)
+	}
 }
 
 // PrintfFunc returns a new function that prints the passed arguments as
 // colorized with color.Printf().
 func (c *Color) PrintfFunc() func(format string, a ...interface{}) {
-	return func(format string, a ...interface{}) { c.Printf(format, a...) }
+	return func(format string, a ...interface{}) {
+		c.Printf(format, a...)
+	}
+}
+
+// FprintlnFunc returns a new function that prints the passed arguments as
+// colorized with color.Fprintln().
+func (c *Color) FprintlnFunc() func(w io.Writer, a ...interface{}) {
+	return func(w io.Writer, a ...interface{}) {
+		c.Fprintln(w, a...)
+	}
 }
 
 // PrintlnFunc returns a new function that prints the passed arguments as
 // colorized with color.Println().
 func (c *Color) PrintlnFunc() func(a ...interface{}) {
-	return func(a ...interface{}) { c.Println(a...) }
+	return func(a ...interface{}) {
+		c.Println(a...)
+	}
 }
 
 // SprintFunc returns a new function that returns colorized strings for the
 // given arguments with fmt.Sprint(). Useful to put into or mix into other
-// string. Windows users should use this in conjuction with color.Output, example:
+// string. Windows users should use this in conjunction with color.Output, example:
 //
 //	put := New(FgYellow).SprintFunc()
 //	fmt.Fprintf(color.Output, "This is a %s", put("warning"))
@@ -216,7 +325,7 @@ func (c *Color) SprintFunc() func(a ...interface{}) string {
 
 // SprintfFunc returns a new function that returns colorized strings for the
 // given arguments with fmt.Sprintf(). Useful to put into or mix into other
-// string. Windows users should use this in conjuction with color.Output.
+// string. Windows users should use this in conjunction with color.Output.
 func (c *Color) SprintfFunc() func(format string, a ...interface{}) string {
 	return func(format string, a ...interface{}) string {
 		return c.wrap(fmt.Sprintf(format, a...))
@@ -225,7 +334,7 @@ func (c *Color) SprintfFunc() func(format string, a ...interface{}) string {
 
 // SprintlnFunc returns a new function that returns colorized strings for the
 // given arguments with fmt.Sprintln(). Useful to put into or mix into other
-// string. Windows users should use this in conjuction with color.Output.
+// string. Windows users should use this in conjunction with color.Output.
 func (c *Color) SprintlnFunc() func(a ...interface{}) string {
 	return func(a ...interface{}) string {
 		return c.wrap(fmt.Sprintln(a...))
@@ -268,7 +377,7 @@ func (c *Color) DisableColor() {
 	c.noColor = boolPtr(true)
 }
 
-// EnableColor enables the color output. Use it in conjuction with
+// EnableColor enables the color output. Use it in conjunction with
 // DisableColor(). Otherwise this method has no side effects.
 func (c *Color) EnableColor() {
 	c.noColor = boolPtr(false)
@@ -313,12 +422,6 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
-// colorsCache is used to reduce the count of created Color objects and
-// allows to reuse already created objects with required Attribute.
-var colorsCache = make(map[Attribute]*Color)
-
-var colorsCacheMu = new(sync.Mutex) // protects colorsCache
-
 func getCachedColor(p Attribute) *Color {
 	colorsCacheMu.Lock()
 	defer colorsCacheMu.Unlock()
@@ -332,94 +435,166 @@ func getCachedColor(p Attribute) *Color {
 	return c
 }
 
-func printColor(format string, p Attribute, a ...interface{}) {
+func colorPrint(format string, p Attribute, a ...interface{}) {
 	c := getCachedColor(p)
-
-	if len(a) == 0 {
-		a = append(a, format)
-		format = "%s"
-	}
 
 	if !strings.HasSuffix(format, "\n") {
 		format += "\n"
 	}
 
-	c.Printf(format, a...)
+	if len(a) == 0 {
+		c.Print(format)
+	} else {
+		c.Printf(format, a...)
+	}
 }
 
-func printString(format string, p Attribute, a ...interface{}) string {
+func colorString(format string, p Attribute, a ...interface{}) string {
 	c := getCachedColor(p)
 
 	if len(a) == 0 {
-		a = append(a, format)
-		format = "%s"
+		return c.SprintFunc()(format)
 	}
 
 	return c.SprintfFunc()(format, a...)
 }
 
-// Black is an convenient helper function to print with black foreground. A
+// Black is a convenient helper function to print with black foreground. A
 // newline is appended to format by default.
-func Black(format string, a ...interface{}) { printColor(format, FgBlack, a...) }
+func Black(format string, a ...interface{}) { colorPrint(format, FgBlack, a...) }
 
-// Red is an convenient helper function to print with red foreground. A
+// Red is a convenient helper function to print with red foreground. A
 // newline is appended to format by default.
-func Red(format string, a ...interface{}) { printColor(format, FgRed, a...) }
+func Red(format string, a ...interface{}) { colorPrint(format, FgRed, a...) }
 
-// Green is an convenient helper function to print with green foreground. A
+// Green is a convenient helper function to print with green foreground. A
 // newline is appended to format by default.
-func Green(format string, a ...interface{}) { printColor(format, FgGreen, a...) }
+func Green(format string, a ...interface{}) { colorPrint(format, FgGreen, a...) }
 
-// Yellow is an convenient helper function to print with yellow foreground.
+// Yellow is a convenient helper function to print with yellow foreground.
 // A newline is appended to format by default.
-func Yellow(format string, a ...interface{}) { printColor(format, FgYellow, a...) }
+func Yellow(format string, a ...interface{}) { colorPrint(format, FgYellow, a...) }
 
-// Blue is an convenient helper function to print with blue foreground. A
+// Blue is a convenient helper function to print with blue foreground. A
 // newline is appended to format by default.
-func Blue(format string, a ...interface{}) { printColor(format, FgBlue, a...) }
+func Blue(format string, a ...interface{}) { colorPrint(format, FgBlue, a...) }
 
-// Magenta is an convenient helper function to print with magenta foreground.
+// Magenta is a convenient helper function to print with magenta foreground.
 // A newline is appended to format by default.
-func Magenta(format string, a ...interface{}) { printColor(format, FgMagenta, a...) }
+func Magenta(format string, a ...interface{}) { colorPrint(format, FgMagenta, a...) }
 
-// Cyan is an convenient helper function to print with cyan foreground. A
+// Cyan is a convenient helper function to print with cyan foreground. A
 // newline is appended to format by default.
-func Cyan(format string, a ...interface{}) { printColor(format, FgCyan, a...) }
+func Cyan(format string, a ...interface{}) { colorPrint(format, FgCyan, a...) }
 
-// White is an convenient helper function to print with white foreground. A
+// White is a convenient helper function to print with white foreground. A
 // newline is appended to format by default.
-func White(format string, a ...interface{}) { printColor(format, FgWhite, a...) }
+func White(format string, a ...interface{}) { colorPrint(format, FgWhite, a...) }
 
-// BlackString is an convenient helper function to return a string with black
+// BlackString is a convenient helper function to return a string with black
 // foreground.
-func BlackString(format string, a ...interface{}) string { return printString(format, FgBlack, a...) }
+func BlackString(format string, a ...interface{}) string { return colorString(format, FgBlack, a...) }
 
-// RedString is an convenient helper function to return a string with red
+// RedString is a convenient helper function to return a string with red
 // foreground.
-func RedString(format string, a ...interface{}) string { return printString(format, FgRed, a...) }
+func RedString(format string, a ...interface{}) string { return colorString(format, FgRed, a...) }
 
-// GreenString is an convenient helper function to return a string with green
+// GreenString is a convenient helper function to return a string with green
 // foreground.
-func GreenString(format string, a ...interface{}) string { return printString(format, FgGreen, a...) }
+func GreenString(format string, a ...interface{}) string { return colorString(format, FgGreen, a...) }
 
-// YellowString is an convenient helper function to return a string with yellow
+// YellowString is a convenient helper function to return a string with yellow
 // foreground.
-func YellowString(format string, a ...interface{}) string { return printString(format, FgYellow, a...) }
+func YellowString(format string, a ...interface{}) string { return colorString(format, FgYellow, a...) }
 
-// BlueString is an convenient helper function to return a string with blue
+// BlueString is a convenient helper function to return a string with blue
 // foreground.
-func BlueString(format string, a ...interface{}) string { return printString(format, FgBlue, a...) }
+func BlueString(format string, a ...interface{}) string { return colorString(format, FgBlue, a...) }
 
-// MagentaString is an convenient helper function to return a string with magenta
+// MagentaString is a convenient helper function to return a string with magenta
 // foreground.
 func MagentaString(format string, a ...interface{}) string {
-	return printString(format, FgMagenta, a...)
+	return colorString(format, FgMagenta, a...)
 }
 
-// CyanString is an convenient helper function to return a string with cyan
+// CyanString is a convenient helper function to return a string with cyan
 // foreground.
-func CyanString(format string, a ...interface{}) string { return printString(format, FgCyan, a...) }
+func CyanString(format string, a ...interface{}) string { return colorString(format, FgCyan, a...) }
 
-// WhiteString is an convenient helper function to return a string with white
+// WhiteString is a convenient helper function to return a string with white
 // foreground.
-func WhiteString(format string, a ...interface{}) string { return printString(format, FgWhite, a...) }
+func WhiteString(format string, a ...interface{}) string { return colorString(format, FgWhite, a...) }
+
+// HiBlack is a convenient helper function to print with hi-intensity black foreground. A
+// newline is appended to format by default.
+func HiBlack(format string, a ...interface{}) { colorPrint(format, FgHiBlack, a...) }
+
+// HiRed is a convenient helper function to print with hi-intensity red foreground. A
+// newline is appended to format by default.
+func HiRed(format string, a ...interface{}) { colorPrint(format, FgHiRed, a...) }
+
+// HiGreen is a convenient helper function to print with hi-intensity green foreground. A
+// newline is appended to format by default.
+func HiGreen(format string, a ...interface{}) { colorPrint(format, FgHiGreen, a...) }
+
+// HiYellow is a convenient helper function to print with hi-intensity yellow foreground.
+// A newline is appended to format by default.
+func HiYellow(format string, a ...interface{}) { colorPrint(format, FgHiYellow, a...) }
+
+// HiBlue is a convenient helper function to print with hi-intensity blue foreground. A
+// newline is appended to format by default.
+func HiBlue(format string, a ...interface{}) { colorPrint(format, FgHiBlue, a...) }
+
+// HiMagenta is a convenient helper function to print with hi-intensity magenta foreground.
+// A newline is appended to format by default.
+func HiMagenta(format string, a ...interface{}) { colorPrint(format, FgHiMagenta, a...) }
+
+// HiCyan is a convenient helper function to print with hi-intensity cyan foreground. A
+// newline is appended to format by default.
+func HiCyan(format string, a ...interface{}) { colorPrint(format, FgHiCyan, a...) }
+
+// HiWhite is a convenient helper function to print with hi-intensity white foreground. A
+// newline is appended to format by default.
+func HiWhite(format string, a ...interface{}) { colorPrint(format, FgHiWhite, a...) }
+
+// HiBlackString is a convenient helper function to return a string with hi-intensity black
+// foreground.
+func HiBlackString(format string, a ...interface{}) string {
+	return colorString(format, FgHiBlack, a...)
+}
+
+// HiRedString is a convenient helper function to return a string with hi-intensity red
+// foreground.
+func HiRedString(format string, a ...interface{}) string { return colorString(format, FgHiRed, a...) }
+
+// HiGreenString is a convenient helper function to return a string with hi-intensity green
+// foreground.
+func HiGreenString(format string, a ...interface{}) string {
+	return colorString(format, FgHiGreen, a...)
+}
+
+// HiYellowString is a convenient helper function to return a string with hi-intensity yellow
+// foreground.
+func HiYellowString(format string, a ...interface{}) string {
+	return colorString(format, FgHiYellow, a...)
+}
+
+// HiBlueString is a convenient helper function to return a string with hi-intensity blue
+// foreground.
+func HiBlueString(format string, a ...interface{}) string { return colorString(format, FgHiBlue, a...) }
+
+// HiMagentaString is a convenient helper function to return a string with hi-intensity magenta
+// foreground.
+func HiMagentaString(format string, a ...interface{}) string {
+	return colorString(format, FgHiMagenta, a...)
+}
+
+// HiCyanString is a convenient helper function to return a string with hi-intensity cyan
+// foreground.
+func HiCyanString(format string, a ...interface{}) string { return colorString(format, FgHiCyan, a...) }
+
+// HiWhiteString is a convenient helper function to return a string with hi-intensity white
+// foreground.
+func HiWhiteString(format string, a ...interface{}) string {
+	return colorString(format, FgHiWhite, a...)
+}

--- a/vendor/github.com/fatih/color/doc.go
+++ b/vendor/github.com/fatih/color/doc.go
@@ -15,6 +15,11 @@ Use simple and default helper functions with predefined foreground colors:
     color.Yellow("Yellow color too!")
     color.Magenta("And many others ..")
 
+    // Hi-intensity colors
+    color.HiGreen("Bright green color.")
+    color.HiBlack("Bright black means gray..")
+    color.HiWhite("Shiny white color!")
+
 However there are times where custom color mixes are required. Below are some
 examples to create custom color objects and use the print functions of each
 separate color object.
@@ -37,6 +42,11 @@ separate color object.
     whiteBackground := red.Add(color.BgWhite)
     whiteBackground.Println("Red text with White background.")
 
+    // Use your own io.Writer output
+    color.New(color.FgBlue).Fprintln(myWriter, "blue color!")
+
+    blue := color.New(color.FgBlue)
+    blue.Fprint(myWriter, "This will print text in blue.")
 
 You can create PrintXxx functions to simplify even more:
 
@@ -49,6 +59,15 @@ You can create PrintXxx functions to simplify even more:
     notice := color.New(color.Bold, color.FgGreen).PrintlnFunc()
     notice("don't forget this...")
 
+You can also FprintXxx functions to pass your own io.Writer:
+
+    blue := color.New(FgBlue).FprintfFunc()
+    blue(myWriter, "important notice: %s", stars)
+
+    // Mix up with multiple attributes
+    success := color.New(color.Bold, color.FgGreen).FprintlnFunc()
+    success(myWriter, don't forget this...")
+
 
 Or create SprintXxx functions to mix strings with other non-colorized strings:
 
@@ -60,7 +79,7 @@ Or create SprintXxx functions to mix strings with other non-colorized strings:
     info := New(FgWhite, BgGreen).SprintFunc()
     fmt.Printf("this %s rocks!\n", info("package"))
 
-Windows support is enabled by default. All Print functions works as intended.
+Windows support is enabled by default. All Print functions work as intended.
 However only for color.SprintXXX functions, user should use fmt.FprintXXX and
 set the output to color.Output:
 

--- a/vendor/github.com/mattn/go-colorable/README.md
+++ b/vendor/github.com/mattn/go-colorable/README.md
@@ -1,5 +1,10 @@
 # go-colorable
 
+[![Godoc Reference](https://godoc.org/github.com/mattn/go-colorable?status.svg)](http://godoc.org/github.com/mattn/go-colorable)
+[![Build Status](https://travis-ci.org/mattn/go-colorable.svg?branch=master)](https://travis-ci.org/mattn/go-colorable)
+[![Coverage Status](https://coveralls.io/repos/github/mattn/go-colorable/badge.svg?branch=master)](https://coveralls.io/github/mattn/go-colorable?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/mattn/go-colorable)](https://goreportcard.com/report/mattn/go-colorable)
+
 Colorable writer for windows.
 
 For example, most of logger packages doesn't show colors on windows. (I know we can do it with ansicon. But I don't want.)

--- a/vendor/github.com/mattn/go-colorable/colorable_others.go
+++ b/vendor/github.com/mattn/go-colorable/colorable_others.go
@@ -1,12 +1,16 @@
 // +build !windows
+// +build !appengine
 
 package colorable
 
 import (
 	"io"
 	"os"
+
+	_ "github.com/mattn/go-isatty"
 )
 
+// NewColorable return new instance of Writer which handle escape sequence.
 func NewColorable(file *os.File) io.Writer {
 	if file == nil {
 		panic("nil passed instead of *os.File to NewColorable()")
@@ -15,10 +19,12 @@ func NewColorable(file *os.File) io.Writer {
 	return file
 }
 
+// NewColorableStdout return new instance of Writer which handle escape sequence for stdout.
 func NewColorableStdout() io.Writer {
 	return os.Stdout
 }
 
+// NewColorableStderr return new instance of Writer which handle escape sequence for stderr.
 func NewColorableStderr() io.Writer {
 	return os.Stderr
 }

--- a/vendor/github.com/mattn/go-colorable/colorable_windows.go
+++ b/vendor/github.com/mattn/go-colorable/colorable_windows.go
@@ -1,3 +1,6 @@
+// +build windows
+// +build !appengine
+
 package colorable
 
 import (
@@ -65,15 +68,18 @@ var (
 	procFillConsoleOutputAttribute = kernel32.NewProc("FillConsoleOutputAttribute")
 	procGetConsoleCursorInfo       = kernel32.NewProc("GetConsoleCursorInfo")
 	procSetConsoleCursorInfo       = kernel32.NewProc("SetConsoleCursorInfo")
+	procSetConsoleTitle            = kernel32.NewProc("SetConsoleTitleW")
 )
 
+// Writer provide colorable Writer to the console
 type Writer struct {
 	out     io.Writer
 	handle  syscall.Handle
-	lastbuf bytes.Buffer
 	oldattr word
+	oldpos  coord
 }
 
+// NewColorable return new instance of Writer which handle escape sequence from File.
 func NewColorable(file *os.File) io.Writer {
 	if file == nil {
 		panic("nil passed instead of *os.File to NewColorable()")
@@ -83,16 +89,17 @@ func NewColorable(file *os.File) io.Writer {
 		var csbi consoleScreenBufferInfo
 		handle := syscall.Handle(file.Fd())
 		procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
-		return &Writer{out: file, handle: handle, oldattr: csbi.attributes}
-	} else {
-		return file
+		return &Writer{out: file, handle: handle, oldattr: csbi.attributes, oldpos: coord{0, 0}}
 	}
+	return file
 }
 
+// NewColorableStdout return new instance of Writer which handle escape sequence for stdout.
 func NewColorableStdout() io.Writer {
 	return NewColorable(os.Stdout)
 }
 
+// NewColorableStderr return new instance of Writer which handle escape sequence for stderr.
 func NewColorableStderr() io.Writer {
 	return NewColorable(os.Stderr)
 }
@@ -356,11 +363,51 @@ var color256 = map[int]int{
 	255: 0xeeeeee,
 }
 
+// `\033]0;TITLESTR\007`
+func doTitleSequence(er *bytes.Reader) error {
+	var c byte
+	var err error
+
+	c, err = er.ReadByte()
+	if err != nil {
+		return err
+	}
+	if c != '0' && c != '2' {
+		return nil
+	}
+	c, err = er.ReadByte()
+	if err != nil {
+		return err
+	}
+	if c != ';' {
+		return nil
+	}
+	title := make([]byte, 0, 80)
+	for {
+		c, err = er.ReadByte()
+		if err != nil {
+			return err
+		}
+		if c == 0x07 || c == '\n' {
+			break
+		}
+		title = append(title, c)
+	}
+	if len(title) > 0 {
+		title8, err := syscall.UTF16PtrFromString(string(title))
+		if err == nil {
+			procSetConsoleTitle.Call(uintptr(unsafe.Pointer(title8)))
+		}
+	}
+	return nil
+}
+
+// Write write data on console
 func (w *Writer) Write(data []byte) (n int, err error) {
 	var csbi consoleScreenBufferInfo
 	procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 
-	er := bytes.NewBuffer(data)
+	er := bytes.NewReader(data)
 	var bw [1]byte
 loop:
 	for {
@@ -380,12 +427,16 @@ loop:
 		}
 		c2, err := er.ReadByte()
 		if err != nil {
-			w.lastbuf.WriteByte(c1)
 			break loop
 		}
+
+		if c2 == ']' {
+			if err := doTitleSequence(er); err != nil {
+				break loop
+			}
+			continue
+		}
 		if c2 != 0x5b {
-			w.lastbuf.WriteByte(c1)
-			w.lastbuf.WriteByte(c2)
 			continue
 		}
 
@@ -394,9 +445,6 @@ loop:
 		for {
 			c, err := er.ReadByte()
 			if err != nil {
-				w.lastbuf.WriteByte(c1)
-				w.lastbuf.WriteByte(c2)
-				w.lastbuf.Write(buf.Bytes())
 				break loop
 			}
 			if ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || c == '@' {
@@ -406,14 +454,12 @@ loop:
 			buf.Write([]byte(string(c)))
 		}
 
-		var csbi consoleScreenBufferInfo
 		switch m {
 		case 'A':
 			n, err = strconv.Atoi(buf.String())
 			if err != nil {
 				continue
 			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 			csbi.cursorPosition.y -= short(n)
 			procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'B':
@@ -421,7 +467,6 @@ loop:
 			if err != nil {
 				continue
 			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 			csbi.cursorPosition.y += short(n)
 			procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'C':
@@ -429,7 +474,6 @@ loop:
 			if err != nil {
 				continue
 			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 			csbi.cursorPosition.x -= short(n)
 			procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'D':
@@ -439,7 +483,6 @@ loop:
 			}
 			if n, err = strconv.Atoi(buf.String()); err == nil {
 				var csbi consoleScreenBufferInfo
-				procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 				csbi.cursorPosition.x += short(n)
 				procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 			}
@@ -448,7 +491,6 @@ loop:
 			if err != nil {
 				continue
 			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 			csbi.cursorPosition.x = 0
 			csbi.cursorPosition.y += short(n)
 			procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
@@ -457,7 +499,6 @@ loop:
 			if err != nil {
 				continue
 			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 			csbi.cursorPosition.x = 0
 			csbi.cursorPosition.y -= short(n)
 			procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
@@ -466,50 +507,65 @@ loop:
 			if err != nil {
 				continue
 			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 			csbi.cursorPosition.x = short(n - 1)
 			procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'H':
-			token := strings.Split(buf.String(), ";")
-			if len(token) != 2 {
-				continue
+			if buf.Len() > 0 {
+				token := strings.Split(buf.String(), ";")
+				switch len(token) {
+				case 1:
+					n1, err := strconv.Atoi(token[0])
+					if err != nil {
+						continue
+					}
+					csbi.cursorPosition.y = short(n1 - 1)
+				case 2:
+					n1, err := strconv.Atoi(token[0])
+					if err != nil {
+						continue
+					}
+					n2, err := strconv.Atoi(token[1])
+					if err != nil {
+						continue
+					}
+					csbi.cursorPosition.x = short(n2 - 1)
+					csbi.cursorPosition.y = short(n1 - 1)
+				}
+			} else {
+				csbi.cursorPosition.y = 0
 			}
-			n1, err := strconv.Atoi(token[0])
-			if err != nil {
-				continue
-			}
-			n2, err := strconv.Atoi(token[1])
-			if err != nil {
-				continue
-			}
-			csbi.cursorPosition.x = short(n2 - 1)
-			csbi.cursorPosition.y = short(n1 - 1)
 			procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'J':
-			n, err := strconv.Atoi(buf.String())
-			if err != nil {
-				continue
+			n := 0
+			if buf.Len() > 0 {
+				n, err = strconv.Atoi(buf.String())
+				if err != nil {
+					continue
+				}
 			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
+			var count, written dword
 			var cursor coord
 			switch n {
 			case 0:
 				cursor = coord{x: csbi.cursorPosition.x, y: csbi.cursorPosition.y}
+				count = dword(csbi.size.x - csbi.cursorPosition.x + (csbi.size.y-csbi.cursorPosition.y)*csbi.size.x)
 			case 1:
 				cursor = coord{x: csbi.window.left, y: csbi.window.top}
+				count = dword(csbi.size.x - csbi.cursorPosition.x + (csbi.window.top-csbi.cursorPosition.y)*csbi.size.x)
 			case 2:
 				cursor = coord{x: csbi.window.left, y: csbi.window.top}
+				count = dword(csbi.size.x - csbi.cursorPosition.x + (csbi.size.y-csbi.cursorPosition.y)*csbi.size.x)
 			}
-			var count, written dword
-			count = dword(csbi.size.x - csbi.cursorPosition.x + (csbi.size.y-csbi.cursorPosition.y)*csbi.size.x)
 			procFillConsoleOutputCharacter.Call(uintptr(w.handle), uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 			procFillConsoleOutputAttribute.Call(uintptr(w.handle), uintptr(csbi.attributes), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 		case 'K':
-			n, err := strconv.Atoi(buf.String())
-			if err != nil {
-				continue
+			n := 0
+			if buf.Len() > 0 {
+				n, err = strconv.Atoi(buf.String())
+				if err != nil {
+					continue
+				}
 			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 			var cursor coord
 			switch n {
 			case 0:
@@ -524,7 +580,6 @@ loop:
 			procFillConsoleOutputCharacter.Call(uintptr(w.handle), uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 			procFillConsoleOutputAttribute.Call(uintptr(w.handle), uintptr(csbi.attributes), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 		case 'm':
-			procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
 			attr := csbi.attributes
 			cs := buf.String()
 			if cs == "" {
@@ -542,7 +597,7 @@ loop:
 						attr |= foregroundIntensity
 					case n == 7:
 						attr = ((attr & foregroundMask) << 4) | ((attr & backgroundMask) >> 4)
-					case 22 == n || n == 25 || n == 25:
+					case n == 22 || n == 25:
 						attr |= foregroundIntensity
 					case n == 27:
 						attr = ((attr & foregroundMask) << 4) | ((attr & backgroundMask) >> 4)
@@ -644,9 +699,14 @@ loop:
 				ci.visible = 0
 				procSetConsoleCursorInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&ci)))
 			}
+		case 's':
+			w.oldpos = csbi.cursorPosition
+		case 'u':
+			procSetConsoleCursorPosition.Call(uintptr(w.handle), *(*uintptr)(unsafe.Pointer(&w.oldpos)))
 		}
 	}
-	return len(data) - w.lastbuf.Len(), nil
+
+	return len(data), nil
 }
 
 type consoleColor struct {
@@ -690,22 +750,22 @@ func (c consoleColor) backgroundAttr() (attr word) {
 }
 
 var color16 = []consoleColor{
-	consoleColor{0x000000, false, false, false, false},
-	consoleColor{0x000080, false, false, true, false},
-	consoleColor{0x008000, false, true, false, false},
-	consoleColor{0x008080, false, true, true, false},
-	consoleColor{0x800000, true, false, false, false},
-	consoleColor{0x800080, true, false, true, false},
-	consoleColor{0x808000, true, true, false, false},
-	consoleColor{0xc0c0c0, true, true, true, false},
-	consoleColor{0x808080, false, false, false, true},
-	consoleColor{0x0000ff, false, false, true, true},
-	consoleColor{0x00ff00, false, true, false, true},
-	consoleColor{0x00ffff, false, true, true, true},
-	consoleColor{0xff0000, true, false, false, true},
-	consoleColor{0xff00ff, true, false, true, true},
-	consoleColor{0xffff00, true, true, false, true},
-	consoleColor{0xffffff, true, true, true, true},
+	{0x000000, false, false, false, false},
+	{0x000080, false, false, true, false},
+	{0x008000, false, true, false, false},
+	{0x008080, false, true, true, false},
+	{0x800000, true, false, false, false},
+	{0x800080, true, false, true, false},
+	{0x808000, true, true, false, false},
+	{0xc0c0c0, true, true, true, false},
+	{0x808080, false, false, false, true},
+	{0x0000ff, false, false, true, true},
+	{0x00ff00, false, true, false, true},
+	{0x00ffff, false, true, true, true},
+	{0xff0000, true, false, false, true},
+	{0xff00ff, true, false, true, true},
+	{0xffff00, true, true, false, true},
+	{0xffffff, true, true, true, true},
 }
 
 type hsv struct {

--- a/vendor/github.com/mattn/go-colorable/noncolorable.go
+++ b/vendor/github.com/mattn/go-colorable/noncolorable.go
@@ -5,15 +5,17 @@ import (
 	"io"
 )
 
+// NonColorable hold writer but remove escape sequence.
 type NonColorable struct {
-	out     io.Writer
-	lastbuf bytes.Buffer
+	out io.Writer
 }
 
+// NewNonColorable return new instance of Writer which remove escape sequence from Writer.
 func NewNonColorable(w io.Writer) io.Writer {
 	return &NonColorable{out: w}
 }
 
+// Write write data on console
 func (w *NonColorable) Write(data []byte) (n int, err error) {
 	er := bytes.NewReader(data)
 	var bw [1]byte
@@ -30,12 +32,9 @@ loop:
 		}
 		c2, err := er.ReadByte()
 		if err != nil {
-			w.lastbuf.WriteByte(c1)
 			break loop
 		}
 		if c2 != 0x5b {
-			w.lastbuf.WriteByte(c1)
-			w.lastbuf.WriteByte(c2)
 			continue
 		}
 
@@ -43,9 +42,6 @@ loop:
 		for {
 			c, err := er.ReadByte()
 			if err != nil {
-				w.lastbuf.WriteByte(c1)
-				w.lastbuf.WriteByte(c2)
-				w.lastbuf.Write(buf.Bytes())
 				break loop
 			}
 			if ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || c == '@' {
@@ -54,5 +50,6 @@ loop:
 			buf.Write([]byte(string(c)))
 		}
 	}
-	return len(data) - w.lastbuf.Len(), nil
+
+	return len(data), nil
 }

--- a/vendor/github.com/mattn/go-isatty/README.md
+++ b/vendor/github.com/mattn/go-isatty/README.md
@@ -1,5 +1,10 @@
 # go-isatty
 
+[![Godoc Reference](https://godoc.org/github.com/mattn/go-isatty?status.svg)](http://godoc.org/github.com/mattn/go-isatty)
+[![Build Status](https://travis-ci.org/mattn/go-isatty.svg?branch=master)](https://travis-ci.org/mattn/go-isatty)
+[![Coverage Status](https://coveralls.io/repos/github/mattn/go-isatty/badge.svg?branch=master)](https://coveralls.io/github/mattn/go-isatty?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/mattn/go-isatty)](https://goreportcard.com/report/mattn/go-isatty)
+
 isatty for golang
 
 ## Usage
@@ -16,6 +21,8 @@ import (
 func main() {
 	if isatty.IsTerminal(os.Stdout.Fd()) {
 		fmt.Println("Is Terminal")
+	} else if isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Cygwin/MSYS2 Terminal")
 	} else {
 		fmt.Println("Is Not Terminal")
 	}
@@ -28,10 +35,16 @@ func main() {
 $ go get github.com/mattn/go-isatty
 ```
 
-# License
+## License
 
 MIT
 
-# Author
+## Author
 
 Yasuhiro Matsumoto (a.k.a mattn)
+
+## Thanks
+
+* k-takata: base idea for IsCygwinTerminal
+
+    https://github.com/k-takata/go-iscygpty

--- a/vendor/github.com/mattn/go-isatty/isatty_appengine.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_appengine.go
@@ -1,9 +1,0 @@
-// +build appengine
-
-package isatty
-
-// IsTerminal returns true if the file descriptor is terminal which
-// is always false on on appengine classic which is a sandboxed PaaS.
-func IsTerminal(fd uintptr) bool {
-	return false
-}

--- a/vendor/github.com/mattn/go-isatty/isatty_others.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_others.go
@@ -1,0 +1,10 @@
+// +build !windows
+// +build !appengine
+
+package isatty
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal. This is also always false on this environment.
+func IsCygwinTerminal(fd uintptr) bool {
+	return false
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_windows.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_windows.go
@@ -4,16 +4,91 @@
 package isatty
 
 import (
+	"strings"
 	"syscall"
+	"unicode/utf16"
 	"unsafe"
 )
 
-var kernel32 = syscall.NewLazyDLL("kernel32.dll")
-var procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+const (
+	fileNameInfo uintptr = 2
+	fileTypePipe         = 3
+)
+
+var (
+	kernel32                         = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleMode               = kernel32.NewProc("GetConsoleMode")
+	procGetFileInformationByHandleEx = kernel32.NewProc("GetFileInformationByHandleEx")
+	procGetFileType                  = kernel32.NewProc("GetFileType")
+)
+
+func init() {
+	// Check if GetFileInformationByHandleEx is available.
+	if procGetFileInformationByHandleEx.Find() != nil {
+		procGetFileInformationByHandleEx = nil
+	}
+}
 
 // IsTerminal return true if the file descriptor is terminal.
 func IsTerminal(fd uintptr) bool {
 	var st uint32
 	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
 	return r != 0 && e == 0
+}
+
+// Check pipe name is used for cygwin/msys2 pty.
+// Cygwin/MSYS2 PTY has a name like:
+//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
+func isCygwinPipeName(name string) bool {
+	token := strings.Split(name, "-")
+	if len(token) < 5 {
+		return false
+	}
+
+	if token[0] != `\msys` && token[0] != `\cygwin` {
+		return false
+	}
+
+	if token[1] == "" {
+		return false
+	}
+
+	if !strings.HasPrefix(token[2], "pty") {
+		return false
+	}
+
+	if token[3] != `from` && token[3] != `to` {
+		return false
+	}
+
+	if token[4] != "master" {
+		return false
+	}
+
+	return true
+}
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal.
+func IsCygwinTerminal(fd uintptr) bool {
+	if procGetFileInformationByHandleEx == nil {
+		return false
+	}
+
+	// Cygwin/msys's pty is a pipe.
+	ft, _, e := syscall.Syscall(procGetFileType.Addr(), 1, fd, 0, 0)
+	if ft != fileTypePipe || e != 0 {
+		return false
+	}
+
+	var buf [2 + syscall.MAX_PATH]uint16
+	r, _, e := syscall.Syscall6(procGetFileInformationByHandleEx.Addr(),
+		4, fd, fileNameInfo, uintptr(unsafe.Pointer(&buf)),
+		uintptr(len(buf)*2), 0, 0)
+	if r == 0 || e != 0 {
+		return false
+	}
+
+	l := *(*uint32)(unsafe.Pointer(&buf))
+	return isCygwinPipeName(string(utf16.Decode(buf[2 : 2+l/2])))
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -146,10 +146,10 @@
 			"revisionTime": "2016-09-08T21:06:52Z"
 		},
 		{
-			"checksumSHA1": "Yn+Uxp0Vz4WiGdrYLLwYX9lzD5I=",
+			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
 			"path": "github.com/fatih/color",
-			"revision": "a360acfe359f146180cfc1c6ea6f4397f5c133ec",
-			"revisionTime": "2016-10-18T20:13:48Z"
+			"revision": "62e9147c64a1ed519147b62a56a14e83e2be02c1",
+			"revisionTime": "2017-05-23T20:24:04Z"
 		},
 		{
 			"checksumSHA1": "xgjI2W3RGiQwNlxsOW2V9fJ9kaM=",
@@ -250,16 +250,16 @@
 			"revisionTime": "2016-09-08T09:36:58Z"
 		},
 		{
-			"checksumSHA1": "gJboNyPEI24yIOSsC+JpOqiN58k=",
+			"checksumSHA1": "rpfgyHCv2iDx1iCofI+kYPGGV/Q=",
 			"path": "github.com/mattn/go-colorable",
-			"revision": "5da554b8d30ea210af19ee14a058919661bf0d04",
-			"revisionTime": "2016-09-29T15:33:04Z"
+			"revision": "941b50ebc6efddf4c41c8e4537a5f68a4e686b24",
+			"revisionTime": "2017-06-15T03:49:14Z"
 		},
 		{
-			"checksumSHA1": "xZuhljnmBysJPta/lMyYmJdujCg=",
+			"checksumSHA1": "trzmsZQDCc13zk/6qANox7Z/KCg=",
 			"path": "github.com/mattn/go-isatty",
-			"revision": "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8",
-			"revisionTime": "2016-08-06T12:27:52Z"
+			"revision": "fc9e8d8ef48496124e79ae0df75490096eccf6fe",
+			"revisionTime": "2017-03-22T23:44:13Z"
 		},
 		{
 			"checksumSHA1": "DdH3xAkzAWJ4B/LGYJyCeRsly2I=",


### PR DESCRIPTION
## The Problem:

A good theory was to upgrade fatih/color to see if colors would be reported on Windows. This PR does that (and has to update related as well).

Unfortunately this does not seem to solve the problem. (Note that govendor fetch had to be coaxed along, so there may be missing dependencies still)

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP: #363 - ddev (especially ddev list) doesn't current show colors, shows raw terminal strings instead.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

