### PR TITLE
Use caching on some remaining tarball downloads

### DIFF
--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -276,32 +276,23 @@ func TestLocalImportFiles(t *testing.T) {
 		assert.NoError(err)
 
 		if site.FilesTarballURL != "" {
-			filePath := filepath.Join(testcommon.CreateTmpDir("local-tarball-files"), "files.tar.gz")
-			err := util.DownloadFile(filePath, site.FilesTarballURL, false)
+			_, tarballPath, err := testcommon.GetCachedArchive(site.Name, "local-tarballs-files", "", site.FilesTarballURL)
 			assert.NoError(err)
-			err = app.ImportFiles(filePath, "")
-			assert.NoError(err)
-			err = os.Remove(filePath)
+			err = app.ImportFiles(tarballPath, "")
 			assert.NoError(err)
 		}
 
 		if site.FilesZipballURL != "" {
-			filePath := filepath.Join(testcommon.CreateTmpDir("local-zipball-files"), "files.zip")
-			err := util.DownloadFile(filePath, site.FilesZipballURL, false)
+			_, zipballPath, err := testcommon.GetCachedArchive(site.Name, "local-zipballs-files", "", site.FilesZipballURL)
 			assert.NoError(err)
-			err = app.ImportFiles(filePath, "")
-			assert.NoError(err)
-			err = os.Remove(filePath)
+			err = app.ImportFiles(zipballPath, "")
 			assert.NoError(err)
 		}
 
 		if site.FullSiteTarballURL != "" {
-			siteTarPath := filepath.Join(testcommon.CreateTmpDir("local-site-tar"), "site.tar.gz")
-			err = util.DownloadFile(siteTarPath, site.FullSiteTarballURL, false)
+			_, siteTarPath, err := testcommon.GetCachedArchive(site.Name, "local-site-tar", "", site.FullSiteTarballURL)
 			assert.NoError(err)
 			err = app.ImportFiles(siteTarPath, "docroot/sites/default/files")
-			assert.NoError(err)
-			err = os.Remove(siteTarPath)
 			assert.NoError(err)
 		}
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -253,7 +253,7 @@ func TestLocalImportDB(t *testing.T) {
 			assert.NoError(err)
 
 			err = app.ImportDB(cachedArchive, "data.sql")
-			assert.NoError(err)
+			assert.NoError(err, "Failed to find data.sql at root of tarball %s", cachedArchive)
 		}
 
 		runTime()


### PR DESCRIPTION
## The Problem:

There were a couple of archive downloads (two quite large) that were still not being cached in our tests.

## The Fix:

* Change to cache them.
* Minor improvements in variable naming to make it clearer what's going on.

## The Test:

Run `make testpkg TESTARGS="-run TestLocalImport"` twice, and verify that it doesn't bother to do the download the second time.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

