### PR TITLE
Remove documentation badge until builds report correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) [![Go Report Card](https://goreportcard.com/badge/github.com/drud/ddev)](https://goreportcard.com/report/github.com/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2017.svg) [![Documentation Status](https://readthedocs.org/projects/ddev/badge/?version=latest)](http://ddev.readthedocs.io/en/latest/?badge=latest)
+[![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) [![Go Report Card](https://goreportcard.com/badge/github.com/drud/ddev)](https://goreportcard.com/report/github.com/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2017.svg)
 
 # ddev
 


### PR DESCRIPTION
## The Problem:
Docs builds have been reporting as  failing for a long time. We don't believe this is our fault and have filed an upstream issue. Unfortunately, thus far the maintainers of readthedocs have not been very responsive on the issue.
 
## The Fix:
If a failing docs badge is our "new normal", let's just remove it until the reporting gets fixed.

## Related issues
https://github.com/rtfd/readthedocs.org/issues/2985#issuecomment-313798290