### PR TITLE
Fix TestDescribe for Windows

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -16,8 +16,8 @@ func TestDescribeBadArgs(t *testing.T) {
 
 	// Create a temporary directory and switch to it for the duration of this test.
 	tmpdir := testcommon.CreateTmpDir("badargs")
-	defer testcommon.Chdir(tmpdir)()
 	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
 
 	// Ensure it fails if we run the vanilla describe outside of an application root.
 	args := []string{"describe"}
@@ -108,8 +108,8 @@ func TestDescribeAppUsingSitename(t *testing.T) {
 
 	// Create a temporary directory and switch to it for the duration of this test.
 	tmpdir := testcommon.CreateTmpDir("describeAppUsingSitename")
-	defer testcommon.Chdir(tmpdir)()
 	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
 
 	for _, v := range DevTestSites {
 		out, err := describeApp(v.Name)
@@ -125,8 +125,8 @@ func TestDescribeAppWithInvalidParams(t *testing.T) {
 
 	// Create a temporary directory and switch to it for the duration of this test.
 	tmpdir := testcommon.CreateTmpDir("TestDescribeAppWithInvalidParams")
-	defer testcommon.Chdir(tmpdir)()
 	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
 
 	// Ensure describeApp fails from an invalid working directory.
 	_, err := describeApp("")

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -87,7 +87,7 @@ func TestDescribeAppFunction(t *testing.T) {
 		assert.Contains(string(out), app.URL())
 		assert.Contains(string(out), app.GetName())
 		assert.Regexp("DDEV ROUTER STATUS.*running", string(out))
-		assert.Contains(string(out), v.Dir)
+		assert.Contains(string(out), platform.RenderHomeRootedDir(v.Dir))
 
 		_, err = exec.RunCommand("docker", []string{"stop", "ddev-router"})
 		assert.NoError(err)
@@ -115,7 +115,7 @@ func TestDescribeAppUsingSitename(t *testing.T) {
 		out, err := describeApp(v.Name)
 		assert.NoError(err)
 		assert.Contains(string(out), "running")
-		assert.Contains(string(out), v.Dir)
+		assert.Contains(string(out), platform.RenderHomeRootedDir(v.Dir))
 	}
 }
 

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
-	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -87,15 +86,14 @@ func TestDescribeAppFunction(t *testing.T) {
 		assert.NoError(err)
 		assert.Contains(string(out), app.URL())
 		assert.Contains(string(out), app.GetName())
-		assert.Contains(string(out), "running")
+		assert.Regexp("DDEV ROUTER STATUS.*running", string(out))
 		assert.Contains(string(out), v.Dir)
-		assert.Contains(string(out), "DDEV ROUTER STATUS: "+color.CyanString("running"))
 
 		_, err = exec.RunCommand("docker", []string{"stop", "ddev-router"})
 		assert.NoError(err)
 		out, err = describeApp("")
 		assert.NoError(err)
-		assert.Contains(string(out), "DDEV ROUTER STATUS: "+color.RedString("stopped"))
+		assert.Regexp("DDEV ROUTER STATUS.*stopped", string(out))
 		assert.Contains(string(out), "The router is not currently running")
 		_, err = exec.RunCommand("docker", []string{"start", "ddev-router"})
 		assert.NoError(err)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -23,7 +23,7 @@ func TestDevList(t *testing.T) {
 		assert.Contains(string(out), v.Name)
 		assert.Contains(string(out), app.URL())
 		assert.Contains(string(out), app.GetType())
-		assert.Contains(string(out), app.AppRoot())
+		assert.Contains(string(out), platform.RenderHomeRootedDir(app.AppRoot()))
 		cleanup()
 	}
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -54,6 +54,9 @@ func TestMain(m *testing.M) {
 	testRun := m.Run()
 
 	removeSites()
+
+	// Avoid being in any of the directories we're cleaning up.
+	_ = os.Chdir(os.TempDir())
 	for i := range DevTestSites {
 		DevTestSites[i].Cleanup()
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -78,14 +78,18 @@ func CreateAppTable() *uitable.Table {
 	return table
 }
 
+// RenderHomeRootedDir shortens a directory name to replace homedir with ~
+func RenderHomeRootedDir(path string) string {
+	userDir, err := homedir.Dir()
+	util.CheckErr(err)
+	result := strings.Replace(path, userDir, "~", 1)
+	result = strings.Replace(result, "\\", "/", -1)
+	return result
+}
+
 // RenderAppRow will add an application row to an existing table for describe and list output.
 func RenderAppRow(table *uitable.Table, site App) {
-	// test tilde expansion
-	appRoot := site.AppRoot()
-	userDir, err := homedir.Dir()
-	if err == nil {
-		appRoot = strings.Replace(appRoot, userDir, "~", 1)
-	}
+	shortRoot := RenderHomeRootedDir(site.AppRoot())
 	status := site.SiteStatus()
 
 	switch {
@@ -100,7 +104,7 @@ func RenderAppRow(table *uitable.Table, site App) {
 	table.AddRow(
 		site.GetName(),
 		site.GetType(),
-		appRoot,
+		shortRoot,
 		site.URL(),
 		status,
 	)


### PR DESCRIPTION
## The Problem:

TestDescribe and friends had minor problems that caused failures on Windows.

## The Fix:

* Fixes the ~/ format in ddev list/ddev describe so it looks the same on windows/linux/mac
* Fix various problems with order of directory deletion

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

