### PR TITLE
Fix broken Makefile for testcmd in OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,15 +61,15 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 BUILD_ARCH = $(shell go env GOARCH)
 ifeq ($(BUILD_OS),linux)
-    DDEV_BINARY_FULLPATH=$(shell pwd)/bin/$(BUILD_OS)/ddev
+    DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/ddev
 endif
 
 ifeq ($(BUILD_OS),windows)
-    DDEV_BINARY_FULLPATH=$(shell pwd)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev.exe
+    DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev.exe
 endif
 
-ifeq ($BUILD_OS),darwin)
-    DDEV_BINARY_FULLPATH=$(shell pwd)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev
+ifeq ($(BUILD_OS),darwin)
+    DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev
 endif
 
 


### PR DESCRIPTION
## The Problem:

I noticed that I recently broke the testcmd build for OSX with a Makefile typo. `make testcmd` has *not* been guaranteed to use the right built ddev on OSX since that point, which is not good. It affects local testing most. But of course it broke my experiment with local CI.

## The Fix:

Use the correct parens when building DDEV_BINARY_FULLPATH for darwin.
It also uses the easier shorthand $(PWD) which is now available from build_tools

## The Test:

`make testcmd` and verify that DDEV_BINARY_FULLPATH is correctly set, and that the tests report using a ddev with the correct full path.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

