### PR TITLE
Add the ddev domain to the output of ddev version

### DIFF
--- a/cmd/ddev/cmd/version.go
+++ b/cmd/ddev/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -42,6 +43,7 @@ func handleVersionCommand() *uitable.Table {
 	table.AddRow("router:", version.RouterImage+":"+version.RouterTag)
 	table.AddRow("commit:", version.COMMIT)
 	table.AddRow("build info:", version.BUILDINFO)
+	table.AddRow("domain:", ddevapp.DDevTLD)
 
 	return table
 }

--- a/cmd/ddev/cmd/version.go
+++ b/cmd/ddev/cmd/version.go
@@ -41,8 +41,8 @@ func handleVersionCommand() *uitable.Table {
 	table.AddRow("dba:", version.DBAImg+":"+version.DBATag)
 	table.AddRow("router:", version.RouterImage+":"+version.RouterTag)
 	table.AddRow("commit:", version.COMMIT)
-	table.AddRow("build info:", version.BUILDINFO)
 	table.AddRow("domain:", version.DDevTLD)
+	table.AddRow("build info:", version.BUILDINFO)
 
 	return table
 }

--- a/cmd/ddev/cmd/version.go
+++ b/cmd/ddev/cmd/version.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -43,7 +42,7 @@ func handleVersionCommand() *uitable.Table {
 	table.AddRow("router:", version.RouterImage+":"+version.RouterTag)
 	table.AddRow("commit:", version.COMMIT)
 	table.AddRow("build info:", version.BUILDINFO)
-	table.AddRow("domain:", ddevapp.DDevTLD)
+	table.AddRow("domain:", version.DDevTLD)
 
 	return table
 }

--- a/cmd/ddev/cmd/version_test.go
+++ b/cmd/ddev/cmd/version_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/version"
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -19,4 +20,5 @@ func TestVersion(t *testing.T) {
 	assert.Contains(output, version.DBTag)
 	assert.Contains(output, version.DBAImg)
 	assert.Contains(output, version.DBATag)
+	assert.Contains(output, ddevapp.DDevTLD)
 }

--- a/cmd/ddev/cmd/version_test.go
+++ b/cmd/ddev/cmd/version_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/version"
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -20,5 +19,5 @@ func TestVersion(t *testing.T) {
 	assert.Contains(output, version.DBTag)
 	assert.Contains(output, version.DBAImg)
 	assert.Contains(output, version.DBATag)
-	assert.Contains(output, ddevapp.DDevTLD)
+	assert.Contains(output, version.DDevTLD)
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -28,9 +28,6 @@ const DefaultProviderName = "default"
 // We're not doing anything with AppVersion, so just default it to 1 for now.
 const CurrentAppVersion = "1"
 
-// DDevTLD defines the tld to use for DDev site URLs.
-const DDevTLD = "ddev.local"
-
 // AllowedAppTypes lists the types of site/app that can be used.
 var AllowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}
 
@@ -298,7 +295,7 @@ func (c *Config) DockerComposeYAMLPath() string {
 
 // Hostname returns the hostname to the app controlled by this config.
 func (c *Config) Hostname() string {
-	return c.Name + "." + DDevTLD
+	return c.Name + "." + version.DDevTLD
 }
 
 // WriteDockerComposeConfig writes a docker-compose.yaml to the app configuration directory.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -93,7 +93,7 @@ func TestHostName(t *testing.T) {
 	assert.NoError(err)
 	config.Name = util.RandString(32)
 
-	assert.Equal(config.Hostname(), config.Name+"."+DDevTLD)
+	assert.Equal(config.Hostname(), config.Name+"."+version.DDevTLD)
 }
 
 // TestWriteDockerComposeYaml tests the writing of a docker-compose.yaml file.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,3 +45,6 @@ var COMMIT = "COMMIT should be overridden"
 
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"
+
+// DDevTLD defines the tld to use for DDev site URLs.
+const DDevTLD = "ddev.local"


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev version` doesn't show any information about the TLD used to spin up sites.

## How this PR Solves The Problem:

Simple addition of the DDevTLD constant to the output of `ddev version`

## Manual Testing Instructions:

Run `ddev version`

## Automated Testing Overview:

One extra assertion was added to test for the TLD in the output.

## Related Issue Link(s):

https://github.com/drud/ddev/issues/441

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

