### PR TITLE
Update circle machine image for later docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   # 'build' is the default build, the only one triggered automatically by github or anything else.
   normal_build_and_test:
     machine:
-      image: circleci/classic:201708-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       GOPATH: /home/circleci/go
@@ -49,7 +49,7 @@ jobs:
   # nightly is triggered only with nightly_build_trigger.sh
   nightly_build:
     machine:
-      image: circleci/classic:201708-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       DRUD_DEBUG: "true"
@@ -121,7 +121,7 @@ jobs:
   # 'tag_build' is used to build a tag for release.
   tag_build:
     machine:
-      image: circleci/classic:201708-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       DRUD_DEBUG: "true"


### PR DESCRIPTION
## The Problem/Issue/Bug:

We like to have stable Circleci behavior, but also keep up-to-date with current Docker versions. This updates the Circle image to have their latest docker and docker-compose. Full information on circleci machine versions is at https://circleci.com/docs/2.0/configuration-reference/#machine

## How this PR Solves The Problem:

Update circleci machine version.

