### PR TITLE
updates docs ToC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ pages:
       - 'Additional Services': 'users/extend/additional-services.md'
       - 'Defining Custom Services': 'users/extend/custom-compose-files.md'
     - 'Integration with Hosting Providers'
-      - 'Pantheon': 'providers/pantheon.md'
+      - 'Pantheon': 'users/providers/pantheon.md'
     - 'Notes for Linux Users': 'users/linux_notes.md'
   - 'Developer Documentation':
     - 'Building, Testing, and Contributing': 'developers/building-contributing.md'


### PR DESCRIPTION
## The Problem:
The pantheon docs aren't showing up on readthedocs due to an invalid path in the table of contents.

## The Fix:
This fixes the invalid path.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

