### PR TITLE
Implement new gometalinter capabilities and take care of warnings about them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: ddev tests
           no_output_timeout: "20m"
 
-      - run: make -s staticrequired
+      - run: make -s gometalinter
 
       - run:
           command: bin/linux/ddev version
@@ -88,7 +88,7 @@ jobs:
           name: ddev tests
           no_output_timeout: "20m"
 
-      - run: make -s staticrequired
+      - run: make -s gometalinter
 
       # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
       # Earlier process updated submodules so now we clean them up to continue.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Makefile for a standard golang repo with associated container
 
+GOMETALINTER_ARGS := --vendored-linters --disable-all --enable=gofmt --enable=vet --enable vetshadow --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode --deadline=2m
+
 ##### These variables need to be adjusted in most repositories #####
 
 # This repo's root import path (under GOPATH).

--- a/Makefile
+++ b/Makefile
@@ -91,4 +91,4 @@ setup:
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
 
 # Required static analysis targets used in circleci - these cause fail if they don't work
-staticrequired: gofmt govet golint errcheck staticcheck codecoroner
+staticrequired: gometalinter

--- a/build-tools/circleci-config-yaml.example
+++ b/build-tools/circleci-config-yaml.example
@@ -16,5 +16,5 @@ stages:
 
       - run: make test
 
-      - run: make -s gofmt golint
+      - run: make -s gometalinter
 

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -21,7 +21,7 @@ BUILD_BASE_DIR ?= $$PWD
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"
 SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
 
-GOMETALINTER_ARGS ?= --vendored-linters --disable=gocyclo --disable=gotype --disable=goconst --disable=gas --deadline=2m
+GOMETALINTER_ARGS ?= --vendored-linters --disable-all --enable=gofmt --enable=vet --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode --deadline=2m
 
 
 COMMIT := $(shell git describe --tags --always --dirty)
@@ -58,8 +58,6 @@ linux darwin windows: $(GOFILES)
         go install -installsuffix static -ldflags ' $(LDFLAGS) ' $(SRC_AND_UNDER)
 	@$(shell touch $@)
 	@echo $(VERSION) >VERSION.txt
-
-static: govendor gofmt govet lint
 
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "

--- a/cmd/ddev/cmd/auth_pantheon.go
+++ b/cmd/ddev/cmd/auth_pantheon.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/go-pantheon/pkg/pantheon"
-	"github.com/mitchellh/go-homedir"
+	gohomedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +22,7 @@ var PantheonAuthCommand = &cobra.Command{
 		if len(args) != 1 {
 			util.Failed("Too many arguments detected. Please provide only your Pantheon Machine token., e.g. `ddev auth-pantheon [token]`. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.")
 		}
-		userDir, err := homedir.Dir()
+		userDir, err := gohomedir.Dir()
 		util.CheckErr(err)
 		sessionLocation := filepath.Join(userDir, ".ddev", "pantheonconfig.json")
 

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestDescribeBadArgs ensures the binary behaves as expected when used with invalid arguments or working directories.
 func TestDescribeBadArgs(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	// Create a temporary directory and switch to it for the duration of this test.
 	tmpdir := testcommon.CreateTmpDir("badargs")
@@ -41,7 +41,7 @@ func TestDescribeBadArgs(t *testing.T) {
 
 // TestDescribe tests that the describe command works properly when using the binary.
 func TestDescribe(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	for _, v := range DevTestSites {
 		// First, try to do a describe from another directory.
@@ -75,7 +75,7 @@ func TestDescribe(t *testing.T) {
 
 // TestDescribeAppFunction performs unit tests on the describeApp function from the working directory.
 func TestDescribeAppFunction(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	for _, v := range DevTestSites {
 		cleanup := v.Chdir()
 
@@ -104,7 +104,7 @@ func TestDescribeAppFunction(t *testing.T) {
 
 // TestDescribeAppUsingSitename performs unit tests on the describeApp function using the sitename as an argument.
 func TestDescribeAppUsingSitename(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	// Create a temporary directory and switch to it for the duration of this test.
 	tmpdir := testcommon.CreateTmpDir("describeAppUsingSitename")
@@ -121,7 +121,7 @@ func TestDescribeAppUsingSitename(t *testing.T) {
 
 // TestDescribeAppWithInvalidParams performs unit tests on the describeApp function using a variety of invalid parameters.
 func TestDescribeAppWithInvalidParams(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	// Create a temporary directory and switch to it for the duration of this test.
 	tmpdir := testcommon.CreateTmpDir("TestDescribeAppWithInvalidParams")

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/drud/ddev/pkg/exec"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestDevExecBadArgs run `ddev exec` without the proper args
 func TestDevExecBadArgs(t *testing.T) {
 	// Change to the first DevTestSite for the duration of this test.
 	defer DevTestSites[0].Chdir()()
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	args := []string{"exec"}
 	out, err := exec.RunCommand(DdevBin, args)
@@ -22,7 +22,7 @@ func TestDevExecBadArgs(t *testing.T) {
 // TestDevExec run `ddev exec pwd` with proper args
 func TestDevExec(t *testing.T) {
 
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	for _, v := range DevTestSites {
 		cleanup := v.Chdir()
 

--- a/cmd/ddev/cmd/import_test.go
+++ b/cmd/ddev/cmd/import_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
-	homedir "github.com/mitchellh/go-homedir"
+	gohomedir "github.com/mitchellh/go-homedir"
 	asrt "github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +19,7 @@ func TestImportTilde(t *testing.T) {
 
 	for _, site := range DevTestSites {
 
-		homedir, err := homedir.Dir()
+		homedir, err := gohomedir.Dir()
 		assert.NoError(err)
 		cwd, _ := os.Getwd()
 		testFile := filepath.Join(homedir, "testfile.tar.gz")

--- a/cmd/ddev/cmd/import_test.go
+++ b/cmd/ddev/cmd/import_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestImportTilde tests passing paths to import-files that use ~ to represent home dir.
 func TestImportTilde(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	for _, site := range DevTestSites {
 

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/plugins/platform"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 func TestDevList(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	args := []string{"list"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 func TestDevLogsBadArgs(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	testDir := testcommon.CreateTmpDir("no-valid-ddev-config")
 
@@ -32,7 +32,7 @@ func TestDevLogsBadArgs(t *testing.T) {
 
 // TestDevLogs tests that the Dev logs functionality is working.
 func TestDevLogs(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	for _, v := range DevTestSites {
 		cleanup := v.Chdir()

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -41,7 +41,7 @@ func appImport(skipConfirmation bool) {
 	if !skipConfirmation {
 		// Unfortunately we cannot use util.Warning here as it automatically adds a newline, which is awkward when dealing with prompts.
 		d := color.New(color.FgYellow)
-		_, err := d.Printf("You're about to delete the current database and files and replace with a fresh import. Would you like to continue (y/N): ")
+		_, err = d.Printf("You're about to delete the current database and files and replace with a fresh import. Would you like to continue (y/N): ")
 		util.CheckErr(err)
 		if !util.AskForConfirmation() {
 			util.Warning("Import cancelled.")

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/drud/ddev/pkg/exec"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestDevRestart runs `drud legacy restart` on the test apps
 func TestDevRemove(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	// Make sure we have running sites.
 	addSites()

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/plugins/platform"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestDevRestart runs `drud legacy restart` on the test apps
 func TestDevRestart(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	containerPrefix := "ddev"
 	for _, site := range DevTestSites {
 		cleanup := site.Chdir()

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -62,6 +62,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		if timeToCheckForUpdates {
+			// nolint: vetshadow
 			updateNeeded, updateURL, err := updatecheck.AvailableUpdates("drud", "ddev", version.DdevVersion)
 
 			if err != nil {

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/plugins/platform"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 var (
@@ -67,7 +67,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetActiveAppRoot(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	_, err := platform.GetActiveAppRoot("")
 	assert.Contains(err.Error(), "unable to determine the application for this command")
@@ -90,35 +90,37 @@ func TestGetActiveAppRoot(t *testing.T) {
 
 // TestCreateGlobalDdevDir checks to make sure that ddev will create a ~/.ddev (and updatecheck)
 func TestCreateGlobalDdevDir(t *testing.T) {
+	assert := asrt.New(t)
+
 	tmpDir := testcommon.CreateTmpDir("globalDdevCheck")
 	origHome := os.Getenv("HOME")
 
 	// Make sure that the tmpDir/.ddev and tmpDir/.ddev/.update don't exist before we run ddev.
 	_, err := os.Stat(filepath.Join(tmpDir, ".ddev"))
-	assert.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	assert.Error(err)
+	assert.True(os.IsNotExist(err))
 
 	_, err = os.Stat(filepath.Join(tmpDir, ".ddev", ".update"))
-	assert.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	assert.Error(err)
+	assert.True(os.IsNotExist(err))
 
 	// Change the homedir temporarily
 	err = os.Setenv("HOME", tmpDir)
-	assert.NoError(t, err)
+	assert.NoError(err)
 
 	args := []string{"list"}
 	_, err = exec.RunCommand(DdevBin, args)
-	assert.NoError(t, err)
+	assert.NoError(err)
 
 	_, err = os.Stat(filepath.Join(tmpDir, ".ddev", ".update"))
-	assert.NoError(t, err)
+	assert.NoError(err)
 
 	// Cleanup our tmp homedir
 	err = os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	assert.NoError(err)
 
 	err = os.Setenv("HOME", origHome)
-	assert.NoError(t, err)
+	assert.NoError(err)
 }
 
 // addSites runs `ddev start` on the test apps

--- a/cmd/ddev/cmd/sequelpro_test.go
+++ b/cmd/ddev/cmd/sequelpro_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestSequelproOperation tests basic operation.
@@ -16,7 +16,7 @@ func TestSequelproOperation(t *testing.T) {
 	if !detectSequelpro() {
 		t.SkipNow()
 	}
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	v := DevTestSites[0]
 	cleanup := v.Chdir()
 
@@ -40,7 +40,7 @@ func TestSequelproBadApp(t *testing.T) {
 		t.SkipNow()
 	}
 
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	// Create a temporary directory and switch to it for the duration of this test.
 	tmpdir := testcommon.CreateTmpDir("sequelpro_badargs")

--- a/cmd/ddev/cmd/version_test.go
+++ b/cmd/ddev/cmd/version_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/drud/ddev/pkg/version"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 func TestVersion(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	v := handleVersionCommand().String()
 	output := strings.TrimSpace(v)
 	assert.Contains(output, version.DdevVersion)

--- a/pkg/appimport/appimport.go
+++ b/pkg/appimport/appimport.go
@@ -9,7 +9,7 @@ import (
 
 	"path/filepath"
 
-	homedir "github.com/mitchellh/go-homedir"
+	gohomedir "github.com/mitchellh/go-homedir"
 )
 
 // ValidateAsset determines if a given asset matches the required criteria for a given asset type.
@@ -19,7 +19,7 @@ func ValidateAsset(assetPath string, assetType string) (string, error) {
 	extensions := []string{"tar", "gz", "tgz", "zip"}
 
 	// Input provided via prompt or "--flag=value" is not expanded by shell. This will help ensure ~ is expanded to the user home directory.
-	assetPath, err := homedir.Expand(assetPath)
+	assetPath, err := gohomedir.Expand(assetPath)
 	if err != nil {
 		return "", fmt.Errorf(invalidAssetError, err)
 	}

--- a/pkg/appimport/appimport_test.go
+++ b/pkg/appimport/appimport_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/drud/ddev/pkg/appimport"
 	"github.com/drud/ddev/pkg/util"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestValidateAsset tests validation of asset paths.
 func TestValidateAsset(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/pkg/appimport/appimport_test.go
+++ b/pkg/appimport/appimport_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/drud/ddev/pkg/appimport"
 	"github.com/drud/ddev/pkg/util"
-	homedir "github.com/mitchellh/go-homedir"
+	gohomedir "github.com/mitchellh/go-homedir"
 	asrt "github.com/stretchr/testify/assert"
 )
 
@@ -27,7 +27,7 @@ func TestValidateAsset(t *testing.T) {
 	testdata := filepath.Join(cwd, "testdata")
 
 	// test tilde expansion
-	userDir, err := homedir.Dir()
+	userDir, err := gohomedir.Dir()
 	testDirName := "tmp.ddev.testpath-" + util.RandString(4)
 	testDir := filepath.Join(userDir, testDirName)
 	assert.NoError(err)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -121,6 +121,7 @@ func Untar(source string, dest string, extractionDir string) error {
 		switch file.Typeflag {
 		case tar.TypeDir:
 			// For a directory, if it doesn't exist, we create it.
+			// nolint: vetshadow
 			finfo, err := os.Stat(fullPath)
 			if err == nil && finfo.IsDir() {
 				continue

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestUnarchive tests unzip/tar/tar.gz/tgz functionality, including the starting extraction-skip directory
@@ -16,7 +16,7 @@ func TestUnarchive(t *testing.T) {
 	// testUnarchiveDir is the directory we may want to use to start extracting.
 	testUnarchiveDir := "dir2/"
 
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	for _, suffix := range []string{"zip", "tar", "tar.gz", "tgz"} {
 		source := filepath.Join("testdata", "testfile"+"."+suffix)

--- a/pkg/cms/config/config_test.go
+++ b/pkg/cms/config/config_test.go
@@ -35,6 +35,7 @@ func TestWriteDrupalConfig(t *testing.T) {
 }
 
 func TestWriteDrushConfig(t *testing.T) {
+
 	dir := testcommon.CreateTmpDir("example")
 
 	file, err := ioutil.TempFile(dir, "file")

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -298,6 +298,7 @@ func (c *Config) WriteDockerComposeConfig() error {
 
 	if !fileutil.FileExists(c.DockerComposeYAMLPath()) {
 
+		// nolint: vetshadow
 		f, err := os.Create(c.DockerComposeYAMLPath())
 		if err != nil {
 			return err

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 
 // TestNewConfig tests functionality around creating a new config, writing it to disk, and reading the resulting config.
 func TestNewConfig(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	// Create a temporary directory and change to it for the duration of this test.
 	testDir := testcommon.CreateTmpDir("TestNewConfig")
 
@@ -62,7 +62,7 @@ func TestNewConfig(t *testing.T) {
 
 // TestAllowedAppType tests the IsAllowedAppType function.
 func TestAllowedAppTypes(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	for _, v := range AllowedAppTypes {
 		assert.True(IsAllowedAppType(v))
 	}
@@ -75,7 +75,7 @@ func TestAllowedAppTypes(t *testing.T) {
 
 // TestPrepDirectory ensures the configuration directory can be created with the correct permissions.
 func TestPrepDirectory(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	// Create a temporary directory and change to it for the duration of this test.
 	testDir := testcommon.CreateTmpDir("TestPrepDirectory")
 	defer testcommon.CleanupDir(testDir)
@@ -96,7 +96,7 @@ func TestPrepDirectory(t *testing.T) {
 
 // TestHostName tests that the TestSite.Hostname() field returns the hostname as expected.
 func TestHostName(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestHostName")
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
@@ -110,7 +110,7 @@ func TestHostName(t *testing.T) {
 // TestWriteDockerComposeYaml tests the writing of a docker-compose.yaml file.
 func TestWriteDockerComposeYaml(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestWriteDockerCompose")
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
@@ -145,7 +145,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 // TestConfigCommand tests the interactive config options.
 func TestConfigCommand(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestConfigCommand")
 
 	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
@@ -196,7 +196,7 @@ func TestConfigCommand(t *testing.T) {
 
 // TestRead tests reading config values from file and fallback to defaults for values not exposed.
 func TestRead(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	// This closely resembles the values one would have from NewConfig()
 	c := &Config{
@@ -225,7 +225,7 @@ func TestRead(t *testing.T) {
 
 // TestValidate tests validation of configuration values.
 func TestValidate(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	cwd, err := os.Getwd()
 	assert.NoError(err)
@@ -257,7 +257,7 @@ func TestValidate(t *testing.T) {
 
 // TestWrite tests writing config values to file
 func TestWrite(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestConfigWrite")
 
 	// This closely resembles the values one would have from NewConfig()

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 /**
@@ -32,7 +32,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	}
 
 	// Set up tests and give ourselves a working directory.
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestPantheonConfigCommand")
 
 	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
@@ -101,7 +101,7 @@ func TestPantheonBackupLinks(t *testing.T) {
 	}
 
 	// Set up tests and give ourselves a working directory.
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestPantheonBackupLinks")
 
 	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/util"
-	"github.com/mitchellh/go-homedir"
+	gohomedir "github.com/mitchellh/go-homedir"
 
 	"fmt"
 
@@ -127,7 +127,7 @@ func (p *PantheonProvider) prepDownloadDir() {
 }
 
 func (p *PantheonProvider) getDownloadDir() string {
-	userDir, err := homedir.Dir()
+	userDir, err := gohomedir.Dir()
 	util.CheckErr(err)
 	destDir := filepath.Join(userDir, ".ddev", "pantheon", p.config.Name)
 	return destDir
@@ -298,7 +298,7 @@ func findPantheonSite(name string) (pantheon.Site, error) {
 
 // getPantheonSession loads the pantheon API config from disk and returns a pantheon session struct.
 func getPantheonSession() *pantheon.AuthSession {
-	userDir, err := homedir.Dir()
+	userDir, err := gohomedir.Dir()
 	util.CheckErr(err)
 	sessionLocation := filepath.Join(userDir, ".ddev", "pantheonconfig.json")
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -64,11 +64,11 @@ func FindContainersByLabels(labels map[string]string) ([]docker.APIContainers, e
 	var returnError error
 	containers, err := GetDockerContainers(true)
 	if err != nil {
-		return []docker.APIContainers{docker.APIContainers{}}, err
+		return []docker.APIContainers{{}}, err
 	}
 	containerMatches := []docker.APIContainers{}
 	if len(labels) < 1 {
-		return []docker.APIContainers{docker.APIContainers{}}, fmt.Errorf("the provided list of labels was empty")
+		return []docker.APIContainers{{}}, fmt.Errorf("the provided list of labels was empty")
 	}
 
 	// First, ensure a site name is set and matches the current application.
@@ -95,7 +95,7 @@ func FindContainersByLabels(labels map[string]string) ([]docker.APIContainers, e
 
 	// If we couldn't find a match return a list with a single (empty) element alongside the error.
 	if len(containerMatches) < 1 {
-		containerMatches = []docker.APIContainers{docker.APIContainers{}}
+		containerMatches = []docker.APIContainers{{}}
 		returnError = fmt.Errorf("could not find containers which matched search criteria: %+v", labels)
 	}
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/testcommon"
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 var (
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 
 // TestGetContainerHealth tests the function for processing container readiness.
 func TestGetContainerHealth(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	container := docker.APIContainers{
 		Status: "Up 24 seconds (health: starting)",
 	}
@@ -88,7 +88,7 @@ func TestGetContainerHealth(t *testing.T) {
 
 // TestContainerWait tests the error cases for the container check wait loop.
 func TestContainerWait(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	labels := map[string]string{
 		"com.ddev.site-name":         "foo",
@@ -106,7 +106,7 @@ func TestContainerWait(t *testing.T) {
 
 // TestComposeCmd tests execution of docker-compose commands.
 func TestComposeCmd(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	composeFiles := []string{filepath.Join("testdata", "docker-compose.yml")}
 
@@ -133,14 +133,14 @@ func TestComposeCmd(t *testing.T) {
 }
 
 func TestGetAppContainers(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	sites, err := GetAppContainers("dockertest")
 	assert.NoError(err)
 	assert.Equal(sites[0].Image, TestRouterImage+":"+TestRouterTag)
 }
 
 func TestGetContainerEnv(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	container, err := FindContainerByLabels(map[string]string{"com.docker.compose.service": "ddevrouter"})
 	assert.NoError(err)

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 var testFileLocation = "testdata/regular_file"
 
 // TestCopyDir tests copying a directory.
 func TestCopyDir(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	sourceDir := testcommon.CreateTmpDir("TestCopyDir_source")
 	targetDir := testcommon.CreateTmpDir("TestCopyDir_target")
 
@@ -59,7 +59,7 @@ func TestCopyDir(t *testing.T) {
 
 // TestCopyFile tests copying a file.
 func TestCopyFile(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	tmpTargetDir := testcommon.CreateTmpDir("TestCopyFile")
 	tmpTargetFile := filepath.Join(tmpTargetDir, filepath.Base(testFileLocation))
 
@@ -79,7 +79,7 @@ func TestCopyFile(t *testing.T) {
 // TestPurgeDirectory tests removal of directory contents without removing
 // the directory itself.
 func TestPurgeDirectory(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	tmpPurgeDir := testcommon.CreateTmpDir("TestPurgeDirectory")
 	tmpPurgeFile := filepath.Join(tmpPurgeDir, "regular_file")
 	tmpPurgeSubFile := filepath.Join(tmpPurgeDir, "subdir", "regular_file")
@@ -106,7 +106,7 @@ func TestPurgeDirectory(t *testing.T) {
 
 // TestFgrepStringInFile tests the FgrepStringInFile utility function.
 func TestFgrepStringInFile(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	result, err := fileutil.FgrepStringInFile("testdata/fgrep_has_positive_contents.txt", "some needle we're looking for")
 	assert.NoError(err)
 	assert.True(result)

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -269,13 +269,13 @@ func (l *LocalApp) SiteStatus() string {
 	services := map[string]string{"web": "", "db": ""}
 
 	if !fileutil.FileExists(l.AppRoot()) {
-		siteStatus := fmt.Sprintf("%s: %v", SiteDirMissing, l.AppRoot())
+		siteStatus = fmt.Sprintf("%s: %v", SiteDirMissing, l.AppRoot())
 		return siteStatus
 	}
 
 	_, err := CheckForConf(l.AppRoot())
 	if err != nil {
-		siteStatus := fmt.Sprintf("%s", SiteConfigMissing)
+		siteStatus = fmt.Sprintf("%s", SiteConfigMissing)
 		return siteStatus
 	}
 
@@ -410,7 +410,7 @@ func (l *LocalApp) ImportFiles(imPath string, extPath string) error {
 		}
 	} else {
 		// create destination directory
-		err := os.MkdirAll(destPath, 0755)
+		err = os.MkdirAll(destPath, 0755)
 		if err != nil {
 			return err
 		}
@@ -918,7 +918,7 @@ func (l *LocalApp) prepSiteDirs() error {
 		fileInfo, err := os.Stat(dir)
 
 		if os.IsNotExist(err) { // If it doesn't exist, create it.
-			err := os.MkdirAll(dir, os.FileMode(int(0774)))
+			err = os.MkdirAll(dir, os.FileMode(int(0774)))
 			if err != nil {
 				return fmt.Errorf("Failed to create directory %s, err: %v", dir, err)
 			}

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -395,11 +395,11 @@ func TestProcessHooks(t *testing.T) {
 		assert.NoError(err)
 
 		conf.Commands = map[string][]ddevapp.Command{
-			"hook-test": []ddevapp.Command{
-				ddevapp.Command{
+			"hook-test": {
+				{
 					Exec: "pwd",
 				},
-				ddevapp.Command{
+				{
 					ExecHost: "pwd",
 				},
 			},

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 var (
@@ -132,7 +132,7 @@ func TestMain(m *testing.M) {
 
 // TestLocalStart tests the functionality that is called when "ddev start" is executed
 func TestLocalStart(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 
@@ -175,7 +175,7 @@ func TestLocalStart(t *testing.T) {
 
 // TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.
 func TestGetApps(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	apps := platform.GetApps()
 	assert.Equal(len(apps["local"]), len(TestSites))
 
@@ -193,7 +193,7 @@ func TestGetApps(t *testing.T) {
 
 // TestLocalImportDB tests the functionality that is called when "ddev import-db" is executed
 func TestLocalImportDB(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 	testDir, _ := os.Getwd()
@@ -261,7 +261,7 @@ func TestLocalImportDB(t *testing.T) {
 
 // TestLocalImportFiles tests the functionality that is called when "ddev import-files" is executed
 func TestLocalImportFiles(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 
@@ -301,7 +301,7 @@ func TestLocalImportFiles(t *testing.T) {
 
 // TestLocalExec tests the execution of commands inside a docker container of a site.
 func TestLocalExec(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 
@@ -347,7 +347,7 @@ func TestLocalExec(t *testing.T) {
 
 // TestLocalLogs tests the container log output functionality.
 func TestLocalLogs(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
@@ -384,7 +384,7 @@ func TestLocalLogs(t *testing.T) {
 
 // TestProcessHooks tests execution of commands defined in config
 func TestProcessHooks(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	for _, site := range TestSites {
 		cleanup := site.Chdir()
@@ -425,7 +425,7 @@ func TestProcessHooks(t *testing.T) {
 
 // TestLocalStop tests the functionality that is called when "ddev stop" is executed
 func TestLocalStop(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
@@ -456,7 +456,7 @@ func TestLocalStop(t *testing.T) {
 
 // TestDescribeStopped tests that the describe command works properly on a stopped site.
 func TestDescribeStopped(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	app, err := platform.GetPluginApp("local")
 	assert.NoError(err)
 
@@ -480,7 +480,7 @@ func TestDescribeStopped(t *testing.T) {
 
 // TestCleanupWithoutCompose ensures app containers can be properly cleaned up without a docker-compose config file present.
 func TestCleanupWithoutCompose(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	site := TestSites[0]
 
 	revertDir := site.Chdir()
@@ -523,7 +523,7 @@ func TestCleanupWithoutCompose(t *testing.T) {
 
 // TestGetappsEmpty ensures that GetApps returns an empty list when no applications are running.
 func TestGetAppsEmpty(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	// Ensure test sites are removed
 	for _, site := range TestSites {
@@ -548,7 +548,7 @@ func TestGetAppsEmpty(t *testing.T) {
 
 // TestRouterNotRunning ensures the router is shut down after all sites are stopped.
 func TestRouterNotRunning(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	containers, err := dockerutil.GetDockerContainers(false)
 	assert.NoError(err)
 

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -184,7 +184,7 @@ func CheckForConf(confPath string) (string, error) {
 	}
 	pathList := strings.Split(confPath, "/")
 
-	for _ = range pathList {
+	for range pathList {
 		confPath = filepath.Dir(confPath)
 		if fileutil.FileExists(confPath + "/.ddev/config.yaml") {
 			return confPath, nil

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/util"
-	homedir "github.com/mitchellh/go-homedir"
+	gohomedir "github.com/mitchellh/go-homedir"
 )
 
 // GetApps returns a list of ddev applictions keyed by platform.
@@ -87,7 +87,7 @@ func CreateAppTable() *uitable.Table {
 
 // RenderHomeRootedDir shortens a directory name to replace homedir with ~
 func RenderHomeRootedDir(path string) string {
-	userDir, err := homedir.Dir()
+	userDir, err := gohomedir.Dir()
 	util.CheckErr(err)
 	result := strings.Replace(path, userDir, "~", 1)
 	result = strings.Replace(result, "\\", "/", -1)

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -155,7 +155,7 @@ func Cleanup(app App) error {
 			Force:         true,
 		}
 		fmt.Printf("Removing container: %s\n", containerName)
-		if err := client.RemoveContainer(removeOpts); err != nil {
+		if err = client.RemoveContainer(removeOpts); err != nil {
 			return fmt.Errorf("could not remove container %s: %v", containerName, err)
 		}
 	}

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 var (
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 // It tests that a site can fully start w/ the compose file present, and
 // checks that any exposed HTTP ports return 200.
 func TestServices(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	if len(ServiceFiles) > 0 {
 		for _, site := range TestSites {

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -127,13 +127,13 @@ func TestInvalidTestSite(t *testing.T) {
 
 	testSites := []TestSite{
 		// This should generate a 404 page on github, which will be downloaded, but cannot be extracted (as it's not a true tar.gz)
-		TestSite{
+		{
 			Name:      "TestInvalidTestSite404",
 			SourceURL: "https://github.com/drud/drupal8/archive/somevaluethatdoesnotexist.tar.gz",
 		},
 		// This is an invalid domain, so it can't even be downloaded. This tests error handling in the case of
 		// a site URL which does not exist
-		TestSite{
+		{
 			Name:      "TestInvalidTestSiteInvalidDomain",
 			SourceURL: "http://invalid_domain/somefilethatdoesnotexists",
 		},

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 
 	"github.com/drud/ddev/pkg/util"
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestTmpDir tests the ability to create a temporary directory.
 func TestTmpDir(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	// Create a temporary directory and ensure it exists.
 	testDir := CreateTmpDir("TestTmpDir")
@@ -31,7 +31,7 @@ func TestTmpDir(t *testing.T) {
 // TestChdir tests the Chdir function and ensures it will change to a temporary directory and then properly return
 // to the original directory when cleaned up.
 func TestChdir(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	// Get the current working directory.
 	startingDir, err := os.Getwd()
 	assert.NoError(err)
@@ -59,7 +59,7 @@ func TestChdir(t *testing.T) {
 
 // TestCaptureStdOut ensures capturing of standard out works as expected.
 func TestCaptureStdOut(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	restoreOutput := CaptureStdOut()
 	text := util.RandString(128)
 	fmt.Print(text)
@@ -70,7 +70,7 @@ func TestCaptureStdOut(t *testing.T) {
 
 // TestValidTestSite tests the TestSite struct behavior in the case of a valid configuration.
 func TestValidTestSite(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	// Get the current working directory.
 	startingDir, err := os.Getwd()
 	assert.NoError(err, "Could not get current directory.")
@@ -123,7 +123,7 @@ func TestValidTestSite(t *testing.T) {
 
 // TestInvalidTestSite ensures that errors are returned in cases where Prepare() can't download or extract an archive.
 func TestInvalidTestSite(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 
 	testSites := []TestSite{
 		// This should generate a 404 page on github, which will be downloaded, but cannot be extracted (as it's not a true tar.gz)

--- a/pkg/updatecheck/updatecheck_test.go
+++ b/pkg/updatecheck/updatecheck_test.go
@@ -7,10 +7,11 @@ import (
 
 	"time"
 
+	"os"
+
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/version"
-	"github.com/stretchr/testify/assert"
-	"os"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 const testOrg = "drud"
@@ -18,7 +19,7 @@ const testRepo = "ddev"
 
 // TestGetContainerHealth tests the function for processing container readiness.
 func TestUpdateNeeded(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	tmpdir := testcommon.CreateTmpDir("TestUpdateNeeded")
 	updateFile := filepath.Join(tmpdir, ".update")
 
@@ -44,7 +45,7 @@ func TestUpdateNeeded(t *testing.T) {
 
 // TestIsReleaseVersion tests isReleaseVersion to ensure it correctly picks up on release builds vs dev builds
 func TestIsReleaseVersion(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	var versionTests = []struct {
 		in  string
 		out bool
@@ -64,7 +65,7 @@ func TestIsReleaseVersion(t *testing.T) {
 
 // TestAvailableUpdates tests isReleaseVersion to ensure it correctly picks up on release builds vs dev builds
 func TestAvailableUpdates(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	if os.Getenv("GOTEST_SHORT") != "" {
 		t.Skip("Skipping TestAvailableUpdates because GOTEST_SHORT env var is set")
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -51,6 +51,8 @@ var letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // setLetterBytes exists solely so that tests can override the default characters used by
 // RandString. It should probably be avoided for 'normal' operations.
+// this is actually used in utils_test.go (test only) so we set nolint on it.
+// nolint: deadcode
 func setLetterBytes(lb string) {
 	letterBytes = lb
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -11,7 +11,7 @@ import (
 	"path"
 
 	"github.com/fatih/color"
-	"github.com/mitchellh/go-homedir"
+	gohomedir "github.com/mitchellh/go-homedir"
 )
 
 func init() {
@@ -68,7 +68,7 @@ func RandString(n int) string {
 
 // GetGlobalDdevDir returns ~/.ddev, the global caching directory
 func GetGlobalDdevDir() string {
-	userHome, err := homedir.Dir()
+	userHome, err := gohomedir.Dir()
 	if err != nil {
 		log.Fatal("could not get home directory for current user. is it set?")
 	}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestRandString ensures that RandString only generates string of the correct value and characters.
 func TestRandString(t *testing.T) {
-	assert := assert.New(t)
+	assert := asrt.New(t)
 	stringLengths := []int{2, 4, 8, 16, 23, 47}
 
 	for _, stringLength := range stringLengths {


### PR DESCRIPTION
## The Problem/Issue/Bug:

In https://github.com/drud/build-tools/pull/42 @tannerjfco improved our handling of gometalinter quite a lot, and we should use that. 

## How this PR Solves The Problem:

* Update to build-tools 1.5.1 which has the new gometalinter capabilities
* Handle the warnings it now offers.
* Implement vetshadow which warns about shadowed variables
* gometalinter uses `gofmt -s` which insists on some simplifications in addition to the normal gofmt behavior. These can of course be calmed with a simple comment.

Key new issues:
1. I changed all imports of testify/assert to be aliased as asrt to solve the shadowing problem of assert vs the import.
2. Change imports of go-homedir from "homedir" alias to  "gohomedir" alias for same reason.
2. Since we're now using gometalinter instead of the individual tools, it's easy to use [comment directives](https://github.com/alecthomas/gometalinter#comment-directives) to calm down a particular tool if it's hitting a false positive (or even something you just don't want to deal with, like removing "dead" code that you don't consider dead.)

## Manual Testing Instructions:

You may want to look at the changes commit-by-commit so there's not just a whole pile of changes.


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

https://github.com/drud/build-tools/pull/42 was the build-tools upgrade for gometalinter.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

