### PR TITLE
Improve surf testbot installation instructions

### DIFF
--- a/docs/developers/surf-testmachine-setup.md
+++ b/docs/developers/surf-testmachine-setup.md
@@ -32,15 +32,16 @@ where `surf-windows-ddev` is the name of the job on the windows machine (it's fr
 
 1. Install [homebrew](https://brew.sh/)
 2. Install golang/git/docker with `brew install golang git docker`
-3. Install nosleep `brew cask install nosleep`
-4. Enable nosleep using its shortcut in the Mac status bar.
-5. In nosleep Preferences, enable "Never sleep on AC Adapter", "Never sleep on Battery", and "Start nosleep utility on system startup".
-6. Set up Mac to [automatically log in on boot](https://support.apple.com/en-us/HT201476). 
-7. Install Surf:
+3. If the xcode command line tools are not yet installed, install them with `xcode select --install`
+4. Install nosleep `brew cask install nosleep`
+5. Enable nosleep using its shortcut in the Mac status bar.
+6. In nosleep Preferences, enable "Never sleep on AC Adapter", "Never sleep on Battery", and "Start nosleep utility on system startup".
+7. Set up Mac to [automatically log in on boot](https://support.apple.com/en-us/HT201476). 
+8. Install Surf:
     - The quickest way to install Surf is with NPM:
     `npm install -g surf-build`
     - OR you can download a release from https://github.com/surf-build/surf/releases.
-8. In a shell, 
+9. In a shell, 
 ```
 export GITHUB_TOKEN=012345...
 export DDEV_PANTHEON_API_TOKEN=012356...
@@ -49,3 +50,4 @@ surf-install -e DDEV_PANTHEON_API_TOKEN -n surf-darwin-ddev -c "surf-run -r http
 where `surf-darwin-ddev` is the name of the job on the mac machine (it's free-form) and `surf-darwin` is the identifier used on github when the build changes statuses; it's also free-form.
 
 9. Reboot the machine and do a test run. Alternatively, test with `surf-build -r https://github.com/drud/ddev -s <some_sha>`
+


### PR DESCRIPTION
## The Problem/Issue/Bug:

There was a (potential) step missing in installation of a macOS surf testbot. This improves the docs.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

