### PR TITLE
"ddev ssh" inappropriately returns (and exclaims) last executed command value, fixes #527

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -201,7 +201,10 @@ func GetContainerHealth(container docker.APIContainers) string {
 }
 
 // ComposeNoCapture executes a docker-compose command while leaving the stdin/stdout/stderr untouched
-// so that people can interact with them directly, for example with ddev ssh.
+// so that people can interact with them directly, for example with ddev ssh. Note that this function
+// will never return an actual error because we don't have a way to distinguish between an error
+// representing a failure to connect to the container and an error representing a command failing
+// inside of the interactive session inside the container.
 func ComposeNoCapture(composeFiles []string, action ...string) error {
 	var arg []string
 
@@ -217,10 +220,7 @@ func ComposeNoCapture(composeFiles []string, action ...string) error {
 	proc.Stdin = os.Stdin
 	proc.Stderr = os.Stderr
 
-	err := proc.Run()
-	if err != nil {
-		return fmt.Errorf("Failed to run docker-compose %v: %v", arg, err)
-	}
+	_ = proc.Run()
 	return nil
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

The original expected outcome of the issue is:

> ddev ssh should only show an error if it failed to actually get you into the shell on the container.

However, we don't have any way of distinguishing between a failure to get a shell in the container and a failure of a command executed in that shell (for instance, if you run `asdfasdfasdf` inside the container and then immediately exit, `ddev ssh` will report an error).

## How this PR Solves The Problem:

At @rfay's suggestion, we're just going to completely ignore the error from docker-compose. This way, we don't erroneously report errors in non-failure cases, but this means that we also don't report errors when there actually is an error.

## Manual Testing Instructions:

* `ddev ssh` should get you a shell in the container
* `ddev ssh -s asdf` should error: ERROR: No such service: asdf
* `ddev ssh`  followed by `exit`: Should return no additional output
* `ddev ssh` followed by `asdfasdfasdf` and then `exit`: Should behave the same as the previous case

## Automated Testing Overview:

This is untested functionality. We should probably test it, but I think that's going to be a somewhat significant effort. Should we open a follow up to add test coverage?

## Related Issue Link(s):
Fixes #527

## Release/Deployment notes:
Shouldn't require any additional release/deployment steps.

