### PR TITLE
Fix discovered json output flaws

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -84,7 +84,8 @@ func TestDescribe(t *testing.T) {
 		assert.True(ok)
 		assert.EqualValues(raw["status"], "running")
 		assert.EqualValues(raw["name"], v.Name)
-		assert.EqualValues(raw["approot"].(string), platform.RenderHomeRootedDir(v.Dir))
+		assert.EqualValues(raw["shortroot"].(string), platform.RenderHomeRootedDir(v.Dir))
+		assert.EqualValues(raw["approot"].(string), v.Dir)
 		cleanup()
 	}
 }
@@ -102,7 +103,8 @@ func TestDescribeAppFunction(t *testing.T) {
 		assert.NoError(err)
 		assert.EqualValues(desc["status"], platform.SiteRunning)
 		assert.EqualValues(app.GetName(), desc["name"])
-		assert.EqualValues(platform.RenderHomeRootedDir(v.Dir), desc["approot"].(string))
+		assert.EqualValues(platform.RenderHomeRootedDir(v.Dir), desc["shortroot"].(string))
+		assert.EqualValues(v.Dir, desc["approot"].(string))
 
 		out, _ := json.Marshal(desc)
 		assert.Contains(string(out), app.URL())

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -53,7 +53,8 @@ func TestDevList(t *testing.T) {
 				found = true
 				assert.Contains(item["url"], app.HostName())
 				assert.EqualValues(app.GetType(), item["type"])
-				assert.EqualValues(platform.RenderHomeRootedDir(app.AppRoot()), item["approot"])
+				assert.EqualValues(platform.RenderHomeRootedDir(app.AppRoot()), item["shortroot"])
+				assert.EqualValues(app.AppRoot(), item["approot"])
 				break
 			}
 		}

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -51,7 +51,8 @@ func TestDevList(t *testing.T) {
 			// Check to see that we can find our item
 			if item["name"] == v.Name {
 				found = true
-				assert.Contains(item["url"], app.HostName())
+				assert.Contains(item["httpurl"], app.HostName())
+				assert.Contains(item["httpsurl"], app.HostName())
 				assert.EqualValues(app.GetType(), item["type"])
 				assert.EqualValues(platform.RenderHomeRootedDir(app.AppRoot()), item["shortroot"])
 				assert.EqualValues(app.AppRoot(), item["approot"])

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -88,14 +88,14 @@ func (l *LocalApp) Describe() (map[string]interface{}, error) {
 	appDesc := make(map[string]interface{})
 
 	var https bool
-	var httpsUrlString string
-	httpUrlString := fmt.Sprintf("http://%s", l.HostName())
+	var httpsURLString string
+	httpURLString := fmt.Sprintf("http://%s", l.HostName())
 	webCon, err := l.FindContainerByType("web")
 	if err == nil {
 		https = dockerutil.CheckForHTTPS(webCon)
 	}
 	if https {
-		httpsUrlString = fmt.Sprintf("https://%s", l.HostName())
+		httpsURLString = fmt.Sprintf("https://%s", l.HostName())
 	}
 
 	appDesc["name"] = l.GetName()
@@ -103,8 +103,8 @@ func (l *LocalApp) Describe() (map[string]interface{}, error) {
 	appDesc["type"] = l.GetType()
 	appDesc["approot"] = l.AppRoot()
 	appDesc["shortroot"] = shortRoot
-	appDesc["httpurl"] = httpUrlString
-	appDesc["httpsurl"] = httpsUrlString
+	appDesc["httpurl"] = httpURLString
+	appDesc["httpsurl"] = httpsURLString
 
 	db, err := l.FindContainerByType("db")
 	if err != nil {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -88,13 +88,14 @@ func (l *LocalApp) Describe() (map[string]interface{}, error) {
 	appDesc := make(map[string]interface{})
 
 	var https bool
-	urlString := fmt.Sprintf("http://%s", l.HostName())
+	var httpsUrlString string
+	httpUrlString := fmt.Sprintf("http://%s", l.HostName())
 	webCon, err := l.FindContainerByType("web")
 	if err == nil {
 		https = dockerutil.CheckForHTTPS(webCon)
 	}
 	if https {
-		urlString = fmt.Sprintf("%s\nhttps://%s", urlString, l.HostName())
+		httpsUrlString = fmt.Sprintf("https://%s", l.HostName())
 	}
 
 	appDesc["name"] = l.GetName()
@@ -102,7 +103,8 @@ func (l *LocalApp) Describe() (map[string]interface{}, error) {
 	appDesc["type"] = l.GetType()
 	appDesc["approot"] = l.AppRoot()
 	appDesc["shortroot"] = shortRoot
-	appDesc["url"] = urlString
+	appDesc["httpurl"] = httpUrlString
+	appDesc["httpsurl"] = httpsUrlString
 
 	db, err := l.FindContainerByType("db")
 	if err != nil {

--- a/pkg/plugins/platform/local.go
+++ b/pkg/plugins/platform/local.go
@@ -100,7 +100,8 @@ func (l *LocalApp) Describe() (map[string]interface{}, error) {
 	appDesc["name"] = l.GetName()
 	appDesc["status"] = l.SiteStatus()
 	appDesc["type"] = l.GetType()
-	appDesc["approot"] = shortRoot
+	appDesc["approot"] = l.AppRoot()
+	appDesc["shortroot"] = shortRoot
 	appDesc["url"] = urlString
 
 	db, err := l.FindContainerByType("db")

--- a/pkg/plugins/platform/local_test.go
+++ b/pkg/plugins/platform/local_test.go
@@ -529,7 +529,9 @@ func TestDescribe(t *testing.T) {
 		assert.NoError(err)
 		assert.EqualValues(desc["status"], platform.SiteRunning)
 		assert.EqualValues(app.GetName(), desc["name"])
-		assert.EqualValues(platform.RenderHomeRootedDir(app.AppRoot()), desc["approot"])
+		assert.EqualValues(platform.RenderHomeRootedDir(app.AppRoot()), desc["shortroot"])
+		assert.EqualValues(app.AppRoot(), desc["approot"])
+
 		// Now stop it and test behavior.
 		err = app.Stop()
 		assert.NoError(err)

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -99,11 +99,12 @@ func RenderAppRow(table *uitable.Table, row map[string]interface{}) {
 		status = color.CyanString(status)
 	}
 
+	urls := row["httpurl"].(string) + "\n" + row["httpsurl"].(string)
 	table.AddRow(
 		row["name"],
 		row["type"],
 		row["shortroot"],
-		row["url"],
+		urls,
 		status,
 	)
 

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -99,7 +99,10 @@ func RenderAppRow(table *uitable.Table, row map[string]interface{}) {
 		status = color.CyanString(status)
 	}
 
-	urls := row["httpurl"].(string) + "\n" + row["httpsurl"].(string)
+	urls := row["httpurl"].(string)
+	if row["httpsurl"] != "" {
+		urls = urls + "\n" + row["httpsurl"].(string)
+	}
 	table.AddRow(
 		row["name"],
 		row["type"],

--- a/pkg/plugins/platform/utils.go
+++ b/pkg/plugins/platform/utils.go
@@ -102,7 +102,7 @@ func RenderAppRow(table *uitable.Table, row map[string]interface{}) {
 	table.AddRow(
 		row["name"],
 		row["type"],
-		row["approot"],
+		row["shortroot"],
 		row["url"],
 		status,
 	)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Reviewing ddev-ui's usage of the new json output we found two immediate flaws:
* ddev was providing a shortened approot instead of the full path, which handicapped ddev-ui, which then had to re-convert the path.
* The 'url' portion of raw desc was a concatenated http+https url. 

## How this PR Solves The Problem:

* desc["approot"] is now the full path. (desc["shortroot"] is also provided)
* desc["httpurl"] and desc["httpsurl"] replace desc["url"]

## Manual Testing Instructions:

`ddev list -j` and `ddev describe -j` to review the changes

## Automated Testing Overview:

The various tests that relied on url and approot were changed; additional assertions were added for shortroot, etc.

## Related Issue Link(s):

## Release/Deployment notes:

Note that the json output is incompatible with previous versions, as "url" is replaced by "httpurl" and "httpsurl".
