### PR TITLE
Swap testsites to do wordpress on short/default for windows performance

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -38,7 +38,7 @@ func TestDevLogs(t *testing.T) {
 		cleanup := v.Chdir()
 
 		confByte := []byte("<?php trigger_error(\"Fatal error\", E_USER_ERROR);")
-		err := ioutil.WriteFile(filepath.Join(v.Dir, "docroot", "index.php"), confByte, 0644)
+		err := ioutil.WriteFile(filepath.Join(v.Dir, v.DocrootBase, "index.php"), confByte, 0644)
 		assert.NoError(err)
 
 		o := util.NewHTTPOptions("http://127.0.0.1/index.php")

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -20,14 +20,13 @@ import (
 var (
 	// DdevBin is the full path to the drud binary
 	DdevBin      = "ddev"
-	DevTestSites = []testcommon.TestSite{
-		{
-			Name:                          "TestMainCmdDrupal8",
-			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
-			ArchiveInternalExtractionPath: "drupal8-0.6.0/",
-			FilesTarballURL:               "https://github.com/drud/drupal8/releases/download/v0.6.0/files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
-		},
+	DevTestSites = []testcommon.TestSite{{
+		Name:                          "TestMainCmdWordpress",
+		SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+		ArchiveInternalExtractionPath: "wordpress-0.4.0/",
+		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+	},
 	}
 )
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -27,6 +27,7 @@ var (
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		HttpProbeURI:                  "wp-admin/setup-config.php",
+		DocrootBase:                   "htdocs",
 	},
 	}
 )

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -26,7 +26,7 @@ var (
 		ArchiveInternalExtractionPath: "wordpress-0.4.0/",
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
-		HttpProbeURI:                  "wp-admin/setup-config.php",
+		HTTPProbeURI:                  "wp-admin/setup-config.php",
 		DocrootBase:                   "htdocs",
 	},
 	}
@@ -140,7 +140,7 @@ func addSites() {
 
 		// Warning: assumes web at port 80, will need adjustment in the future.
 		urls := []string{
-			"http://127.0.0.1/" + site.HttpProbeURI,
+			"http://127.0.0.1/" + site.HTTPProbeURI,
 			"http://127.0.0.1:" + appports.GetPort("mailhog"),
 			"http://127.0.0.1:" + appports.GetPort("dba"),
 		}

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -26,6 +26,7 @@ var (
 		ArchiveInternalExtractionPath: "wordpress-0.4.0/",
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+		HttpProbeURI:                  "wp-admin/setup-config.php",
 	},
 	}
 )
@@ -136,8 +137,9 @@ func addSites() {
 			log.Fatalln("Could not find an active ddev configuration:", err)
 		}
 
+		// Warning: assumes web at port 80, will need adjustment in the future.
 		urls := []string{
-			"http://127.0.0.1/core/install.php",
+			"http://127.0.0.1/" + site.HttpProbeURI,
 			"http://127.0.0.1:" + appports.GetPort("mailhog"),
 			"http://127.0.0.1:" + appports.GetPort("dba"),
 		}

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -25,6 +25,13 @@ import (
 var (
 	TestSites = []testcommon.TestSite{
 		{
+			Name:                          "TestMainPkgWordpress",
+			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
+			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+		},
+		{
 			Name:                          "TestMainPkgDrupal8",
 			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
 			ArchiveInternalExtractionPath: "drupal8-0.6.0/",
@@ -33,13 +40,6 @@ var (
 			DBTarURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 			DBZipURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.zip",
 			FullSiteTarballURL:            "https://github.com/drud/drupal8/releases/download/v0.6.0/site.tar.gz",
-		},
-		{
-			Name:                          "TestMainPkgWordpress",
-			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
-			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		},
 		{
 			Name:                          "TestMainPkgDrupalKickstart",

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -10,6 +10,8 @@ import (
 
 	"strings"
 
+	"runtime"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -19,7 +21,6 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
-	"runtime"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
 			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+			DocrootBase:                   "htdocs",
 		},
 		{
 			Name:                          "TestMainPkgDrupal8",
@@ -40,6 +42,7 @@ var (
 			DBTarURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 			DBZipURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.zip",
 			FullSiteTarballURL:            "https://github.com/drud/drupal8/releases/download/v0.6.0/site.tar.gz",
+			DocrootBase:                   "docroot",
 		},
 		{
 			Name:                          "TestMainPkgDrupalKickstart",
@@ -48,6 +51,7 @@ var (
 			FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
 			FullSiteTarballURL:            "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/site.tar.gz",
+			DocrootBase:                   "docroot",
 		},
 	}
 )

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -44,6 +44,8 @@ type TestSite struct {
 	Dir string
 	// HttpProbeURI is the URI that can be probed to look for a working web container
 	HttpProbeURI string
+	// DocrootBase is the subdirectory witin the site that is the root/index.php
+	DocrootBase string
 }
 
 // Prepare downloads and extracts a site codebase to a temporary directory.

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -42,8 +42,8 @@ type TestSite struct {
 	DBZipURL string
 	// Dir is the rooted full path of the test site
 	Dir string
-	// HttpProbeURI is the URI that can be probed to look for a working web container
-	HttpProbeURI string
+	// HTTPProbeURI is the URI that can be probed to look for a working web container
+	HTTPProbeURI string
 	// DocrootBase is the subdirectory witin the site that is the root/index.php
 	DocrootBase string
 }

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -42,6 +42,8 @@ type TestSite struct {
 	DBZipURL string
 	// Dir is the rooted full path of the test site
 	Dir string
+	// HttpProbeURI is the URI that can be probed to look for a working web container
+	HttpProbeURI string
 }
 
 // Prepare downloads and extracts a site codebase to a temporary directory.

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -84,6 +84,7 @@ func TestValidTestSite(t *testing.T) {
 		ArchiveInternalExtractionPath: "wordpress-0.4.0/",
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+		DocrootBase:                   "htdocs",
 	}
 
 	// Create a testsite and ensure the prepare() method extracts files into a temporary directory.
@@ -93,8 +94,7 @@ func TestValidTestSite(t *testing.T) {
 		t.FailNow()
 	}
 	assert.NotNil(ts.Dir, "Directory is set.")
-	// Our wordpress setup site has an 'htdocs' dir, not 'docroot'
-	docroot := filepath.Join(ts.Dir, "htdocs")
+	docroot := filepath.Join(ts.Dir, ts.DocrootBase)
 	dirStat, err := os.Stat(docroot)
 	assert.NoError(err, "Docroot exists after prepare()")
 	if err != nil {

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -79,9 +79,11 @@ func TestValidTestSite(t *testing.T) {
 	// of the archive for this test, only that it exists and can be extracted. This should (knock on wood)
 	//not need to be updated over time.
 	ts := TestSite{
-		Name:                          "TestValidTestSiteDrupal8",
-		SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
-		ArchiveInternalExtractionPath: "drupal8-0.6.0/",
+		Name:                          "TestValidTestSiteWordpress",
+		SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+		ArchiveInternalExtractionPath: "wordpress-0.4.0/",
+		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 	}
 
 	// Create a testsite and ensure the prepare() method extracts files into a temporary directory.

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -93,9 +93,13 @@ func TestValidTestSite(t *testing.T) {
 		t.FailNow()
 	}
 	assert.NotNil(ts.Dir, "Directory is set.")
-	docroot := filepath.Join(ts.Dir, "docroot")
+	// Our wordpress setup site has an 'htdocs' dir, not 'docroot'
+	docroot := filepath.Join(ts.Dir, "htdocs")
 	dirStat, err := os.Stat(docroot)
 	assert.NoError(err, "Docroot exists after prepare()")
+	if err != nil {
+		t.Fatalf("Directory did not exist after prepare(): %s", docroot)
+	}
 	assert.True(dirStat.IsDir(), "Docroot is a directory")
 
 	cleanup := ts.Chdir()


### PR DESCRIPTION
## The Problem:

Windows directory-copy performance is totally amazing, taking 5:40 to copy the Drupal8 test site for tests on an SSD-backed filesystem. This is true even with Microsoft's native xcopy.

## The Fix:

Skip copying the biggest directories by default (for local dev, and short tests) by using the Wordpress tarball (10% of the files, 1400 vs 14000). 

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

