### PR TITLE
Colorize 'you must add to hosts' warning

### DIFF
--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -875,7 +875,7 @@ func (l *LocalApp) AddHostsEntry() error {
 
 	_, err := osexec.Command("sudo", "-h").Output()
 	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
-		util.Warning(fmt.Sprintf("You must manually add the following entry to your hosts file:\n%s %s", dockerIP, l.HostName()))
+		util.Warning("You must manually add the following entry to your hosts file:\n%s %s", dockerIP, l.HostName())
 		return nil
 	}
 

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -873,6 +873,12 @@ func (l *LocalApp) AddHostsEntry() error {
 		dockerIP = dockerHostURL.Hostname()
 	}
 
+	_, err := osexec.Command("sudo", "-h").Output()
+	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
+		util.Warning(fmt.Sprintf("You must manually add the following entry to your hosts file:\n%s %s", dockerIP, l.HostName()))
+		return nil
+	}
+
 	hosts, err := goodhosts.NewHosts()
 	if err != nil {
 		log.Fatalf("could not open hostfile. %s", err)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -872,13 +872,6 @@ func (l *LocalApp) AddHostsEntry() error {
 		}
 		dockerIP = dockerHostURL.Hostname()
 	}
-
-	_, err := osexec.Command("sudo", "-h").Output()
-	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
-		util.Warning("You must manually add the following entry to your hosts file:\n%s %s", dockerIP, l.HostName())
-		return nil
-	}
-
 	hosts, err := goodhosts.NewHosts()
 	if err != nil {
 		log.Fatalf("could not open hostfile. %s", err)
@@ -889,7 +882,7 @@ func (l *LocalApp) AddHostsEntry() error {
 
 	_, err = osexec.Command("sudo", "-h").Output()
 	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
-		fmt.Printf("You must manually add the following entry to your host file:\n%s %s\n", dockerIP, l.HostName())
+		util.Warning("You must manually add the following entry to your hosts file:\n%s %s", dockerIP, l.HostName())
 		return nil
 	}
 


### PR DESCRIPTION
## The Problem:

The sudo warning was not very good, lost in the midst of a bunch of other text.

## The Fix:

Colorize it with util.Warning()

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

