### PR TITLE
Bump nginx-php-fpm-local version to v0.8.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= v0.8.1
+WebTag ?= v0.8.2
 DBImg ?= drud/mysql-local-57
 DBTag ?= v0.6.3
 RouterImage ?= drud/ddev-router

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ ifeq ($(BUILD_OS),darwin)
     DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev
 endif
 
-
 # Override test section with tests specific to ddev
 test: testpkg testcmd
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,7 +17,7 @@ var DockerVersionConstraint = ">= 17.05.0-ce"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.8.0" // Note that this is overridden by make
+var WebTag = "v0.8.2" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

We had a nightly build failure caused by docker.nginx-php-fpm-local due to our pinning of php7.1. This bumps docker.nginx-php-fpm-local to v0.8.2

This should pass after @cweagans docker-pushes v0.8.2 but will fail right now, but that's OK. We'll just rebuild after that. I just wanted to get the PR up.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

