### PR TITLE
Fix missed shortroot conversion in test, broke windows test only somehow

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -143,7 +143,8 @@ func TestDescribeAppUsingSitename(t *testing.T) {
 		assert.NoError(err)
 		assert.EqualValues(desc["status"], platform.SiteRunning)
 		assert.EqualValues(app.GetName(), desc["name"])
-		assert.EqualValues(platform.RenderHomeRootedDir(v.Dir), desc["approot"].(string))
+		assert.EqualValues(platform.RenderHomeRootedDir(v.Dir), desc["shortroot"].(string))
+		assert.EqualValues(v.Dir, desc["approot"].(string))
 
 		out, _ := json.Marshal(desc)
 		assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

I seem to have committed the json fix in #543 with Windows tests still failing. I don't understand how this change could have not broken all the other tests, so will look at that. But this little fixup should solve the windows tests.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

