### PR TITLE
Use single quotes instead of backticks for user-facing messages, fixes #404

### DIFF
--- a/cmd/ddev/cmd/auth_pantheon.go
+++ b/cmd/ddev/cmd/auth_pantheon.go
@@ -17,10 +17,10 @@ var PantheonAuthCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		if len(args) == 0 {
-			util.Failed("You must provide a Pantheon machine token, e.g. `ddev auth-pantheon [token]`. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.")
+			util.Failed("You must provide a Pantheon machine token, e.g. 'ddev auth-pantheon [token]'. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.")
 		}
 		if len(args) != 1 {
-			util.Failed("Too many arguments detected. Please provide only your Pantheon Machine token., e.g. `ddev auth-pantheon [token]`. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.")
+			util.Failed("Too many arguments detected. Please provide only your Pantheon Machine token., e.g. 'ddev auth-pantheon [token]'. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.")
 		}
 		userDir, err := gohomedir.Dir()
 		util.CheckErr(err)
@@ -36,7 +36,7 @@ var PantheonAuthCommand = &cobra.Command{
 		if err != nil {
 			util.Failed("Failed session.Write(), err=%v", err)
 		}
-		util.Success("Authentication successful!\nYou may now use the `ddev config pantheon` command when configuring sites!")
+		util.Success("Authentication successful!\nYou may now use the 'ddev config pantheon' command when configuring sites!")
 	},
 }
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -87,7 +87,7 @@ var ConfigCommand = &cobra.Command{
 			}
 			// pantheonEnvironment must be appropriate, and can only be used with pantheon provider.
 			if provider != "pantheon" && pantheonEnvironment != "" {
-				util.Failed("--pantheon-environment can only be used with pantheon provider, for example ddev config pantheon --pantheon-environment=dev --docroot=docroot")
+				util.Failed("--pantheon-environment can only be used with pantheon provider, for example 'ddev config pantheon --pantheon-environment=dev --docroot=docroot'")
 			}
 			if appType != "" && appType != "drupal7" && appType != "drupal8" && appType != "wordpress" {
 				util.Failed("apptype must be drupal7, drupal8, or wordpress")

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -24,7 +24,7 @@ running 'ddev stop <sitename>.`,
 		var siteName string
 
 		if len(args) > 1 {
-			util.Failed("Too many arguments provided. Please use `ddev describe` or `ddev describe [appname]`")
+			util.Failed("Too many arguments provided. Please use 'ddev describe' or 'ddev describe [appname]'")
 		}
 
 		if len(args) == 1 {

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -30,11 +30,11 @@ var LocalDevExecCmd = &cobra.Command{
 		}
 
 		if strings.Contains(app.SiteStatus(), platform.SiteNotFound) {
-			util.Failed("App not running locally. Try `ddev start`.")
+			util.Failed("App not running locally. Try 'ddev start'.")
 		}
 
 		if strings.Contains(app.SiteStatus(), platform.SiteStopped) {
-			util.Failed("App is stopped. Run `ddev start` to start the environment.")
+			util.Failed("App is stopped. Run 'ddev start' to start the environment.")
 		}
 
 		app.DockerEnv()

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -26,11 +26,11 @@ var LocalDevLogsCmd = &cobra.Command{
 		}
 
 		if strings.Contains(app.SiteStatus(), platform.SiteNotFound) {
-			util.Failed("App not running locally. Try `ddev start`.")
+			util.Failed("App not running locally. Try 'ddev start'.")
 		}
 
 		if strings.Contains(app.SiteStatus(), platform.SiteStopped) {
-			util.Failed("App is stopped. Run `ddev start` to start the environment.")
+			util.Failed("App is stopped. Run 'ddev start' to start the environment.")
 		}
 
 		err = app.Logs(serviceType, follow, timestamp, tail)

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -23,7 +23,7 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 		var siteName string
 
 		if len(args) > 1 {
-			util.Failed("Too many arguments provided. Please use `ddev remove` or `ddev remove [appname]`")
+			util.Failed("Too many arguments provided. Please use 'ddev remove' or 'ddev remove [appname]'")
 		}
 
 		if len(args) == 1 {
@@ -36,7 +36,7 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 		}
 
 		if app.SiteStatus() == platform.SiteNotFound {
-			util.Failed("App not running locally. Try `ddev start`.")
+			util.Failed("App not running locally. Try 'ddev start'.")
 		}
 
 		err = app.Down(removeData)

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -20,11 +20,11 @@ var LocalDevSSHCmd = &cobra.Command{
 		}
 
 		if strings.Contains(app.SiteStatus(), platform.SiteNotFound) {
-			util.Failed("App not running locally. Try `ddev start`.")
+			util.Failed("App not running locally. Try 'ddev start'.")
 		}
 
 		if strings.Contains(app.SiteStatus(), platform.SiteStopped) {
-			util.Failed("App is stopped. Run `ddev start` to start the environment.")
+			util.Failed("App is stopped. Run 'ddev start' to start the environment.")
 		}
 
 		app.DockerEnv()

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -17,7 +17,7 @@ to stop by running 'ddev stop <sitename>.`,
 		var siteName string
 
 		if len(args) > 1 {
-			util.Failed("Too many arguments provided. Please use `ddev stop` or `ddev stop [sitename]`")
+			util.Failed("Too many arguments provided. Please use 'ddev stop' or 'ddev stop [sitename]'")
 		}
 
 		if len(args) == 1 {


### PR DESCRIPTION
## The Problem/Issue/Bug:

End users don't recognize backticks, so we should use single quotes instead.

## How this PR Solves The Problem:

Simple find and replace of backticks -> quotes in user-facing text. There are a number of places in the codebase where we still use backticks in comments, but those were left in place.

## Manual Testing Instructions:

Check error messages for the following commands:

* `ddev auth-pantheon`
* `ddev config`
* `ddev describe`
* `ddev exec`
* `ddev logs`
* `ddev remove`
* `ddev ssh`
* `ddev stop`

## Automated Testing Overview:

This is just simple text changes for end users. No tests needed.

## Related Issue Link(s):

https://github.com/drud/ddev/issues/404

## Release/Deployment notes:

