### PR TITLE
Fix panics on ddev list and ddev start (with no config), fixes #521

### DIFF
--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -27,10 +27,10 @@ var DevListCmd = &cobra.Command{
 		table := platform.CreateAppTable()
 		for _, site := range sites {
 			desc, err := site.Describe()
-			appDescs = append(appDescs, desc)
 			if err != nil {
 				util.Failed("Failed to describe site %s: %v", site.GetName(), err)
 			}
+			appDescs = append(appDescs, desc)
 			platform.RenderAppRow(table, desc)
 		}
 

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -33,7 +33,7 @@ provide a working environment for development.`,
 func appStart() {
 	app, err := platform.GetActiveApp("")
 	if err != nil {
-		util.Failed("Failed to start %s, err: %v", app.GetName(), err)
+		util.Failed("Failed to start: %v", err)
 	}
 
 	output.UserOut.Printf("Starting environment for %s...", app.GetName())

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -45,9 +45,12 @@ func (l *LocalApp) GetType() string {
 // Init populates LocalApp settings based on the current working directory.
 func (l *LocalApp) Init(basePath string) error {
 	config, err := ddevapp.NewConfig(basePath, "")
+
+	// Save config to l.AppConfig so we can capture and display the site's
+	// status regardless of its validity
+	l.AppConfig = config
+
 	if err != nil {
-		// Save config to l.AppConfig so we can capture and display the site's status.
-		l.AppConfig = config
 		return err
 	}
 
@@ -55,8 +58,6 @@ func (l *LocalApp) Init(basePath string) error {
 	if err != nil {
 		return err
 	}
-
-	l.AppConfig = config
 
 	web, err := l.FindContainerByType("web")
 	if err == nil {

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -676,9 +676,6 @@ func TestListWithoutDir(t *testing.T) {
 	// Make sure we move out of the directory for Windows' sake
 	garbageDir := testcommon.CreateTmpDir("RestingHere")
 	defer testcommon.CleanupDir(garbageDir)
-	// Changing directory must be pushed on defer stack last so it happens
-	// before any cleanups, so windows tests won't break.
-	defer os.Chdir(packageDir)
 
 	err = os.Chdir(garbageDir)
 	assert.NoError(err)
@@ -704,6 +701,11 @@ func TestListWithoutDir(t *testing.T) {
 	assert.Contains(table.String(), fmt.Sprintf("app directory missing: %s", testDir))
 
 	err = app.Down(true)
+	assert.NoError(err)
+
+	// Change back to package dir. Lots of things will have to be cleaned up
+	// in defers, and for windows we have to not be sitting in them.
+	err = os.Chdir(packageDir)
 	assert.NoError(err)
 }
 

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -177,6 +177,27 @@ func TestLocalStart(t *testing.T) {
 	testcommon.CleanupDir(another.Dir)
 }
 
+// TestStartWithoutDdev makes sure we don't have a regression where lack of .ddev
+// causes a panic.
+func TestStartWithoutDdevConfig(t *testing.T) {
+	// Set up tests and give ourselves a working directory.
+	assert := asrt.New(t)
+	testDir := testcommon.CreateTmpDir("TestStartWithoutDdevConfig")
+
+	// testcommon.Chdir()() and CleanupDir() check their own errors (and exit)
+	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
+
+	err := os.MkdirAll(testDir+"/sites/default", 0777)
+	assert.NoError(err)
+	err = os.Chdir(testDir)
+	assert.NoError(err)
+
+	_, err = platform.GetActiveApp("")
+	assert.Error(err)
+	assert.Contains(err.Error(), "unable to determine")
+}
+
 // TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.
 func TestGetApps(t *testing.T) {
 	assert := asrt.New(t)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* OP #521 describes a situation where a site is running, but its directories have been removed. That reversion is fixed here.
* Around the same time I discovered that `ddev start` in a non-site directory no longer worked. 

## How this PR Solves The Problem:

* Fixes both of the problems
* (Will) add tests for both of those cases

## Manual Testing Instructions:

* Create a site and remove its directory, then try `ddev list`. For example:
```
cd /tmp
mkdir -p junk/sites/default
cd junk
ddev start # Tell it the apptype is drupal7
mv junk junk.bak
```
then try a `ddev list`. You should get proper output.

* Try a `ddev start` in any directory without a .ddev

## Automated Testing Overview:

(In Progress): Tests for these two situations.

## Related Issue Link(s):

OP #521

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

