### PR TITLE
check hosts file before checking non-interactive/no sudo, fixes #259

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -795,17 +795,17 @@ func (l *LocalApp) AddHostsEntry() error {
 		dockerIP = dockerHostURL.Hostname()
 	}
 
-	_, err := osexec.Command("sudo", "-h").Output()
-	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
-		fmt.Printf("You must manually add the following entry to your host file:\n%s %s\n", dockerIP, l.HostName())
-		return nil
-	}
-
 	hosts, err := goodhosts.NewHosts()
 	if err != nil {
 		log.Fatalf("could not open hostfile. %s", err)
 	}
 	if hosts.Has(dockerIP, l.HostName()) {
+		return nil
+	}
+
+	_, err = osexec.Command("sudo", "-h").Output()
+	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
+		fmt.Printf("You must manually add the following entry to your host file:\n%s %s\n", dockerIP, l.HostName())
 		return nil
 	}
 


### PR DESCRIPTION
## The Problem:
#259 OP. On Windows, you will get notification to manually add hosts entry even if the hosts entry is in place.

## The Fix:
This is due to our check for non-interactive env var and for sudo occurring before we check the hosts entries. This changes to check the hosts file before we try to check for non-interactive or sudo.

I was really hoping to find a solution for privilege escalation, but unfortunately I couldn't quite get something working. The closest I got was providing a manifest file for Windows using https://github.com/akavel/rsrc to embed in the binary. This successfully triggers a UAC prompt from the command line, but I couldn't determine how to make it happen for only a sub command, such as ddev hostname. It would trigger for every command, including ddev with no args or ddev -h, and on every command. If we could get this working for just a sub-command, it seems like it would achieve what we're after.

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
<assemblyIdentity
    version="9.0.0.0"
    processorArchitecture="x86"
    name="ddev.exe"
    type="win32"
/>
<description>ddev</description>
<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
    <security>
        <requestedPrivileges>
            <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
        </requestedPrivileges>
    </security>
</trustInfo>
</assembly>
```

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

