### PR TITLE
ddev rm, describe, and stop are now reliable even when a site directory is missing; fixes #459

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -26,7 +26,7 @@ func TestDescribeBadArgs(t *testing.T) {
 	args := []string{"describe"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "unable to determine the application for this command")
+	assert.Contains(string(out), "could not find containers which matched search criteria")
 
 	// Ensure we get a failure if we run a describe on a named application which does not exist.
 	args = []string{"describe", util.RandString(16)}

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -26,7 +26,7 @@ func TestDescribeBadArgs(t *testing.T) {
 	args := []string{"describe"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "could not find containers which matched search criteria")
+	assert.Contains(string(out), "Please specify a site name or change directories")
 
 	// Ensure we get a failure if we run a describe on a named application which does not exist.
 	args = []string{"describe", util.RandString(16)}

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -27,7 +27,7 @@ func TestDevLogsBadArgs(t *testing.T) {
 	args := []string{"logs"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "could not find containers which matched search criteria")
+	assert.Contains(string(out), "Please specify a site name or change directories")
 }
 
 // TestDevLogs tests that the Dev logs functionality is working.

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -27,7 +27,7 @@ func TestDevLogsBadArgs(t *testing.T) {
 	args := []string{"logs"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "unable to determine the application for this command")
+	assert.Contains(string(out), "could not find containers which matched search criteria")
 }
 
 // TestDevLogs tests that the Dev logs functionality is working.

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -15,7 +15,7 @@ var LocalDevRMCmd = &cobra.Command{
 	Short:   "Remove the local development environment for a site.",
 	Long: `Remove the local development environment for a site. You can run 'ddev remove'
 from a site directory to remove that site, or you can specify a site to remove
-by running 'ddev rm <sitename>'. By default, remove is a non-destructive operation and will
+by running 'ddev remove <sitename>'. By default, remove is a non-destructive operation and will
 leave database contents intact.
 
 To remove database contents, you may use the --remove-data flag with remove.`,

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
-	"github.com/drud/ddev/pkg/fileutil"
 )
 
 var removeData bool
@@ -45,7 +45,7 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 			if err != nil {
 				util.Failed("Failed to remove %s: %s", app.GetName(), err)
 			}
-		}else{
+		} else {
 			err = platform.Cleanup(app)
 			if err != nil {
 				util.Failed("Failed to remove %s: %s", app.GetName(), err)

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -32,7 +32,6 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 
 		app, err := platform.GetActiveApp(siteName)
 		if err != nil {
-			app.Down(removeData)
 			util.Failed("Failed to remove: %v", err)
 		}
 

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -40,16 +39,9 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 			util.Failed("App not running locally. Try `ddev start`.")
 		}
 
-		if fileutil.FileExists(app.AppRoot()) {
-			err = app.Down(removeData)
-			if err != nil {
-				util.Failed("Failed to remove %s: %s", app.GetName(), err)
-			}
-		} else {
-			err = platform.Cleanup(app)
-			if err != nil {
-				util.Failed("Failed to remove %s: %s", app.GetName(), err)
-			}
+		err = app.Down(removeData)
+		if err != nil {
+			util.Failed("Failed to remove %s: %s", app.GetName(), err)
 		}
 
 		util.Success("Successfully removed the %s application.", app.GetName())

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -32,6 +32,7 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 
 		app, err := platform.GetActiveApp(siteName)
 		if err != nil {
+			app.Down(removeData)
 			util.Failed("Failed to remove: %v", err)
 		}
 

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
+	"github.com/drud/ddev/pkg/fileutil"
 )
 
 var removeData bool
@@ -39,9 +40,16 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 			util.Failed("App not running locally. Try `ddev start`.")
 		}
 
-		err = app.Down(removeData)
-		if err != nil {
-			util.Failed("Failed to remove %s: %s", app.GetName(), err)
+		if fileutil.FileExists(app.AppRoot()) {
+			err = app.Down(removeData)
+			if err != nil {
+				util.Failed("Failed to remove %s: %s", app.GetName(), err)
+			}
+		}else{
+			err = platform.Cleanup(app)
+			if err != nil {
+				util.Failed("Failed to remove %s: %s", app.GetName(), err)
+			}
 		}
 
 		util.Success("Successfully removed the %s application.", app.GetName())

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -72,7 +72,7 @@ func TestGetActiveAppRoot(t *testing.T) {
 	assert := asrt.New(t)
 
 	_, err := platform.GetActiveAppRoot("")
-	assert.Contains(err.Error(), "unable to determine the application for this command")
+	assert.Contains(err.Error(), "could not find containers which matched search criteria")
 
 	_, err = platform.GetActiveAppRoot("potato")
 	assert.Error(err)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -72,7 +72,7 @@ func TestGetActiveAppRoot(t *testing.T) {
 	assert := asrt.New(t)
 
 	_, err := platform.GetActiveAppRoot("")
-	assert.Contains(err.Error(), "Please specify a site name or change directories.")
+	assert.Contains(err.Error(), "Please specify a site name or change directories")
 
 	_, err = platform.GetActiveAppRoot("potato")
 	assert.Error(err)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -72,7 +72,7 @@ func TestGetActiveAppRoot(t *testing.T) {
 	assert := asrt.New(t)
 
 	_, err := platform.GetActiveAppRoot("")
-	assert.Contains(err.Error(), "could not find containers which matched search criteria")
+	assert.Contains(err.Error(), "Please specify a site name or change directories.")
 
 	_, err = platform.GetActiveAppRoot("potato")
 	assert.Error(err)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -948,7 +948,7 @@ func GetActiveAppRoot(siteName string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("error determining the current directory: %s", err)
 		}
-		_, err := CheckForConf(siteDir)
+		_, err = CheckForConf(siteDir)
 		if err != nil {
 			return "", fmt.Errorf("Could not find a site in %s. Please specify a site name or change directories: %s", siteDir, err)
 		}
@@ -991,7 +991,10 @@ func GetActiveApp(siteName string) (App, error) {
 		return app, err
 	}
 
-	app.Init(activeAppRoot)
+	err = app.Init(activeAppRoot)
+	if err != nil {
+		return app, err
+	}
 	// Make sure AppConfig.Name is set in case this is app is being used for Cleanup().
 	if app.GetName() == "" {
 		app, _ := app.(*LocalApp)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -991,10 +991,8 @@ func GetActiveApp(siteName string) (App, error) {
 		return app, err
 	}
 
-	err = app.Init(activeAppRoot)
-	if err != nil {
-		return app, err
-	}
+	_ = app.Init(activeAppRoot)
+
 	// Make sure AppConfig.Name is set in case this is app is being used for Cleanup().
 	if app.GetName() == "" {
 		app, _ := app.(*LocalApp)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -676,7 +676,7 @@ func (l *LocalApp) Stop() error {
 	}
 
 	if strings.Contains(l.SiteStatus(), SiteDirMissing) || strings.Contains(l.SiteStatus(), SiteConfigMissing) {
-		return fmt.Errorf("ddev can no longer find your application files at %s. If you would like to continue using ddev to manage this site please restore your files to that directory. If you would like to remove this site from ddev, you may run ddev rm %s", l.AppRoot(), l.GetName())
+		return fmt.Errorf("ddev can no longer find your application files at %s. If you would like to continue using ddev to manage this site please restore your files to that directory. If you would like to remove this site from ddev, you may run 'ddev remove %s'", l.AppRoot(), l.GetName())
 	}
 
 	_, _, err := dockerutil.ComposeCmd(l.ComposeFiles(), "stop")

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -988,7 +988,9 @@ func GetActiveApp(siteName string) (App, error) {
 
 	_ = app.Init(activeAppRoot)
 	// Check to see if there are any missing AppConfig values that still need to be restored.
-	if restoreIsNeeded(app) {
+	localApp, _ := app.(*LocalApp)
+
+	if localApp.AppConfig.Name == "" || localApp.AppConfig.DataDir == "" {
 		err = restoreApp(app, siteName)
 		if err != nil {
 			return app, err
@@ -998,11 +1000,12 @@ func GetActiveApp(siteName string) (App, error) {
 	return app, nil
 }
 
-// restoreApp manually restores an AppConfig's Name and/or DataDir and returns an error if it cannot manually restore.
+// restoreApp recreates an AppConfig's Name and/or DataDir and returns an error
+// if it cannot restore them.
 func restoreApp(app App, siteName string) error {
 	localApp, _ := app.(*LocalApp)
 	if siteName == "" {
-		return fmt.Errorf("error manually restoring AppConfig: no siteName given")
+		return fmt.Errorf("error restoring AppConfig: no siteName given")
 	}
 	localApp.AppConfig.Name = siteName
 	// Ensure that AppConfig.DataDir is set so that site data can be removed if necessary.
@@ -1010,19 +1013,6 @@ func restoreApp(app App, siteName string) error {
 	localApp.AppConfig.DataDir = dataDir
 
 	return nil
-}
-
-// restoreIsNeeded returns a boolean indicating whether or not an AppConfig has necessary values set (currently Name and DataDir).
-func restoreIsNeeded(app App) bool {
-	localApp, _ := app.(*LocalApp)
-	// Make sure AppConfig.Name is set in case this app is being used for Cleanup().
-	if localApp.AppConfig.Name == "" {
-		return true
-	}
-	if localApp.AppConfig.DataDir == "" {
-		return true
-	}
-	return false
 }
 
 // validateDataDirRemoval validates that dataDir is a safe filepath to be removed by ddev.

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -986,6 +986,9 @@ func GetActiveApp(siteName string) (App, error) {
 		return app, err
 	}
 
+	// Ignore app.Init() error, since app.Init() fails if no directory found.
+	// We already were successful with *finding* the app, and if we get an
+	// incomplete one we have to add to it.
 	_ = app.Init(activeAppRoot)
 	// Check to see if there are any missing AppConfig values that still need to be restored.
 	localApp, _ := app.(*LocalApp)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -945,7 +945,7 @@ func GetActiveAppRoot(siteName string) (string, error) {
 		}
 		_, err = CheckForConf(siteDir)
 		if err != nil {
-			return "", fmt.Errorf("Could not find a site in %s. Please specify a site name or change directories: %s", siteDir, err)
+			return "", fmt.Errorf("Could not find a site in %s. Have you run 'ddev config'? Please specify a site name or change directories: %s", siteDir, err)
 		}
 	} else {
 		var ok bool

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -971,6 +971,10 @@ func GetActiveApp(siteName string) (App, error) {
 	}
 	activeAppRoot, err := GetActiveAppRoot(siteName)
 	if err != nil {
+		// Return a config so we may delete the app in the case of a missing directory or config.
+		webContainer := dockerutil.FindContainerByLabels()
+		siteStruct := app.(*LocalApp)
+		siteStruct.AppConfig.SiteSettingsPath =
 		return app, err
 	}
 

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -1033,8 +1033,9 @@ func validateDataDirRemoval(config *ddevapp.Config) error {
 		return unsafeFilePathErr
 	}
 	// Get the last element of dataDir and use it to check that there is something after GlobalDdevDir.
-	pathTail := filepath.Base(dataDir)
-	if pathTail == ".ddev" || pathTail != config.Name || pathTail == "" {
+	lastPathElem := filepath.Base(dataDir)
+	nextLastPathElem := filepath.Base(filepath.Dir(dataDir))
+	if lastPathElem == ".ddev" || nextLastPathElem != config.Name || lastPathElem == "" {
 		return unsafeFilePathErr
 	}
 	return nil

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -948,6 +948,10 @@ func GetActiveAppRoot(siteName string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("error determining the current directory: %s", err)
 		}
+		_, err := CheckForConf(siteDir)
+		if err != nil {
+			return "", fmt.Errorf("Could not find a site in %s. Please specify a site name or change directories.", siteDir)
+		}
 	} else {
 		var ok bool
 

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -674,6 +674,12 @@ func (l *LocalApp) Stop() error {
 		return fmt.Errorf("no site to remove")
 	}
 
+	if l.SiteStatus() == SiteDirMissing || l.SiteStatus() == SiteConfigMissing {
+		return fmt.Errorf("ddev can no longer find your application files at %s. "+
+			"If you would like to continue using ddev to manage this site please restore your files to that directory. "+
+			"If you would like to remove this site from ddev, you may run ‘ddev rm %s‘.", l.AppRoot(), l.GetName())
+	}
+
 	_, _, err := dockerutil.ComposeCmd(l.ComposeFiles(), "stop")
 
 	if err != nil {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -997,7 +997,7 @@ func GetActiveApp(siteName string) (App, error) {
 	}
 
 	_ = app.Init(activeAppRoot)
-	// Make sure AppConfig.Name is set in case this is app is being used for Cleanup().
+	// Make sure AppConfig.Name is set in case this app is being used for Cleanup().
 	if app.GetName() == "" {
 		app, _ := app.(*LocalApp)
 		app.AppConfig.Name = siteName

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -847,7 +847,19 @@ func (l *LocalApp) Down(removeData bool) error {
 				}
 			}
 		}
-		dir := filepath.Dir(l.AppConfig.DataDir)
+		// Check to see if the AppRoot exists.
+		// If it does not exist, manually set the data directory to remove.
+		var dir string
+		if fileutil.FileExists(l.AppConfig.AppRoot) {
+			dir = filepath.Dir(l.AppConfig.DataDir)
+		} else {
+			user, err := user.Current()
+			if err != nil {
+				return err
+			}
+			dir = fmt.Sprintf("%s/.ddev/%s", user.HomeDir, l.GetName())
+		}
+
 		// mysql data can be set to read-only on linux hosts. PurgeDirectory ensures files
 		// are writable before we attempt to remove them.
 		if !fileutil.FileExists(dir) {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -847,19 +847,8 @@ func (l *LocalApp) Down(removeData bool) error {
 				}
 			}
 		}
-		// Check to see if the AppRoot exists.
-		// If it does not exist, manually set the data directory to remove.
-		var dir string
-		if fileutil.FileExists(l.AppConfig.AppRoot) {
-			dir = filepath.Dir(l.AppConfig.DataDir)
-		} else {
-			user, err := user.Current()
-			if err != nil {
-				return err
-			}
-			dir = fmt.Sprintf("%s/.ddev/%s", user.HomeDir, l.GetName())
-		}
-
+		// Convenience identifier
+		dir := l.AppConfig.DataDir
 		// mysql data can be set to read-only on linux hosts. PurgeDirectory ensures files
 		// are writable before we attempt to remove them.
 		if !fileutil.FileExists(dir) {
@@ -1008,11 +997,16 @@ func GetActiveApp(siteName string) (App, error) {
 	}
 
 	_ = app.Init(activeAppRoot)
-
 	// Make sure AppConfig.Name is set in case this is app is being used for Cleanup().
 	if app.GetName() == "" {
 		app, _ := app.(*LocalApp)
 		app.AppConfig.Name = siteName
+		// Since the site may be used for Cleanup(), also check that AppConfig.DataDir is set.
+		// This ensures that the sites data can be removed with the containers.
+		if app.AppConfig.DataDir == "" {
+			dataDir := fmt.Sprintf("%s/%s", util.GetGlobalDdevDir(), app.AppConfig.Name)
+			app.AppConfig.DataDir = dataDir
+		}
 	}
 
 	return app, nil

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -1024,6 +1024,10 @@ func RestoreIsNeeded(app App) bool {
 // ValidateDataDirRemoval validates that dataDir is a safe filepath to be removed by ddev.
 func ValidateDataDirRemoval(dataDir string) error {
 	unsafeFilePathErr := fmt.Errorf("filepath: %s unsafe for removal", dataDir)
+	// Check for an empty filepath
+	if dataDir == "" {
+		return unsafeFilePathErr
+	}
 	// Get the current working directory.
 	currDir, err := os.Getwd()
 	if err != nil {
@@ -1031,11 +1035,6 @@ func ValidateDataDirRemoval(dataDir string) error {
 	}
 	// Check that dataDir is not the current directory.
 	if dataDir == currDir {
-		return unsafeFilePathErr
-	}
-	// Get all but the last element of dataDir and check that it is equal to the GlobalDdevDir.
-	pathHead := filepath.Dir(dataDir)
-	if pathHead != util.GetGlobalDdevDir() {
 		return unsafeFilePathErr
 	}
 	// Get the last element of dataDir and use it to check that there is something after GlobalDdevDir.

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -70,6 +70,12 @@ func (l *LocalApp) Init(basePath string) error {
 	return nil
 }
 
+// InitFromMissingDirectory populates local app settings based on manually given arguments.
+func (l *LocalApp) InitFromMissingDirectory(name string, appType string) {
+	l.AppConfig.Name = name
+	l.AppConfig.AppType = appType
+}
+
 // FindContainerByType will find a container for this site denoted by the containerType if it is available.
 func (l *LocalApp) FindContainerByType(containerType string) (docker.APIContainers, error) {
 	labels := map[string]string{

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -834,7 +834,7 @@ func (l *LocalApp) Down(removeData bool) error {
 			}
 		}
 		// Check that l.AppConfig.DataDir is a directory that is safe to remove.
-		err = validateDataDirRemoval(l.AppConfig.DataDir)
+		err = validateDataDirRemoval(l.AppConfig)
 		if err != nil {
 			return fmt.Errorf("failed to remove data directories: %v", err)
 		}
@@ -850,7 +850,7 @@ func (l *LocalApp) Down(removeData bool) error {
 			// PurgeDirectory leaves the directory itself in place, so we remove it here.
 			err = os.RemoveAll(l.AppConfig.DataDir)
 			if err != nil {
-				return fmt.Errorf("failed to remove data directories: %v", err)
+				return fmt.Errorf("failed to remove data directory %s: %v", l.AppConfig.DataDir, err)
 			}
 			util.Success("Application data removed")
 		}
@@ -1026,7 +1026,8 @@ func restoreIsNeeded(app App) bool {
 }
 
 // validateDataDirRemoval validates that dataDir is a safe filepath to be removed by ddev.
-func validateDataDirRemoval(dataDir string) error {
+func validateDataDirRemoval(config *ddevapp.Config) error {
+	dataDir := config.DataDir
 	unsafeFilePathErr := fmt.Errorf("filepath: %s unsafe for removal", dataDir)
 	// Check for an empty filepath
 	if dataDir == "" {
@@ -1043,7 +1044,7 @@ func validateDataDirRemoval(dataDir string) error {
 	}
 	// Get the last element of dataDir and use it to check that there is something after GlobalDdevDir.
 	pathTail := filepath.Base(dataDir)
-	if pathTail == ".ddev" {
+	if pathTail == ".ddev" || pathTail != config.Name || pathTail == "" {
 		return unsafeFilePathErr
 	}
 	return nil

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -950,7 +950,7 @@ func GetActiveAppRoot(siteName string) (string, error) {
 		}
 		_, err := CheckForConf(siteDir)
 		if err != nil {
-			return "", fmt.Errorf("Could not find a site in %s. Please specify a site name or change directories.", siteDir)
+			return "", fmt.Errorf("Could not find a site in %s. Please specify a site name or change directories: %s", siteDir, err)
 		}
 	} else {
 		var ok bool

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -834,7 +834,7 @@ func (l *LocalApp) Down(removeData bool) error {
 			}
 		}
 		// Check that l.AppConfig.DataDir is a directory that is safe to remove.
-		err = ValidateDataDirRemoval(l.AppConfig.DataDir)
+		err = validateDataDirRemoval(l.AppConfig.DataDir)
 		if err != nil {
 			return fmt.Errorf("failed to remove data directories: %v", err)
 		}
@@ -988,8 +988,8 @@ func GetActiveApp(siteName string) (App, error) {
 
 	_ = app.Init(activeAppRoot)
 	// Check to see if there are any missing AppConfig values that still need to be restored.
-	if RestoreIsNeeded(app) {
-		err = RestoreApp(app, siteName)
+	if restoreIsNeeded(app) {
+		err = restoreApp(app, siteName)
 		if err != nil {
 			return app, err
 		}
@@ -998,8 +998,8 @@ func GetActiveApp(siteName string) (App, error) {
 	return app, nil
 }
 
-// RestoreApp manually restores an AppConfig's Name and/or DataDir and returns an error if it cannot manually restore.
-func RestoreApp(app App, siteName string) error {
+// restoreApp manually restores an AppConfig's Name and/or DataDir and returns an error if it cannot manually restore.
+func restoreApp(app App, siteName string) error {
 	localApp, _ := app.(*LocalApp)
 	if siteName == "" {
 		return fmt.Errorf("error manually restoring AppConfig: no siteName given")
@@ -1012,8 +1012,8 @@ func RestoreApp(app App, siteName string) error {
 	return nil
 }
 
-// RestoreIsNeeded returns a boolean indicating whether or not an AppConfig has necessary values set (currently Name and DataDir).
-func RestoreIsNeeded(app App) bool {
+// restoreIsNeeded returns a boolean indicating whether or not an AppConfig has necessary values set (currently Name and DataDir).
+func restoreIsNeeded(app App) bool {
 	localApp, _ := app.(*LocalApp)
 	// Make sure AppConfig.Name is set in case this app is being used for Cleanup().
 	if localApp.AppConfig.Name == "" {
@@ -1025,8 +1025,8 @@ func RestoreIsNeeded(app App) bool {
 	return false
 }
 
-// ValidateDataDirRemoval validates that dataDir is a safe filepath to be removed by ddev.
-func ValidateDataDirRemoval(dataDir string) error {
+// validateDataDirRemoval validates that dataDir is a safe filepath to be removed by ddev.
+func validateDataDirRemoval(dataDir string) error {
 	unsafeFilePathErr := fmt.Errorf("filepath: %s unsafe for removal", dataDir)
 	// Check for an empty filepath
 	if dataDir == "" {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -674,10 +674,8 @@ func (l *LocalApp) Stop() error {
 		return fmt.Errorf("no site to remove")
 	}
 
-	if l.SiteStatus() == SiteDirMissing || l.SiteStatus() == SiteConfigMissing {
-		return fmt.Errorf("ddev can no longer find your application files at %s. "+
-			"If you would like to continue using ddev to manage this site please restore your files to that directory. "+
-			"If you would like to remove this site from ddev, you may run ‘ddev rm %s‘.", l.AppRoot(), l.GetName())
+	if strings.Contains(l.SiteStatus(), SiteDirMissing) || strings.Contains(l.SiteStatus(), SiteConfigMissing) {
+		return fmt.Errorf("ddev can no longer find your application files at %s. If you would like to continue using ddev to manage this site please restore your files to that directory. If you would like to remove this site from ddev, you may run ddev rm %s", l.AppRoot(), l.GetName())
 	}
 
 	_, _, err := dockerutil.ComposeCmd(l.ComposeFiles(), "stop")

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -70,12 +70,6 @@ func (l *LocalApp) Init(basePath string) error {
 	return nil
 }
 
-// InitFromMissingDirectory populates local app settings based on manually given arguments.
-func (l *LocalApp) InitFromMissingDirectory(name string, appType string) {
-	l.AppConfig.Name = name
-	l.AppConfig.AppType = appType
-}
-
 // FindContainerByType will find a container for this site denoted by the containerType if it is available.
 func (l *LocalApp) FindContainerByType(containerType string) (docker.APIContainers, error) {
 	labels := map[string]string{

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -655,7 +655,10 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	assert.NoError(err)
 
 	// Call the Down command()
-	err = app.Down(false)
+	// Notice that we set the removeData parameter to true.
+	// This gives us added test coverage over sites with missing directories
+	// by ensuring any associated database files get cleaned up as well.
+	err = app.Down(true)
 	assert.NoError(err)
 
 	for _, containerType := range [3]string{"web", "db", "dba"} {

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -493,8 +493,8 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
 
-	err = app.Stop()
-	assert.Contains(err, "If you would like to continue using ddev to manage this site please restore your files to that directory.")
+	out := app.Stop()
+	assert.Contains(out, "If you would like to continue using ddev to manage this site please restore your files to that directory.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
 	assert.NoError(err)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -475,16 +475,16 @@ func TestLocalStop(t *testing.T) {
 // TestLocalStopMissingDirectory tests that the 'ddev stop' command works properly on sites with missing directories or ddev configs.
 func TestLocalStopMissingDirectory(t *testing.T) {
 	assert := asrt.New(t)
-	app, err := platform.GetPluginApp("local")
+	_, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
 	// Cleanup the temp directory
-	defer os.RemoveAll(tempPath)
+	defer assert.NoError(os.RemoveAll(tempPath))
 
-	app, err = platform.GetActiveApp(site.Name)
+	app, err := platform.GetActiveApp(site.Name)
 	assert.NoError(err)
 	// Restart the site since it was stopped in the previous test.
 	if app.SiteStatus() != platform.SiteRunning {
@@ -539,16 +539,16 @@ func TestDescribe(t *testing.T) {
 // TestDescribeMissingDirectory tests that the describe command works properly on sites with missing directories or ddev configs.
 func TestDescribeMissingDirectory(t *testing.T) {
 	assert := asrt.New(t)
-	app, err := platform.GetPluginApp("local")
+	_, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
 	// Cleanup the temp directory.
-	defer os.RemoveAll(tempPath)
+	defer assert.NoError(os.RemoveAll(tempPath))
 
-	app, err = platform.GetActiveApp(site.Name)
+	app, err := platform.GetActiveApp(site.Name)
 	assert.NoError(err)
 	// Move the site directory to a temp location to mimick a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
@@ -644,7 +644,7 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
 	// Cleanup the temp directory
-	defer os.RemoveAll(tempPath)
+	defer assert.NoError(os.RemoveAll(tempPath))
 
 	// Call the Down command()
 	err = app.Down(false)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -479,11 +479,15 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	site := TestSites[0]
+	app, err := platform.GetPluginApp("local")
+	assert.NoError(err)
+	err = app.Init(site.Dir)
+	assert.NoError(err)
+
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
 	defer removeAllErrCheck(tempPath, assert)
 
-	app, err := platform.GetActiveApp(site.Name)
 	assert.NoError(err)
 	// Restart the site since it was stopped in the previous test.
 	if app.SiteStatus() != platform.SiteRunning {

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -505,6 +505,24 @@ func TestDescribe(t *testing.T) {
 	}
 }
 
+// TestDescribeMissingDirectory tests that the describe command works properly on sites with missing directories or ddev configs.
+func TestDescribeMissingDirectory(t *testing.T) {
+	assert := asrt.New(t)
+	app, err := platform.GetPluginApp("local")
+	assert.NoError(err)
+
+	for _, site := range TestSites {
+		site.Cleanup()
+		app, err = platform.GetActiveApp(site.Name)
+		assert.NoError(err)
+
+		out, err := app.Describe()
+		assert.NoError(err)
+		assert.Contains(out, platform.SiteDirMissing, "Output did not include the phrase 'app directory missing' when describing a site with missing directories.")
+	}
+}
+
+
 // TestRouterPortsCheck makes sure that we can detect if the ports are available before starting the router.
 func TestRouterPortsCheck(t *testing.T) {
 	assert := asrt.New(t)
@@ -561,6 +579,7 @@ func TestRouterPortsCheck(t *testing.T) {
 	out, err := exec.RunCommand("docker", []string{"rm", "-f", containerId})
 	assert.NoError(err, "Failed to docker rm the port-occupier container, err=%v output=%v", err, out)
 }
+
 
 // TestCleanupWithoutCompose ensures app containers can be properly cleaned up without a docker-compose config file present.
 func TestCleanupWithoutCompose(t *testing.T) {

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -153,7 +153,7 @@ func TestLocalStart(t *testing.T) {
 		assert.True(composeFile)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
-			containerName, err := getContainerByType(containerType, app)
+			containerName, err := constructContainerName(containerType, app)
 			assert.NoError(err)
 			check, err := testcommon.ContainerCheck(containerName, "running")
 			assert.NoError(err)
@@ -460,7 +460,7 @@ func TestLocalStop(t *testing.T) {
 		assert.NoError(err)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
-			containerName, err := getContainerByType(containerType, app)
+			containerName, err := constructContainerName(containerType, app)
 			assert.NoError(err)
 			check, err := testcommon.ContainerCheck(containerName, "exited")
 			assert.NoError(err)
@@ -660,7 +660,7 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	assert.NoError(err)
 
 	for _, containerType := range [3]string{"web", "db", "dba"} {
-		_, err := getContainerByType(containerType, app)
+		_, err := constructContainerName(containerType, app)
 		assert.Error(err)
 	}
 
@@ -789,8 +789,8 @@ func TestListWithoutDir(t *testing.T) {
 	assert.NoError(err)
 }
 
-// getContainerByType builds a container name given the type (web/db/dba) and the app
-func getContainerByType(containerType string, app platform.App) (string, error) {
+// constructContainerName builds a container name given the type (web/db/dba) and the app
+func constructContainerName(containerType string, app platform.App) (string, error) {
 	container, err := app.FindContainerByType(containerType)
 	if err != nil {
 		return "", err

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -475,10 +475,9 @@ func TestLocalStop(t *testing.T) {
 // TestLocalStopMissingDirectory tests that the 'ddev stop' command works properly on sites with missing directories or ddev configs.
 func TestLocalStopMissingDirectory(t *testing.T) {
 	assert := asrt.New(t)
-	_, err := platform.GetPluginApp("local")
-	assert.NoError(err)
 
 	site := TestSites[0]
+	testcommon.ClearDockerEnv()
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 	err = app.Init(site.Dir)
@@ -504,6 +503,7 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
 	assert.NoError(err)
+
 }
 
 // TestDescribe tests that the describe command works properly on a stopped site.
@@ -542,9 +542,6 @@ func TestDescribe(t *testing.T) {
 // TestDescribeMissingDirectory tests that the describe command works properly on sites with missing directories or ddev configs.
 func TestDescribeMissingDirectory(t *testing.T) {
 	assert := asrt.New(t)
-	_, err := platform.GetPluginApp("local")
-	assert.NoError(err)
-
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -125,7 +125,7 @@ func TestMain(m *testing.M) {
 
 		err = app.Down(true)
 		if err != nil {
-			log.Fatalf("TestMain startup: app.Down() failed on site %s, err=%v", TestSites[i].Name, err)
+			log.Fatalf("TestMain shutdown: app.Down() failed on site %s, err=%v", TestSites[i].Name, err)
 		}
 
 		runTime()
@@ -564,7 +564,6 @@ func TestDescribeMissingDirectory(t *testing.T) {
 	assert.NoError(err)
 }
 
-
 // TestRouterPortsCheck makes sure that we can detect if the ports are available before starting the router.
 func TestRouterPortsCheck(t *testing.T) {
 	assert := asrt.New(t)
@@ -621,7 +620,6 @@ func TestRouterPortsCheck(t *testing.T) {
 	out, err := exec.RunCommand("docker", []string{"rm", "-f", containerId})
 	assert.NoError(err, "Failed to docker rm the port-occupier container, err=%v output=%v", err, out)
 }
-
 
 // TestCleanupWithoutCompose ensures app containers can be properly cleaned up without a docker-compose config file present.
 func TestCleanupWithoutCompose(t *testing.T) {

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -494,7 +494,8 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	out := app.Stop()
-	assert.Contains(out, "If you would like to continue using ddev to manage this site please restore your files to that directory.")
+	assert.Error(out)
+	assert.Contains(out.Error(), "If you would like to continue using ddev to manage this site please restore your files to that directory.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
 	assert.NoError(err)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -484,16 +484,16 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	err = app.Init(site.Dir)
 	assert.NoError(err)
 
-	tempPath := testcommon.CreateTmpDir("site-copy")
-	siteCopyDest := filepath.Join(tempPath, "site")
-	defer removeAllErrCheck(tempPath, assert)
-
-	assert.NoError(err)
 	// Restart the site since it was stopped in the previous test.
 	if app.SiteStatus() != platform.SiteRunning {
 		err = app.Start()
 		assert.NoError(err)
 	}
+
+	tempPath := testcommon.CreateTmpDir("site-copy")
+	siteCopyDest := filepath.Join(tempPath, "site")
+	defer removeAllErrCheck(tempPath, assert)
+
 	// Move the site directory to a temp location to mimic a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -481,8 +481,6 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
-	// Cleanup the temp directory
-	defer assert.NoError(os.RemoveAll(tempPath))
 
 	app, err := platform.GetActiveApp(site.Name)
 	assert.NoError(err)
@@ -491,7 +489,7 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 		err = app.Start()
 		assert.NoError(err)
 	}
-	// Move the site directory to a temp location to mimick a missing directory.
+	// Move the site directory to a temp location to mimic a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
 
@@ -500,6 +498,9 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	assert.Contains(out.Error(), "If you would like to continue using ddev to manage this site please restore your files to that directory.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
+	assert.NoError(err)
+	// Cleanup the temp directory.
+	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 
@@ -545,8 +546,6 @@ func TestDescribeMissingDirectory(t *testing.T) {
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
-	// Cleanup the temp directory.
-	defer assert.NoError(os.RemoveAll(tempPath))
 
 	app, err := platform.GetActiveApp(site.Name)
 	assert.NoError(err)
@@ -559,6 +558,9 @@ func TestDescribeMissingDirectory(t *testing.T) {
 	assert.Contains(out, platform.SiteDirMissing, "Output did not include the phrase 'app directory missing' when describing a site with missing directories.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
+	assert.NoError(err)
+	// Cleanup the temp directory.
+	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 
@@ -643,8 +645,6 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	// Move site directory to a temp directory to mimick a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
-	// Cleanup the temp directory
-	defer assert.NoError(os.RemoveAll(tempPath))
 
 	// Call the Down command()
 	err = app.Down(false)
@@ -672,6 +672,9 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	revertDir()
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
+	assert.NoError(err)
+	// Cleanup the temp directory.
+	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -546,8 +546,11 @@ func TestDescribeMissingDirectory(t *testing.T) {
 	siteCopyDest := filepath.Join(tempPath, "site")
 	defer removeAllErrCheck(tempPath, assert)
 
-	app, err := platform.GetActiveApp(site.Name)
+	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
+	err = app.Init(site.Dir)
+	assert.NoError(err)
+
 	// Move the site directory to a temp location to mimick a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
@@ -638,10 +641,11 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	// Setup by creating temp directory and nesting a folder for our site.
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
+	defer removeAllErrCheck(tempPath, assert)
+
 	// Move site directory to a temp directory to mimick a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
-	defer removeAllErrCheck(tempPath, assert)
 
 	// Call the Down command()
 	err = app.Down(false)

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -481,6 +481,7 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
+	defer removeAllErrCheck(tempPath, assert)
 
 	app, err := platform.GetActiveApp(site.Name)
 	assert.NoError(err)
@@ -498,9 +499,6 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	assert.Contains(out.Error(), "If you would like to continue using ddev to manage this site please restore your files to that directory.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
-	assert.NoError(err)
-	// Cleanup the temp directory.
-	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 
@@ -546,6 +544,7 @@ func TestDescribeMissingDirectory(t *testing.T) {
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
+	defer removeAllErrCheck(tempPath, assert)
 
 	app, err := platform.GetActiveApp(site.Name)
 	assert.NoError(err)
@@ -558,9 +557,6 @@ func TestDescribeMissingDirectory(t *testing.T) {
 	assert.Contains(out, platform.SiteDirMissing, "Output did not include the phrase 'app directory missing' when describing a site with missing directories.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
-	assert.NoError(err)
-	// Cleanup the temp directory.
-	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 
@@ -645,6 +641,7 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	// Move site directory to a temp directory to mimick a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
+	defer removeAllErrCheck(tempPath, assert)
 
 	// Call the Down command()
 	err = app.Down(false)
@@ -672,9 +669,6 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	revertDir()
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
-	assert.NoError(err)
-	// Cleanup the temp directory.
-	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 
@@ -791,4 +785,9 @@ func getContainerByType(containerType string, app platform.App) (string, error) 
 	}
 	name := dockerutil.ContainerName(container)
 	return name, nil
+}
+
+func removeAllErrCheck(path string, assert *asrt.Assertions) {
+	err := os.RemoveAll(path)
+	assert.NoError(err)
 }

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -481,6 +481,8 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
+	// Cleanup the temp directory
+	defer os.RemoveAll(tempPath)
 
 	app, err = platform.GetActiveApp(site.Name)
 	assert.NoError(err)
@@ -498,9 +500,6 @@ func TestLocalStopMissingDirectory(t *testing.T) {
 	assert.Contains(out.Error(), "If you would like to continue using ddev to manage this site please restore your files to that directory.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
-	assert.NoError(err)
-	// Cleanup the temp directory
-	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 
@@ -546,6 +545,8 @@ func TestDescribeMissingDirectory(t *testing.T) {
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
+	// Cleanup the temp directory.
+	defer os.RemoveAll(tempPath)
 
 	app, err = platform.GetActiveApp(site.Name)
 	assert.NoError(err)
@@ -558,9 +559,6 @@ func TestDescribeMissingDirectory(t *testing.T) {
 	assert.Contains(out, platform.SiteDirMissing, "Output did not include the phrase 'app directory missing' when describing a site with missing directories.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
-	assert.NoError(err)
-	// Cleanup the temp directory
-	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 
@@ -645,6 +643,8 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	// Move site directory to a temp directory to mimick a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
+	// Cleanup the temp directory
+	defer os.RemoveAll(tempPath)
 
 	// Call the Down command()
 	err = app.Down(false)
@@ -672,9 +672,6 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	revertDir()
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
-	assert.NoError(err)
-	// Cleanup the temp directory
-	err = os.RemoveAll(tempPath)
 	assert.NoError(err)
 }
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -2,11 +2,11 @@ package platform_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
-
-	"os"
 
 	"strings"
 
@@ -626,6 +626,12 @@ func TestRouterPortsCheck(t *testing.T) {
 // TestCleanupWithoutCompose ensures app containers can be properly cleaned up without a docker-compose config file present.
 func TestCleanupWithoutCompose(t *testing.T) {
 	assert := asrt.New(t)
+	// Skip test because we can't rename folders while they're in use if running on Windows.
+	if runtime.GOOS == "windows" {
+		log.Println("Skipping test TestCleanupWithoutCompose on Windows")
+		t.Skip()
+	}
+
 	site := TestSites[0]
 
 	revertDir := site.Chdir()

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -17,7 +17,7 @@ const SiteNotFound = "not found"
 const SiteDirMissing = "app directory missing"
 
 // SiteConfigMissing defines the string used to denote when a site is missing its .ddev/config.yml file.
-const SiteConfigMissing = ".ddev/config.yml missing"
+const SiteConfigMissing = ".ddev/config.yaml missing"
 
 // SiteStopped defines the string used to denote when a site is in the stopped state.
 const SiteStopped = "stopped"

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -90,6 +90,10 @@ func RenderAppRow(table *uitable.Table, row map[string]interface{}) {
 		status = color.YellowString(status)
 	case strings.Contains(status, SiteNotFound):
 		status = color.RedString(status)
+	case strings.Contains(status, SiteDirMissing):
+		status = color.RedString(status)
+	case strings.Contains(status, SiteConfigMissing):
+		status = color.RedString(status)
 	default:
 		status = color.CyanString(status)
 	}

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -19,8 +19,8 @@ import (
 )
 
 // GetApps returns a list of ddev applictions keyed by platform.
-func GetApps() map[string][]App {
-	apps := make(map[string][]App)
+func        GetApps() map[string][]App {
+ 	apps := make(map[string][]App)
 	for platformType := range PluginMap {
 		labels := map[string]string{
 			"com.ddev.platform":          "ddev",

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -19,8 +19,8 @@ import (
 )
 
 // GetApps returns a list of ddev applictions keyed by platform.
-func        GetApps() map[string][]App {
- 	apps := make(map[string][]App)
+func GetApps() map[string][]App {
+	apps := make(map[string][]App)
 	for platformType := range PluginMap {
 		labels := map[string]string{
 			"com.ddev.platform":          "ddev",

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -90,10 +90,6 @@ func RenderAppRow(table *uitable.Table, row map[string]interface{}) {
 		status = color.YellowString(status)
 	case strings.Contains(status, SiteNotFound):
 		status = color.RedString(status)
-	case strings.Contains(status, SiteDirMissing):
-		status = color.RedString(status)
-	case strings.Contains(status, SiteConfigMissing):
-		status = color.RedString(status)
 	default:
 		status = color.CyanString(status)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:
ddev rm, describe, and stop were unable to remove sites that were missing their config.yml or sites that did not have directories associated with them. This made it impossible to cleanup corrupted sites pointed out by ddev list.
## How this PR Solves The Problem:
This PR solves the problem by using a site's containers to grab it's site-name and using that site-name to run Cleanup() on the site. It also checks for a missing directory and if the approot is missing it skips `app.Down()` and uses `Cleanup()`.
## Manual Testing Instructions:
Test this PR using the following steps:
- Start a site using `ddev start`
- `rm -r` the site directory
- `ddev list` the site to see that it reports its status as `app directory missing:`
- Use `ddev rm <sitename>` to remove the site 

## Automated Testing Overview:
Tests for `ddev rm` are run in `TestCleanupWithoutCompose`. Tests for `ddev describe` are run in `TestDescribeMissingDirectory`. And tests for `ddev stop` are run in `TestLocalStopMissingDirectory`.

## Related Issue Link(s):
#459 
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

