### PR TITLE
Bump docker and docker-compose versions to current stable

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -22,10 +22,9 @@ sudo apt-get install -qq apt-transport-https ca-certificates  curl software-prop
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Per docker docs, you always need the stable repository, even if you want to install edge builds as well.
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
 sudo apt-get update -qq
-sudo apt-get install -qq docker-ce=17.05.0~ce-0~ubuntu-$(lsb_release -cs)
+sudo apt-get install -qq docker-ce=17.06.0~ce-0~ubuntu
 
 # docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.12.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -s -L "https://github.com/docker/compose/releases/download/1.14.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
## The Problem:

It's time to bump our testing docker version. We ask people to install recent stable, so here we go.

