### PR TITLE
Use ddev.site instead of ddev.local for site domains, provide offline fallback for hosts entry

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/drud/ddev/pkg/ddevapp"
+
 	"os"
 
 	"io/ioutil"
@@ -44,7 +46,7 @@ func TestDevLogs(t *testing.T) {
 		o := util.NewHTTPOptions("http://127.0.0.1/index.php")
 		o.ExpectedStatus = 500
 		o.Timeout = 30
-		o.Headers["Host"] = v.Name + ".ddev.local"
+		o.Headers["Host"] = v.Name + "." + ddevapp.DDevTLD
 		err = util.EnsureHTTPStatus(o)
 		assert.NoError(err)
 

--- a/cmd/ddev/cmd/offline.go
+++ b/cmd/ddev/cmd/offline.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"log"
+	"os"
+
+	"github.com/drud/ddev/pkg/plugins/platform"
+
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// OfflineCmd represents the local command
+var OfflineCmd = &cobra.Command{
+	Use:   "offline [enable/disable]",
+	Short: "Manage your hostfile entries.",
+	Long:  `Manage your hostfile entries.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		switch {
+		case args[0] == "enable":
+			err := platform.SetOfflineMode()
+			if err != nil {
+				log.Fatal(err)
+			}
+		case args[0] == "disable":
+			err := platform.UnsetOfflineMode()
+			if err != nil {
+				log.Fatal(err)
+			}
+		default:
+			err := cmd.Usage()
+			util.CheckErr(err)
+			os.Exit(0)
+		}
+	},
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	RootCmd.AddCommand(OfflineCmd)
+}

--- a/cmd/ddev/cmd/offline.go
+++ b/cmd/ddev/cmd/offline.go
@@ -13,8 +13,10 @@ import (
 // OfflineCmd represents the local command
 var OfflineCmd = &cobra.Command{
 	Use:   "offline [enable/disable]",
-	Short: "Manage your hostfile entries.",
-	Long:  `Manage your hostfile entries.`,
+	Short: "Enable or disable offline mode.",
+	Long: `Enable or disable offline mode. When offline mode is enabled, ddev will use
+hosts file entries for local development domains instead of relying on remote
+DNS for ddev.site.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		switch {
 		case args[0] == "enable":
@@ -22,11 +24,13 @@ var OfflineCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
+			util.Success("Offline mode enabled. ddev will use hosts file entries for local development domains.")
 		case args[0] == "disable":
 			err := platform.UnsetOfflineMode()
 			if err != nil {
 				log.Fatal(err)
 			}
+			util.Success("Offline mode disabled. Hosts entries will no longer be added for sites.")
 		default:
 			err := cmd.Usage()
 			util.CheckErr(err)

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -18,6 +18,7 @@ Available Commands:
   import-files Import the uploaded files directory of an existing site to the default public upload directory of your application.
   list         List applications that exist locally
   logs         Get the logs from your running services.
+  offline      Enable or disable offline mode.
   restart      Restart the local development environment for a site.
   remove       Remove an application's local services.
   sequelpro    Easily connect local site to sequelpro
@@ -63,7 +64,7 @@ When running `ddev start` you should see output informing you that the site's en
 
 ```
 Successfully started wordpress-site
-Your application can be reached at: http://wordpress-site.ddev.local
+Your application can be reached at: http://wordpress-site.ddev.site
 ```
 
 Quickstart instructions regarding database imports, can be found under [Database Imports](#database-imports).
@@ -95,7 +96,7 @@ When running `ddev start` you should see output informing you that the site's en
 
 ```
 Successfully started my-drupal7-site
-Your application can be reached at: http://my-drupal7-site.ddev.local
+Your application can be reached at: http://my-drupal7-site.ddev.site
 ```
 
 Quickstart instructions regarding database imports, can be found under [Database Imports](#database-imports).
@@ -138,7 +139,7 @@ When running `ddev start` you should see output informing you that the site's en
 
 ```
 Successfully started my-drupal8-site
-Your application can be reached at: http://my-drupal8-site.ddev.local
+Your application can be reached at: http://my-drupal8-site.ddev.site
 ```
 
 ### Database Imports
@@ -195,7 +196,7 @@ Creating local-drupal8-db
 Creating local-drupal8-web
 Waiting for the environment to become ready. This may take a couple of minutes...
 Successfully started drupal8
-Your application can be reached at: http://drupal8.ddev.local
+Your application can be reached at: http://drupal8.ddev.site
 ```
 
 And you can now visit your working site. Enjoy!
@@ -208,14 +209,14 @@ To see a list of your current sites you can use `ddev list`.
 ➜  ddev list
 1 local site found.
 NAME     TYPE     LOCATION                 URL                        STATUS
-drupal8  drupal8  ~/Projects/ddev/drupal8  http://drupal8.ddev.local  running
+drupal8  drupal8  ~/Projects/ddev/drupal8  http://drupal8.ddev.site  running
 ```
 
 You can also see more detailed information about a site by running `ddev describe` from its working directory. You can also run `ddev describe [site-name]` from any location to see the detailed information for a running site.
 
 ```
 NAME     TYPE     LOCATION                 URL                        STATUS
-drupal8  drupal8  ~/Projects/ddev/drupal8  http://drupal8.ddev.local  running
+drupal8  drupal8  ~/Projects/ddev/drupal8  http://drupal8.ddev.site  running
 
 MySQL Credentials
 -----------------
@@ -229,8 +230,8 @@ For example: mysql --host 127.0.0.1 --port 32894
 
 Other Services
 --------------
-MailHog:   	http://drupal8.ddev.local:8025
-phpMyAdmin:	http://drupal8.ddev.local:8036
+MailHog:   	http://drupal8.ddev.site:8025
+phpMyAdmin:	http://drupal8.ddev.site:8036
 ```
 
 ## Importing assets for an existing site

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -16,7 +16,7 @@ These tools can be accessed for single commands using [`ddev exec <command>`](cl
 
 Its web interface can be accessed at its default port after your site has been started. e.g.:
 ```
-http://mysite.ddev.local:8025
+http://mysite.ddev.site:8025
 ```
 
 Please note this will not intercept emails if your application is configured to use SMTP or a 3rd-party ESP integration. If you are using SMTP for outgoing mail handling ([Swiftmailer](https://www.drupal.org/project/swiftmailer) or [SMTP](https://www.drupal.org/project/smtp) modules for example), update your application configuration to use `localhost` on port `1025` as the SMTP server locally in order to use MailHog.

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -16,6 +16,6 @@ This recipe adds an Apache Solr 5.4 container to a project. It will setup a solr
 
 **Interacting with Apache Solr**
 
-- The Solr admin interface will be accessible at http://<sitename>.ddev.local:8983
-- The host connection for apache solr will be <sitename>.ddev.local
+- The Solr admin interface will be accessible at http://<sitename>.ddev.site:8983
+- The host connection for apache solr will be <sitename>.ddev.site
 - The Solr core will be "dev"

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -17,10 +17,6 @@ When defining additional services for your project, it is recommended to follow 
 
   - `com.ddev.approot: $DDEV_APPROOT`
 
-  - `com.ddev.app-url: $DDEV_URL`
-
-  - `com.ddev.container-type: [servicename]`
-
 - Exposing ports for service: you can expose the port for a service to be accessible as `sitename.ddev.local:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
 
   - Define only the internal port in the `ports` section for docker-compose. The `hostPort:containerPort` convention normally used to expose ports in docker should not be used here, since we are leveraging the ddev router to expose the ports.

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -17,7 +17,7 @@ When defining additional services for your project, it is recommended to follow 
 
   - `com.ddev.approot: $DDEV_APPROOT`
 
-- Exposing ports for service: you can expose the port for a service to be accessible as `sitename.ddev.local:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
+- Exposing ports for service: you can expose the port for a service to be accessible as `sitename.ddev.site:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
 
   - Define only the internal port in the `ports` section for docker-compose. The `hostPort:containerPort` convention normally used to expose ports in docker should not be used here, since we are leveraging the ddev router to expose the ports.
 

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -42,7 +42,7 @@ _Use wp-cli to replace the production URL with development URL in the database o
 ```
 hooks:
   post-import-db:
-    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
+    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.site"
 ```
 
 ### `exec-host`: Execute a shell command on your system.
@@ -66,10 +66,10 @@ hooks:
   post-start:
     # Install WordPress after start
     - exec: "wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db"
-    - exec: "wp core install --url=http://mysite.ddev.local --title=MySite --admin_user=admin --admin_email=admin@mail.test"
+    - exec: "wp core install --url=http://mysite.ddev.site --title=MySite --admin_user=admin --admin_email=admin@mail.test"
   post-import-db:
     # Update the URL of your site throughout your database after import
-    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
+    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.site"
 ```
 
 ## Drupal 7 Example

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -71,7 +71,7 @@ Before, beginning anything else, please set your Debugger Port to 11011. (Prefer
 2. Under "Run as", choose "Local web site (running on local web server)".
 3. Under "Name and Location", give the sources folder of the **docroot/webroot** of your site.
 ![Netbeans project name and location](images/netbeans_project_name_location.png)
-4. Under "Run configuration" the project URL to the full URL of your dev site, for example http://drud-d8.ddev.local/, and choose the index file.
+4. Under "Run configuration" the project URL to the full URL of your dev site, for example http://drud-d8.ddev.site/, and choose the index file.
 ![Netbeans run configuration](images/netbeans_project_run_configuration.png)
 5. Set a breakpoint.
 6. Click the "Debug" button.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -31,7 +31,7 @@ const CurrentAppVersion = "1"
 const DDevDefaultPlatform = "local"
 
 // DDevTLD defines the tld to use for DDev site URLs.
-const DDevTLD = "ddev.local"
+const DDevTLD = "ddev.site"
 
 // AllowedAppTypes lists the types of site/app that can be used.
 var AllowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -43,7 +43,7 @@ services:
       - DOCROOT=$DDEV_DOCROOT
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
+      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
       - HTTP_EXPOSE=80,{{ .mailhogport }}
     labels:
@@ -71,7 +71,7 @@ services:
       - PMA_USER=db
       - PMA_PASSWORD=db
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
+      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       - HTTP_EXPOSE={{ .dbaport }}
 networks:
   default:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -19,7 +19,6 @@ services:
       com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
       com.ddev.approot: $DDEV_APPROOT
-      com.ddev.app-url: $DDEV_URL
     environment:
       - DDEV_UID=$DDEV_UID
       - DDEV_GID=$DDEV_GID
@@ -52,7 +51,7 @@ services:
       com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
       com.ddev.approot: $DDEV_APPROOT
-      com.ddev.app-url: $DDEV_URL
+      com.ddev.hostname: $DDEV_HOSTNAME
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
@@ -62,7 +61,6 @@ services:
       com.ddev.platform: {{ .plugin }}
       com.ddev.app-type: {{ .appType }}
       com.ddev.approot: $DDEV_APPROOT
-      com.ddev.app-url: $DDEV_URL
     depends_on:
       - db
     links:

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -872,7 +872,7 @@ func (l *LocalApp) HostName() string {
 
 // AddHostsEntry will add the local site URL to the local hostfile.
 func (l *LocalApp) AddHostsEntry() error {
-	if fileutil.FileExists(offlineFile) {
+	if !fileutil.FileExists(offlineFile) {
 		return nil
 	}
 

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -238,6 +238,10 @@ func SetOfflineMode() error {
 		"com.docker.compose.service": "web",
 	}
 	sites, err := dockerutil.FindContainersByLabels(labels)
+	if err != nil {
+		return err
+	}
+
 	for _, site := range sites {
 		hostname := site.Labels["com.ddev.hostname"]
 		if !hosts.Has(dockerIP, hostname) {

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -223,14 +223,14 @@ func SetOfflineMode() error {
 	var addHostnames []string
 	dockerIP := getDockerIP()
 
+	err := ioutil.WriteFile(offlineFile, []byte(""), 0644)
+	if err != nil {
+		return err
+	}
+
 	hosts, err := goodhosts.NewHosts()
 	if err != nil {
 		log.Fatalf("could not open hostfile. %s", err)
-	}
-
-	err = ioutil.WriteFile(offlineFile, []byte(""), 0644)
-	if err != nil {
-		return err
 	}
 
 	labels := map[string]string{
@@ -246,13 +246,12 @@ func SetOfflineMode() error {
 	}
 
 	if len(addHostnames) == 0 {
-		util.Success("Offline mode enabled. ddev will use hosts file entries for local development domains.")
 		return nil
 	}
 
 	_, err = osexec.Command("sudo", "-h").Output()
 	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
-		util.Warning("Offline mode enabled. You must manually add the following entry to your hosts file:\n%s %s", dockerIP, strings.Join(addHostnames, " "))
+		util.Warning("You must manually add the following entries to your hosts file:\n%s %s", dockerIP, strings.Join(addHostnames, " "))
 		return nil
 	}
 
@@ -272,10 +271,6 @@ func SetOfflineMode() error {
 // to disable it.
 func UnsetOfflineMode() error {
 	err := os.Remove(offlineFile)
-	if err == nil {
-		util.Success("Offline mode disabled. Hosts entries will no longer be added for sites.")
-		return nil
-	}
 	return err
 }
 

--- a/services/docker-compose.solr.yaml
+++ b/services/docker-compose.solr.yaml
@@ -21,8 +21,8 @@ services:
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
     environment:
-      - VIRTUAL_HOST=$DDEV_HOSTNAME # This defines the host name the service should be accessible from. This will be sitename.ddev.local
-      - HTTP_EXPOSE=8983 # This defines the port the service should be accessible from at sitename.ddev.local
+      - VIRTUAL_HOST=$DDEV_HOSTNAME # This defines the host name the service should be accessible from. This will be sitename.ddev.site
+      - HTTP_EXPOSE=8983 # This defines the port the service should be accessible from at sitename.ddev.site
     volumes:
       - "./solr:/solr-conf" # This exposes a mount to the host system `.ddev/solr-conf` directory.
     entrypoint:
@@ -30,7 +30,7 @@ services:
       - solr-precreate
       - dev
       - /solr-conf
-# This links the solr service to the web service defined in the main docker-compose.yml, allowing applications running in the web service to access the solr service at sitename.ddev.local:8983
+# This links the solr service to the web service defined in the main docker-compose.yml, allowing applications running in the web service to access the solr service at sitename.ddev.site:8983
   web:
     links:
       - solr:$DDEV_HOSTNAME

--- a/testing/ddev-perf-test.sh
+++ b/testing/ddev-perf-test.sh
@@ -34,7 +34,7 @@ downloads=(drupal-7.54 commerce_kickstart-7.x-2.45 drupal-8.3.2)
 
 for ((i=0; i<${#sites[@]}; ++i)); do
 	site=${sites[$i]}
-	base_url=http://$site.ddev.local
+	base_url=http://$site.ddev.site
 
 
 	if [ ! -d "$site" ] ; then
@@ -86,7 +86,7 @@ END
     elapsed=$($CURLIT -fL $base_url)
     echo "${BLUE}$site: anon curl ($?) again after site install: $elapsed ${RESET}"
 
-	$TIMEIT ddev exec drush uli -l $site.ddev.local >$site.uli.txt 2>&1 || (echo "Failed drush uli" && continue)
+	$TIMEIT ddev exec drush uli -l $site.ddev.site >$site.uli.txt 2>&1 || (echo "Failed drush uli" && continue)
 	echo "${BLUE}$site: ddev uli: $(cat time.out) ${RESET}"
 
 	# This technique doesn't work on d8 due to some new form fields on the uli page.


### PR DESCRIPTION
## The Problem/Issue/Bug:
#416 OP - We want to provide a real domain for local dev sites to use in order to avoid hosts file modification. We still want to provide the hosts modification as a fallback behavior.

## How this PR Solves The Problem:

- Changes local TLD from ddev.local to ddev.site, which is configured to route to 127.0.0.1 for any requests.
- Introduces a new offline mode, which is controlled with the new `ddev offline` command. I admit I jumped the gun on this part, as its proposed but not yet accepted, but I think its a good way to handle the concerns we had switching to use ddev.site.

## Manual Testing Instructions:

- configure a new ddev site and start it. The URL for the site should be <sitename>.ddev.site instead of <sitename>.ddev.local. You should not be prompted to create a hosts entry
- run `ddev offline enable`. You should now be prompted to create a hosts entry for the site. For extra credit,  you can spin up another site or two before enabling offline, and see that any running sites should be part of the hosts entry being created.
- configure another ddev site and start it. You should be prompted to create a hosts entry for the site.
- running `ddev offline disable` should make it so any new site spin ups do not prompt for hosts entry

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

