### PR TITLE
API/json implementation and interaction with ddev, fixes #477

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ If you've encountered trouble using ddev, please use these resources to get help
 
 ## Contributing
 Interested in contributing to ddev? We would love your suggestions, contributions, and help! Please review our [Guidelines for Contributing](https://github.com/drud/ddev/blob/master/CONTRIBUTING.md), then [create an issue](https://github.com/drud/ddev/issues/new) or open a pull request!
+

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"log"
 	"os"
-
-	"path/filepath"
 
 	"path"
 
+	"path/filepath"
+
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -36,14 +36,14 @@ var ConfigCommand = &cobra.Command{
 
 		appRoot, err := os.Getwd()
 		if err != nil {
-			util.Failed("Could not determine current working directory: %v\n", err)
+			util.Failed("Could not determine current working directory: %v", err)
 
 		}
 
 		provider := ddevapp.DefaultProviderName
 
 		if len(args) > 1 {
-			log.Fatal("Invalid argument detected. Please use 'ddev config' or 'ddev config [provider]' to configure a site.")
+			output.UserOut.Fatal("Invalid argument detected. Please use 'ddev config' or 'ddev config [provider]' to configure a site.")
 		}
 
 		if len(args) == 1 {
@@ -59,7 +59,7 @@ var ConfigCommand = &cobra.Command{
 		if siteName == "" && docrootRelPath == "" && pantheonEnvironment == "" && appType == "" {
 			err = c.PromptForConfig()
 			if err != nil {
-				util.Failed("There was a problem configuring your application: %v\n", err)
+				util.Failed("There was a problem configuring your application: %v", err)
 			}
 		} else { // In this case we have to validate the provided items, or set to sane defaults
 
@@ -97,7 +97,7 @@ var ConfigCommand = &cobra.Command{
 			fullPath, _ := filepath.Abs(c.Docroot)
 			if err == nil && (appType == "" || appType == foundAppType) { // Found an app, matches passed-in or no apptype passed
 				appType = foundAppType
-				util.Success("Found a %s codebase at %s\n", foundAppType, fullPath)
+				util.Success("Found a %s codebase at %s", foundAppType, fullPath)
 			} else if appType != "" && err != nil { // apptype was passed, but we found no app at all
 				util.Warning("You have specified an apptype of %s but no app of that type is found in %s", appType, fullPath)
 			} else if appType != "" && err == nil && foundAppType != appType { // apptype was passed, app was found, but not the same type
@@ -127,7 +127,7 @@ var ConfigCommand = &cobra.Command{
 		}
 		err = c.Write()
 		if err != nil {
-			util.Failed("Could not write ddev config file: %v\n", err)
+			util.Failed("Could not write ddev config file: %v", err)
 		}
 
 		// If a provider is specified, prompt about whether to do an import after config.

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -5,6 +5,7 @@ import (
 
 	"strings"
 
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -38,10 +39,11 @@ var LocalDevExecCmd = &cobra.Command{
 
 		app.DockerEnv()
 
-		err = app.Exec(serviceType, true, args...)
+		out, _, err := app.Exec(serviceType, args...)
 		if err != nil {
 			util.Failed("Failed to execute command %s: %v", args, err)
 		}
+		output.UserOut.Print(out)
 	},
 }
 

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
+	"github.com/drud/ddev/pkg/output"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/spf13/cobra"
@@ -15,29 +15,28 @@ var HostNameCmd = &cobra.Command{
 	Long:  `Manage your hostfile entries.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 2 {
-			log.Fatal("Invalid arguments supplied. Please use 'drud legacy hostname [hostname] [ip]'")
+			output.UserOut.Fatal("Invalid arguments supplied. Please use 'ddev hostname [hostname] [ip]'")
 		}
 
 		hostname, ip := args[0], args[1]
 		hosts, err := goodhosts.NewHosts()
 		if err != nil {
-			log.Fatalf("could not open hostfile. %s", err)
+			output.UserOut.Fatalf("could not open hosts file. %s", err)
 		}
 		if hosts.Has(ip, hostname) {
-			fmt.Println("Entry exists!")
+			log.Debugf("Hosts file entry %s exists, taking no action", hostname)
 			return
 		}
 
 		err = hosts.Add(ip, hostname)
 		if err != nil {
-			log.Fatal("Could not add hostname")
+			output.UserOut.Fatal("Could not add hostname")
 		}
 
 		if err := hosts.Flush(); err != nil {
-			log.Fatalf("could not write hosts file: %s", err)
+			output.UserOut.Fatalf("could not write hosts file: %s", err)
 		}
 	},
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/output"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/drud/ddev/pkg/util"
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +22,7 @@ var HostNameCmd = &cobra.Command{
 		hostname, ip := args[0], args[1]
 		hosts, err := goodhosts.NewHosts()
 		if err != nil {
-			output.UserOut.Fatalf("could not open hosts file. %s", err)
+			util.Failed("could not open hosts file. %s", err)
 		}
 		if hosts.Has(ip, hostname) {
 			log.Debugf("Hosts file entry %s exists, taking no action", hostname)
@@ -30,11 +31,11 @@ var HostNameCmd = &cobra.Command{
 
 		err = hosts.Add(ip, hostname)
 		if err != nil {
-			output.UserOut.Fatal("Could not add hostname")
+			util.Failed("Could not add hostname")
 		}
 
 		if err := hosts.Flush(); err != nil {
-			output.UserOut.Fatalf("could not write hosts file: %s", err)
+			util.Failed("Could not write hosts file: %s", err)
 		}
 	},
 }

--- a/cmd/ddev/cmd/import_test.go
+++ b/cmd/ddev/cmd/import_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestImportTilde(t *testing.T) {
 		args := []string{"import-files", "--src", "~/testfile.tar.gz"}
 		out, err := exec.RunCommand(DdevBin, args)
 		if err != nil {
-			log.Println("Error Output from ddev import-files:", out, site)
+			t.Log("Error Output from ddev import-files:", out, site)
 		}
 		assert.NoError(err)
 		assert.Contains(string(out), "Successfully imported files")
@@ -42,7 +41,7 @@ func TestImportTilde(t *testing.T) {
 		args = []string{"import-files", "--src=~/testfile.tar.gz"}
 		out, err = exec.RunCommand(DdevBin, args)
 		if err != nil {
-			log.Println("Error Output from ddev import-files:", out, site)
+			t.Log("Error Output from ddev import-files:", out, site)
 		}
 		assert.NoError(err)
 		assert.Contains(string(out), "Successfully imported files")

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -34,7 +34,7 @@ var DevListCmd = &cobra.Command{
 			platform.RenderAppRow(table, desc)
 		}
 
-		output.UserOut.WithField("raw", appDescs).Print(table)
+		output.UserOut.WithField("raw", appDescs).Print(table.String() + "\n" + platform.RenderRouterStatus())
 	},
 }
 

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -15,15 +16,25 @@ var DevListCmd = &cobra.Command{
 	Long:  `List applications that exist locally.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		apps := platform.GetApps()
+		var appDescs []map[string]interface{}
 
-		if len(apps) < 1 {
-			fmt.Println("There are no running ddev applications.")
+		sites, ok := apps["local"]
+		if !ok || len(sites) < 1 {
+			output.UserOut.Println("There are no running ddev applications.")
 			os.Exit(0)
 		}
 
-		for platformType, sites := range apps {
-			platform.RenderAppTable(platformType, sites)
+		table := platform.CreateAppTable()
+		for _, site := range sites {
+			desc, err := site.Describe()
+			appDescs = append(appDescs, desc)
+			if err != nil {
+				util.Failed("Failed to describe site %s: %v", site.GetName(), err)
+			}
+			platform.RenderAppRow(table, desc)
 		}
+
+		output.UserOut.WithField("raw", appDescs).Print(table)
 	},
 }
 

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -3,28 +3,62 @@ package cmd
 import (
 	"testing"
 
+	"encoding/json"
+
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/plugins/platform"
+	log "github.com/sirupsen/logrus"
 	asrt "github.com/stretchr/testify/assert"
 )
 
+// TestDevList runs the binary with "ddev list" and checks the results
 func TestDevList(t *testing.T) {
 	assert := asrt.New(t)
+
+	// Execute "ddev list" and harvest plain text output.
 	args := []string{"list"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	for _, v := range DevTestSites {
-		cleanup := v.Chdir()
 
-		app, err := platform.GetActiveApp("")
-		if err != nil {
-			assert.Fail("Could not find an active ddev configuration: %v", err)
-		}
+	// Execute "ddev list -j" and harvest the json output
+	args = []string{"list", "-j"}
+	jsonOut, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+
+	// Unmarshall the json results. The list function has 4 fields to output
+	data := make(log.Fields, 4)
+	err = json.Unmarshal([]byte(jsonOut), &data)
+	assert.NoError(err)
+	raw, ok := data["raw"].([]interface{})
+	assert.True(ok)
+
+	for _, v := range DevTestSites {
+		app, err := platform.GetActiveApp(v.Name)
+		assert.NoError(err)
+
+		// Look for standard items in the regular ddev list output
 		assert.Contains(string(out), v.Name)
 		assert.Contains(string(out), app.URL())
 		assert.Contains(string(out), app.GetType())
 		assert.Contains(string(out), platform.RenderHomeRootedDir(app.AppRoot()))
-		cleanup()
+
+		// Look through list results in json for this site.
+		found := false
+		for _, listitem := range raw {
+			_ = listitem
+			item, ok := listitem.(map[string]interface{})
+			assert.True(ok)
+			// Check to see that we can find our item
+			if item["name"] == v.Name {
+				found = true
+				assert.EqualValues(app.URL(), item["url"])
+				assert.EqualValues(app.GetType(), item["type"])
+				assert.EqualValues(platform.RenderHomeRootedDir(app.AppRoot()), item["approot"])
+				break
+			}
+		}
+		assert.True(found, "Failed to find site %s in ddev list -j", v.Name)
+
 	}
 
 }

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -44,7 +44,7 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 			util.Failed("Failed to remove %s: %s", app.GetName(), err)
 		}
 
-		util.Success("Successfully removed the %s application.\n", app.GetName())
+		util.Success("Successfully removed the %s application.", app.GetName())
 	},
 }
 

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -7,7 +7,7 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDevRestart runs `drud legacy restart` on the test apps
+// TestDevRemove runs `ddev rm` on the test apps
 func TestDevRemove(t *testing.T) {
 	assert := asrt.New(t)
 

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -29,7 +29,7 @@ var LocalDevReconfigCmd = &cobra.Command{
 			util.Failed("Failed to restart: %v", err)
 		}
 
-		fmt.Printf("Restarting environment for %s...", app.GetName())
+		output.UserOut.Printf("Restarting environment for %s...", app.GetName())
 		err = app.Stop()
 		if err != nil {
 			util.Failed("Failed to restart %s: %v", app.GetName(), err)

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -1,18 +1,21 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
+
+	"encoding/json"
+
+	"strings"
 
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/plugins/platform"
+	log "github.com/sirupsen/logrus"
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDevRestart runs `drud legacy restart` on the test apps
+// TestDevRestart runs `ddev restart` on the test apps
 func TestDevRestart(t *testing.T) {
 	assert := asrt.New(t)
-	containerPrefix := "ddev"
 	for _, site := range DevTestSites {
 		cleanup := site.Chdir()
 
@@ -25,13 +28,48 @@ func TestDevRestart(t *testing.T) {
 			assert.Fail("Could not find an active ddev configuration: %v", err)
 		}
 
-		format := fmt.Sprintf
-		assert.Contains(string(out), format("Stopping %s-%s-web", containerPrefix, app.GetName()))
-		assert.Contains(string(out), format("Stopping %s-%s-db", containerPrefix, app.GetName()))
-		assert.Contains(string(out), format("Stopping %s-%s-dba", containerPrefix, app.GetName()))
-		assert.Contains(string(out), format("Starting %s-%s-web", containerPrefix, app.GetName()))
-		assert.Contains(string(out), format("Starting %s-%s-db", containerPrefix, app.GetName()))
-		assert.Contains(string(out), format("Starting %s-%s-dba", containerPrefix, app.GetName()))
+		assert.Contains(string(out), "Your application can be reached at")
+		assert.Contains(string(out), app.URL())
+
+		cleanup()
+	}
+}
+
+// TestDevRestartJSON runs `ddev restart -j` on the test apps and harvests and checks the output
+func TestDevRestartJSON(t *testing.T) {
+	assert := asrt.New(t)
+	for _, site := range DevTestSites {
+		cleanup := site.Chdir()
+
+		app, err := platform.GetActiveApp("")
+		if err != nil {
+			assert.Fail("Could not find an active ddev configuration: %v", err)
+		}
+
+		args := []string{"restart", "-j"}
+		out, err := exec.RunCommand(DdevBin, args)
+		assert.NoError(err)
+		logStrings := strings.Split(out, "\n")
+		// We expect 4 lines of json in result, and a blank (Restarting,
+		// need-add-hosts, successfully restarted, can be reached at,
+		// blank at end)
+		assert.True(len(logStrings) >= 3)
+
+		// Wander through the json output lines making sure they're reasonable json.
+		for _, entry := range logStrings {
+			if entry != "" { // Ignore empty line.
+				// Unmarshall the json results. Normal log entries have 3 fields
+				data := make(log.Fields, 3)
+				err = json.Unmarshal([]byte(entry), &data)
+				assert.NoError(err)
+				if !strings.Contains(data["msg"].(string), "You must manually add the following") {
+					assert.EqualValues(data["level"], "info")
+				}
+				assert.NotEmpty(data["msg"])
+			}
+		}
+
+		// Go ahead and look for normal strings within the json output.
 		assert.Contains(string(out), "Your application can be reached at")
 		assert.Contains(string(out), app.URL())
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/updatecheck"
 	"github.com/drud/ddev/pkg/util"
@@ -17,7 +18,6 @@ import (
 )
 
 var (
-	logLevel       = log.WarnLevel
 	plugin         = "local"
 	updateInterval = time.Hour * 24 * 7 // One week interval between updates
 	serviceType    string
@@ -31,9 +31,11 @@ var RootCmd = &cobra.Command{
 	Short: "A CLI for interacting with ddev.",
 	Long:  "This Command Line Interface (CLI) gives you the ability to interact with the ddev to create a local development environment.",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		ignores := []string{"list", "version", "describe", "config"}
+		ignores := []string{"list", "version", "describe", "config", "hostname"}
 		skip := false
 		command := strings.Join(os.Args, " ")
+
+		output.LogSetUp()
 
 		for _, k := range ignores {
 			if strings.Contains(command, " "+k) {
@@ -89,7 +91,7 @@ var RootCmd = &cobra.Command{
 			}
 
 			if updateNeeded {
-				util.Warning("\n\nA new update is available! please visit %s to download the update!\n\n", updateURL)
+				util.Warning("\n\nA new update is available! please visit %s to download the update.", updateURL)
 			}
 		}
 
@@ -108,15 +110,6 @@ func Execute() {
 
 }
 
-func init() {
-	drudDebug := os.Getenv("DRUD_DEBUG")
-	if drudDebug != "" {
-		logLevel = log.DebugLevel
-	}
-
-	log.SetLevel(logLevel)
-}
-
 func dockerNetworkPreRun() {
 	client := dockerutil.GetDockerClient()
 
@@ -124,4 +117,8 @@ func dockerNetworkPreRun() {
 	if err != nil {
 		util.Failed("Unable to create/ensure docker network %s, error: %v", netName, err)
 	}
+}
+
+func init() {
+	RootCmd.PersistentFlags().BoolVarP(&output.JSONOutput, "json-output", "j", false, "If true, user-oriented output will be in JSON format.")
 }

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -33,14 +33,16 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	output.LogSetUp()
+
 	if os.Getenv("DDEV_BINARY_FULLPATH") != "" {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
 	}
-	fmt.Println("Running ddev with ddev=", DdevBin)
+	log.Println("Running ddev with ddev=", DdevBin)
 
 	err := os.Setenv("DRUD_NONINTERACTIVE", "true")
 	if err != nil {
-		fmt.Println("could not set noninteractive mode")
+		log.Errorln("could not set noninteractive mode, failed to Setenv, err: ", err)
 	}
 
 	for i := range DevTestSites {
@@ -51,7 +53,7 @@ func TestMain(m *testing.M) {
 	}
 	addSites()
 
-	fmt.Println("Running tests.")
+	log.Debugln("Running tests.")
 	testRun := m.Run()
 
 	removeSites()

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +12,7 @@ import (
 
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/pkg/errors"
@@ -29,12 +30,12 @@ var localDevSequelproCmd = &cobra.Command{
 	Long:  `A helper command for easily using sequelpro (OSX database browser) with a ddev app that has been initialized locally.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
-			log.Fatalf("invalid arguments to sequelpro command: %v", args)
+			output.UserOut.Fatalf("invalid arguments to sequelpro command: %v", args)
 		}
 
 		out, err := handleSequelProCommand(SequelproLoc)
 		if err != nil {
-			log.Fatalf("Could not run sequelpro command: %s", err)
+			output.UserOut.Fatalf("Could not run sequelpro command: %s", err)
 		}
 		util.Success(out)
 	},
@@ -65,7 +66,7 @@ func handleSequelProCommand(appLocation string) (string, error) {
 	tmpFilePath := filepath.Join(app.AppRoot(), ".ddev/sequelpro.spf")
 	tmpFile, err := os.Create(tmpFilePath)
 	if err != nil {
-		log.Fatalln(err)
+		output.UserOut.Fatalln(err)
 	}
 	defer util.CheckClose(tmpFile)
 

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -29,11 +29,11 @@ var LocalDevSSHCmd = &cobra.Command{
 
 		app.DockerEnv()
 
-		err = app.Exec(serviceType, false, "bash")
+		err = app.ExecWithTty(serviceType, "bash")
+
 		if err != nil {
 			util.Failed("Failed to ssh %s: %s", app.GetName(), err)
 		}
-
 	},
 }
 

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -36,7 +36,7 @@ func appStart() {
 		util.Failed("Failed to start %s, err: %v", app.GetName(), err)
 	}
 
-	fmt.Printf("Starting environment for %s...\n", app.GetName())
+	output.UserOut.Printf("Starting environment for %s...", app.GetName())
 
 	err = app.Start()
 	if err != nil {

--- a/cmd/ddev/cmd/version.go
+++ b/cmd/ddev/cmd/version.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"fmt"
-
 	"os"
 
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/gosuri/uitable"
@@ -23,7 +22,7 @@ var versionCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		out := handleVersionCommand()
-		fmt.Println(out)
+		output.UserOut.Println(out)
 	},
 }
 

--- a/pkg/appimport/appimport_test.go
+++ b/pkg/appimport/appimport_test.go
@@ -8,8 +8,6 @@ import (
 
 	"os"
 
-	"log"
-
 	"github.com/drud/ddev/pkg/appimport"
 	"github.com/drud/ddev/pkg/util"
 	gohomedir "github.com/mitchellh/go-homedir"
@@ -22,7 +20,7 @@ func TestValidateAsset(t *testing.T) {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		log.Fatalf("failed to get cwd: %s", err)
+		t.Fatalf("failed to get cwd: %s", err)
 	}
 	testdata := filepath.Join(cwd, "testdata")
 

--- a/pkg/appports/ports.go
+++ b/pkg/appports/ports.go
@@ -3,7 +3,7 @@ package appports
 import (
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/drud/ddev/pkg/util"
 )
 
 // Define the DBA and MailHog ports as variables so that we can override them with ldflags if required.
@@ -29,7 +29,7 @@ func GetPort(service string) string {
 	service = strings.ToLower(service)
 	val, ok := ports[service]
 	if !ok {
-		log.Fatalf("Could not find port for service %s", service)
+		util.Failed("Could not find port for service %s", service)
 	}
 
 	return val

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/pkg/errors"
@@ -230,10 +231,10 @@ func (c *Config) Read() error {
 // WarnIfConfigReplace just messages user about whether config is being replaced or created
 func (c *Config) WarnIfConfigReplace() {
 	if c.ConfigExists() {
-		util.Warning("You are re-configuring the app at %s. \nThe existing configuration will be updated and replaced.\n\n", c.AppRoot)
+		util.Warning("You are reconfiguring the app at %s. \nThe existing configuration will be updated and replaced.", c.AppRoot)
 	} else {
-		util.Success("Creating a new ddev project config in the current directory (%s)", c.AppRoot)
-		util.Success("Once completed, your configuration will be written to %s\n", c.ConfigPath)
+		output.UserOut.Printf("Creating a new ddev project config in the current directory (%s)", c.AppRoot)
+		output.UserOut.Printf("Once completed, your configuration will be written to %s", c.ConfigPath)
 	}
 }
 
@@ -249,7 +250,7 @@ func (c *Config) PromptForConfig() error {
 			break
 		}
 
-		fmt.Printf("%v\n", err)
+		output.UserOut.Printf("%v", err)
 	}
 
 	for {
@@ -259,7 +260,7 @@ func (c *Config) PromptForConfig() error {
 			break
 		}
 
-		fmt.Printf("%v\n", err)
+		output.UserOut.Printf("%v", err)
 	}
 
 	err := c.appTypePrompt()
@@ -383,8 +384,8 @@ func (c *Config) docrootPrompt() error {
 	}
 
 	// Determine the document root.
-	fmt.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your application root (%s)\n", c.AppRoot)
-	fmt.Println("You may leave this value blank if your site files are in the application root")
+	output.UserOut.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your application root (%s)", c.AppRoot)
+	output.UserOut.Println("You may leave this value blank if your site files are in the application root")
 	var docrootPrompt = "Docroot Location"
 	if c.Docroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, c.Docroot)
@@ -396,7 +397,7 @@ func (c *Config) docrootPrompt() error {
 	// Ensure the docroot exists. If it doesn't, prompt the user to verify they entered it correctly.
 	fullPath := filepath.Join(c.AppRoot, c.Docroot)
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		fmt.Printf("No directory could be found at %s. Please enter a valid docroot\n", fullPath)
+		output.UserOut.Errorf("No directory could be found at %s. Please enter a valid docroot\n", fullPath)
 		c.Docroot = ""
 		return c.docrootPrompt()
 	}
@@ -429,7 +430,7 @@ func (c *Config) appTypePrompt() error {
 	appType, err = DetermineAppType(absDocroot)
 	if err == nil {
 		// If we found an application type just set it and inform the user.
-		util.Success("Found a %s codebase at %s\n", appType, filepath.Join(c.AppRoot, c.Docroot))
+		util.Success("Found a %s codebase at %s.", appType, filepath.Join(c.AppRoot, c.Docroot))
 		c.AppType = appType
 		return provider.ValidateField("AppType", c.AppType)
 	}
@@ -440,7 +441,7 @@ func (c *Config) appTypePrompt() error {
 		appType = strings.ToLower(util.GetInput(c.AppType))
 
 		if IsAllowedAppType(appType) != true {
-			fmt.Printf("%s is not a valid application type. Allowed application types are: %s\n", appType, strings.Join(AllowedAppTypes, ", "))
+			output.UserOut.Errorf("%s is not a valid application type. Allowed application types are: %s\n", appType, strings.Join(AllowedAppTypes, ", "))
 		}
 		c.AppType = appType
 	}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	. "github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -17,6 +18,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	output.LogSetUp()
+
 	// Ensure the ddev directory is created before tests run.
 	_ = util.GetGlobalDdevDir()
 	os.Exit(m.Run())
@@ -170,7 +173,7 @@ func TestConfigCommand(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 
-	restoreOutput := testcommon.CaptureStdOut()
+	restoreOutput := testcommon.CaptureUserOut()
 	err = config.PromptForConfig()
 	assert.NoError(err, t)
 	out := restoreOutput()

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -68,7 +68,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 
-	restoreOutput := testcommon.CaptureStdOut()
+	restoreOutput := testcommon.CaptureUserOut()
 	err = config.PromptForConfig()
 	assert.NoError(err, t)
 	out := restoreOutput()

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -2,12 +2,12 @@ package ddevapp
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	gohomedir "github.com/mitchellh/go-homedir"
 
@@ -69,13 +69,11 @@ func (p *PantheonProvider) PromptForConfig() error {
 		err := p.environmentPrompt()
 
 		if err == nil {
-			break
+			return nil
 		}
 
-		fmt.Printf("%v\n", err)
+		output.UserOut.Errorf("%v\n", err)
 	}
-
-	return nil
 }
 
 // GetBackup will download the most recent backup specified by backupType. Valid values for backupType are "database" or "files".
@@ -325,7 +323,7 @@ func getPantheonSession() *pantheon.AuthSession {
 
 	err = session.Auth()
 	if err != nil {
-		log.Fatalf("Could not authenticate with pantheon: %v", err)
+		output.UserOut.Fatalf("Could not authenticate with pantheon: %v", err)
 	}
 
 	err = session.Write(sessionLocation)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -247,7 +247,7 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 
 		// If we're using debug output, show docker-compose stderr output
 		// but default is to show dots
-		if !debugOutput {
+		if !debugOutput && !output.JSONOutput {
 			if strings.Contains(line, "done") {
 				fmt.Print(".")
 			}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -234,7 +234,7 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 	stderrPipe, err := proc.StderrPipe()
 	util.CheckErr(err)
 
-	if err := proc.Start(); err != nil {
+	if err = proc.Start(); err != nil {
 		return "", "", fmt.Errorf("Failed to exec docker-compose: %v", err)
 	}
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -218,8 +218,6 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 	var stdout bytes.Buffer
 	var stderr string
 
-	debugOutput := ("" != os.Getenv("DRUD_DEBUG"))
-
 	for _, file := range composeFiles {
 		arg = append(arg, "-f")
 		arg = append(arg, file)
@@ -243,17 +241,12 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 
 	for in.Scan() {
 		line := in.Text()
-		stderr = stderr + "\n" + line
-
-		// If we're using debug output, show docker-compose stderr output
-		// but default is to show dots
-		if !debugOutput && !output.JSONOutput {
-			if strings.Contains(line, "done") {
-				fmt.Print(".")
-			}
-		} else { // If we are doing debug output, print the line
-			output.UserOut.Println(line)
+		if len(stderr) > 0 {
+			stderr = stderr + "\n"
 		}
+		stderr = stderr + line
+		line = strings.Trim(line, "\n\r")
+		output.UserOut.Println(line)
 	}
 
 	err = proc.Wait()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"bytes"
 
 	"github.com/Masterminds/semver"
+	"github.com/drud/ddev/pkg/output"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -32,7 +32,7 @@ func EnsureNetwork(client *docker.Client, name string) error {
 		if err != nil {
 			return err
 		}
-		log.Println("Network", name, "created")
+		output.UserOut.Println("Network", name, "created")
 
 	}
 	return nil
@@ -42,7 +42,7 @@ func EnsureNetwork(client *docker.Client, name string) error {
 func GetDockerClient() *docker.Client {
 	client, err := docker.NewClientFromEnv()
 	if err != nil {
-		log.Fatalf("could not get docker client. is docker running? error: %v", err)
+		util.Failed("could not get docker client. is docker running? error: %v", err)
 	}
 
 	return client

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -246,15 +246,17 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 		stderr = stderr + "\n" + line
 
 		// If we're using debug output, show docker-compose stderr output
+		// but default is to show dots
 		if !debugOutput {
 			if strings.Contains(line, "done") {
 				fmt.Print(".")
 			}
-		} else {
+		} else { // If we are doing debug output, print the line
 			output.UserOut.Println(line)
 		}
 	}
 
+	err = proc.Wait()
 	if err != nil {
 		return stdout.String(), stderr, fmt.Errorf("Failed to run docker-compose %v, err='%v', stdout='%s', stderr='%s'", arg, err, stdout.String(), stderr)
 	}

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -1,14 +1,15 @@
 package dockerutil_test
 
 import (
-	"log"
 	"os"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 
 	"path/filepath"
 
 	. "github.com/drud/ddev/pkg/dockerutil"
-	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/output"
 	docker "github.com/fsouza/go-dockerclient"
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -20,6 +21,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	output.LogSetUp()
+
 	// prep docker container for docker util tests
 	client := GetDockerClient()
 
@@ -110,25 +113,21 @@ func TestComposeCmd(t *testing.T) {
 
 	composeFiles := []string{filepath.Join("testdata", "docker-compose.yml")}
 
-	stdout := testcommon.CaptureStdOut()
-	err := ComposeCmd(composeFiles, "config", "--services")
+	stdout, _, err := ComposeCmd(composeFiles, "config", "--services")
 	assert.NoError(err)
-	out := stdout()
-	assert.Contains(out, "web")
-	assert.Contains(out, "db")
+	assert.Contains(stdout, "web")
+	assert.Contains(stdout, "db")
 
 	composeFiles = append(composeFiles, filepath.Join("testdata", "docker-compose.override.yml"))
 
-	stdout = testcommon.CaptureStdOut()
-	err = ComposeCmd(composeFiles, "config", "--services")
+	stdout, _, err = ComposeCmd(composeFiles, "config", "--services")
 	assert.NoError(err)
-	out = stdout()
-	assert.Contains(out, "web")
-	assert.Contains(out, "db")
-	assert.Contains(out, "foo")
+	assert.Contains(stdout, "web")
+	assert.Contains(stdout, "db")
+	assert.Contains(stdout, "foo")
 
 	composeFiles = []string{"invalid.yml"}
-	err = ComposeCmd(composeFiles, "config", "--services")
+	_, _, err = ComposeCmd(composeFiles, "config", "--services")
 	assert.Error(err)
 }
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -113,18 +113,20 @@ func TestComposeCmd(t *testing.T) {
 
 	composeFiles := []string{filepath.Join("testdata", "docker-compose.yml")}
 
-	stdout, _, err := ComposeCmd(composeFiles, "config", "--services")
+	stdout, stderr, err := ComposeCmd(composeFiles, "config", "--services")
 	assert.NoError(err)
 	assert.Contains(stdout, "web")
 	assert.Contains(stdout, "db")
+	assert.Contains(stderr, "Defaulting to a blank string")
 
 	composeFiles = append(composeFiles, filepath.Join("testdata", "docker-compose.override.yml"))
 
-	stdout, _, err = ComposeCmd(composeFiles, "config", "--services")
+	stdout, stderr, err = ComposeCmd(composeFiles, "config", "--services")
 	assert.NoError(err)
 	assert.Contains(stdout, "web")
 	assert.Contains(stdout, "db")
 	assert.Contains(stdout, "foo")
+	assert.Contains(stderr, "Defaulting to a blank string")
 
 	composeFiles = []string{"invalid.yml"}
 	_, _, err = ComposeCmd(composeFiles, "config", "--services")

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -28,7 +28,7 @@ func RunCommand(command string, args []string) (string, error) {
 
 // RunCommandPipe runs a command on the host system while piping output to stderr and stdout.
 func RunCommandPipe(command string, args []string) error {
-	log.WithFields(log.Fields{
+	output.UserOut.WithFields(log.Fields{
 		"Command": command + " " + strings.Join(args[:], " "),
 	}).Info("Running Command")
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -5,12 +5,13 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/drud/ddev/pkg/output"
 	log "github.com/sirupsen/logrus"
 )
 
 // RunCommand runs a command on the host system.
 func RunCommand(command string, args []string) (string, error) {
-	log.WithFields(log.Fields{
+	output.UserOut.WithFields(log.Fields{
 		"Command": command + " " + strings.Join(args[:], " "),
 	}).Info("Running Command")
 
@@ -18,7 +19,7 @@ func RunCommand(command string, args []string) (string, error) {
 		command, args...,
 	).CombinedOutput()
 
-	log.WithFields(log.Fields{
+	output.UserOut.WithFields(log.Fields{
 		"Result": string(out),
 	}).Debug("Command Result")
 

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -11,6 +11,7 @@ import (
 
 	"runtime"
 
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 )
 
@@ -103,7 +104,7 @@ func CopyDir(src string, dst string) error {
 		} else {
 			err = CopyFile(srcPath, dstPath)
 			if err != nil && entry.Mode()&os.ModeSymlink != 0 {
-				fmt.Printf("failed to copy symlink %s, skipping...\n", srcPath)
+				output.UserOut.Warnf("failed to copy symlink %s, skipping...\n", srcPath)
 				continue
 			}
 			if err != nil {

--- a/pkg/output/json_formatter.go
+++ b/pkg/output/json_formatter.go
@@ -1,0 +1,121 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh/terminal"
+
+	"encoding/json"
+)
+
+// Below is from logrus json_formatter.go
+// json_formatter.go: https://github.com/sirupsen/logrus/blob/f006c2ac4710855cf0f916dd6b77acf6b048dc6e/json_formatter.go
+// The original json_formatter.go is in sirupsen_org/json_formatter.go.sirupsen
+// for direct comparison.
+
+type fieldKey string
+
+// FieldMap allows customization of the key names for default fields.
+type FieldMap map[fieldKey]string
+
+// Default key names for the default fields
+const (
+	FieldKeyMsg   = "msg"
+	FieldKeyLevel = "level"
+	FieldKeyTime  = "time"
+)
+
+func (f FieldMap) resolve(key fieldKey) string {
+	if k, ok := f[key]; ok {
+		return k
+	}
+
+	return string(key)
+}
+
+// JSONFormatter formats logs into parsable json
+type JSONFormatter struct {
+	// TimestampFormat sets the format used for marshaling timestamps.
+	TimestampFormat string
+
+	// DisableTimestamp allows disabling automatic timestamps in output
+	DisableTimestamp bool
+
+	// FieldMap allows users to customize the names of keys for default fields.
+	// As an example:
+	// formatter := &JSONFormatter{
+	//   	FieldMap: FieldMap{
+	// 		 FieldKeyTime: "@timestamp",
+	// 		 FieldKeyLevel: "@level",
+	// 		 FieldKeyMsg: "@message",
+	//    },
+	// }
+	FieldMap FieldMap
+
+	// Whether the logger's out is to a terminal
+	isTerminal bool
+
+	sync.Once
+}
+
+func (f *JSONFormatter) init(entry *log.Entry) {
+	if entry.Logger != nil {
+		f.isTerminal = f.checkIfTerminal(entry.Logger.Out)
+	}
+}
+
+// checkIfTerminal checks so we can alter json output based on output type.
+// Direct usage of this is to pretty-print json during testing on normal term.
+func (f *JSONFormatter) checkIfTerminal(w io.Writer) bool {
+	switch v := w.(type) {
+	case *os.File:
+		return terminal.IsTerminal(int(v.Fd()))
+	default:
+		return false
+	}
+}
+
+// Format renders a single log entry
+func (f *JSONFormatter) Format(entry *log.Entry) ([]byte, error) {
+	data := make(log.Fields, len(entry.Data)+3)
+	for k, v := range entry.Data {
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/sirupsen/logrus/issues/137
+			data[k] = v.Error()
+		default:
+			data[k] = v
+		}
+	}
+	prefixFieldClashes(data)
+	f.Do(func() { f.init(entry) })
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = defaultTimestampFormat
+	}
+
+	if !f.DisableTimestamp {
+		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
+	}
+	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
+	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
+
+	var serialized []byte
+	var err error
+	if !f.isTerminal {
+		serialized, err = json.Marshal(data)
+	} else {
+		serialized, err = json.MarshalIndent(data, "", "    ")
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+	return append(serialized, '\n'), nil
+}

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -1,0 +1,41 @@
+package output
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// UserOut is the customized logrus log used for direct user output
+	UserOut = log.New()
+	// UserOutFormatter is the specialized formatter for UserOut
+	UserOutFormatter = new(TextFormatter)
+	// JSONOutput is a bool telling whether we're outputting in json. Set by command-line args.
+	JSONOutput = false
+)
+
+// LogSetUp sets up UserOut and log loggers as needed by ddev
+func LogSetUp() {
+	// Use stdout instead of stderr for all user output
+	log.SetOutput(os.Stdout)
+	UserOut.Out = os.Stdout
+
+	if !JSONOutput {
+		UserOut.Formatter = UserOutFormatter
+	} else {
+		UserOut.Formatter = &JSONFormatter{}
+	}
+
+	UserOutFormatter.DisableTimestamp = true
+	// Always use log.DebugLevel for UserOut
+	UserOut.Level = log.DebugLevel // UserOut will by default always output
+
+	// But we use custom DRUD_DEBUG-settable loglevel for log
+	logLevel := log.InfoLevel
+	drudDebug := os.Getenv("DRUD_DEBUG")
+	if drudDebug != "" {
+		logLevel = log.DebugLevel
+	}
+	log.SetLevel(logLevel)
+}

--- a/pkg/output/sirupsen_orig/json_formatter.go.sirupsen
+++ b/pkg/output/sirupsen_orig/json_formatter.go.sirupsen
@@ -1,0 +1,79 @@
+package logrus
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type fieldKey string
+
+// FieldMap allows customization of the key names for default fields.
+type FieldMap map[fieldKey]string
+
+// Default key names for the default fields
+const (
+	FieldKeyMsg   = "msg"
+	FieldKeyLevel = "level"
+	FieldKeyTime  = "time"
+)
+
+func (f FieldMap) resolve(key fieldKey) string {
+	if k, ok := f[key]; ok {
+		return k
+	}
+
+	return string(key)
+}
+
+// JSONFormatter formats logs into parsable json
+type JSONFormatter struct {
+	// TimestampFormat sets the format used for marshaling timestamps.
+	TimestampFormat string
+
+	// DisableTimestamp allows disabling automatic timestamps in output
+	DisableTimestamp bool
+
+	// FieldMap allows users to customize the names of keys for default fields.
+	// As an example:
+	// formatter := &JSONFormatter{
+	//   	FieldMap: FieldMap{
+	// 		 FieldKeyTime: "@timestamp",
+	// 		 FieldKeyLevel: "@level",
+	// 		 FieldKeyMsg: "@message",
+	//    },
+	// }
+	FieldMap FieldMap
+}
+
+// Format renders a single log entry
+func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
+	data := make(Fields, len(entry.Data)+3)
+	for k, v := range entry.Data {
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/sirupsen/logrus/issues/137
+			data[k] = v.Error()
+		default:
+			data[k] = v
+		}
+	}
+	prefixFieldClashes(data)
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = defaultTimestampFormat
+	}
+
+	if !f.DisableTimestamp {
+		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
+	}
+	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
+	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
+
+	serialized, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+	return append(serialized, '\n'), nil
+}

--- a/pkg/output/sirupsen_orig/text_formatter.go.sirupsen
+++ b/pkg/output/sirupsen_orig/text_formatter.go.sirupsen
@@ -1,0 +1,191 @@
+package logrus
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+const (
+	nocolor = 0
+	red     = 31
+	green   = 32
+	yellow  = 33
+	blue    = 36
+	gray    = 37
+)
+
+var (
+	baseTimestamp time.Time
+)
+
+func init() {
+	baseTimestamp = time.Now()
+}
+
+// TextFormatter formats logs into text
+type TextFormatter struct {
+	// Set to true to bypass checking for a TTY before outputting colors.
+	ForceColors bool
+
+	// Force disabling colors.
+	DisableColors bool
+
+	// Disable timestamp logging. useful when output is redirected to logging
+	// system that already adds timestamps.
+	DisableTimestamp bool
+
+	// Enable logging the full timestamp when a TTY is attached instead of just
+	// the time passed since beginning of execution.
+	FullTimestamp bool
+
+	// TimestampFormat to use for display when a full timestamp is printed
+	TimestampFormat string
+
+	// The fields are sorted by default for a consistent output. For applications
+	// that log extremely frequently and don't use the JSON formatter this may not
+	// be desired.
+	DisableSorting bool
+
+	// QuoteEmptyFields will wrap empty fields in quotes if true
+	QuoteEmptyFields bool
+
+	// Whether the logger's out is to a terminal
+	isTerminal bool
+
+	sync.Once
+}
+
+func (f *TextFormatter) init(entry *Entry) {
+	if entry.Logger != nil {
+		f.isTerminal = f.checkIfTerminal(entry.Logger.Out)
+	}
+}
+
+func (f *TextFormatter) checkIfTerminal(w io.Writer) bool {
+	switch v := w.(type) {
+	case *os.File:
+		return terminal.IsTerminal(int(v.Fd()))
+	default:
+		return false
+	}
+}
+
+// Format renders a single log entry
+func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
+	var b *bytes.Buffer
+	keys := make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+
+	if !f.DisableSorting {
+		sort.Strings(keys)
+	}
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+
+	prefixFieldClashes(entry.Data)
+
+	f.Do(func() { f.init(entry) })
+
+	isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = defaultTimestampFormat
+	}
+	if isColored {
+		f.printColored(b, entry, keys, timestampFormat)
+	} else {
+		if !f.DisableTimestamp {
+			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+		}
+		f.appendKeyValue(b, "level", entry.Level.String())
+		if entry.Message != "" {
+			f.appendKeyValue(b, "msg", entry.Message)
+		}
+		for _, key := range keys {
+			f.appendKeyValue(b, key, entry.Data[key])
+		}
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string, timestampFormat string) {
+	var levelColor int
+	switch entry.Level {
+	case DebugLevel:
+		levelColor = gray
+	case WarnLevel:
+		levelColor = yellow
+	case ErrorLevel, FatalLevel, PanicLevel:
+		levelColor = red
+	default:
+		levelColor = blue
+	}
+
+	levelText := strings.ToUpper(entry.Level.String())[0:4]
+
+	if f.DisableTimestamp {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %-44s ", levelColor, levelText, entry.Message)
+	} else if !f.FullTimestamp {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, int(entry.Time.Sub(baseTimestamp)/time.Second), entry.Message)
+	} else {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
+	}
+	for _, k := range keys {
+		v := entry.Data[k]
+		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=", levelColor, k)
+		f.appendValue(b, v)
+	}
+}
+
+func (f *TextFormatter) needsQuoting(text string) bool {
+	if f.QuoteEmptyFields && len(text) == 0 {
+		return true
+	}
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == '.' || ch == '_' || ch == '/' || ch == '@' || ch == '^' || ch == '+') {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
+	if b.Len() > 0 {
+		b.WriteByte(' ')
+	}
+	b.WriteString(key)
+	b.WriteByte('=')
+	f.appendValue(b, value)
+}
+
+func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
+	stringVal, ok := value.(string)
+	if !ok {
+		stringVal = fmt.Sprint(value)
+	}
+
+	if !f.needsQuoting(stringVal) {
+		b.WriteString(stringVal)
+	} else {
+		b.WriteString(fmt.Sprintf("%q", stringVal))
+	}
+}

--- a/pkg/output/text_formatter.go
+++ b/pkg/output/text_formatter.go
@@ -26,7 +26,7 @@ const (
 	red     = 31
 	green   = 32 // nolint: varcheck
 	yellow  = 33
-	blue    = 36
+	blue    = 36 // nolint: varcheck
 	gray    = 37
 )
 

--- a/pkg/output/text_formatter.go
+++ b/pkg/output/text_formatter.go
@@ -1,0 +1,213 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// This file is minor adaptations from sirupsen/Logrus at f006c2a (v1.0.3)
+// text_formatter.go: https://github.com/sirupsen/logrus/blob/f006c2ac4710855cf0f916dd6b77acf6b048dc6e/text_formatter.go
+// The original text_formatter.go is in sirupsen_org/text_formatter.go.sirupsen
+// for direct comparison.
+
+const defaultTimestampFormat = time.RFC3339
+
+// nolint: deadcode
+const (
+	nocolor = 0
+	red     = 31
+	green   = 32 // nolint: varcheck
+	yellow  = 33
+	blue    = 36
+	gray    = 37
+)
+
+// TextFormatter formats logs into text.
+// This is a specialization of https://github.com/sirupsen/logrus/blob/master/text_formatter.go
+// It's intended to be used for all user-oriented output from ddev
+type TextFormatter struct {
+	// Set to true to bypass checking for a TTY before outputting colors.
+	ForceColors bool
+
+	// Force disabling colors.
+	DisableColors bool
+
+	// Disable timestamp logging. useful when output is redirected to logging
+	// system that already adds timestamps.
+	DisableTimestamp bool
+
+	// Enable logging the full timestamp when a TTY is attached instead of just
+	// the time passed since beginning of execution.
+	FullTimestamp bool
+
+	// TimestampFormat to use for display when a full timestamp is printed
+	TimestampFormat string
+
+	// The fields are sorted by default for a consistent output. For applications
+	// that log extremely frequently and don't use the JSON formatter this may not
+	// be desired.
+	DisableSorting bool
+
+	// QuoteEmptyFields will wrap empty fields in quotes if true
+	QuoteEmptyFields bool
+
+	// Whether the logger's out is to a terminal
+	isTerminal bool
+
+	sync.Once
+}
+
+func (f *TextFormatter) init(entry *log.Entry) {
+	if entry.Logger != nil {
+		f.isTerminal = f.checkIfTerminal(entry.Logger.Out)
+	}
+}
+
+func (f *TextFormatter) checkIfTerminal(w io.Writer) bool {
+	switch v := w.(type) {
+	case *os.File:
+		return terminal.IsTerminal(int(v.Fd()))
+	default:
+		return false
+	}
+}
+
+// Format renders a single log entry. A key named "raw" is discarded here as it's for json consumption.
+func (f *TextFormatter) Format(entry *log.Entry) ([]byte, error) {
+	var b *bytes.Buffer
+	keys := make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		// Discard key named "raw" as it's for json consumption only.
+		if k != "raw" {
+			keys = append(keys, k)
+		}
+	}
+
+	if !f.DisableSorting {
+		sort.Strings(keys)
+	}
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+
+	prefixFieldClashes(entry.Data)
+
+	f.Do(func() { f.init(entry) })
+
+	isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = defaultTimestampFormat
+	}
+	if isColored {
+		f.printColored(b, entry, keys, timestampFormat)
+	} else {
+		if !f.DisableTimestamp {
+			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+		}
+		if entry.Message != "" {
+			f.appendValue(b, entry.Message)
+		}
+		for _, key := range keys {
+			f.appendKeyValue(b, key, entry.Data[key])
+		}
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func (f *TextFormatter) printColored(b *bytes.Buffer, entry *log.Entry, keys []string, timestampFormat string) {
+	var levelColor int
+	switch entry.Level {
+	case log.InfoLevel:
+		levelColor = blue
+	case log.DebugLevel:
+		levelColor = gray
+	case log.WarnLevel:
+		levelColor = yellow
+	case log.ErrorLevel, log.FatalLevel, log.PanicLevel:
+		levelColor = red
+	default:
+		levelColor = nocolor
+	}
+
+	fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m ", levelColor, entry.Message)
+
+	for _, k := range keys {
+		v := entry.Data[k]
+		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=", levelColor, k)
+		f.appendValue(b, v)
+	}
+}
+
+func (f *TextFormatter) needsQuoting(text string) bool {
+	if f.QuoteEmptyFields && len(text) == 0 {
+		return true
+	}
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == '.' || ch == '_' || ch == '/' || ch == '@' || ch == '^' || ch == '+') {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
+	if b.Len() > 0 {
+		b.WriteByte(' ')
+	}
+	b.WriteString(key)
+	b.WriteByte('=')
+	f.appendValue(b, value)
+}
+
+func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
+	stringVal, ok := value.(string)
+	if !ok {
+		stringVal = fmt.Sprint(value)
+	}
+
+	// No quoting here; Original does quoting of values and empty values
+	b.WriteString(stringVal)
+}
+
+// This is to not silently overwrite `time`, `msg` and `level` fields when
+// dumping it. If this code wasn't there doing:
+//
+//  logrus.WithField("level", 1).Info("hello")
+//
+// Would just silently drop the user provided level. Instead with this code
+// it'll logged as:
+//
+//  {"level": "info", "fields.level": 1, "msg": "hello", "time": "..."}
+//
+// It's not exported because it's still using Data in an opinionated way. It's to
+// avoid code duplication between the two default formatters.
+func prefixFieldClashes(data log.Fields) {
+	if t, ok := data["time"]; ok {
+		data["fields.time"] = t
+	}
+
+	if m, ok := data["msg"]; ok {
+		data["fields.msg"] = m
+	}
+
+	if l, ok := data["level"]; ok {
+		data["fields.level"] = l
+	}
+}

--- a/pkg/output/text_formatter.go
+++ b/pkg/output/text_formatter.go
@@ -131,8 +131,8 @@ func (f *TextFormatter) Format(entry *log.Entry) ([]byte, error) {
 func (f *TextFormatter) printColored(b *bytes.Buffer, entry *log.Entry, keys []string, timestampFormat string) {
 	var levelColor int
 	switch entry.Level {
-	case log.InfoLevel:
-		levelColor = blue
+	//case log.InfoLevel:
+	//	levelColor = blue
 	case log.DebugLevel:
 		levelColor = gray
 	case log.WarnLevel:

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/lextoumbourou/goodhosts"
 	shellwords "github.com/mattn/go-shellwords"
-	log "github.com/sirupsen/logrus"
 )
 
 const containerWaitTimeout = 35
@@ -459,7 +458,7 @@ func (l *LocalApp) DockerComposeYAMLPath() string {
 func (l *LocalApp) ComposeFiles() []string {
 	files, err := filepath.Glob(filepath.Join(l.AppConfDir(), "docker-compose*"))
 	if err != nil {
-		log.Fatalf("Failed to load compose files: %v", err)
+		util.Failed("Failed to load compose files: %v", err)
 	}
 
 	for i, file := range files {
@@ -875,7 +874,7 @@ func (l *LocalApp) AddHostsEntry() error {
 	}
 	hosts, err := goodhosts.NewHosts()
 	if err != nil {
-		log.Fatalf("could not open hostfile. %s", err)
+		util.Failed("could not open hostfile. %s", err)
 	}
 	if hosts.Has(dockerIP, l.HostName()) {
 		return nil

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -25,7 +25,7 @@ const SiteStopped = "stopped"
 // App is an interface apps for Drud Local must implement to use shared functionality
 type App interface {
 	Init(string) error
-	Describe() (string, error)
+	Describe() (map[string]interface{}, error)
 	GetType() string
 	AppRoot() string
 	GetName() string
@@ -42,7 +42,9 @@ type App interface {
 	ImportFiles(imPath string, extPath string) error
 	SiteStatus() string
 	FindContainerByType(containerType string) (docker.APIContainers, error)
-	Exec(service string, tty bool, cmd ...string) error
+	// Returns err, stdout, stderr
+	Exec(service string, cmd ...string) (string, string, error)
+	ExecWithTty(service string, cmd ...string) error
 	Logs(service string, follow bool, timestamps bool, tail string) error
 }
 

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -7,10 +7,9 @@ import (
 
 	"path/filepath"
 
-	"fmt"
-
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
@@ -32,6 +31,8 @@ var (
 
 // TestMain runs the tests in servicetest
 func TestMain(m *testing.M) {
+	output.LogSetUp()
+
 	if os.Getenv("GOTEST_SHORT") != "" {
 		log.Info("servicetest skipped in short mode because GOTEST_SHORT is set")
 		os.Exit(0)
@@ -86,7 +87,7 @@ func TestServices(t *testing.T) {
 			assert.NoError(err)
 
 			for _, service := range ServiceFiles {
-				log.Info("Checking containers for ", service)
+				t.Log("Checking containers for ", service)
 				serviceName := strings.TrimPrefix(service, "docker-compose.")
 				serviceName = strings.TrimSuffix(serviceName, ".yaml")
 
@@ -116,7 +117,7 @@ func TestServices(t *testing.T) {
 					containerPorts := container.Ports
 					for _, port := range containerPorts {
 						if string(port.PrivatePort) == expose && port.PublicPort != 0 {
-							fmt.Println("Checking for 200 status for port ", port.PrivatePort)
+							log.Debugln("Checking for 200 status for port ", port.PrivatePort)
 							o := util.NewHTTPOptions("http://127.0.0.1:" + string(port.PublicPort))
 							o.ExpectedStatus = 200
 							o.Timeout = 30

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/pkg/errors"
 )
@@ -165,6 +166,34 @@ func Chdir(path string) func() {
 	}
 }
 
+// CaptureUserOut captures output written to UserOut to a string.
+// Capturing starts when it is called. It returns an anonymous function that
+// when called, will return a string containing the output during capture, and
+// revert once again to the original value of os.StdOut.
+func CaptureUserOut() func() string {
+	old := output.UserOut.Out // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	output.UserOut.Out = w
+
+	return func() string {
+		outC := make(chan string)
+		// copy the output in a separate goroutine so printing can't block indefinitely
+		go func() {
+			var buf bytes.Buffer
+			_, err := io.Copy(&buf, r)
+			util.CheckErr(err)
+			outC <- buf.String()
+		}()
+
+		// back to normal state
+		util.CheckClose(w)
+		output.UserOut.Out = old // restoring the real stdout
+
+		out := <-outC
+		return out
+	}
+}
+
 // CaptureStdOut captures Stdout to a string. Capturing starts when it is called. It returns an anonymous function that when called, will return a string
 // containing the output during capture, and revert once again to the original value of os.StdOut.
 func CaptureStdOut() func() string {
@@ -188,7 +217,6 @@ func CaptureStdOut() func() string {
 		out := <-outC
 		return out
 	}
-
 }
 
 // ClearDockerEnv unsets env vars set in platform DockerEnv() so that

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -57,15 +58,26 @@ func TestChdir(t *testing.T) {
 	CleanupDir(testDir)
 }
 
-// TestCaptureStdOut ensures capturing of standard out works as expected.
+// TestCaptureUserOut ensures capturing of stdout works as expected.
+func TestCaptureUserOut(t *testing.T) {
+	assert := asrt.New(t)
+	restoreOutput := CaptureUserOut()
+	text := util.RandString(128)
+	output.UserOut.Println(text)
+	out := restoreOutput()
+
+	assert.Contains(out, text)
+}
+
+// TestCaptureStdOut ensures capturing of stdout works as expected.
 func TestCaptureStdOut(t *testing.T) {
 	assert := asrt.New(t)
 	restoreOutput := CaptureStdOut()
 	text := util.RandString(128)
-	fmt.Print(text)
+	fmt.Println(text)
 	out := restoreOutput()
 
-	assert.Equal(text, out)
+	assert.Contains(out, text)
 }
 
 // TestValidTestSite tests the TestSite struct behavior in the case of a valid configuration.

--- a/pkg/updatecheck/updatecheck_test.go
+++ b/pkg/updatecheck/updatecheck_test.go
@@ -82,7 +82,7 @@ func TestAvailableUpdates(t *testing.T) {
 	for _, tt := range versionTests {
 		updateNeeded, updateURL, err := AvailableUpdates(testOrg, testRepo, tt.in)
 		if err != nil {
-			t.Fatalf("AvailableUpdates() failed, err=%v", err)
+			t.Skipf("AvailableUpdates() failed, err=%v", err)
 		}
 		assert.Equal(updateNeeded, tt.out, fmt.Sprintf("Unexpected output from AvailableUpdates. Input: %s Output: %t Expected: %t Org: %s Repo: %s", tt.in, updateNeeded, tt.out, testOrg, testRepo))
 

--- a/pkg/util/errcheck.go
+++ b/pkg/util/errcheck.go
@@ -12,7 +12,7 @@ import (
 // From https://davidnix.io/post/error-handling-in-go/
 func CheckErr(err error) {
 	if err != nil {
-		log.Panic("ERROR:", err)
+		log.Panic("CheckErr(): ERROR:", err)
 	}
 }
 

--- a/pkg/util/errcheck.go
+++ b/pkg/util/errcheck.go
@@ -2,7 +2,8 @@ package util
 
 import (
 	"io"
-	"log"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // CheckErr exits with a log.Fatal() if an error is encountered.

--- a/pkg/util/errcheck.go
+++ b/pkg/util/errcheck.go
@@ -7,7 +7,8 @@ import (
 )
 
 // CheckErr exits with a log.Fatal() if an error is encountered.
-// It is normally used for errors that we never expect to happen, and don't have any normal handling technique.
+// It is normally used for errors that we never expect to happen,
+// and don't have any normal handling technique.
 // From https://davidnix.io/post/error-handling-in-go/
 func CheckErr(err error) {
 	if err != nil {

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cheggaaa/pb"
+	"github.com/drud/ddev/pkg/output"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -92,7 +93,7 @@ func EnsureHTTPStatus(o *HTTPOptions) error {
 
 	client := &http.Client{}
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return errors.New("Redirect")
+		return errors.New("received http redirect")
 	}
 
 	var respCode int
@@ -122,7 +123,7 @@ func EnsureHTTPStatus(o *HTTPOptions) error {
 				defer CheckClose(resp.Body)
 				if o.ExpectedStatus != 0 && resp.StatusCode == o.ExpectedStatus {
 					// Log expected vs. actual if we do not get a match.
-					log.WithFields(log.Fields{
+					output.UserOut.WithFields(log.Fields{
 						"URL":      o.URL,
 						"expected": o.ExpectedStatus,
 						"got":      resp.StatusCode,

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -9,6 +9,7 @@ import (
 	"path"
 
 	"github.com/drud/ddev/pkg/output"
+	"github.com/fatih/color"
 	gohomedir "github.com/mitchellh/go-homedir"
 )
 
@@ -45,6 +46,7 @@ func Warning(format string, a ...interface{}) {
 
 // Success will indicate an operation succeeded with colored confirmation text.
 func Success(format string, a ...interface{}) {
+	format = color.CyanString(format)
 	if a != nil {
 		output.UserOut.Infof(format, a...)
 	} else {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,16 +1,14 @@
 package util
 
 import (
-	"fmt"
 	"math/rand"
 	"os"
 	"strings"
 	"time"
 
-	"log"
 	"path"
 
-	"github.com/fatih/color"
+	"github.com/drud/ddev/pkg/output"
 	gohomedir "github.com/mitchellh/go-homedir"
 )
 
@@ -18,25 +16,40 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// Failed will print an red error message and exit with failure.
+// Failed will print a red error message and exit with failure.
 func Failed(format string, a ...interface{}) {
-	Error(format, a...)
-	os.Exit(1)
+	if a != nil {
+		output.UserOut.Fatalf(format, a...)
+	} else {
+		output.UserOut.Fatal(format)
+	}
 }
 
 // Error will print an red error message but will not exit.
 func Error(format string, a ...interface{}) {
-	color.Red(format, a...)
+	if a != nil {
+		output.UserOut.Errorf(format, a...)
+	} else {
+		output.UserOut.Error(format)
+	}
 }
 
 // Warning will present the user with warning text.
 func Warning(format string, a ...interface{}) {
-	color.Yellow(format, a...)
+	if a != nil {
+		output.UserOut.Warnf(format, a...)
+	} else {
+		output.UserOut.Warn(format)
+	}
 }
 
 // Success will indicate an operation succeeded with colored confirmation text.
 func Success(format string, a ...interface{}) {
-	color.Cyan(format, a...)
+	if a != nil {
+		output.UserOut.Infof(format, a...)
+	} else {
+		output.UserOut.Info(format)
+	}
 }
 
 // FormatPlural is a simple wrapper which returns different strings based on the count value.
@@ -70,7 +83,7 @@ func RandString(n int) string {
 func GetGlobalDdevDir() string {
 	userHome, err := gohomedir.Dir()
 	if err != nil {
-		log.Fatal("could not get home directory for current user. is it set?")
+		Failed("could not get home directory for current user. is it set?")
 	}
 	ddevDir := path.Join(userHome, ".ddev")
 
@@ -96,7 +109,7 @@ func AskForConfirmation() bool {
 	} else if containsString(nokayResponses, responseLower) {
 		return false
 	} else {
-		fmt.Println("Please type yes or no and then press enter:")
+		output.UserOut.Println("Please type yes or no and then press enter:")
 		return AskForConfirmation()
 	}
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #477: It will be done in several sections:

Work to do from #477:

- [x] Add a UserOut logger (just a logrus.New()) 
- [x]  Set a custom formatter like [UserTextFormatter](https://github.com/rfay/logrustry/blob/master/cmd/logrustry/text_formatter.go) to the UserOut - it will drop the timestamp and loglevel, can do other things as well. This is a fork of the logrus TextFormatter.
- [x]  Add a ddev command flag to specify json output, like --json. This would cause setting the UserOut formatter to log.JSONFormatter
- [x] Use logrus (UserOut) for all output aimed at the user
- [x]  Remove all imports of the stdlib log
- [x]  Remove all usage of log in tests, they should be using t.log and family
- [x]  Remove all usages of fmt.Print* and the like
- [x]  `ddev list` and `ddev describe` need more attention than this because they painstakingly build the text as a simple output buffer. We'll need to refactor them so that they build a data structure and then either output the data structure as json or render the table and output it.  
- [x] Retest all interactive prompts to make sure they still look right. For example, database import and files import interactive prompts
- [x] Automated tests for json output

Note that `ddev logs` turns output responsibility over to docker, so can't currently output in json.  We need to consider whether we want to be able to turn container logs into json.

## Design and Structure

This PR changes ddev to use a single output mechanism for all user-destined output. The UserOut log object (based on spf13/logrus) has been modified to output directly to the user, except when the --json flag is provided, in which case it outputs a json response to the same command. So for example, `ddev list` gives traditional output (but using UserOut, not direct stdout), but `ddev list --json` or `ddev list -j` gives the same a machine-readable json version.

## JSON output

For the json `ddev list` and `ddev describe` commands a field named "raw" is added. This is what should be consumed by ddev-ui. The normal msg is there, but it's intended for non-json uses, and would be inappropriate to parse. 

For all other commands, the normal response (or error response) is just wrapped in a json envelope with severity, etc.

## Manual Testing Instructions:

Try all commands. Try the commands with --json (or -j). The json output is pretty-printed when output to a terminal, to make it easier to analyze. 


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

