### PR TITLE
Update to support DDEV_PHP_VERSION in config and defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= 20171120_version_simplification
+WebTag ?= 20171204_version_simplification
 DBImg ?= drud/mysql-local-57
 DBTag ?= v0.6.3
 RouterImage ?= drud/ddev-router

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= v0.8.2
+WebTag ?= 20171120_version_simplification
 DBImg ?= drud/mysql-local-57
 DBTag ?= v0.6.3
 RouterImage ?= drud/ddev-router

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= 20171204_version_simplification
+WebTag ?= v0.9.0
 DBImg ?= drud/mysql-local-57
 DBTag ?= v0.6.3
 RouterImage ?= drud/ddev-router

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -3,7 +3,7 @@ ddev provides several ways in which the environment for a project using ddev can
 
 ## Changing PHP version
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to (currently) "5.6", "7.0", "7.1", or "7.2". The current default is php 7.1.
+The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to (currently) "5.6", "7.0", or "7.1". The current default is php 7.1.
 
 ## Adding services to a project
 

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -1,7 +1,12 @@
 <h1>Extending and Customizing Environments</h1>
 ddev provides several ways in which the environment for a project using ddev can be customized and extended.
 
+## Changing PHP version
+
+The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to (currently) "5.6", "7.0", "7.1", or "7.2". The current default is php 7.1.
+
 ## Adding services to a project
+
 For most standard web applications, ddev provides everything you need to successfully provision and develop a web application on your local machine out of the box. More complex and sophisticated web applications, however, often require integration with services beyond the standard requirements of a web and database server. Examples of these additional services are Apache Solr, Redis, Varnish, etc. While ddev likely won't ever provide all of these additional services out of the box, it is designed to provide simple ways for the environment to be customized and extended to meet the needs of your application.
 
 A collection of vetted service configurations is available in the [Additional Services Documentation](additional-services.md).

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -24,6 +24,9 @@ import (
 // DefaultProviderName contains the name of the default provider which will be used if one is not otherwise specified.
 const DefaultProviderName = "default"
 
+// DdevDefaultPHPVersion is the default PHP version, overridden by $DDEV_PHP_VERSION
+const DdevDefaultPHPVersion = "7.1"
+
 // CurrentAppVersion sets the current YAML config file version.
 // We're not doing anything with AppVersion, so just default it to 1 for now.
 const CurrentAppVersion = "1"
@@ -57,6 +60,7 @@ func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	app.AppRoot = AppRoot
 	app.ConfigPath = app.GetConfigPath("config.yaml")
 	app.APIVersion = CurrentAppVersion
+	app.PHPVersion = DdevDefaultPHPVersion
 
 	// These should always default to the latest image/tag names from the Version package.
 	app.WebImage = version.WebImg + ":" + version.WebTag
@@ -147,6 +151,10 @@ func (app *DdevApp) ReadConfig() error {
 	if app.Name == "" {
 		app.Name = filepath.Base(app.AppRoot)
 	}
+	if app.PHPVersion == "" {
+		app.PHPVersion = DdevDefaultPHPVersion
+	}
+
 	if app.WebImage == "" {
 		app.WebImage = version.WebImg + ":" + version.WebTag
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -55,6 +55,7 @@ type DdevApp struct {
 	Name                  string               `yaml:"name"`
 	Type                  string               `yaml:"type"`
 	Docroot               string               `yaml:"docroot"`
+	PHPVersion            string               `yaml:"php_version"`
 	WebImage              string               `yaml:"webimage"`
 	DBImage               string               `yaml:"dbimage"`
 	DBAImage              string               `yaml:"dbaimage"`
@@ -695,6 +696,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_HOSTNAME":        app.HostName(),
 		"DDEV_UID":             "",
 		"DDEV_GID":             "",
+		"DDEV_PHP_VERSION":     app.PHPVersion,
 	}
 	if runtime.GOOS == "linux" {
 		curUser, err := user.Current()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -350,7 +350,7 @@ func TestDdevExec(t *testing.T) {
 		default:
 		}
 
-		assert.Regexp("/etc/php.*cli/php.ini", out)
+		assert.Regexp("/etc/php.*/php.ini", out)
 
 		runTime()
 		switchDir()

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -42,6 +42,7 @@ services:
       - DDEV_GID=$DDEV_GID
       - DDEV_URL=$DDEV_URL
       - DOCROOT=$DDEV_DOCROOT
+      - DDEV_PHP_VERSION=$DDEV_PHP_VERSION
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -233,6 +233,7 @@ func ClearDockerEnv() {
 		"DDEV_HOSTNAME",
 		"DDEV_IMPORTDIR",
 		"DDEV_DATADIR",
+		"DDEV_PHP_VERSION",
 	}
 	for _, env := range envVars {
 		err := os.Unsetenv(env)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20171120_version_simplification" // Note that this is overridden by make
+var WebTag = "20171204_version_simplification" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-local-57" // Note that this is overridden by make

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20171204_version_simplification" // Note that this is overridden by make
+var WebTag = "v0.9.0" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-local-57" // Note that this is overridden by make

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.8.2" // Note that this is overridden by make
+var WebTag = "20171120_version_simplification" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

We'd like to be able to support more than one PHP version.

## How this PR Solves The Problem:

Introduce the php_version variable in our config, default it to 7.1, pass it to nginx-php-fpm-local, which as of https://github.com/drud/docker.nginx-php-fpm-local/pull/43 can support php versions 5.6-7.2

Adds a paragraph of documentation for those who want to change the php_version.

## Manual Testing Instructions:

in a fresh site, set `php_version: 5.6` or whatever in your .ddev/config and start it. Note that docker-compose.yml *must* be deleted for this to work, as a new docker-compose.yml needs to be generated.

## Automated Testing Overview:

There is no new testing at this point. We may want to add tests for various PHP versions, but there is minor testing in docker.nginx-php-fpm-local to make sure we have the right versions. Currently the default version (php7.1) will be used.

## Related Issue Link(s):

https://github.com/drud/docker.nginx-php-fpm-local/pull/43  provides the actual functionality.

## Release/Deployment notes:

- [x] Update to a real nginx-php-fpm-local tag after https://github.com/drud/docker.nginx-php-fpm-local/pull/43 is pulled (and a release created and an image pushed)
- [x] php-xdebug does not yet seem to be supported by php-7.2, so step-debugging doesn't yet work with it.
