### PR TITLE
Add automation of nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,16 @@ workflows:
   normal_build_and_test:
     jobs:
       - normal_build_and_test
+  nightly_build:
+    triggers:
+      - schedule:
+          cron: "0 3 * * 1-5"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - nightly_build
   tag_build:
     jobs:
       - tag_build:
@@ -167,5 +177,3 @@ workflows:
                 - "/.*/"
             branches:
               ignore: /.*/
-
-


### PR DESCRIPTION
## The Problem/Issue/Bug:

We currently run a jenkins job to trigger the nightly build, but Circleci now offers this as a feature. [Circleci Instructions](https://circleci.com/docs/2.0/workflows/?mkt_tok=eyJpIjoiWVdVNE4yRTRaalpoWmpObSIsInQiOiJiYWY4ZGpybmU2VUExdVdYQklBcDlvbWJZMnFZNnpsVlVPWk9ybzQ3Y1VRWGxpdjJtbDdKcktHK01STEpSOXpjWThnbjg1K3hrSTBWb0JXWnRveHVmZHlqaUNzTzNCYXhhRE45ZHFTbElqQjdIQVM2eVkyb3RjTm9aSVwvRm1TangifQ%3D%3D#scheduling-a-workflow)

## How this PR Solves The Problem:

Use the "trigger' feature in workflows to get circleci to automatically trigger, instead of hitting the circle API

## Manual Testing Instructions:

Just look and see what happens. This is set up and testing currently on rfay/ddev, so you can see the behavior there, https://circleci.com/gh/rfay/ddev/tree/master

Unfortunately the key stanza must be on *master* so it's hard to easily test in a PR. However, it's there on rfay/master, so that should be behaving.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

This does no harm, and makes no change to the current nightly arrangement. However, after we're happy with this we should:
- [ ] Disable the nightly build job which is triggered by the api via drud-prod jenkins.
