### PR TITLE
Make installation via homebrew the default instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ To upgrade to the latest version of ddev, simply run:
 ```
 brew upgrade ddev
 ```
+If you need to install homebrew, instructions can be found [here](https://brew.sh/).
   
 ### Installation Script - Linux and macOS
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,16 @@ If you need to use another environment after using ddev, simply ensure all of yo
 ## Installation
 ### Homebrew - macOS
 
-For macOS users, we recommend downloading and installing ddev via homebrew:
+For macOS users, we recommend downloading and installing ddev via [homebrew](https://brew.sh/):
 ```
 brew tap drud/ddev && brew install ddev
 ```
-To upgrade to the latest version of ddev, simply run:
+Later, to upgrade to a newer version of ddev, simply run:
 ```
 brew upgrade ddev
 ```
-If you need to install homebrew, instructions can be found [here](https://brew.sh/).
   
-### Installation Script - Linux and macOS
+### Installation Script - MacOS or Linux
 
 Linux and macOS end-users can use this line of code to your terminal to download, verify, and install ddev using our [install script](https://github.com/drud/ddev/blob/master/install_ddev.sh):
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ ddev requires ports 80 and 3306 to be available for use on your system when site
 If you need to use another environment after using ddev, simply ensure all of your ddev sites are stopped or removed. ddev only uses system ports when at least one site is running.
 
 ## Installation
+### Homebrew - macOS
+
+For macOS users, we recommend downloading and installing ddev via homebrew:
+```
+brew tap drud/ddev && brew install ddev
+```
+To upgrade to the latest version of ddev, simply run:
+```
+brew upgrade ddev
+```
+  
 ### Installation Script - Linux and macOS
 
 Linux and macOS end-users can use this line of code to your terminal to download, verify, and install ddev using our [install script](https://github.com/drud/ddev/blob/master/install_ddev.sh):


### PR DESCRIPTION
## The Problem/Issue/Bug:
Homebrew is the most straight forward and is the expected way of installing software for many macOS users.
## How this PR Solves The Problem:
This PR solves the problem by listing homebrew as the first installation instruction for macOS. Docs provide code examples to download, install, and upgrade ddev. As well as a link to the homebrew download/install instructions - that user's without homebrew may use as a reference.
## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#434 
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

