### PR TITLE
fix installer script colors, remove tput dep, fixes #490

### DIFF
--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -3,10 +3,10 @@ set -e
 
 # Download and install latest ddev release
 
-RED=$(tput setaf 1)
-GREEN=$(tput setaf 2)
-YELLOW=$(tput setaf 3)
-RESET=$(tput sgr0)
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RESET='\033[0m'
 OS=$(uname)
 BINOWNER=$(ls -ld /usr/local/bin | awk '{print $3}')
 USER=$(whoami)
@@ -24,12 +24,12 @@ elif [[ "$OS" == "Linux" ]]; then
     SHACMD="sha256sum"
     FILEBASE="ddev_linux"
 else
-    echo "${RED}Sorry, this installer does not support your platform at this time.${RESET}"
+    printf "${RED}Sorry, this installer does not support your platform at this time.${RESET}\n"
     exit 1
 fi
 
 if ! docker --version >/dev/null 2>&1; then
-    echo "${YELLOW}Docker is required for ddev. Download and install docker at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}"
+    printf "${YELLOW}Docker is required for ddev. Download and install docker at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
 fi
 
 TARBALL="$FILEBASE.$LATEST_VERSION.tar.gz"
@@ -42,24 +42,24 @@ cd /tmp; $SHACMD -c "$SHAFILE"
 tar -xzf $TARBALL -C /tmp
 chmod ugo+x /tmp/ddev
 
-echo "Download verified. Ready to place ddev in your /usr/local/bin."
+printf "Download verified. Ready to place ddev in your /usr/local/bin.\n"
 
 if [[ "$BINOWNER" == "$USER" ]]; then
     mv /tmp/ddev /usr/local/bin/
 else
-    echo "${YELLOW}Running \"sudo mv /tmp/ddev /usr/local/bin/\" Please enter your password if prompted.${RESET}"
+    printf "${YELLOW}Running \"sudo mv /tmp/ddev /usr/local/bin/\" Please enter your password if prompted.${RESET}\n"
     sudo mv /tmp/ddev /usr/local/bin/
 fi
 
 if which brew &&  [ -f `brew --prefix`/etc/bash_completion ]; then
 	bash_completion_dir=$(brew --prefix)/etc/bash_completion.d
     cp /tmp/ddev_bash_completion.sh $bash_completion_dir/ddev
-    echo "$(GREEN)Installed ddev bash completions in $bash_completion_dir$(RESET)"
+    printf "${GREEN}Installed ddev bash completions in $bash_completion_dir${RESET}\n"
     rm /tmp/ddev_bash_completion.sh
 else
-	echo "$(YELLOW)Bash completion for ddev was not installed. You may manually install /tmp/ddev_bash_completions.sh in your bash_completions.d directory.$(RESET)"
+	printf "${YELLOW}Bash completion for ddev was not installed. You may manually install /tmp/ddev_bash_completions.sh in your bash_completions.d directory.${RESET}\n"
 fi
 
 rm /tmp/$TARBALL /tmp/$SHAFILE
 
-echo "${GREEN}ddev is now installed. Run \"ddev\" to verify your installation and see usage.${RESET}"
+printf "${GREEN}ddev is now installed. Run \"ddev\" to verify your installation and see usage.${RESET}\n"


### PR DESCRIPTION
## The Problem/Issue/Bug:
#490 OP - We have fancy colors in our install script, but they totally blew up in a fresh ubuntu install.

## How this PR Solves The Problem:
There were 2 main issues at hand:
- Some instances of the color variables were written as $(VAR) instead of ${VAR}, causing them to produce errors, as the var name would be invoked as a command in subshell. These have been fixed.
- We were using tput for coloring. This is present in many systems, but we've seen it not present in a few linux variants (notably as an error produced by wp-cli). I've replaced the tput usage with escape sequences. I don't _think_ this was the actual issue causing OP, but I believe it should help reduce portability issues.

## Manual Testing Instructions:
Run the install script on Ubuntu. It should not esplode.
Run the install script on OSX. It should not esplode either.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

