### PR TITLE
updates and fixes for performance test

### DIFF
--- a/testing/ddev-perf-test.sh
+++ b/testing/ddev-perf-test.sh
@@ -6,10 +6,7 @@ YELLOW=$(tput setaf 3)
 RESET=$(tput sgr0)
 
 TIMECMD=gtime
-if [ $(which $TIMECMD) = "" ]; then
-  echo "please install gnu time with \"brew install gnu-time\"."
-  exit 1
-fi
+command -v $TIMECMD >/dev/null 2>&1 || { echo >&2 "please install gnu time with \"brew install gnu-time\"."; exit 1; }
 TIMEFMT='-f %e'
 TIMEIT="$TIMECMD $TIMEFMT -o time.out"
 CURLIT='curl  -o /dev/null --fail -sfL -w %{time_total}'
@@ -41,7 +38,7 @@ for ((i=0; i<${#sites[@]}; ++i)); do
 
 
 	if [ ! -d "$site" ] ; then
-		drush dl -y ${downloads[$i]} --drupal-project-rename=$site >>$log 2>&1
+		drush dl -y ${downloads[$i]} --drupal-project-rename=$site > /dev/null 2>&1
 	fi
 
 	PROFILE=standard
@@ -80,7 +77,7 @@ END
 	fi
 
 	# drush si - if it fails we continue to next site.
-	$TIMEIT ddev exec drush si $PROFILE -y --db-url=mysql://root:root@db/data >>$log 2>&1 || (echo "Failed drush si" && continue)
+	$TIMEIT ddev exec drush si $PROFILE -y --db-url=mysql://db:db@db/db >>$log 2>&1 || (echo "Failed drush si" && continue)
     echo "${BLUE}$site: drush site-install: $(cat time.out) ${RESET}"
 
     elapsed=$($CURLIT -fL $base_url)


### PR DESCRIPTION
## The Problem:
I hit a couple snags with the performance test script when looking to test drud/docker.mysql-local#26. This provides fixes to get it working as expected.

## The Fix:
- The check for "gtime" did not catch that I did not have gnu-time installed. Apparently `which` can differ quite a bit in behavior across different platforms https://stackoverflow.com/a/677212. Replaced with an approach using `command` that seems to work as expected.
- drush dl output was being redirected to a not-yet-existent file, which prevented the site from downloading as expected. It is now outputting to /dev/null, as I didn't see a reason to log the drupal download output.
- drush si credentials needed to be updated since we changed all values to "db"

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

