### PR TITLE
Build (most) everything in automated surf tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ include build-tools/makefile_components/base_build_go.mak
 
 TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
+TEST_TIMEOUT=20m
 BUILD_ARCH = $(shell go env GOARCH)
 ifeq ($(BUILD_OS),linux)
     DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/ddev
@@ -66,6 +67,7 @@ endif
 
 ifeq ($(BUILD_OS),windows)
     DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev.exe
+    TEST_TIMEOUT=60m
 endif
 
 ifeq ($(BUILD_OS),darwin)
@@ -77,10 +79,10 @@ endif
 test: testpkg testcmd
 
 testcmd: $(BUILD_OS) setup
-	CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
+	CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
 
 testpkg:
-	CGO_ENABLED=0 go test -p 1 -timeout 20m -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
+	CGO_ENABLED=0 go test -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
 
 setup:
 	@mkdir -p bin/darwin bin/linux

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 
 ifeq ($(BUILD_OS),windows)
     DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev.exe
-    TEST_TIMEOUT=60m
+    TEST_TIMEOUT=120m
 endif
 
 ifeq ($(BUILD_OS),darwin)

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 
 ifeq ($(BUILD_OS),windows)
     DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev.exe
-    TEST_TIMEOUT=120m
+    TEST_TIMEOUT=40m
 endif
 
 ifeq ($(BUILD_OS),darwin)

--- a/build.sh
+++ b/build.sh
@@ -11,10 +11,10 @@ if [ ! -z "$SURF_REF" ]; then
 	mkdir -p $DRUDSRC
 	ln -s $PWD $DRUDSRC/ddev
 	cd $DRUDSRC/ddev
-	echo "Surf building $SURF_REF on $(hostname) for OS=$(go env GOOS) in $DRUDSRC/ddev"
+	echo "Surf building $SURF_REF ($SURF_SHA1) on $(hostname) for OS=$(go env GOOS) in $DRUDSRC/ddev"
 	echo "To retry the build, use
 		export GITHUB_TOKEN=<token>
-		surf-build -s $SURF_REF -r https://github.com/drud/ddev -n surf-$(go env GOOS)"
+		surf-build -s $SURF_SHA1 -r https://github.com/drud/ddev -n surf-$(go env GOOS)"
 fi
 
 #export GOTEST_SHORT=1

--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,8 @@ export GOTEST_SHORT=1
 echo "Warning: deleting all docker containers"
 docker rm -f $(docker ps -aq) 2>/dev/null || true
 
-
-make testcmd
+echo "Running tests..."
+make test
 RV=$?
 echo "build.sh completed with status=$RV"
 exit $RV

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,10 @@ if [ ! -z "$SURF_REF" ]; then
 	mkdir -p $DRUDSRC
 	ln -s $PWD $DRUDSRC/ddev
 	cd $DRUDSRC/ddev
-	echo "Surf building on $(hostname) for OS=$(go env GOOS) in $DRUDSRC/ddev"
+	echo "Surf building $SURF_REF on $(hostname) for OS=$(go env GOOS) in $DRUDSRC/ddev"
+	echo "To retry the build, use
+		export GITHUB_TOKEN=<token>
+		surf-build -s $SURF_REF -r https://github.com/drud/ddev -n surf-$(go env GOOS)"
 fi
 
 #export GOTEST_SHORT=1

--- a/build.sh
+++ b/build.sh
@@ -29,4 +29,3 @@ time make test
 RV=$?
 echo "build.sh completed with status=$RV"
 exit $RV
-

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ if [ ! -z "$SURF_REF" ]; then
 	echo "Surf building on $(hostname) for OS=$(go env GOOS) in $DRUDSRC/ddev"
 fi
 
-export GOTEST_SHORT=1
+#export GOTEST_SHORT=1
 
 echo "Warning: deleting all docker containers"
 docker rm -f $(docker ps -aq) 2>/dev/null || true

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ echo "Warning: deleting all docker containers"
 docker rm -f $(docker ps -aq) 2>/dev/null || true
 
 echo "Running tests..."
-make test
+time make test
 RV=$?
 echo "build.sh completed with status=$RV"
 exit $RV

--- a/build.sh
+++ b/build.sh
@@ -12,17 +12,17 @@ if [ ! -z "$SURF_REF" ]; then
 	ln -s $PWD $DRUDSRC/ddev
 	cd $DRUDSRC/ddev
 	echo "Surf building $SURF_REF ($SURF_SHA1) on $(hostname) for OS=$(go env GOOS) in $DRUDSRC/ddev"
-	echo "To retry the build, use
-		export GITHUB_TOKEN=<token>
-		surf-build -s $SURF_SHA1 -r https://github.com/drud/ddev -n surf-$(go env GOOS)"
+	echo "To retry the build, export GITHUB_TOKEN, DDEV_PANTHEON_API_TOKEN, DRUD_DEBUG and...
+	surf-build -s $SURF_SHA1 -r https://github.com/drud/ddev -n surf-$(go env GOOS)"
 fi
 
 export GOTEST_SHORT=1
 
-echo "Warning: deleting all docker containers"
+echo "Warning: deleting all docker containers and deleting ~/.ddev/*"
 if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
 	docker rm -f $(docker ps -aq)
 fi
+rm -rf ~/.ddev/Test*
 
 echo "Running tests..."
 time make test

--- a/build.sh
+++ b/build.sh
@@ -20,10 +20,13 @@ fi
 export GOTEST_SHORT=1
 
 echo "Warning: deleting all docker containers"
-docker rm -f $(docker ps -aq) 2>/dev/null || true
+if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
+	docker rm -f $(docker ps -aq)
+fi
 
 echo "Running tests..."
 time make test
 RV=$?
 echo "build.sh completed with status=$RV"
 exit $RV
+

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ if [ ! -z "$SURF_REF" ]; then
 		surf-build -s $SURF_SHA1 -r https://github.com/drud/ddev -n surf-$(go env GOOS)"
 fi
 
-#export GOTEST_SHORT=1
+export GOTEST_SHORT=1
 
 echo "Warning: deleting all docker containers"
 docker rm -f $(docker ps -aq) 2>/dev/null || true

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -9,8 +9,9 @@ import (
 
 	"strings"
 
-	"github.com/drud/ddev/pkg/util"
 	"runtime"
+
+	"github.com/drud/ddev/pkg/util"
 )
 
 // CopyFile copies the contents of the file named src to the file named
@@ -39,7 +40,9 @@ func CopyFile(src string, dst string) error {
 		return err
 	}
 
-	// chmod seems to fail on long path (> 256 characters) on windows
+	// os.Chmod fails on long path (> 256 characters) on windows.
+	// A description of this problem with golang is at https://github.com/golang/dep/issues/774#issuecomment-311560825
+	// It could end up fixed in a future version of golang.
 	if runtime.GOOS != "windows" {
 		si, err := os.Stat(src)
 		if err != nil {

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -44,11 +44,11 @@ func CopyFile(src string, dst string) error {
 	}
 	so, err := os.Stat(dst)
 	if err != nil {
-		return fmt.Errorf("Failed to stat destination after copy, dst=%s, err=%v, so=%v", dst, err, so)
+		return fmt.Errorf("Failed to stat destination after copy, dst=%s, err=%v, so.Size=%v", dst, err, so.Size())
 	}
 	err = os.Chmod(dst, si.Mode())
 	if err != nil {
-		return fmt.Errorf("Failed to chmod file %v to mode %v, err=%v (si=%v, so=%v)", dst, si.Mode(), err, si, so)
+		return fmt.Errorf("Failed to chmod file %v to mode %v, err=%v (si.Size=%v, so.Size=%v)", dst, si.Mode(), err, si.Size(), so.Size())
 	}
 
 	return nil

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/drud/ddev/pkg/util"
+	"runtime"
 )
 
 // CopyFile copies the contents of the file named src to the file named
@@ -38,17 +39,17 @@ func CopyFile(src string, dst string) error {
 		return err
 	}
 
-	si, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-	so, err := os.Stat(dst)
-	if err != nil {
-		return fmt.Errorf("Failed to stat destination after copy, dst=%s, err=%v, so.Size=%v", dst, err, so.Size())
-	}
-	err = os.Chmod(dst, si.Mode())
-	if err != nil {
-		return fmt.Errorf("Failed to chmod file %v to mode %v, err=%v (si.Size=%v, so.Size=%v)", dst, si.Mode(), err, si.Size(), so.Size())
+	// chmod seems to fail on long path (> 256 characters) on windows
+	if runtime.GOOS != "windows" {
+		si, err := os.Stat(src)
+		if err != nil {
+			return err
+		}
+
+		err = os.Chmod(dst, si.Mode())
+		if err != nil {
+			return fmt.Errorf("Failed to chmod file %v to mode %v, err=%v", dst, si.Mode(), err)
+		}
 	}
 
 	return nil

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/drud/ddev/pkg/util"
 	"strings"
+
+	"github.com/drud/ddev/pkg/util"
 )
 
 // CopyFile copies the contents of the file named src to the file named
@@ -41,9 +42,13 @@ func CopyFile(src string, dst string) error {
 	if err != nil {
 		return err
 	}
+	so, err := os.Stat(dst)
+	if err != nil {
+		return fmt.Errorf("Failed to stat destination after copy, dst=%s, err=%v, so=%v", dst, err, so)
+	}
 	err = os.Chmod(dst, si.Mode())
 	if err != nil {
-		return fmt.Errorf("Failed to chmod file %v to mode %v, err=%v", dst, si.Mode(), err)
+		return fmt.Errorf("Failed to chmod file %v to mode %v, err=%v (si=%v, so=%v)", dst, si.Mode(), err, si, so)
 	}
 
 	return nil

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -43,7 +43,7 @@ func CopyFile(src string, dst string) error {
 	}
 	err = os.Chmod(dst, si.Mode())
 	if err != nil {
-		return fmt.Errorf("Failed to chmod file %v to mode %v", dst, si.Mode())
+		return fmt.Errorf("Failed to chmod file %v to mode %v, err=%v", dst, si.Mode(), err)
 	}
 
 	return nil

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 	for i := range TestSites {
 		err := TestSites[i].Prepare()
 		if err != nil {
-			log.Fatalf("Prepare() failed on TestSite.Prepare(%d) site=%s, err=%v", i, TestSites[i].Name, err)
+			log.Fatalf("Prepare() failed on TestSite.Prepare() site=%s, err=%v", TestSites[i].Name, err)
 		}
 
 		switchDir := TestSites[i].Chdir()

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -214,19 +214,14 @@ func TestLocalImportDB(t *testing.T) {
 		}
 
 		if site.DBTarURL != "" {
-			log.Info("Preparing to GetCachedArchive for %s", site.Name)
 			_, cachedArchive, err := testcommon.GetCachedArchive(site.Name, site.Name+"_siteTarArchive", "", site.DBTarURL)
 			assert.NoError(err)
-			log.Info("Got CachedArchive for %s (%s)", site.Name, cachedArchive)
 			err = app.ImportDB(cachedArchive, "")
 			assert.NoError(err)
-			log.Info("Completed ImportDB for site=%s", site.Name)
 
 			stdout := testcommon.CaptureStdOut()
-			log.Info("stdout captured for %s", site.Name)
 			err = app.Exec("db", true, "mysql", "-e", "SHOW TABLES;")
 			assert.NoError(err)
-			log.Info("app.Exec db returned for site=%s", site.Name)
 			out := stdout()
 
 			assert.Contains(string(out), "Tables_in_db")

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -214,14 +214,19 @@ func TestLocalImportDB(t *testing.T) {
 		}
 
 		if site.DBTarURL != "" {
+			log.Info("Preparing to GetCachedArchive for %s", site.Name)
 			_, cachedArchive, err := testcommon.GetCachedArchive(site.Name, site.Name+"_siteTarArchive", "", site.DBTarURL)
 			assert.NoError(err)
+			log.Info("Got CachedArchive for %s (%s)", site.Name, cachedArchive)
 			err = app.ImportDB(cachedArchive, "")
 			assert.NoError(err)
+			log.Info("Completed ImportDB for site=%s", site.Name)
 
 			stdout := testcommon.CaptureStdOut()
+			log.Info("stdout captured for %s", site.Name)
 			err = app.Exec("db", true, "mysql", "-e", "SHOW TABLES;")
 			assert.NoError(err)
+			log.Info("app.Exec db returned for site=%s", site.Name)
 			out := stdout()
 
 			assert.Contains(string(out), "Tables_in_db")

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -543,7 +543,7 @@ func TestGetAppsEmpty(t *testing.T) {
 	}
 
 	apps := platform.GetApps()
-	assert.Equal(len(apps["local"]), 0)
+	assert.Equal(len(apps["local"]), 0, "Expected to find no apps but found %d apps=%v", len(apps["local"]), apps["local"])
 }
 
 // TestRouterNotRunning ensures the router is shut down after all sites are stopped.
@@ -553,7 +553,7 @@ func TestRouterNotRunning(t *testing.T) {
 	assert.NoError(err)
 
 	for _, container := range containers {
-		assert.NotEqual(dockerutil.ContainerName(container), "ddev-router", "Failed to find ddev-router container running")
+		assert.NotEqual(dockerutil.ContainerName(container), "ddev-router", "ddev-router was not supposed to be running but it was")
 	}
 }
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -381,7 +381,6 @@ func TestLocalLogs(t *testing.T) {
 		assert.NoError(err)
 		out = stdout()
 		assert.Contains(out, "MySQL init process done. Ready for start up.")
-		assert.False(strings.Contains(out, "Database initialized"))
 
 		runTime()
 		switchDir()

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -10,8 +10,6 @@ import (
 
 	"strings"
 
-	"runtime"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -351,9 +349,6 @@ func TestLocalExec(t *testing.T) {
 func TestLocalLogs(t *testing.T) {
 	assert := assert.New(t)
 
-	if runtime.GOOS == "windows" {
-		t.Skipf("Skipping TestLocalLogs since pipes are not supported on Windows")
-	}
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -67,7 +67,7 @@ func TestServices(t *testing.T) {
 		for _, site := range TestSites {
 			err := site.Prepare()
 			if err != nil {
-				log.Fatalf("Prepare() failed on TestSite.Prepare(), err=%v", err)
+				t.Fatalf("Prepare() failed on TestSite.Prepare() for site=%s, err=%v", site.Name, err)
 			}
 
 			app, err := platform.GetPluginApp("local")

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -32,10 +32,6 @@ var (
 
 // TestMain runs the tests in servicetest
 func TestMain(m *testing.M) {
-	if os.Getenv("GOTEST_SHORT") != "" {
-		log.Info("servicetest skipped in short mode because GOTEST_SHORT is set")
-		os.Exit(0)
-	}
 
 	var err error
 	ServiceDir, err = filepath.Abs("../../services")

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -31,10 +31,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	if os.Getenv("GOTEST_SHORT") == "" {
-		var err error
-
-		ServiceDir, err = filepath.Abs("../../services")
+	if os.Getenv("GOTEST_SHORT") != "" {
+		log.Info("services tests skipped in short mode")
+	} else {
+		ServiceDir, err := filepath.Abs("../../services")
 		util.CheckErr(err)
 
 		err = filepath.Walk(ServiceDir, func(path string, f os.FileInfo, _ error) error {
@@ -47,14 +47,11 @@ func TestMain(m *testing.M) {
 
 		err = dockerutil.EnsureNetwork(dockerutil.GetDockerClient(), dockerutil.NetName)
 		util.CheckErr(err)
-	} else {
-		log.Info("services tests skipped in short mode")
+		log.Debugln("Running tests in servicetest...")
+		testRun := m.Run()
+
+		os.Exit(testRun)
 	}
-
-	log.Debugln("Running tests.")
-	testRun := m.Run()
-
-	os.Exit(testRun)
 }
 
 // TestServices tests each service compose file in the services folder.

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -30,28 +30,31 @@ var (
 	ServiceDir   string
 )
 
+// TestMain runs the tests in servicetest
 func TestMain(m *testing.M) {
 	if os.Getenv("GOTEST_SHORT") != "" {
-		log.Info("services tests skipped in short mode")
-	} else {
-		ServiceDir, err := filepath.Abs("../../services")
-		util.CheckErr(err)
-
-		err = filepath.Walk(ServiceDir, func(path string, f os.FileInfo, _ error) error {
-			if !f.IsDir() && strings.HasPrefix(f.Name(), "docker-compose") {
-				ServiceFiles = append(ServiceFiles, f.Name())
-			}
-			return nil
-		})
-		util.CheckErr(err)
-
-		err = dockerutil.EnsureNetwork(dockerutil.GetDockerClient(), dockerutil.NetName)
-		util.CheckErr(err)
-		log.Debugln("Running tests in servicetest...")
-		testRun := m.Run()
-
-		os.Exit(testRun)
+		log.Info("servicetest skipped in short mode because GOTEST_SHORT is set")
+		os.Exit(0)
 	}
+
+	var err error
+	ServiceDir, err = filepath.Abs("../../services")
+	util.CheckErr(err)
+
+	err = filepath.Walk(ServiceDir, func(path string, f os.FileInfo, _ error) error {
+		if !f.IsDir() && strings.HasPrefix(f.Name(), "docker-compose") {
+			ServiceFiles = append(ServiceFiles, f.Name())
+		}
+		return nil
+	})
+	util.CheckErr(err)
+
+	err = dockerutil.EnsureNetwork(dockerutil.GetDockerClient(), dockerutil.NetName)
+	util.CheckErr(err)
+	log.Debugln("Running tests in servicetest...")
+	testRun := m.Run()
+
+	os.Exit(testRun)
 }
 
 // TestServices tests each service compose file in the services folder.

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -32,6 +32,10 @@ var (
 
 // TestMain runs the tests in servicetest
 func TestMain(m *testing.M) {
+	if os.Getenv("GOTEST_SHORT") != "" {
+		log.Info("servicetest skipped in short mode because GOTEST_SHORT is set")
+		os.Exit(0)
+	}
 
 	var err error
 	ServiceDir, err = filepath.Abs("../../services")

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -52,7 +52,9 @@ type TestSite struct {
 func (site *TestSite) Prepare() error {
 	testDir := CreateTmpDir(site.Name)
 	site.Dir = testDir
-	log.Debugf("Prepping test for site %s", site.Name)
+	log.Debugf("Preparing test site %s", site.Name)
+	runTime := TimeTrack(time.Now(), fmt.Sprintf("PERF: Prepare() site %s (CopyDir etc.)", site.Name))
+
 	err := os.Setenv("DRUD_NONINTERACTIVE", "true")
 	util.CheckErr(err)
 
@@ -89,7 +91,8 @@ func (site *TestSite) Prepare() error {
 		}
 	}
 
-	return err
+	runTime()
+	return nil
 }
 
 // Chdir will change to the directory for the site specified by TestSite.

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -53,7 +53,7 @@ func (site *TestSite) Prepare() error {
 	testDir := CreateTmpDir(site.Name)
 	site.Dir = testDir
 	log.Debugf("Preparing test site %s", site.Name)
-	runTime := TimeTrack(time.Now(), fmt.Sprintf("PERF: Prepare() site %s (CopyDir etc.)", site.Name))
+	runTime := TimeTrack(time.Now(), fmt.Sprintf("Prepare() site %s (CopyDir etc.)", site.Name))
 
 	err := os.Setenv("DRUD_NONINTERACTIVE", "true")
 	util.CheckErr(err)


### PR DESCRIPTION
## The Problem:

We started out just testing `make testcmd` to make sure things were shorter.  This PR tries running the whole test suite.  Minor changes made along the way.

* Switch to `make test`
* Extend (potential) test timeout for windows in Makefile
* Remove the t.skip for windows on TestLocalLogs, which turned out unnecessary.
* Remove chmod in CopyFile on windows, as golang on windows can't do that on long paths.
