### PR TITLE
workaround for readthedocs broken search rtfd/readthedocs.org#1088

### DIFF
--- a/docs/assets/fix-search.js
+++ b/docs/assets/fix-search.js
@@ -1,0 +1,27 @@
+// See various broken search issues, but especially:
+// https://github.com/rtfd/readthedocs.org/pull/2289
+// https://github.com/rtfd/readthedocs.org/issues/1088
+
+function fixSearch() {
+    var target = document.getElementById('rtd-search-form');
+    var config = {attributes: true, childList: true};
+  
+    var observer = new MutationObserver(function(mutations) {
+      observer.disconnect();
+      var form = $('#rtd-search-form');
+      form.empty();
+      form.attr('action', 'https://' + window.location.hostname + '/en/' + determineSelectedBranch() + '/search.html');
+      $('<input>').attr({
+        type: "text",
+        name: "q",
+        placeholder: "Search docs"
+      }).appendTo(form);
+    });
+    if (window.location.origin.indexOf('readthedocs') > -1) {
+      observer.observe(target, config);
+    }
+  }
+  
+  $(document).ready(function () {
+    fixSearch();
+  })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: ddev Documentation
 edit_uri: edit/master/docs/
 copyright: DRUD Technology, LLC
 theme: readthedocs
+extra_js: [assets/fix-search.js]
 markdown_extensions:
   - markdown.extensions.toc
 pages:


### PR DESCRIPTION
## The Problem/Issue/Bug:
OP #528 - search on our docs on readthedocs isn't working.

## How this PR Solves The Problem:
This PR introduces a workaround found in https://github.com/rtfd/readthedocs.org/issues/1088#issuecomment-224715045 to get working search results again.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

