### PR TITLE
Refresh updatefile on each check even if we're not updating, fixes #479

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -17,9 +17,8 @@ import (
 )
 
 var (
-	logLevel = log.WarnLevel
-	plugin   = "local"
-	// 1 week
+	logLevel       = log.WarnLevel
+	plugin         = "local"
 	updateInterval = time.Hour * 24 * 7 // One week interval between updates
 	serviceType    string
 )
@@ -50,6 +49,17 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
+		err := dockerutil.CheckDockerVersion(version.DockerVersionConstraint)
+		if err != nil {
+			if err.Error() == "no docker" {
+				if os.Args[1] != "version" && os.Args[1] != "config" {
+					util.Failed("Could not connect to docker. Please ensure Docker is installed and running.")
+				}
+			} else {
+				util.Failed("The docker version currently installed does not meet ddev's requirements: %v", err)
+			}
+		}
+
 		// Verify that the ~/.ddev exists
 		userDdevDir := util.GetGlobalDdevDir()
 
@@ -64,6 +74,10 @@ var RootCmd = &cobra.Command{
 		if timeToCheckForUpdates {
 			// Recreate the updatefile with current time so we won't do this again soon.
 			err = updatecheck.ResetUpdateTime(updateFile)
+			if err != nil {
+				util.Warning("Failed to update updatecheck file %s", updateFile)
+				return // Do not continue as we'll end up with github api violations.
+			}
 
 			// nolint: vetshadow
 			updateNeeded, updateURL, err := updatecheck.AvailableUpdates("drud", "ddev", version.DdevVersion)
@@ -76,22 +90,9 @@ var RootCmd = &cobra.Command{
 
 			if updateNeeded {
 				util.Warning("\n\nA new update is available! please visit %s to download the update!\n\n", updateURL)
-				if err != nil {
-					util.Warning("Could not reset automated update checking interval: %v", err)
-				}
 			}
 		}
 
-		err = dockerutil.CheckDockerVersion(version.DockerVersionConstraint)
-		if err != nil {
-			if err.Error() == "no docker" {
-				if os.Args[1] != "version" && os.Args[1] != "config" {
-					util.Failed("Could not connect to docker. Please ensure Docker is installed and running.")
-				}
-			} else {
-				util.Failed("The docker version currently installed does not meet ddev's requirements: %v", err)
-			}
-		}
 	},
 }
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -20,7 +20,7 @@ var (
 	logLevel = log.WarnLevel
 	plugin   = "local"
 	// 1 week
-	updateInterval = time.Hour * 24 * 7
+	updateInterval = time.Hour * 24 * 7 // One week interval between updates
 	serviceType    string
 )
 
@@ -62,6 +62,9 @@ var RootCmd = &cobra.Command{
 		}
 
 		if timeToCheckForUpdates {
+			// Recreate the updatefile with current time so we won't do this again soon.
+			err = updatecheck.ResetUpdateTime(updateFile)
+
 			// nolint: vetshadow
 			updateNeeded, updateURL, err := updatecheck.AvailableUpdates("drud", "ddev", version.DdevVersion)
 
@@ -73,7 +76,6 @@ var RootCmd = &cobra.Command{
 
 			if updateNeeded {
 				util.Warning("\n\nA new update is available! please visit %s to download the update!\n\n", updateURL)
-				err = updatecheck.ResetUpdateTime(updateFile)
 				if err != nil {
 					util.Warning("Could not reset automated update checking interval: %v", err)
 				}


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #479: Our update strategy is not working because we only refresh the update file *if* an update is found. Thus we're regularly running afoul of github's API limit, it even broke a test today. Basically, once the update file gets older than a week, every single invocation of ddev results in a hit on github.

## How this PR Solves The Problem:

Instead of refreshing the update file when an update is ready, it does it every time we hit the update interval (and before we even check for an update). 

Note: This also does the docker check *before* the update check, because the docker check is fatal and the update check is not. That lets the update check just return with a warning in some situations.

## Manual Testing Instructions:

* Set the date on ~/.ddev/.update back to sometime more than a week in the past, then do a ddev commands. To set the date, try `touch -t 201708200000 ~/.update` then use `ls -al ~/.ddev/.update` to review the results. 
* WIthout this patch, you should end up with a github hit; I'm not sure the easiest way to verify that.
* With this patch, you should end up with a github hit, but your ~/.ddev/.update will have been refreshed, and the next time you do it you won't have that.

## Automated Testing Overview:

There were no existing tests around this code (that I found), and I didn't add any.

## Related Issue Link(s):

OP #479

## Release/Deployment notes:

Our users start getting impacted by this bug one week after first using the tool, and until an update comes out. One way we can help them is by adding this to an interim release, thus causing the file to be refreshed in buggy versions of ddev. So we should prepare a tag and release.
