### PR TITLE
Experimental: Create CI for windows and darwin using surf, fixes #254

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,9 @@
+@echo "Building using bash and build.sh"
+"C:\Program Files\git\bin\bash" build.sh
+
+if %ERRORLEVEL% EQU 0 (
+   @echo Successful build
+) else (
+   @echo Failure Reason Given is %errorlevel%
+   exit /b %errorlevel%
+)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script is used to build drud/ddev using surf 
+# (https://github.com/surf-build/surf)
+
+# Manufacture a $GOPATH environment that can mount on docker (when surf build)
+if [ ! -z "$SURF_REF" ]; then
+	BUILD=$(date "+%Y%m%d%H%M%S")
+	export GOPATH=~/tmp/ddevbuild_$BUILD
+	DRUDSRC=$GOPATH/src/github.com/drud
+	mkdir -p $DRUDSRC
+	ln -s $PWD $DRUDSRC/ddev
+	cd $DRUDSRC/ddev
+	echo "Surf building on $(hostname) for OS=$(go env GOOS) in $DRUDSRC/ddev"
+fi
+
+export GOTEST_SHORT=1
+
+echo "Warning: deleting all docker containers"
+docker rm -f $(docker ps -aq) 2>/dev/null || true
+
+
+make testcmd
+RV=$?
+echo "build.sh completed with status=$RV"
+exit $?

--- a/build.sh
+++ b/build.sh
@@ -23,4 +23,4 @@ docker rm -f $(docker ps -aq) 2>/dev/null || true
 make testcmd
 RV=$?
 echo "build.sh completed with status=$RV"
-exit $?
+exit $RV


### PR DESCRIPTION
## The Problem:

We need to test on windows and darwin at least a little bit. This is experimental, and requires some equipment deployment, but it's pretty easy. We need to see if we can make it stable enough not to be annoying though.

## The Fix:

The [surf](https://github.com/surf-build/surf) package seems to do the job for us. 

This PR adds two scripts, build.sh and build.cmd, which are used by the build system to do what needs to be done. 

Nothing happens yet until a listener on one or more platforms is out there polling github for changes.  So the introduction of these two files means nothing unless there is a polling surf build server that tries to use them.

Note that I currently have this just running `make testcmd` so the test is a bit shorter and simpler until we're sure we want it to run a full test. And it's using GOTEST_SHORT=1.

## The Test:

See if tests work out for us and this approach adds value.

## Related Issue Link(s):

OP #254 - requesting automated tests for windows.

## Release/Deployment notes:

We have to run build servers. That's going to take some organizing effort. Currently they're running on windows and darwin dev laptops. The build servers don't require much - they're polling.

The command on the build server is
```
surf-run -r https://github.com/drud/ddev -j 1 -- surf-build -n surf-$(go env GOOS)
```

Installation of surf-run requires npm already being installed and is described on https://github.com/surf-build/surf