### PR TITLE
re-workaround readthedocs broken search

### DIFF
--- a/docs/assets/fix-search.js
+++ b/docs/assets/fix-search.js
@@ -1,27 +1,44 @@
-// See various broken search issues, but especially:
-// https://github.com/rtfd/readthedocs.org/pull/2289
-// https://github.com/rtfd/readthedocs.org/issues/1088
+(function (){
+  var MutationObserver = (function () {
+    var prefixes = ['WebKit', 'Moz', 'O', 'Ms', '']
+    for (var i=0; i < prefixes.length; i++) {
+      if (prefixes[i] + 'MutationObserver' in window) {
+        return window[prefixes[i] + 'MutationObserver'];
+      }
+    }
+    return false;
+  }());
 
-function fixSearch() {
+  /*
+  * RTD messes up MkDocs' search feature by tinkering with the search box defined in the theme, see
+  * https://github.com/rtfd/readthedocs.org/issues/1088. This function sets up a DOM4 MutationObserver
+  * to react to changes to the search form (triggered by RTD on doc ready). It then reverts everything
+  * the RTD JS code modified.
+  *
+  * @see https://github.com/rtfd/readthedocs.org/issues/1088#issuecomment-224715045
+  */
+  $(document).ready(function () {
+    if (!MutationObserver) {
+      return;
+    }
     var target = document.getElementById('rtd-search-form');
     var config = {attributes: true, childList: true};
-  
+
     var observer = new MutationObserver(function(mutations) {
+      // if it isn't disconnected it'll loop infinitely because the observed element is modified
       observer.disconnect();
       var form = $('#rtd-search-form');
+      var path = window.location.pathname;
+      var branch = path.split('/')[2];
       form.empty();
-      form.attr('action', 'https://' + window.location.hostname + '/en/' + determineSelectedBranch() + '/search.html');
+      form.attr('action', window.location.origin + '/en/' + branch + '/search.html');
       $('<input>').attr({
         type: "text",
         name: "q",
         placeholder: "Search docs"
       }).appendTo(form);
     });
-    if (window.location.origin.indexOf('readthedocs') > -1) {
-      observer.observe(target, config);
-    }
-  }
-  
-  $(document).ready(function () {
-    fixSearch();
-  })
+
+    observer.observe(target, config);
+  });
+}());

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,8 @@ site_name: ddev Documentation
 edit_uri: edit/master/docs/
 copyright: DRUD Technology, LLC
 theme: readthedocs
-extra_js: [assets/fix-search.js]
+extra_javascript:
+  - assets/fix-search.js
 markdown_extensions:
   - markdown.extensions.toc
 pages:


### PR DESCRIPTION
## The Problem/Issue/Bug:
#530 introduced a well-shared workaround for search broken on readthedocs mkdocs sites. Unfortunately the fix applied did not resolve the search issues. I looked a bit closer at a project I knew to have working docs search and found a variation on the js fix, but more importantly a difference in how extra js is defined in mkdocs.yml. This fix has been tested against a temporary alt version of the docs site and works as expected.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

