### PR TITLE
Make installing via homebrew the default instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ To upgrade to the latest version of ddev, simply run:
 ```
 brew upgrade ddev
 ```
+If you need to install homebrew, instructions can be found [here](https://brew.sh/).
   
 ### Installation Script - Linux and macOS
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ ddev requires ports 80 and 3306 to be available for use on your system when site
 If you need to use another environment after using ddev, simply ensure all of your ddev sites are stopped or removed. ddev only uses system ports when at least one site is running.
 
 ## Installation
+### Homebrew - macOS
+
+For macOS users, we recommend downloading and installing ddev via homebrew:
+```
+brew tap drud/ddev && brew install ddev
+```
+To upgrade to the latest version of ddev, simply run:
+```
+brew upgrade ddev
+```
+  
 ### Installation Script - Linux and macOS
 
 Linux and macOS end-users can use this line of code to your terminal to download, verify, and install ddev using our [install script](https://github.com/drud/ddev/blob/master/install_ddev.sh):

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -104,7 +104,7 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	// and it is up to the caller to determine if that's an issue.
 	err := c.Read()
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf("Unable to read config.yaml, %v, err=%v", c.ConfigPath, err)
 	}
 
 	return c, err

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -47,6 +47,7 @@ func (l *LocalApp) GetType() string {
 func (l *LocalApp) Init(basePath string) error {
 	config, err := ddevapp.NewConfig(basePath, "")
 	if err != nil {
+		l.AppConfig = config
 		return err
 	}
 
@@ -266,6 +267,10 @@ func (l *LocalApp) SiteStatus() string {
 	var siteStatus string
 	services := map[string]string{"web": "", "db": ""}
 
+	if (!fileutil.FileExists(l.AppRoot())) {
+		siteStatus := fmt.Sprintf("Ooops, app directory was killed: %v", l.AppRoot())
+		return siteStatus
+	}
 	for service := range services {
 		container, err := l.FindContainerByType(service)
 		if err != nil {

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -19,8 +19,8 @@ import (
 )
 
 // GetApps returns a list of ddev applictions keyed by platform.
-func GetApps() map[string][]App {
-	apps := make(map[string][]App)
+func        GetApps() map[string][]App {
+ 	apps := make(map[string][]App)
 	for platformType := range PluginMap {
 		labels := map[string]string{
 			"com.ddev.platform":          "ddev",
@@ -45,9 +45,10 @@ func GetApps() map[string][]App {
 				}
 
 				err = site.Init(approot)
-				if err == nil {
-					apps[platformType] = append(apps[platformType], site)
+				if (err != nil) {
+					log.Printf("Failed to init %v err=%v", approot, err)
 				}
+				apps[platformType] = append(apps[platformType], site)
 			}
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:
Homebrew is the most straight forward and is the expected way of installing software for many macOS users.
## How this PR Solves The Problem:
This PR solves the problem by listing homebrew as the first installation instruction for macOS. Docs provide code examples to download, install, and upgrade ddev. As well as a link to the homebrew download/install instructions - that user's without homebrew may use as a reference.
## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#434 
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

