### PR TITLE
Allow command-line arguments for "ddev config", fixes #476

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -33,11 +33,7 @@ var ConfigCommand = &cobra.Command{
 
 		c, err := ddevapp.NewConfig(appRoot, provider)
 		if err != nil {
-			// If there is an error reading the config and the file exists, we're not sure
-			// how to proceed.
-			if c.ConfigExists() {
-				util.Failed("Could not read config: %v", err)
-			}
+			util.Failed("Could not create new config: %v", err)
 		}
 
 		// Set the provider value after load so we can ensure we use the passed in provider value

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -48,13 +48,13 @@ var ConfigCommand = &cobra.Command{
 		c.Name = siteName
 		c.Docroot = docrootRelPath
 
-		if siteName == "" && docrootRelPath == "" {
+		if siteName == "" && docrootRelPath == "" && pantheonEnvironment == "" {
 			err = c.PromptForConfig()
 			if err != nil {
 				util.Failed("There was a problem configuring your application: %v\n", err)
 			}
 		} else {
-
+			// Handle the case where flags have been passed in and we config that way
 			appType, err := ddevapp.DetermineAppType(c.Docroot)
 			if err != nil {
 				fullPath, _ := filepath.Abs(c.Docroot)
@@ -62,7 +62,7 @@ var ConfigCommand = &cobra.Command{
 			}
 			// If we found an application type just set it and inform the user.
 			util.Success("Found a %s codebase at %s\n", c.AppType, filepath.Join(c.AppRoot, c.Docroot))
-			prov, err := c.GetProvider()
+			prov, _ := c.GetProvider()
 
 			c.AppType = appType
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -67,7 +67,7 @@ var ConfigCommand = &cobra.Command{
 				appType, err = ddevapp.DetermineAppType(c.Docroot)
 				if err != nil {
 					fullPath, _ := filepath.Abs(c.Docroot)
-					util.Failed("Failed to determine app Type (drupal7/drupal8/wordpress), your docroot may be incorrect - looking in directory %v (full path: %v), err: %v", c.Docroot, fullPath, err)
+					util.Failed("Failed to determine app type (drupal7/drupal8/wordpress).\nYour docroot %v[docroot] may be incorrect - looking in directory %v[abspath]: %v[err]", c.Docroot, fullPath, err)
 				}
 			}
 
@@ -107,7 +107,7 @@ func init() {
 	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", "Provide the sitename of site to configure (normally the same as the directory name)")
 	ConfigCommand.Flags().StringVarP(&docrootRelPath, "docroot", "", "", "Provide the relative docroot of the site, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory")
 	ConfigCommand.Flags().StringVarP(&pantheonEnvironment, "pantheon-environment", "", "dev", "Provide the environment for a Pantheon site (Pantheon-only)")
-	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "wordpress", "Provide the app type (like wordpress or drupal7 or drupal8). This is normally autodetected and this flag is not necessary")
+	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", "Provide the app type (like wordpress or drupal7 or drupal8). This is normally autodetected and this flag is not necessary")
 
 	RootCmd.AddCommand(ConfigCommand)
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -67,7 +67,7 @@ var ConfigCommand = &cobra.Command{
 				appType, err = ddevapp.DetermineAppType(c.Docroot)
 				if err != nil {
 					fullPath, _ := filepath.Abs(c.Docroot)
-					util.Failed("Failed to determine app type (drupal7/drupal8/wordpress).\nYour docroot %v[docroot] may be incorrect - looking in directory %v[abspath]: %v[err]", c.Docroot, fullPath, err)
+					util.Failed("Failed to determine app type (drupal7/drupal8/wordpress).\nYour docroot %v may be incorrect - looking in directory %v, error=%v", c.Docroot, fullPath, err)
 				}
 			}
 
@@ -80,7 +80,7 @@ var ConfigCommand = &cobra.Command{
 			// But pantheon *does* validate "Name"
 			err = prov.ValidateField("Name", c.Name)
 			if err != nil {
-				util.Failed("Failed to validate sitename %v[sitename] with %v[provider]: %v[err]", c.Name, provider, err)
+				util.Failed("Failed to validate sitename %v with provider %v: %v", c.Name, provider, err)
 			}
 			if provider == "pantheon" {
 				pantheonProvider := prov.(*ddevapp.PantheonProvider)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -11,9 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// docrootRelPath is the relative path to the docroot where index.php is
 var docrootRelPath string
+
+// siteName is the name of the site
 var siteName string
+
+// pantheonEnvironment is the environment for pantheon, dev/test/prod
 var pantheonEnvironment string
+
+// appType is the ddev app type, like drupal7/drupal8/wordpress
+var appType string
 
 // ConfigCommand represents the `ddev config` command
 var ConfigCommand = &cobra.Command{
@@ -48,18 +56,21 @@ var ConfigCommand = &cobra.Command{
 		c.Name = siteName
 		c.Docroot = docrootRelPath
 
-		if siteName == "" && docrootRelPath == "" && pantheonEnvironment == "" {
+		if siteName == "" && docrootRelPath == "" && pantheonEnvironment == "" && appType == "" {
 			err = c.PromptForConfig()
 			if err != nil {
 				util.Failed("There was a problem configuring your application: %v\n", err)
 			}
 		} else {
 			// Handle the case where flags have been passed in and we config that way
-			appType, err := ddevapp.DetermineAppType(c.Docroot)
-			if err != nil {
-				fullPath, _ := filepath.Abs(c.Docroot)
-				util.Failed("Failed to determine app Type (drupal7/drupal8/wordpress), your docroot may be incorrect - looking in directory %v (full path: %v), err: %v", c.Docroot, fullPath, err)
+			if appType == "" {
+				appType, err = ddevapp.DetermineAppType(c.Docroot)
+				if err != nil {
+					fullPath, _ := filepath.Abs(c.Docroot)
+					util.Failed("Failed to determine app Type (drupal7/drupal8/wordpress), your docroot may be incorrect - looking in directory %v (full path: %v), err: %v", c.Docroot, fullPath, err)
+				}
 			}
+
 			// If we found an application type just set it and inform the user.
 			util.Success("Found a %s codebase at %s\n", c.AppType, filepath.Join(c.AppRoot, c.Docroot))
 			prov, _ := c.GetProvider()
@@ -96,5 +107,7 @@ func init() {
 	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", "Provide the sitename of site to configure (normally the same as the directory name)")
 	ConfigCommand.Flags().StringVarP(&docrootRelPath, "docroot", "", "", "Provide the relative docroot of the site, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory")
 	ConfigCommand.Flags().StringVarP(&pantheonEnvironment, "pantheon-environment", "", "dev", "Provide the environment for a Pantheon site (Pantheon-only)")
+	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "wordpress", "Provide the app type (like wordpress or drupal7 or drupal8). This is normally autodetected and this flag is not necessary")
+
 	RootCmd.AddCommand(ConfigCommand)
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -120,6 +120,8 @@ var ConfigCommand = &cobra.Command{
 			err = prov.Validate()
 			if err != nil {
 				util.Failed("Failed to validate sitename %v and environment %v with provider %v: %v", c.Name, pantheonEnvironment, provider, err)
+			} else {
+				util.Success("Using pantheon sitename '%s' and environment '%s'.", c.Name, pantheonEnvironment)
 			}
 
 		}

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -90,7 +90,7 @@ var ConfigCommand = &cobra.Command{
 				util.Failed("--pantheon-environment can only be used with pantheon provider, for example ddev config pantheon --pantheon-environment=dev --docroot=docroot")
 			}
 			if appType != "" && appType != "drupal7" && appType != "drupal8" && appType != "wordpress" {
-				util.Failed("apptype must be drupal7 or drupal8 or wordpress")
+				util.Failed("apptype must be drupal7, drupal8, or wordpress")
 			}
 
 			foundAppType, err := ddevapp.DetermineAppType(c.Docroot)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -106,7 +106,7 @@ var ConfigCommand = &cobra.Command{
 func init() {
 	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", "Provide the sitename of site to configure (normally the same as the directory name)")
 	ConfigCommand.Flags().StringVarP(&docrootRelPath, "docroot", "", "", "Provide the relative docroot of the site, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory")
-	ConfigCommand.Flags().StringVarP(&pantheonEnvironment, "pantheon-environment", "", "dev", "Provide the environment for a Pantheon site (Pantheon-only)")
+	ConfigCommand.Flags().StringVarP(&pantheonEnvironment, "pantheon-environment", "", "", "Choose the environment for a Pantheon site (dev/test/prod) (Pantheon-only)")
 	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", "Provide the app type (like wordpress or drupal7 or drupal8). This is normally autodetected and this flag is not necessary")
 
 	RootCmd.AddCommand(ConfigCommand)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -44,7 +44,7 @@ var ConfigCommand = &cobra.Command{
 		// for this configuration.
 		c.Provider = provider
 
-		err = c.Config()
+		err = c.PromptForConfig()
 		if err != nil {
 			util.Failed("There was a problem configuring your application: %v\n", err)
 		}

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -80,7 +80,7 @@ var ConfigCommand = &cobra.Command{
 			// But pantheon *does* validate "Name"
 			err = prov.ValidateField("Name", c.Name)
 			if err != nil {
-				util.Failed("Failed to validate sitename %v with ddev prov %v err: %v", c.Name, provider, err)
+				util.Failed("Failed to validate sitename %v[sitename] with %v[provider]: %v[err]", c.Name, provider, err)
 			}
 			if provider == "pantheon" {
 				pantheonProvider := prov.(*ddevapp.PantheonProvider)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -66,6 +66,10 @@ var ConfigCommand = &cobra.Command{
 				util.Failed("There was a problem configuring your application: %v\n", err)
 			}
 		} else { // In this case we have to validate the provided items, or set to sane defaults
+
+			// Let them know if we're replacing the config.yaml
+			c.WarnIfConfigReplace()
+
 			// c.Name gets set to basename if not provided, or set to sitneName if provided
 			if c.Name != "" && siteName == "" { // If we already have a c.Name and no siteName, leave c.Name alone
 				// Sorry this is empty but it make the logic clearer.

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -55,10 +55,6 @@ var ConfigCommand = &cobra.Command{
 			util.Failed("Could not create new config: %v", err)
 		}
 
-		// Set the provider value after load so we can ensure we use the passed in provider value
-		// for this configuration.
-		c.Provider = provider
-
 		// If they have not given us any flags, we prompt for full info. Otherwise, we assume they're in control.
 		if siteName == "" && docrootRelPath == "" && pantheonEnvironment == "" && appType == "" {
 			err = c.PromptForConfig()
@@ -72,7 +68,7 @@ var ConfigCommand = &cobra.Command{
 
 			// c.Name gets set to basename if not provided, or set to sitneName if provided
 			if c.Name != "" && siteName == "" { // If we already have a c.Name and no siteName, leave c.Name alone
-				// Sorry this is empty but it make the logic clearer.
+				// Sorry this is empty but it makes the logic clearer.
 			} else if siteName != "" { // if we have a siteName passed in, use it for c.Name
 				c.Name = siteName
 			} else { // No siteName passed, c.Name not set: use c.Name from the directory
@@ -130,7 +126,6 @@ var ConfigCommand = &cobra.Command{
 		err = c.Write()
 		if err != nil {
 			util.Failed("Could not write ddev config file: %v\n", err)
-
 		}
 
 		// If a provider is specified, prompt about whether to do an import after config.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -95,11 +95,6 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	c.DBImage = version.DBImg + ":" + version.DBTag
 	c.DBAImage = version.DBAImg + ":" + version.DBATag
 
-	c.Provider = provider
-
-	if c.Provider == "" {
-		c.Provider = DefaultProviderName
-	}
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
 	if _, err := os.Stat(c.ConfigPath); !os.IsNotExist(err) {
@@ -107,6 +102,17 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 		if err != nil {
 			return c, fmt.Errorf("%v exists but cannot be read: %v", c.ConfigPath, err)
 		}
+	}
+
+	// Allow override with "pantheon" from function provider arg, but nothing else.
+	// Otherwise we accept whatever might have been in config file if there was anything.
+	switch {
+	case provider == "" || provider == DefaultProviderName:
+		c.Provider = DefaultProviderName
+	case provider == "pantheon":
+		c.Provider = "pantheon"
+	default:
+		return c, fmt.Errorf("Provider '%s' is not implemented", provider)
 	}
 
 	return c, nil

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -70,7 +70,7 @@ type Command struct {
 type Provider interface {
 	Init(*Config) error
 	ValidateField(string, string) error
-	Config() error
+	PromptForConfig() error
 	Write(string) error
 	Read(string) error
 	Validate() error
@@ -219,8 +219,8 @@ func (c *Config) Read() error {
 	return err
 }
 
-// Config goes through a set of prompts to receive user input and generate an Config struct.
-func (c *Config) Config() error {
+// PromptForConfig goes through a set of prompts to receive user input and generate an Config struct.
+func (c *Config) PromptForConfig() error {
 
 	if c.ConfigExists() {
 		util.Warning("You are re-configuring %s. The existing configuration will be replaced.\n\n", c.AppRoot)
@@ -254,7 +254,7 @@ func (c *Config) Config() error {
 		return err
 	}
 
-	err = c.providerInstance.Config()
+	err = c.providerInstance.PromptForConfig()
 
 	return err
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -415,7 +415,7 @@ func (c *Config) appTypePrompt() error {
 		"Location": absDocroot,
 	}).Debug("Attempting to auto-determine application type")
 
-	appType, err = determineAppType(absDocroot)
+	appType, err = DetermineAppType(absDocroot)
 	if err == nil {
 		// If we found an application type just set it and inform the user.
 		util.Success("Found a %s codebase at %s\n", appType, filepath.Join(c.AppRoot, c.Docroot))
@@ -465,7 +465,7 @@ func PrepDdevDirectory(dir string) error {
 
 // DetermineAppType uses some predetermined file checks to determine if a local app
 // is of any of the known types
-func determineAppType(basePath string) (string, error) {
+func DetermineAppType(basePath string) (string, error) {
 	defaultLocations := map[string]string{
 		"scripts/drupal.sh":      "drupal7",
 		"core/scripts/drupal.sh": "drupal8",
@@ -487,7 +487,7 @@ func determineAppType(basePath string) (string, error) {
 		}
 	}
 
-	return "", errors.New("determineAppType() couldn't determine app's type")
+	return "", errors.New("DetermineAppType() couldn't determine app's type")
 }
 
 // setSiteSettingsPath determines the location for site's db settings file based on apptype.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -105,7 +105,7 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	if _, err := os.Stat(c.ConfigPath); !os.IsNotExist(err) {
 		err = c.Read()
 		if err != nil {
-			return c, fmt.Errorf("config.yaml exists but cannot be successfully read, %v, err=%v", c.ConfigPath, err)
+			return c, fmt.Errorf("%v[configPath] exists but cannot be read: %v[err]", c.ConfigPath, err)
 		}
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -105,7 +105,7 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	if _, err := os.Stat(c.ConfigPath); !os.IsNotExist(err) {
 		err = c.Read()
 		if err != nil {
-			return c, fmt.Errorf("%v[configPath] exists but cannot be read: %v[err]", c.ConfigPath, err)
+			return c, fmt.Errorf("%v exists but cannot be read: %v", c.ConfigPath, err)
 		}
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -221,15 +221,20 @@ func (c *Config) Read() error {
 	return err
 }
 
+// WarnIfConfigReplace just messages user about whether config is being replaced or created
+func (c *Config) WarnIfConfigReplace() {
+	if c.ConfigExists() {
+		util.Warning("You are re-configuring the app at %s. \nThe existing configuration will be updated and replaced.\n\n", c.AppRoot)
+	} else {
+		util.Success("Creating a new ddev project config in the current directory (%s)", c.AppRoot)
+		util.Success("Once completed, your configuration will be written to %s\n", c.ConfigPath)
+	}
+}
+
 // PromptForConfig goes through a set of prompts to receive user input and generate an Config struct.
 func (c *Config) PromptForConfig() error {
 
-	if c.ConfigExists() {
-		util.Warning("You are re-configuring %s. The existing configuration will be replaced.\n\n", c.AppRoot)
-	} else {
-		fmt.Printf("Creating a new ddev project config in the current directory (%s)\n", c.AppRoot)
-		fmt.Printf("Once completed, your configuration will be written to %s\n\n\n", c.ConfigPath)
-	}
+	c.WarnIfConfigReplace()
 
 	for {
 		err := c.namePrompt()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -77,7 +77,7 @@ type Provider interface {
 	GetBackup(string) (fileLocation string, importPath string, err error)
 }
 
-// NewConfig creates a new Config struct with defaults set. It is preferred to using new() directly.
+// NewConfig creates a new Config struct with defaults set and overridden by any existing config.yml.
 func NewConfig(AppRoot string, provider string) (*Config, error) {
 	// Set defaults.
 	c := &Config{}
@@ -102,12 +102,14 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	}
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
-	err := c.Read()
-	if err != nil {
-		return c, fmt.Errorf("Unable to read config.yaml, %v, err=%v", c.ConfigPath, err)
+	if _, err := os.Stat(c.ConfigPath); !os.IsNotExist(err) {
+		err = c.Read()
+		if err != nil {
+			return c, fmt.Errorf("config.yaml exists but cannot be successfully read, %v, err=%v", c.ConfigPath, err)
+		}
 	}
 
-	return c, err
+	return c, nil
 }
 
 // GetProvider returns a pointer to the provider instance interface.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -176,7 +176,6 @@ func TestConfigCommand(t *testing.T) {
 	out := restoreOutput()
 
 	// Ensure we have expected vales in output.
-	assert.Contains(out, "Creating a new ddev project")
 	assert.Contains(out, testDir)
 	assert.Contains(out, fmt.Sprintf("No directory could be found at %s", filepath.Join(testDir, invalidDir)))
 	assert.Contains(out, fmt.Sprintf("%s is not a valid application type", invalidAppType))

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -175,7 +175,7 @@ func TestConfigCommand(t *testing.T) {
 	util.SetInputScanner(scanner)
 
 	restoreOutput := testcommon.CaptureStdOut()
-	err = config.Config()
+	err = config.PromptForConfig()
 	assert.NoError(err, t)
 	out := restoreOutput()
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -33,9 +33,7 @@ func TestNewConfig(t *testing.T) {
 
 	// Load a new Config
 	newConfig, err := NewConfig(testDir, DefaultProviderName)
-
-	// An error should be returned because no config file is present.
-	assert.Error(err)
+	assert.NoError(err)
 
 	// Ensure the config uses specified defaults.
 	assert.Equal(newConfig.APIVersion, CurrentAppVersion)
@@ -53,7 +51,6 @@ func TestNewConfig(t *testing.T) {
 	assert.NoError(err)
 
 	loadedConfig, err := NewConfig(testDir, DefaultProviderName)
-	// There should be no error this time, since the config should be available for loading.
 	assert.NoError(err)
 	assert.Equal(newConfig.Name, loadedConfig.Name)
 	assert.Equal(newConfig.AppType, loadedConfig.AppType)
@@ -82,8 +79,7 @@ func TestPrepDirectory(t *testing.T) {
 	defer testcommon.Chdir(testDir)()
 
 	config, err := NewConfig(testDir, DefaultProviderName)
-	// We should get an error here, since no config exists.
-	assert.Error(err)
+	assert.NoError(err)
 
 	// Prep the directory.
 	err = PrepDdevDirectory(filepath.Dir(config.ConfigPath))
@@ -101,7 +97,7 @@ func TestHostName(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 	config, err := NewConfig(testDir, DefaultProviderName)
-	assert.Error(err)
+	assert.NoError(err)
 	config.Name = util.RandString(32)
 
 	assert.Equal(config.Hostname(), config.Name+"."+DDevTLD)
@@ -117,7 +113,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 
 	// Create a config
 	config, err := NewConfig(testDir, DefaultProviderName)
-	assert.Error(err)
+	assert.NoError(err)
 	config.Name = util.RandString(32)
 	config.AppType = AllowedAppTypes[0]
 
@@ -159,9 +155,9 @@ func TestConfigCommand(t *testing.T) {
 	}
 
 	// Create the ddevapp we'll use for testing.
-	// This should return an error, since no existing config can be read.
+	// This will not return an error, since there is no existing config.
 	config, err := NewConfig(testDir, DefaultProviderName)
-	assert.Error(err)
+	assert.NoError(err)
 
 	// Randomize some values to use for Stdin during testing.
 	name := strings.ToLower(util.RandString(16))

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -116,7 +116,7 @@ func TestPantheonBackupLinks(t *testing.T) {
 	assert.NoError(err)
 
 	provider.Sitename = pantheonTestSiteName
-	provider.Environment = pantheonTestEnvName
+	provider.EnvironmentName = pantheonTestEnvName
 
 	// Ensure GetBackup triggers an error for unknown backup types.
 	_, _, err = provider.GetBackup(util.RandString(8))

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -46,9 +46,8 @@ func TestPantheonConfigCommand(t *testing.T) {
 	}
 
 	// Create the ddevapp we'll use for testing.
-	// This should return an error, since no existing config can be read.
 	config, err := NewConfig(testDir, "pantheon")
-	assert.Error(err)
+	assert.NoError(err)
 
 	// Randomize some values to use for Stdin during testing.
 	invalidName := strings.ToLower(util.RandString(16))
@@ -109,8 +108,7 @@ func TestPantheonBackupLinks(t *testing.T) {
 	defer testcommon.Chdir(testDir)()
 
 	config, err := NewConfig(testDir, "pantheon")
-	// No config should exist so this will result in an error
-	assert.Error(err)
+	assert.NoError(err)
 	config.Name = pantheonTestSiteName
 
 	provider := PantheonProvider{}

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -70,7 +70,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	util.SetInputScanner(scanner)
 
 	restoreOutput := testcommon.CaptureStdOut()
-	err = config.Config()
+	err = config.PromptForConfig()
 	assert.NoError(err, t)
 	out := restoreOutput()
 

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -80,7 +80,6 @@ func TestPantheonConfigCommand(t *testing.T) {
 	assert.NoError(err)
 
 	// Ensure we have expected string values in output.
-	assert.Contains(out, "Creating a new ddev project")
 	assert.Contains(out, testDir)
 	assert.Contains(out, fmt.Sprintf("could not find a pantheon site named %s", invalidName))
 	assert.Contains(out, fmt.Sprintf("could not find an environment named '%s'", invalidEnvironment))

--- a/pkg/ddevapp/providerDefault.go
+++ b/pkg/ddevapp/providerDefault.go
@@ -16,7 +16,7 @@ func (p *DefaultProvider) ValidateField(field, value string) error {
 	return nil
 }
 
-// Config provides a no-op for the Config operation.
+// PromptForConfig provides a no-op for the Config operation.
 func (p *DefaultProvider) PromptForConfig() error {
 	return nil
 }

--- a/pkg/ddevapp/providerDefault.go
+++ b/pkg/ddevapp/providerDefault.go
@@ -1,6 +1,5 @@
 package ddevapp
 
-import "errors"
 import "os"
 
 // DefaultProvider provides a no-op for the provider plugin interface methods.
@@ -38,9 +37,9 @@ func (p *DefaultProvider) Read(configPath string) error {
 	return nil
 }
 
-// Validate always returns an error from the default provider, as we have no provider to import data from.
+// Validate always succeeds, because the default provider is a fine provider.
 func (p *DefaultProvider) Validate() error {
-	return errors.New("could not perform import because there is no configured provider for this application. please see `ddev config` documentation")
+	return nil
 }
 
 // GetBackup provides a no-op for the GetBackup operation.

--- a/pkg/ddevapp/providerDefault.go
+++ b/pkg/ddevapp/providerDefault.go
@@ -17,7 +17,7 @@ func (p *DefaultProvider) ValidateField(field, value string) error {
 }
 
 // Config provides a no-op for the Config operation.
-func (p *DefaultProvider) Config() error {
+func (p *DefaultProvider) PromptForConfig() error {
 	return nil
 }
 

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -56,10 +56,16 @@ func (p *PantheonProvider) ValidateField(field, value string) error {
 	return nil
 }
 
+// SetSiteNameAndEnv sets the environment of the provider (dev/test/live)
+func (p *PantheonProvider) SetSiteNameAndEnv(environment string) {
+	p.Sitename = p.config.Name
+	p.EnvironmentName = environment
+}
+
 // PromptForConfig provides interactive configuration prompts when running `ddev config pantheon`
 func (p *PantheonProvider) PromptForConfig() error {
-	p.Sitename = p.config.Name
 	for {
+		p.SetSiteNameAndEnv("dev")
 		err := p.environmentPrompt()
 
 		if err == nil {
@@ -182,12 +188,12 @@ func (p *PantheonProvider) environmentPrompt() error {
 	fmt.Print(environmentPrompt + ": ")
 	envName := util.GetInput(p.EnvironmentName)
 
-	environment, ok := p.siteEnvironments.Environments[p.Environment]
-	p.environment = environment
+	_, ok := p.siteEnvironments.Environments[envName]
 
 	if !ok {
-		return fmt.Errorf("could not find an environment named '%s'", p.Environment)
+		return fmt.Errorf("could not find an environment named '%s'", envName)
 	}
+	p.SetSiteNameAndEnv(envName)
 	return nil
 }
 

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -56,7 +56,7 @@ func (p *PantheonProvider) ValidateField(field, value string) error {
 	return nil
 }
 
-// Config provides interactive configuration prompts when running `ddev config pantheon`
+// PromptForConfig provides interactive configuration prompts when running `ddev config pantheon`
 func (p *PantheonProvider) PromptForConfig() error {
 	p.Sitename = p.config.Name
 	for {

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -57,7 +57,7 @@ func (p *PantheonProvider) ValidateField(field, value string) error {
 }
 
 // Config provides interactive configuration prompts when running `ddev config pantheon`
-func (p *PantheonProvider) Config() error {
+func (p *PantheonProvider) PromptForConfig() error {
 	p.Sitename = p.config.Name
 	for {
 		err := p.environmentPrompt()

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -24,7 +24,7 @@ type PantheonProvider struct {
 	Sitename         string                   `yaml:"site"`
 	site             pantheon.Site            `yaml:"-"`
 	siteEnvironments pantheon.EnvironmentList `yaml:"-"`
-	Environment      string                   `yaml:"environment"`
+	EnvironmentName  string                   `yaml:"environment"`
 	environment      pantheon.Environment     `yaml:"-"`
 }
 
@@ -88,7 +88,7 @@ func (p *PantheonProvider) GetBackup(backupType string) (fileLocation string, im
 	session := getPantheonSession()
 
 	// Find either a files or database backup, depending on what was asked for.
-	bl := pantheon.NewBackupList(p.site.ID, p.Environment)
+	bl := pantheon.NewBackupList(p.site.ID, p.EnvironmentName)
 	err = session.Request("GET", bl)
 	if err != nil {
 		return "", "", err
@@ -113,7 +113,7 @@ func (p *PantheonProvider) GetBackup(backupType string) (fileLocation string, im
 	}
 
 	if backupType == "files" {
-		importPath = fmt.Sprintf("files_%s", p.Environment)
+		importPath = fmt.Sprintf("files_%s", p.EnvironmentName)
 	}
 
 	return destFile, importPath, nil
@@ -153,7 +153,7 @@ func (p *PantheonProvider) getPantheonBackupLink(archiveType string, bl *pantheo
 	}
 
 	// If no matches were found, just return an empty backup along with an error.
-	return &pantheon.Backup{}, fmt.Errorf("could not find a backup of type %s. please visit your pantheon dashboard and ensure the '%s' environment has a backup available", archiveType, p.Environment)
+	return &pantheon.Backup{}, fmt.Errorf("could not find a backup of type %s. please visit your pantheon dashboard and ensure the '%s' environment has a backup available", archiveType, p.EnvironmentName)
 }
 
 // environmentPrompt contains the user prompts for interactive configuration of the pantheon environment.
@@ -163,8 +163,8 @@ func (p *PantheonProvider) environmentPrompt() error {
 		return err
 	}
 
-	if p.Environment == "" {
-		p.Environment = "dev"
+	if p.EnvironmentName == "" {
+		p.EnvironmentName = "dev"
 	}
 
 	fmt.Println("\nConfigure import environment:")
@@ -175,12 +175,12 @@ func (p *PantheonProvider) environmentPrompt() error {
 	}
 	fmt.Println("\n\t- " + strings.Join(keys, "\n\t- ") + "\n")
 	var environmentPrompt = "Type the name to select an environment to import from"
-	if p.Environment != "" {
-		environmentPrompt = fmt.Sprintf("%s (%s)", environmentPrompt, p.Environment)
+	if p.EnvironmentName != "" {
+		environmentPrompt = fmt.Sprintf("%s (%s)", environmentPrompt, p.EnvironmentName)
 	}
 
 	fmt.Print(environmentPrompt + ": ")
-	p.Environment = util.GetInput(p.Environment)
+	envName := util.GetInput(p.EnvironmentName)
 
 	environment, ok := p.siteEnvironments.Environments[p.Environment]
 	p.environment = environment
@@ -266,10 +266,10 @@ func (p *PantheonProvider) environmentExists() error {
 		return err
 	}
 
-	_, ok := p.siteEnvironments.Environments[p.Environment]
+	_, ok := p.siteEnvironments.Environments[p.EnvironmentName]
 
 	if !ok {
-		return fmt.Errorf("could not find an environment named '%s'", p.Environment)
+		return fmt.Errorf("could not find an environment named '%s'", p.EnvironmentName)
 	}
 
 	return nil

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -391,7 +391,7 @@ func TestProcessHooks(t *testing.T) {
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ProcessHooks", site.Name))
 
 		testcommon.ClearDockerEnv()
-		conf, err := ddevapp.NewConfig(site.Dir, ddevapp.DDevDefaultPlatform)
+		conf, err := ddevapp.NewConfig(site.Dir, ddevapp.DefaultProviderName)
 		assert.NoError(err)
 
 		conf.Commands = map[string][]ddevapp.Command{


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #476: We need to handle config without user prompting, so we'll add new flags to `ddev config`.

## How this PR Solves The Problem:

* Add new flags for configuration --sitename --docroot --pantheon-environment
* Rename Pantheon's "Environment" to "EnvironmentName", since there was also an "environment" and it was impossible to figure out which was which.
* Rename Config() to PromptForConfig() to make the code more readable.
* Refactor Config() so it doesn't return an error when there's no existing config.yaml - instead it only returns an error when the existing has problems.


## Manual Testing Instructions:

Start with no site .ddev file.
* Test existing config paths (`ddev config`, `ddev config pantheon`
* `ddev config --sitename=junker99`, `ddev config --sitename=junker99 --docroot=docroot`
* `ddev config pantheon --pantheon-environment=dev --sitename=rfay-drupal8` and then try a `ddev pull`


## Automated Testing Overview:

I didn't add any new automated testing.

## Related Issue Link(s):

OP #476

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

