### PR TITLE
use official d8 release for testing

### DIFF
--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -34,13 +34,13 @@ var (
 		{
 			Name:                          "TestMainPkgDrupal8",
 			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "drupal8-0.6.0/",
+			ArchiveInternalExtractionPath: "drupal-8.4.0/",
 			FilesTarballURL:               "https://github.com/drud/drupal8/releases/download/v0.6.0/files.tar.gz",
 			FilesZipballURL:               "https://github.com/drud/drupal8/releases/download/v0.6.0/files.zip",
 			DBTarURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 			DBZipURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.zip",
 			FullSiteTarballURL:            "https://github.com/drud/drupal8/releases/download/v0.6.0/site.tar.gz",
-			DocrootBase:                   "docroot",
+			AppType:                       "drupal8",
 		},
 		{
 			Name:                          "TestMainPkgDrupalKickstart",

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -33,7 +33,7 @@ var (
 		},
 		{
 			Name:                          "TestMainPkgDrupal8",
-			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.4.0.tar.gz",
 			ArchiveInternalExtractionPath: "drupal8-0.6.0/",
 			FilesTarballURL:               "https://github.com/drud/drupal8/releases/download/v0.6.0/files.tar.gz",
 			FilesZipballURL:               "https://github.com/drud/drupal8/releases/download/v0.6.0/files.zip",

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -287,6 +287,7 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 	if err != nil {
 		_ = fileutil.PurgeDirectory(extractPath)
 		_ = os.RemoveAll(extractPath)
+		_ = os.RemoveAll(archiveFullPath)
 		return "", "", fmt.Errorf("archive extraction of %s failed err=%v", archiveFullPath, err)
 	}
 	return extractPath, archiveFullPath, nil

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -274,7 +274,7 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 	_ = os.MkdirAll(extractPath, 0777)
 	err := util.DownloadFile(archiveFullPath, sourceURL, false)
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to download url=%s into %s, err=%v", sourceURL, archiveFullPath, err)
+		return extractPath, archiveFullPath, fmt.Errorf("Failed to download url=%s into %s, err=%v", sourceURL, archiveFullPath, err)
 	}
 
 	log.Debugf("Downloaded %s into %s", sourceURL, archiveFullPath)
@@ -288,7 +288,7 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 		_ = fileutil.PurgeDirectory(extractPath)
 		_ = os.RemoveAll(extractPath)
 		_ = os.RemoveAll(archiveFullPath)
-		return "", "", fmt.Errorf("archive extraction of %s failed err=%v", archiveFullPath, err)
+		return extractPath, archiveFullPath, fmt.Errorf("archive extraction of %s failed err=%v", archiveFullPath, err)
 	}
 	return extractPath, archiveFullPath, nil
 }

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -120,3 +120,25 @@ func TestValidTestSite(t *testing.T) {
 	assert.Error(err, "Could not stat temporary directory after cleanup")
 
 }
+
+// TestGetCachedArchive tests download and extraction of archives for test sites
+// to testcache directory.
+func TestGetCachedArchive(t *testing.T) {
+	assert := asrt.New(t)
+
+	sourceURL := "https://raw.githubusercontent.com/drud/ddev/master/.gitignore"
+	exPath, archPath, err := GetCachedArchive("TestInvalidArchive", "test", "", sourceURL)
+	assert.Error(err)
+	assert.Contains(err.Error(), fmt.Sprintf("archive extraction of %s failed", archPath))
+
+	err = os.RemoveAll(filepath.Dir(exPath))
+	assert.NoError(err)
+
+	sourceURL = "http://invalid_domain/somefilethatdoesnotexists"
+	exPath, archPath, err = GetCachedArchive("TestInvalidDownloadURL", "test", "", sourceURL)
+	assert.Error(err)
+	assert.Contains(err.Error(), fmt.Sprintf("Failed to download url=%s into %s", sourceURL, archPath))
+
+	err = os.RemoveAll(filepath.Dir(exPath))
+	assert.NoError(err)
+}

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -120,29 +120,3 @@ func TestValidTestSite(t *testing.T) {
 	assert.Error(err, "Could not stat temporary directory after cleanup")
 
 }
-
-// TestInvalidTestSite ensures that errors are returned in cases where Prepare() can't download or extract an archive.
-func TestInvalidTestSite(t *testing.T) {
-	assert := asrt.New(t)
-
-	testSites := []TestSite{
-		// This should generate a 404 page on github, which will be downloaded, but cannot be extracted (as it's not a true tar.gz)
-		{
-			Name:      "TestInvalidTestSite404",
-			SourceURL: "https://github.com/drud/drupal8/archive/somevaluethatdoesnotexist.tar.gz",
-		},
-		// This is an invalid domain, so it can't even be downloaded. This tests error handling in the case of
-		// a site URL which does not exist
-		{
-			Name:      "TestInvalidTestSiteInvalidDomain",
-			SourceURL: "http://invalid_domain/somefilethatdoesnotexists",
-		},
-	}
-
-	for i := range testSites {
-		ts := testSites[i]
-		// Create a testsite and ensure the prepare() method extracts files into a temporary directory.
-		err := ts.Prepare()
-		assert.Error(err, "ts.Prepare() fails because of missing config.yml or untar failure")
-	}
-}


### PR DESCRIPTION
## The Problem/Issue/Bug:
OP #463 - We want to ensure ddev works with the latest drupal 8 release. 

## How this PR Solves The Problem:
This PR changes the archive to use the official d8 release download instead of our test/demo drupal8 repo archive. Originally, I attempted to integrate the composer-built project from drupal-composer/drupal-project, but handling through composer takes over 4m testing locally, and we don't want to slow down our tests that much. Instead, we'll use the d8 release download, and we'll just have to remember to update the URL on "major" (8.x.0) releases.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#463
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

