### PR TITLE
Fix failed override of provider introduced in #495

### DIFF
--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -25,7 +26,7 @@ can be provided if it is not located at the top-level of the archive.`,
 			util.CheckErr(err)
 			os.Exit(0)
 		}
-		dockerNetworkPreRun()
+		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := platform.GetActiveApp("")

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ the assets being imported.`,
 			util.CheckErr(err)
 			os.Exit(0)
 		}
-		dockerNetworkPreRun()
+		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := platform.GetActiveApp("")

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/fatih/color"
@@ -24,7 +25,7 @@ var PullCmd = &cobra.Command{
 			util.CheckErr(err)
 			os.Exit(0)
 		}
-		dockerNetworkPreRun()
+		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		appImport(skipConfirmation)

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -35,7 +35,7 @@ func appImport(skipConfirmation bool) {
 	app, err := platform.GetActiveApp("")
 
 	if err != nil {
-		util.Failed("%v", err)
+		util.Failed("appImport failed: %v", err)
 	}
 
 	if !skipConfirmation {

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -3,14 +3,15 @@ package cmd
 import (
 	"os"
 
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
 
-// LocalDevReconfigCmd rebuilds an apps settings
-var LocalDevReconfigCmd = &cobra.Command{
+// LocalDevRestartCmd rebuilds an apps settings
+var LocalDevRestartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "Restart the local development environment for a site.",
 	Long:  `Restart stops the containers for site's environment and starts them back up again.`,
@@ -21,7 +22,7 @@ var LocalDevReconfigCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		dockerNetworkPreRun()
+		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := platform.GetActiveApp("")
@@ -46,6 +47,6 @@ var LocalDevReconfigCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(LocalDevReconfigCmd)
+	RootCmd.AddCommand(LocalDevRestartCmd)
 
 }

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -110,15 +110,6 @@ func Execute() {
 
 }
 
-func dockerNetworkPreRun() {
-	client := dockerutil.GetDockerClient()
-
-	err := dockerutil.EnsureNetwork(client, netName)
-	if err != nil {
-		util.Failed("Unable to create/ensure docker network %s, error: %v", netName, err)
-	}
-}
-
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&output.JSONOutput, "json-output", "j", false, "If true, user-oriented output will be in JSON format.")
 }

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -23,8 +23,6 @@ var (
 	serviceType    string
 )
 
-const netName = "ddev_default"
-
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "ddev",

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/util"
@@ -23,7 +24,7 @@ provide a working environment for development.`,
 			os.Exit(0)
 		}
 
-		dockerNetworkPreRun()
+		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		appStart()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -291,7 +291,7 @@ func (c *Config) Validate() error {
 	// validate apptype
 	match = IsAllowedAppType(c.AppType)
 	if !match {
-		return fmt.Errorf("%s is not a valid apptype", c.AppType)
+		return fmt.Errorf("'%s' is not a valid apptype", c.AppType)
 	}
 
 	return nil
@@ -459,7 +459,7 @@ func IsAllowedAppType(appType string) bool {
 	return false
 }
 
-// PrepDdevDirectory creates a .ddev directory in the current working
+// PrepDdevDirectory creates a .ddev directory in the current working directory
 func PrepDdevDirectory(dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -442,7 +442,7 @@ func (c *Config) appTypePrompt() error {
 		appType = strings.ToLower(util.GetInput(c.AppType))
 
 		if IsAllowedAppType(appType) != true {
-			output.UserOut.Errorf("%s is not a valid application type. Allowed application types are: %s\n", appType, strings.Join(AllowedAppTypes, ", "))
+			output.UserOut.Errorf("'%s' is not a valid application type. Allowed application types are: %s\n", appType, strings.Join(AllowedAppTypes, ", "))
 		}
 		c.AppType = appType
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -108,9 +108,11 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	// Allow override with "pantheon" from function provider arg, but nothing else.
 	// Otherwise we accept whatever might have been in config file if there was anything.
 	if provider == "" && c.Provider != "" {
-		// Do nothing. This is the case where the config has a provider and no override is provided
+		// Do nothing. This is the case where the config has a provider and no override is provided. Config wins.
 	} else if provider == "pantheon" || provider == DefaultProviderName {
-		c.Provider = provider
+		c.Provider = provider // Use the provider passed-in. Function argument wins.
+	} else if provider == "" && c.Provider == "" {
+		c.Provider = DefaultProviderName // Nothing passed in, nothing configured. Set c.Provider to default
 	} else {
 		return c, fmt.Errorf("Provider '%s' is not implemented", provider)
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -234,8 +234,8 @@ func (c *Config) WarnIfConfigReplace() {
 	if c.ConfigExists() {
 		util.Warning("You are reconfiguring the app at %s. \nThe existing configuration will be updated and replaced.", c.AppRoot)
 	} else {
-		output.UserOut.Printf("Creating a new ddev project config in the current directory (%s)", c.AppRoot)
-		output.UserOut.Printf("Once completed, your configuration will be written to %s", c.ConfigPath)
+		util.Success("Creating a new ddev project config in the current directory (%s)", c.AppRoot)
+		util.Success("Once completed, your configuration will be written to %s\n", c.ConfigPath)
 	}
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -107,12 +107,11 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 
 	// Allow override with "pantheon" from function provider arg, but nothing else.
 	// Otherwise we accept whatever might have been in config file if there was anything.
-	switch {
-	case provider == "" || provider == DefaultProviderName:
-		c.Provider = DefaultProviderName
-	case provider == "pantheon":
-		c.Provider = "pantheon"
-	default:
+	if provider == "" && c.Provider != "" {
+		// Do nothing. This is the case where the config has a provider and no override is provided
+	} else if provider == "pantheon" || provider == DefaultProviderName {
+		c.Provider = provider
+	} else {
 		return c, fmt.Errorf("Provider '%s' is not implemented", provider)
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -191,7 +191,7 @@ func (c *Config) Read() error {
 
 	source, err := ioutil.ReadFile(c.ConfigPath)
 	if err != nil {
-		return fmt.Errorf("could not find an active ddev configuration, have you run 'ddev config'? %v", err)
+		return fmt.Errorf("could not find an active ddev configuration at %s have you run 'ddev config'? %v", c.ConfigPath, err)
 	}
 
 	// validate extend command keys

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -181,7 +181,7 @@ func TestConfigCommand(t *testing.T) {
 	// Ensure we have expected vales in output.
 	assert.Contains(out, testDir)
 	assert.Contains(out, fmt.Sprintf("No directory could be found at %s", filepath.Join(testDir, invalidDir)))
-	assert.Contains(out, fmt.Sprintf("%s is not a valid application type", invalidAppType))
+	assert.Contains(out, fmt.Sprintf("'%s' is not a valid application type", invalidAppType))
 
 	// Ensure values were properly set on the config struct.
 	assert.Equal(name, config.Name)
@@ -250,7 +250,7 @@ func TestValidate(t *testing.T) {
 	c.Docroot = "testing"
 	c.AppType = "potato"
 	err = c.Validate()
-	assert.EqualError(err, fmt.Sprintf("%s is not a valid apptype", c.AppType))
+	assert.EqualError(err, fmt.Sprintf("'%s' is not a valid apptype", c.AppType))
 }
 
 // TestWrite tests writing config values to file

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -212,6 +212,9 @@ func TestRead(t *testing.T) {
 	}
 
 	err := c.Read()
+	if err != nil {
+		t.Fatalf("Unable to c.Read(), err: %v", err)
+	}
 	assert.NoError(err)
 
 	// Values not defined in file, we should still have default values
@@ -240,7 +243,9 @@ func TestValidate(t *testing.T) {
 	}
 
 	err = c.Validate()
-	assert.NoError(err)
+	if err != nil {
+		t.Fatalf("Failed to c.Validate(), err=%v", err)
+	}
 
 	c.Name = "Invalid!"
 	err = c.Validate()

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -224,7 +224,6 @@ func TestRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to c.Read(), err: %v", err)
 	}
-	assert.NoError(err)
 
 	// Values not defined in file, we should still have default values
 	assert.Equal(c.Name, "TestRead")

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	. "github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
@@ -22,6 +23,16 @@ func TestMain(m *testing.M) {
 
 	// Ensure the ddev directory is created before tests run.
 	_ = util.GetGlobalDdevDir()
+
+	// Since this test may be first time ddev has been used, we need the
+	// ddev_default network available. This would normally be done in a
+	// TestMain, so can be moved to one when we need one.
+	dockerutil.EnsureDdevNetwork()
+
+	// Avoid having sudo try to add to /etc/hosts.
+	// This is normally done by Testsite.Prepare()
+	_ = os.Setenv("DRUD_NONINTERACTIVE", "true")
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -196,8 +196,6 @@ func TestConfigCommand(t *testing.T) {
 func TestRead(t *testing.T) {
 	assert := asrt.New(t)
 
-	testcommon.LogPwd(t, "Entering TestRead")
-
 	// This closely resembles the values one would have from NewConfig()
 	c := &Config{
 		ConfigPath: filepath.Join("testing", "config.yaml"),
@@ -228,8 +226,6 @@ func TestRead(t *testing.T) {
 
 // TestValidate tests validation of configuration values.
 func TestValidate(t *testing.T) {
-	testcommon.LogPwd(t, "Entering TestValidate")
-
 	assert := asrt.New(t)
 
 	cwd, err := os.Getwd()

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -196,6 +196,8 @@ func TestConfigCommand(t *testing.T) {
 func TestRead(t *testing.T) {
 	assert := asrt.New(t)
 
+	testcommon.LogPwd(t, "Entering TestRead")
+
 	// This closely resembles the values one would have from NewConfig()
 	c := &Config{
 		ConfigPath: filepath.Join("testing", "config.yaml"),
@@ -223,6 +225,8 @@ func TestRead(t *testing.T) {
 
 // TestValidate tests validation of configuration values.
 func TestValidate(t *testing.T) {
+	testcommon.LogPwd(t, "Entering TestValidate")
+
 	assert := asrt.New(t)
 
 	cwd, err := os.Getwd()

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -136,11 +136,6 @@ func TestPantheonPull(t *testing.T) {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
 
-	// Avoid having sudo try to add hostsfile.
-	// This is normally done by Testsite.Prepare()
-	err := os.Setenv("DRUD_NONINTERACTIVE", "true")
-	util.CheckErr(err)
-
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestPantheonPull")
@@ -151,7 +146,7 @@ func TestPantheonPull(t *testing.T) {
 
 	// Move into the properly named pantheon site (must match pantheon sitename)
 	siteDir := testDir + "/" + pantheonTestSiteName
-	err = os.MkdirAll(siteDir+"/sites/default", 0777)
+	err := os.MkdirAll(siteDir+"/sites/default", 0777)
 	assert.NoError(err)
 	err = os.Chdir(siteDir)
 	assert.NoError(err)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -138,24 +138,26 @@ func TestPantheonPull(t *testing.T) {
 
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
-	testDir := testcommon.CreateTmpDir("TestPantheonPullBackupLinks")
+	testDir := testcommon.CreateTmpDir("TestPantheonPull")
 
 	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
 	// Move into the properly named pantheon site (must match pantheon sitename)
-	testDir = testDir + "/" + pantheonTestSiteName
-	err := os.MkdirAll(testDir+"/sites/default", 0777)
+	siteDir := testDir + "/" + pantheonTestSiteName
+	err := os.MkdirAll(siteDir+"/sites/default", 0777)
 	assert.NoError(err)
-	os.Chdir(testDir)
+	os.Chdir(siteDir)
 
-	config, err := NewConfig(testDir, "pantheon")
+	config, err := NewConfig(siteDir, "pantheon")
 	assert.NoError(err)
 	config.Name = pantheonTestSiteName
 	config.AppType = "drupal8"
 	err = config.Write()
 	assert.NoError(err)
+
+	testcommon.ClearDockerEnv()
 
 	provider := PantheonProvider{}
 	err = provider.Init(config)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	. "github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/plugins/platform"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
@@ -126,5 +127,60 @@ func TestPantheonBackupLinks(t *testing.T) {
 
 	assert.Equal(importPath, "")
 	assert.Contains(backupLink, "database.sql.gz")
+	assert.NoError(err)
+}
+
+// TestPantheonPull ensures we can pull backups from pantheon for a configured environment.
+func TestPantheonPull(t *testing.T) {
+	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
+		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
+	}
+
+	// Set up tests and give ourselves a working directory.
+	assert := asrt.New(t)
+	testDir := testcommon.CreateTmpDir("TestPantheonPullBackupLinks")
+
+	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
+
+	// Move into the properly named pantheon site (must match pantheon sitename)
+	testDir = testDir + "/" + pantheonTestSiteName
+	err := os.MkdirAll(testDir+"/sites/default", 0777)
+	assert.NoError(err)
+	os.Chdir(testDir)
+
+	config, err := NewConfig(testDir, "pantheon")
+	assert.NoError(err)
+	config.Name = pantheonTestSiteName
+	config.AppType = "drupal8"
+	err = config.Write()
+	assert.NoError(err)
+
+	provider := PantheonProvider{}
+	err = provider.Init(config)
+	assert.NoError(err)
+
+	provider.Sitename = pantheonTestSiteName
+	provider.EnvironmentName = pantheonTestEnvName
+	err = provider.Write(config.GetPath("import.yaml"))
+	assert.NoError(err)
+
+	// Ensure GetBackup triggers an error for unknown backup types.
+	_, _, err = provider.GetBackup(util.RandString(8))
+	assert.Error(err)
+
+	// Ensure we can do a pull on the configured site.
+	backupLink, importPath, err := provider.GetBackup("database")
+
+	assert.Equal(importPath, "")
+	assert.Contains(backupLink, "database.sql.gz")
+	assert.NoError(err)
+
+	app, err := platform.GetActiveApp("")
+	assert.NoError(err)
+	err = app.Import()
+	assert.NoError(err)
+	err = app.Down(true)
 	assert.NoError(err)
 }

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -28,6 +28,8 @@ const pantheonTestEnvName = "bbowman"
 
 // TestConfigCommand tests the interactive config options.
 func TestPantheonConfigCommand(t *testing.T) {
+	testcommon.LogPwd(t, "Entering TestPantheonConfigCommand")
+
 	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
@@ -95,6 +97,8 @@ func TestPantheonConfigCommand(t *testing.T) {
 
 // TestPantheonBackupLinks ensures we can get backups from pantheon for a configured environment.
 func TestPantheonBackupLinks(t *testing.T) {
+	testcommon.LogPwd(t, "Entering TestPantheonBackupLinks")
+
 	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
@@ -132,6 +136,8 @@ func TestPantheonBackupLinks(t *testing.T) {
 
 // TestPantheonPull ensures we can pull backups from pantheon for a configured environment.
 func TestPantheonPull(t *testing.T) {
+	testcommon.LogPwd(t, "Entering TestPantheonPull")
+
 	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
@@ -148,7 +154,8 @@ func TestPantheonPull(t *testing.T) {
 	siteDir := testDir + "/" + pantheonTestSiteName
 	err := os.MkdirAll(siteDir+"/sites/default", 0777)
 	assert.NoError(err)
-	os.Chdir(siteDir)
+	err = os.Chdir(siteDir)
+	assert.NoError(err)
 
 	config, err := NewConfig(siteDir, "pantheon")
 	assert.NoError(err)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -28,8 +28,6 @@ const pantheonTestEnvName = "bbowman"
 
 // TestConfigCommand tests the interactive config options.
 func TestPantheonConfigCommand(t *testing.T) {
-	testcommon.LogPwd(t, "Entering TestPantheonConfigCommand")
-
 	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
@@ -97,8 +95,6 @@ func TestPantheonConfigCommand(t *testing.T) {
 
 // TestPantheonBackupLinks ensures we can get backups from pantheon for a configured environment.
 func TestPantheonBackupLinks(t *testing.T) {
-	testcommon.LogPwd(t, "Entering TestPantheonBackupLinks")
-
 	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
@@ -136,8 +132,6 @@ func TestPantheonBackupLinks(t *testing.T) {
 
 // TestPantheonPull ensures we can pull backups from pantheon for a configured environment.
 func TestPantheonPull(t *testing.T) {
-	testcommon.LogPwd(t, "Entering TestPantheonPull")
-
 	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
@@ -181,10 +175,8 @@ func TestPantheonPull(t *testing.T) {
 	assert.NoError(err)
 
 	// Ensure we can do a pull on the configured site.
-	testcommon.LogPwd(t, "About to run GetActiveApp()")
 	app, err := platform.GetActiveApp("")
 	assert.NoError(err)
-	testcommon.LogPwd(t, "About to run app.Import()")
 	err = app.Import()
 	assert.NoError(err)
 	err = app.Down(true)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -176,8 +176,12 @@ func TestPantheonPull(t *testing.T) {
 	assert.NoError(err)
 
 	// Ensure we can do a pull on the configured site.
+	testcommon.LogPwd(t, "About to run GetActiveApp()")
 	app, err := platform.GetActiveApp("")
 	assert.NoError(err)
+	testcommon.LogPwd(t, "About to run app.Import()")
+	appConfig := app.(*platform.LocalApp).AppConfig
+	t.Logf("About to run app.Import() with AppConfig=%v", appConfig)
 	err = app.Import()
 	assert.NoError(err)
 	err = app.Down(true)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -168,17 +168,7 @@ func TestPantheonPull(t *testing.T) {
 	err = provider.Write(config.GetPath("import.yaml"))
 	assert.NoError(err)
 
-	// Ensure GetBackup triggers an error for unknown backup types.
-	_, _, err = provider.GetBackup(util.RandString(8))
-	assert.Error(err)
-
 	// Ensure we can do a pull on the configured site.
-	backupLink, importPath, err := provider.GetBackup("database")
-
-	assert.Equal(importPath, "")
-	assert.Contains(backupLink, "database.sql.gz")
-	assert.NoError(err)
-
 	app, err := platform.GetActiveApp("")
 	assert.NoError(err)
 	err = app.Import()

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -142,6 +142,11 @@ func TestPantheonPull(t *testing.T) {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}
 
+	// Avoid having sudo try to add hostsfile.
+	// This is normally done by Testsite.Prepare()
+	err := os.Setenv("DRUD_NONINTERACTIVE", "true")
+	util.CheckErr(err)
+
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestPantheonPull")
@@ -152,7 +157,7 @@ func TestPantheonPull(t *testing.T) {
 
 	// Move into the properly named pantheon site (must match pantheon sitename)
 	siteDir := testDir + "/" + pantheonTestSiteName
-	err := os.MkdirAll(siteDir+"/sites/default", 0777)
+	err = os.MkdirAll(siteDir+"/sites/default", 0777)
 	assert.NoError(err)
 	err = os.Chdir(siteDir)
 	assert.NoError(err)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -180,8 +180,6 @@ func TestPantheonPull(t *testing.T) {
 	app, err := platform.GetActiveApp("")
 	assert.NoError(err)
 	testcommon.LogPwd(t, "About to run app.Import()")
-	appConfig := app.(*platform.LocalApp).AppConfig
-	t.Logf("About to run app.Import() with AppConfig=%v", appConfig)
 	err = app.Import()
 	assert.NoError(err)
 	err = app.Down(true)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -37,6 +38,17 @@ func EnsureNetwork(client *docker.Client, name string) error {
 
 	}
 	return nil
+}
+
+// EnsureDdevNetwork just creates or ensures the ddev_default network exists or
+// exits with fatal.
+func EnsureDdevNetwork() {
+	// ensure we have docker network
+	client := GetDockerClient()
+	err := EnsureNetwork(client, NetName)
+	if err != nil {
+		log.Fatalf("Failed to ensure docker network %s: %v", NetName, err)
+	}
 }
 
 // GetDockerClient returns a docker client for a docker-machine.

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -302,6 +302,7 @@ func (l *LocalApp) SiteStatus() string {
 
 // Import performs an import from the a configured provider plugin, if one exists.
 func (l *LocalApp) Import() error {
+	log.Infof("Import() - l.AppConfig=%v", l.AppConfig)
 	provider, err := l.AppConfig.GetProvider()
 	if err != nil {
 		return err

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -32,7 +32,7 @@ import (
 
 const containerWaitTimeout = 35
 
-// LocalApp implements the AppBase interface local development apps
+// LocalApp implements the platform.App interface
 type LocalApp struct {
 	AppConfig *ddevapp.Config
 }
@@ -225,7 +225,7 @@ func (l *LocalApp) ImportDB(imPath string, extPath string) error {
 		return err
 	}
 
-	err = l.Config()
+	err = l.CreateSettingsFile()
 	if err != nil {
 		if err.Error() != "app config exists" {
 			return fmt.Errorf("failed to write configuration file for %s: %v", l.GetName(), err)
@@ -699,7 +699,7 @@ func (l *LocalApp) Wait(containerTypes ...string) error {
 	return nil
 }
 
-func (l *LocalApp) determineConfigLocation() (string, error) {
+func (l *LocalApp) determinSettingsPath() (string, error) {
 	possibleLocations := []string{l.AppConfig.SiteSettingsPath, l.AppConfig.SiteLocalSettingsPath}
 	for _, loc := range possibleLocations {
 		// If the file is found we need to check for a signature to determine if it's safe to use.
@@ -719,15 +719,15 @@ func (l *LocalApp) determineConfigLocation() (string, error) {
 	return "", fmt.Errorf("settings files already exist and are being manged by the user")
 }
 
-// Config creates the apps config file adding things like database host, name, and password
-// as well as other sensitive data like salts.
-func (l *LocalApp) Config() error {
+// CreateSettingsFile creates the app's settings.php or equivalent,
+// adding things like database host, name, and password
+func (l *LocalApp) CreateSettingsFile() error {
 	// If neither settings file options are set, then
 	if l.AppConfig.SiteLocalSettingsPath == "" && l.AppConfig.SiteSettingsPath == "" {
 		return nil
 	}
 
-	settingsFilePath, err := l.determineConfigLocation()
+	settingsFilePath, err := l.determinSettingsPath()
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -700,7 +700,7 @@ func (l *LocalApp) Wait(containerTypes ...string) error {
 	return nil
 }
 
-func (l *LocalApp) determinSettingsPath() (string, error) {
+func (l *LocalApp) determineSettingsPath() (string, error) {
 	possibleLocations := []string{l.AppConfig.SiteSettingsPath, l.AppConfig.SiteLocalSettingsPath}
 	for _, loc := range possibleLocations {
 		// If the file is found we need to check for a signature to determine if it's safe to use.
@@ -728,7 +728,7 @@ func (l *LocalApp) CreateSettingsFile() error {
 		return nil
 	}
 
-	settingsFilePath, err := l.determinSettingsPath()
+	settingsFilePath, err := l.determineSettingsPath()
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -302,7 +302,6 @@ func (l *LocalApp) SiteStatus() string {
 
 // Import performs an import from the a configured provider plugin, if one exists.
 func (l *LocalApp) Import() error {
-	log.Infof("Import() - l.AppConfig=%v", l.AppConfig)
 	provider, err := l.AppConfig.GetProvider()
 	if err != nil {
 		return err

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -66,8 +66,9 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	if len(platform.GetApps()) > 0 {
-		log.Fatalf("Local plugin tests require no sites running. You have %v site(s) running.", len(platform.GetApps()))
+	count := len(platform.GetApps()["local"])
+	if count > 0 {
+		log.Fatalf("Local plugin tests require no sites running. You have %v site(s) running.", count)
 	}
 
 	if os.Getenv("GOTEST_SHORT") != "" {

--- a/pkg/plugins/platform/types.go
+++ b/pkg/plugins/platform/types.go
@@ -34,7 +34,7 @@ type App interface {
 	DockerEnv()
 	DockerComposeYAMLPath() string
 	Down(removeData bool) error
-	Config() error
+	CreateSettingsFile() error
 	HostName() string
 	URL() string
 	Import() error

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -13,6 +14,8 @@ import (
 	"path"
 
 	"fmt"
+
+	"testing"
 
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -319,4 +322,13 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 		return extractPath, archiveFullPath, fmt.Errorf("archive extraction of %s failed err=%v", archiveFullPath, err)
 	}
 	return extractPath, archiveFullPath, nil
+}
+
+// LogPwd uses t.Logf to log the current directory, with file/line from caller
+func LogPwd(t *testing.T, msg string) {
+	pwd, _ := os.Getwd()
+	_, file, _, _ := runtime.Caller(0)
+	_, _, line, _ := runtime.Caller(0)
+
+	t.Logf("%s pwd = %s (%s:%d)", msg, pwd, file, line)
 }

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -123,6 +123,8 @@ func CleanupDir(dir string) {
 	err := os.RemoveAll(dir)
 	if err != nil {
 		log.Warn(fmt.Sprintf("Failed to remove directory %s, err: %v", dir, err))
+	} else {
+		log.Infof("testcommon.CleanupDir() removed directory at %s", dir)
 	}
 }
 
@@ -166,6 +168,7 @@ func Chdir(path string) func() {
 		if err != nil {
 			log.Fatalf("Failed to change directory to original dir=%s, err=%v", curDir, err)
 		}
+		log.Infof("testcommon.Chdir restored directory to %s", curDir)
 	}
 }
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -14,8 +13,6 @@ import (
 	"path"
 
 	"fmt"
-
-	"testing"
 
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -123,8 +120,6 @@ func CleanupDir(dir string) {
 	err := os.RemoveAll(dir)
 	if err != nil {
 		log.Warn(fmt.Sprintf("Failed to remove directory %s, err: %v", dir, err))
-	} else {
-		log.Infof("testcommon.CleanupDir() removed directory at %s", dir)
 	}
 }
 
@@ -168,7 +163,6 @@ func Chdir(path string) func() {
 		if err != nil {
 			log.Fatalf("Failed to change directory to original dir=%s, err=%v", curDir, err)
 		}
-		log.Infof("testcommon.Chdir restored directory to %s", curDir)
 	}
 }
 
@@ -325,13 +319,4 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 		return extractPath, archiveFullPath, fmt.Errorf("archive extraction of %s failed err=%v", archiveFullPath, err)
 	}
 	return extractPath, archiveFullPath, nil
-}
-
-// LogPwd uses t.Logf to log the current directory, with file/line from caller
-func LogPwd(t *testing.T, msg string) {
-	pwd, _ := os.Getwd()
-	_, file, _, _ := runtime.Caller(0)
-	_, _, line, _ := runtime.Caller(0)
-
-	t.Logf("%s pwd = %s (%s:%d)", msg, pwd, file, line)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

In #495 (Command-line args for ddev config) a failed piece of logic allowed the provider to be overridden. This broke at least ddev pull, it may have broken several other things. 

## How this PR Solves The Problem:

* The bug fix is in pkg/ddevapp/config.go and is a simple logic rearrangement. 
* Adds explicit test for `app.Import()` to TestPantheonPull as well.
* Refactors DockerNetworkPreRun() from root.go into dockerutils.EnsureDdevNetwork()
* Missing DRUD_NONINTERACTIVE due to shortcut TestPantheonPull structure caused lots of consternation and odd chasing (only on linux/circleci). Along the way a few error messages were improved.
* platform.Config() was refactored to platform.CreateSettingsFile() to avoid the confusion between ddev's config.yml (everywhere else we use "config") and the application settings file.

## Manual Testing Instructions:

Try `ddev pull` using master (broken) and with this PR. 

## Automated Testing Overview:

This adds TestPantheonPull, which is a fair approximation of what the pull command does.

## Related Issue Link(s):

Regression occurred in #495 (Allow command-line args for config command)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

No deployment needed.
