### PR TITLE
Fix typo, fail test if AvailableUpdates() fails

### DIFF
--- a/pkg/updatecheck/updatecheck_test.go
+++ b/pkg/updatecheck/updatecheck_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/stretchr/testify/assert"
+	"os"
 )
 
 const testOrg = "drud"
@@ -64,6 +65,9 @@ func TestIsReleaseVersion(t *testing.T) {
 // TestAvailableUpdates tests isReleaseVersion to ensure it correctly picks up on release builds vs dev builds
 func TestAvailableUpdates(t *testing.T) {
 	assert := assert.New(t)
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skipping TestAvailableUpdates because GOTEST_SHORT env var is set")
+	}
 	var versionTests = []struct {
 		in  string
 		out bool

--- a/pkg/updatecheck/updatecheck_test.go
+++ b/pkg/updatecheck/updatecheck_test.go
@@ -76,8 +76,10 @@ func TestAvailableUpdates(t *testing.T) {
 
 	for _, tt := range versionTests {
 		updateNeeded, updateURL, err := AvailableUpdates(testOrg, testRepo, tt.in)
-		assert.NoError(err)
-		assert.Equal(updateNeeded, tt.out, fmt.Sprintf("Got output which was not expected from AvailabeUpdates. Input: %s Output: %t Expected: %t Org: %s Repo: %s", tt.in, updateNeeded, tt.out, testOrg, testRepo))
+		if err != nil {
+			t.Fatalf("AvailableUpdates() failed, err=%v", err)
+		}
+		assert.Equal(updateNeeded, tt.out, fmt.Sprintf("Unexpected output from AvailableUpdates. Input: %s Output: %t Expected: %t Org: %s Repo: %s", tt.in, updateNeeded, tt.out, testOrg, testRepo))
 
 		if updateNeeded {
 			assert.Contains(updateURL, "https://")


### PR DESCRIPTION
## The Problem:

github rate limiting can cause test fail, and fix typo.

## The Fix:

* Fix typo
* Fail test on err
* Skip TestAvailableUpdates if GOTEST_SHORT is set

Note: This PR could probably be improved using the "Client Secret" approach, https://developer.github.com/v3/#increasing-the-unauthenticated-rate-limit-for-oauth-applications - however, we don't really need to add complexity at this time.

It also might be able to be improved by authenticating with GITHUB_TOKEN (available on test servers) if it's available. But again, that complexity is probably not needed for this issue.


## The Test:

