### PR TITLE
Add homebrew install instructions to index.md for readthedocs. Fixes #434

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,17 @@ ddev requires ports 80 and 3306 to be available for use on your system when site
 If you need to use another environment after using ddev, simply ensure all of your ddev sites are stopped or removed. ddev only occupies system ports when at least one site is running.
 
 ## Installation
+### Homebrew - macOS
+
+For macOS users, we recommend downloading and installing ddev via [homebrew](https://brew.sh/):
+```
+brew tap drud/ddev && brew install ddev
+```
+Later, to upgrade to a newer version of ddev, simply run:
+```
+brew upgrade ddev
+```
+
 ### Installation Script - Linux and macOS
 
 Linux and macOS end-users can use this line of code to your terminal to download, verify, and install ddev using our [install script](https://github.com/drud/ddev/blob/master/install_ddev.sh):


### PR DESCRIPTION
## The Problem/Issue/Bug:
Homebrew install instructions only existed in the README.md and was not present in docs/index.md which gets picked up by readthedocs.
## How this PR Solves The Problem:
This PR simply adds the homebrew install instructions to docs/index.md.
## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#434 
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

