### PR TITLE
update web image and test for php 7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm7-local
-WebTag ?= v0.7.4
+WebTag ?= v0.7.4-3-gfa8ceef
 DBImg ?= drud/mysql-local-57
 DBTag ?= v0.6.2
 RouterImage ?= drud/ddev-router

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -337,7 +337,7 @@ func TestLocalExec(t *testing.T) {
 		}
 		out = stdout()
 
-		assert.Contains(string(out), "/etc/php/7.0/cli/php.ini")
+		assert.Contains(string(out), "/etc/php/7.1/cli/php.ini")
 
 		runTime()
 		switchDir()


### PR DESCRIPTION
## The Problem/Issue/Bug:
#330 OP - Update to PHP 7.1

## How this PR Solves The Problem:
- Updates web tag to new version with PHP 7.1 update (provisional tag- update before merge)

## Manual Testing Instructions:
This can be tested with ddev by setting a site's webimage tag to `v0.7.4-3-gfa8ceef`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Minor test adjustment for updated php ini path.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

