### PR TITLE
Fix bug where provider was always assumed, fixes #437

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -56,10 +56,12 @@ var ConfigCommand = &cobra.Command{
 		}
 
 		// If a provider is specified, prompt about whether to do an import after config.
-		if provider != "" {
-			util.Success("Configuration complete. You may now run `ddev start` or `ddev pull`")
+		switch provider {
+		case ddevapp.DefaultProviderName:
+			util.Success("Configuration complete. You may now run 'ddev start'.")
+		default:
+			util.Success("Configuration complete. You may now run 'ddev start' or 'ddev pull'")
 		}
-		util.Success("Initial configuration file written successfully. See the configuration file for additional configuration options.")
 	},
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

The ddev response after config was always saying "you can now 'pull'", but of course you can only do that with pantheon.

This turned out to be a simple bug, assumption of the name of the default provider being "" when it's actually ddevapp.DefaultProviderName.

## How this PR Solves The Problem:

Change the comparison. I switched it to a "switch" as well since it seemed like clearer code.

## Manual Testing Instructions:

Try a `ddev config` and also a `ddev config pantheon` and verify that the correct response is given at the end of the config input.

## Automated Testing Overview:

No changes were made.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

