### PR TITLE
[nginx-tag] Bump nginx tag to v0.7.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm7-local
-WebTag ?= v0.7.3
+WebTag ?= v0.7.4
 DBImg ?= drud/mysql-local-57
 DBTag ?= v0.6.2
 RouterImage ?= drud/ddev-router

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,7 +17,7 @@ var DockerVersionConstraint = ">= 17.05.0-ce"
 var WebImg = "drud/nginx-php-fpm7-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.7.3" // Note that this is overridden by make
+var WebTag = "v0.7.4" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem:
We've rolled a 0.7.4 version of the nginx container and need to update ddev to use it.

## The Test:

- Create a new site using ddev config. Ensure .ddev/config.yaml uses the v0.7.4 tag for the nginx container.
- Start the site
- Run a site install or any other command that has a prompt. E.g. `drush si --db-url=mysql://db:db@db:3306/db`
- You should still see a prompt, but it should be automatically answered with a 'y'. As in `Do you want to continue? (y/n): y`

