### PR TITLE
Forgot to update the testing-local version of golang - followup to #446

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -11,7 +11,7 @@ sudo apt-get install -qq mysql-client realpath zip
 
 # golang of the version we want
 sudo apt-get remove -qq golang &&
-wget -q -O /tmp/golang.tgz https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz &&
+wget -q -O /tmp/golang.tgz https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz &&
 cd /tmp && tar -xf golang.tgz &&
 sudo rm -rf /usr/local/go && sudo mv go /usr/local
 


### PR DESCRIPTION
## The Problem:

In #446 I forgot to do the *circle machine* golang upgrade, so ddev testing was done with 1.8.3. This PR updates the version of golang installed on the circleci machine.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

