### PR TITLE
"ddev list" shows sites based on container, even if directory is removed: fix for #374

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -104,7 +104,7 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	// and it is up to the caller to determine if that's an issue.
 	err := c.Read()
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf("Unable to read config.yaml, %v, err=%v", c.ConfigPath, err)
 	}
 
 	return c, err

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -69,6 +69,12 @@ func (l *LocalApp) Init(basePath string) error {
 	return nil
 }
 
+// InitFromMissingDirectory populates local app settings based on manually given arguments.
+func (l *LocalApp) InitFromMissingDirectory(name string, appType string) {
+	l.AppConfig.Name = name
+	l.AppConfig.AppType = appType
+}
+
 // FindContainerByType will find a container for this site denoted by the containerType if it is available.
 func (l *LocalApp) FindContainerByType(containerType string) (docker.APIContainers, error) {
 	labels := map[string]string{
@@ -267,8 +273,8 @@ func (l *LocalApp) SiteStatus() string {
 	var siteStatus string
 	services := map[string]string{"web": "", "db": ""}
 
-	if (!fileutil.FileExists(l.AppRoot())) {
-		siteStatus := fmt.Sprintf("Ooops, app directory was killed: %v", l.AppRoot())
+	if !fileutil.FileExists(l.AppRoot()) {
+		siteStatus := fmt.Sprintf("%s: %v", SiteDirMissing, l.AppRoot())
 		return siteStatus
 	}
 	for service := range services {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -47,6 +47,7 @@ func (l *LocalApp) GetType() string {
 func (l *LocalApp) Init(basePath string) error {
 	config, err := ddevapp.NewConfig(basePath, "")
 	if err != nil {
+		// Save config to l.AppConfig so we can capture and display the site's status.
 		l.AppConfig = config
 		return err
 	}
@@ -67,12 +68,6 @@ func (l *LocalApp) Init(basePath string) error {
 	}
 
 	return nil
-}
-
-// InitFromMissingDirectory populates local app settings based on manually given arguments.
-func (l *LocalApp) InitFromMissingDirectory(name string, appType string) {
-	l.AppConfig.Name = name
-	l.AppConfig.AppType = appType
 }
 
 // FindContainerByType will find a container for this site denoted by the containerType if it is available.

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -272,6 +272,13 @@ func (l *LocalApp) SiteStatus() string {
 		siteStatus := fmt.Sprintf("%s: %v", SiteDirMissing, l.AppRoot())
 		return siteStatus
 	}
+
+	_, err := CheckForConf(l.AppRoot())
+	if err != nil {
+		siteStatus := fmt.Sprintf("%s", SiteConfigMissing)
+		return siteStatus
+	}
+
 	for service := range services {
 		container, err := l.FindContainerByType(service)
 		if err != nil {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -47,6 +47,7 @@ func (l *LocalApp) GetType() string {
 func (l *LocalApp) Init(basePath string) error {
 	config, err := ddevapp.NewConfig(basePath, "")
 	if err != nil {
+		l.AppConfig = config
 		return err
 	}
 
@@ -266,6 +267,10 @@ func (l *LocalApp) SiteStatus() string {
 	var siteStatus string
 	services := map[string]string{"web": "", "db": ""}
 
+	if (!fileutil.FileExists(l.AppRoot())) {
+		siteStatus := fmt.Sprintf("Ooops, app directory was killed: %v", l.AppRoot())
+		return siteStatus
+	}
 	for service := range services {
 		container, err := l.FindContainerByType(service)
 		if err != nil {

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -16,6 +16,9 @@ const SiteNotFound = "not found"
 // SiteDirMissing defines the string used to denote when a site is missing its application directory.
 const SiteDirMissing = "app directory missing"
 
+// SiteConfigMissing defines the string used to denote when a site is missing its .ddev/config.yml file.
+const SiteConfigMissing = ".ddev/config.yml missing"
+
 // SiteStopped defines the string used to denote when a site is in the stopped state.
 const SiteStopped = "stopped"
 

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -13,6 +13,9 @@ const SiteRunning = "running"
 // SiteNotFound defines the string used to denote a site where the containers were not found/do not exist.
 const SiteNotFound = "not found"
 
+// SiteDirMissing defines the string used to denote when a site is missing its application directory.
+const SiteDirMissing = "app directory missing"
+
 // SiteStopped defines the string used to denote when a site is in the stopped state.
 const SiteStopped = "stopped"
 
@@ -46,7 +49,7 @@ var PluginMap = map[string]App{
 }
 
 // GetPluginApp will return an application of the type specified by pluginType
-func GetPluginApp(pluginType string) (App, error) {
+func GetPluginApp(pluginType string) (*LocalApp, error) {
 	switch strings.ToLower(pluginType) {
 	case "local":
 		return &LocalApp{}, nil

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -49,7 +49,7 @@ var PluginMap = map[string]App{
 }
 
 // GetPluginApp will return an application of the type specified by pluginType
-func GetPluginApp(pluginType string) (*LocalApp, error) {
+func GetPluginApp(pluginType string) (App, error) {
 	switch strings.ToLower(pluginType) {
 	case "local":
 		return &LocalApp{}, nil

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -47,7 +47,7 @@ func GetApps() map[string][]App {
 				err = site.Init(approot)
 				if err != nil {
 					// Cast 'site' from type App to type LocalApp, so we can manually enter AppConfig values.
-					site := LocalApp(site)
+					site := site.(*LocalApp)
 					site.AppConfig.Name = siteContainer.Labels["com.ddev.site-name"]
 					site.AppConfig.AppType = siteContainer.Labels["com.ddev.app-type"]
 					log.Printf("Failed to init %v err=%v", approot, err)

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -46,9 +46,10 @@ func GetApps() map[string][]App {
 
 				err = site.Init(approot)
 				if err != nil {
-					siteName := siteContainer.Labels["com.ddev.site-name"]
-					appType := siteContainer.Labels["com.ddev.app-type"]
-					site.InitFromMissingDirectory(siteName, appType)
+					// Cast 'site' from type App to type LocalApp, so we can manually enter AppConfig values.
+					site := LocalApp(site)
+					site.AppConfig.Name = siteContainer.Labels["com.ddev.site-name"]
+					site.AppConfig.AppType = siteContainer.Labels["com.ddev.app-type"]
 					log.Printf("Failed to init %v err=%v", approot, err)
 				}
 				apps[platformType] = append(apps[platformType], site)

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -47,10 +47,13 @@ func GetApps() map[string][]App {
 				err = site.Init(approot)
 				if err != nil {
 					// Cast 'site' from type App to type LocalApp, so we can manually enter AppConfig values.
-					site := site.(*LocalApp)
-					site.AppConfig.Name = siteContainer.Labels["com.ddev.site-name"]
-					site.AppConfig.AppType = siteContainer.Labels["com.ddev.app-type"]
-					log.Printf("Failed to init %v err=%v", approot, err)
+					siteStruct, ok := site.(*LocalApp)
+					if !ok {
+						log.Fatalf("Failed to init %v err=%v", approot, err)
+					}
+
+					siteStruct.AppConfig.Name = siteContainer.Labels["com.ddev.site-name"]
+					siteStruct.AppConfig.AppType = siteContainer.Labels["com.ddev.app-type"]
 				}
 				apps[platformType] = append(apps[platformType], site)
 			}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -49,7 +49,7 @@ func GetApps() map[string][]App {
 					// Cast 'site' from type App to type LocalApp, so we can manually enter AppConfig values.
 					siteStruct, ok := site.(*LocalApp)
 					if !ok {
-						log.Fatalf("Failed to init %v err=%v", approot, err)
+						log.Fatalf("Failed to cast siteStruct(type App) to *LocalApp{}: %v", siteStruct)
 					}
 
 					siteStruct.AppConfig.Name = siteContainer.Labels["com.ddev.site-name"]

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -19,8 +19,8 @@ import (
 )
 
 // GetApps returns a list of ddev applictions keyed by platform.
-func GetApps() map[string][]App {
-	apps := make(map[string][]App)
+func        GetApps() map[string][]App {
+ 	apps := make(map[string][]App)
 	for platformType := range PluginMap {
 		labels := map[string]string{
 			"com.ddev.platform":          "ddev",
@@ -45,9 +45,10 @@ func GetApps() map[string][]App {
 				}
 
 				err = site.Init(approot)
-				if err == nil {
-					apps[platformType] = append(apps[platformType], site)
+				if (err != nil) {
+					log.Printf("Failed to init %v err=%v", approot, err)
 				}
+				apps[platformType] = append(apps[platformType], site)
 			}
 		}
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -106,6 +106,8 @@ func RenderAppRow(table *uitable.Table, site App) {
 		status = color.RedString(status)
 	case strings.Contains(status, SiteDirMissing):
 		status = color.RedString(status)
+	case strings.Contains(status, SiteConfigMissing):
+		status = color.RedString(status)
 	default:
 		status = color.CyanString(status)
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -19,8 +19,8 @@ import (
 )
 
 // GetApps returns a list of ddev applictions keyed by platform.
-func        GetApps() map[string][]App {
- 	apps := make(map[string][]App)
+func GetApps() map[string][]App {
+	apps := make(map[string][]App)
 	for platformType := range PluginMap {
 		labels := map[string]string{
 			"com.ddev.platform":          "ddev",
@@ -45,7 +45,10 @@ func        GetApps() map[string][]App {
 				}
 
 				err = site.Init(approot)
-				if (err != nil) {
+				if err != nil {
+					siteName := siteContainer.Labels["com.ddev.site-name"]
+					appType := siteContainer.Labels["com.ddev.app-type"]
+					site.InitFromMissingDirectory(siteName, appType)
 					log.Printf("Failed to init %v err=%v", approot, err)
 				}
 				apps[platformType] = append(apps[platformType], site)
@@ -67,7 +70,6 @@ func RenderAppTable(platform string, apps []App) {
 		fmt.Println(table)
 		fmt.Println(PrintRouterStatus())
 	}
-
 }
 
 // CreateAppTable will create a new app table for describe and list output
@@ -97,6 +99,8 @@ func RenderAppRow(table *uitable.Table, site App) {
 	case strings.Contains(status, SiteStopped):
 		status = color.YellowString(status)
 	case strings.Contains(status, SiteNotFound):
+		status = color.RedString(status)
+	case strings.Contains(status, SiteDirMissing):
 		status = color.RedString(status)
 	default:
 		status = color.CyanString(status)

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -49,7 +49,7 @@ func GetApps() map[string][]App {
 					// Cast 'site' from type App to type LocalApp, so we can manually enter AppConfig values.
 					siteStruct, ok := site.(*LocalApp)
 					if !ok {
-						log.Fatalf("Failed to cast siteStruct(type App) to *LocalApp{}: %v", siteStruct)
+						log.Fatalf("Failed to cast siteStruct(type App) to *LocalApp{}. site=%v", site)
 					}
 
 					siteStruct.AppConfig.Name = siteContainer.Labels["com.ddev.site-name"]


### PR DESCRIPTION
## The Problem:
A reoccurring issue in `ddev list` was its failure to list sites whose directories had been removed but containers were still running. This pitfall in `ddev list` made it possible for containers (which were no longer useful) to heap up on a user's machine if they repeatedly removed sites using `rm -r <dir>` instead of `ddev rm` - which stops all containers associated with a particular site.  
## The Fix:
**TLDR;** check to see if a site's root directory exists. If it doesn't exist, store information about the site temporarily and list it with status "not found".
`ddev list` already had visibility into the ddev containers that were running on a machine, it simply would not include sites with missing directories because those sites would raise an error when attempting to initialize from a missing root `site.Init(<root_dir>)`. 
## The Test:
- Start a site
- rm -r the site directory
- ddev list
    - ddev list should list the site with "status: not found"
- ddev rm <site_name>
- `ddev list` then `docker ps`
    - the site and it's containers should no longer be visible
## Related Issue Link(s):
#374 