### PR TITLE
Revert to using Circleci's docker version, upgrade docker-compose, fixes #471

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit
+set -x
 
 # Basic tools
 
@@ -15,16 +16,6 @@ wget -q -O /tmp/golang.tgz https://storage.googleapis.com/golang/go1.9.linux-amd
 cd /tmp && tar -xf golang.tgz &&
 sudo rm -rf /usr/local/go && sudo mv go /usr/local
 
-# Docker setup
-sudo apt-get remove -qq docker docker-engine
-sudo apt-get update -qq
-sudo apt-get install -qq apt-transport-https ca-certificates  curl software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-# Per docker docs, you always need the stable repository, even if you want to install edge builds as well.
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo apt-get update -qq
-sudo apt-get install -qq docker-ce=17.06.0~ce-0~ubuntu
-
 # docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.14.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -s -L "https://github.com/docker/compose/releases/download/1.16.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -5,10 +5,10 @@ set -x
 
 # Basic tools
 
-# mysql - old key is expired, so get the new one
-#sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5 >/dev/null 2>&1
 sudo apt-get update -qq
 sudo apt-get install -qq mysql-client realpath zip
+
+go version
 
 # golang of the version we want
 sudo apt-get remove -qq golang &&

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -6,7 +6,7 @@ set -x
 # Basic tools
 
 # mysql - old key is expired, so get the new one
-sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5 >/dev/null 2>&1
+#sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5 >/dev/null 2>&1
 sudo apt-get update -qq
 sudo apt-get install -qq mysql-client realpath zip
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   # 'build' is the default build, the only one triggered automatically by github or anything else.
   normal_build_and_test:
-    machine: true
+    machine:
+      image: circleci/classic:201708-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       GOPATH: /home/circleci/go
@@ -47,7 +48,8 @@ jobs:
 
   # nightly is triggered only with nightly_build_trigger.sh
   nightly_build:
-    machine: true
+    machine:
+      image: circleci/classic:201708-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       DRUD_DEBUG: "true"
@@ -118,7 +120,8 @@ jobs:
 
   # 'tag_build' is used to build a tag for release.
   tag_build:
-    machine: true
+    machine:
+      image: circleci/classic:201708-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       DRUD_DEBUG: "true"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#471: We've been having an enormous number of Circleci build failures during the setup-the-vm stage, and we don't have any visibility into the failure. And Circleci now (in latest build) has a docker version we can use successfully. So:

* Stop installing docker ourselves
* Turn on set -x so we can see what's failing
* Upgrade version of docker-compose we're using
* It seems we no longer have to download the signing key for mysql as the problem has sorted itself out. Getting the key was the most common failure.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

