### PR TITLE
Check for docker-compose at install and run time, fixes #491

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -60,9 +60,13 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		err = dockerutil.CheckDockerCompose()
+		err = dockerutil.CheckDockerCompose(version.DockerComposeVersionConstraint)
 		if err != nil {
-			util.Failed("docker-compose does not appear to be installed.")
+			if err.Error() == "no docker-compose" {
+				util.Failed("docker-compose does not appear to be installed.")
+			} else {
+				util.Failed("The docker-compose version currently installed does not meet ddev's requirements: %v", err)
+			}
 		}
 
 		// Verify that the ~/.ddev exists

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -60,6 +60,11 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
+		err = dockerutil.CheckDockerCompose()
+		if err != nil {
+			util.Failed("docker-compose does not appear to be installed.")
+		}
+
 		// Verify that the ~/.ddev exists
 		userDdevDir := util.GetGlobalDdevDir()
 

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -32,6 +32,10 @@ if ! docker --version >/dev/null 2>&1; then
     printf "${YELLOW}Docker is required for ddev. Download and install docker at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
 fi
 
+if ! docker-compose --version >/dev/null 2>&1; then
+    printf "${YELLOW}Docker Compose is required for ddev. Download and install docker-compose at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
+fi
+
 TARBALL="$FILEBASE.$LATEST_VERSION.tar.gz"
 SHAFILE="$TARBALL.sha256.txt"
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -350,11 +350,8 @@ func CheckDockerCompose(versionConstraint string) error {
 		return err
 	}
 
-	fmt.Println(out)
-	fmt.Println(string(out))
-
 	version := string(out)
-	version = strings.TrimSuffix(version, "\n")
+	version = strings.TrimSpace(version)
 
 	dockerComposeVersion, err := semver.NewVersion(version)
 	if err != nil {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -350,6 +350,9 @@ func CheckDockerCompose(versionConstraint string) error {
 		return err
 	}
 
+	fmt.Println(out)
+	fmt.Println(string(out))
+
 	version := string(out)
 	version = strings.TrimSuffix(version, "\n")
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -328,6 +329,22 @@ func CheckDockerVersion(versionConstraint string) error {
 		}
 		return fmt.Errorf(msgs)
 	}
+	return nil
+}
+
+// CheckDockerCompose determines if docker-compose is present and executable on the host system. This
+// relies on docker-compose being somewhere in the user's $PATH.
+func CheckDockerCompose() error {
+	executableName := "docker-compose"
+	if runtime.GOOS == "Windows" {
+		executableName = "docker-compose.exe"
+	}
+
+	_, err := exec.LookPath(executableName)
+	if err != nil {
+		return fmt.Errorf("no docker-compose")
+	}
+
 	return nil
 }
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -162,4 +162,3 @@ func TestGetContainerEnv(t *testing.T) {
 	env = GetContainerEnv("NONEXISTENT", container)
 	assert.Equal("", env)
 }
-

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -133,6 +133,13 @@ func TestComposeCmd(t *testing.T) {
 	assert.Error(err)
 }
 
+func TestCheckCompose(t *testing.T) {
+	assert := asrt.New(t)
+
+	err := CheckDockerCompose()
+	assert.NoError(err)
+}
+
 func TestGetAppContainers(t *testing.T) {
 	assert := asrt.New(t)
 	sites, err := GetAppContainers("dockertest")

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -137,7 +137,7 @@ func TestComposeCmd(t *testing.T) {
 func TestCheckCompose(t *testing.T) {
 	assert := asrt.New(t)
 
-	err := CheckDockerCompose()
+	err := CheckDockerCompose(version.DockerComposeVersionConstraint)
 	assert.NoError(err)
 }
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -162,3 +162,4 @@ func TestGetContainerEnv(t *testing.T) {
 	env = GetContainerEnv("NONEXISTENT", container)
 	assert.Equal("", env)
 }
+

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -133,6 +133,7 @@ func TestComposeCmd(t *testing.T) {
 	assert.Error(err)
 }
 
+// TestCheckCompose tests detection of docker-compose.
 func TestCheckCompose(t *testing.T) {
 	assert := asrt.New(t)
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/output"
+	"github.com/drud/ddev/pkg/version"
 	docker "github.com/fsouza/go-dockerclient"
 	asrt "github.com/stretchr/testify/assert"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,6 +13,9 @@ var DdevVersion = "v0.3.0-dev" // Note that this is overridden by make
 // for examples defining version constraints.
 var DockerVersionConstraint = ">= 17.05.0-ce"
 
+// DockerComposeVersionConstraint is the current minimum version of docker-compose required for ddev.
+var DockerComposeVersionConstraint = ">= 1.10.0"
+
 // WebImg defines the default web image used for applications.
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

As noted in https://github.com/drud/ddev/issues/491, we don't actually check for `docker-compose` anywhere, but it's a fundamental part of the ddev environment.

## How this PR Solves The Problem:

* Tests for `docker-compose` in the install script
* Tests for `docker-compose` in root.go

## Manual Testing Instructions:

* Remove `docker-compose` from your path and run any `ddev` command. You should see an error about `docker-compose` not being installed.
* Add `docker-compose` back into your path and repeat. See no errors.
* Remove `docker-compose` from your path and attempt to use the install script to install. You should see a message about docker-compose not being installed.
* Add `docker-compose` back into your path and repeat. See no docker-compose related message.

## Automated Testing Overview:

No test for the failure path was included here because the existing tests already use `docker-compose`, meaning that `docker-compose` will always be installed on a test box. We don't have any way to test the failure case from the Go tests that I can see.

A test for the happy path was included.

## Related Issue Link(s):

https://github.com/drud/ddev/issues/491

## Release/Deployment notes:

Nothing special should have to happen to release this.

