### PR TITLE
Change usage to macOS Sierra and higher, fixes #480

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 - [Docker](https://www.docker.com/community-edition) version 17.05 or greater
 - OS Support
-  - macOS Sierra
+  - macOS Sierra and higher (macOS 10.12 and higher)
   - Linux (See [Linux notes](users/linux_notes.md))
     * Ubuntu 16.04 LTS
     * Debian Jessie


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #480: Our macOS support said "Sierra", and we need it to say "Sierra and Higher". Minor change, just docs.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

