### PR TITLE
Refactor all config into the ddevapp, fixes #458

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -105,7 +105,7 @@ var ConfigCommand = &cobra.Command{
 			} else {
 				util.Failed("Failed to determine app type (drupal7/drupal8/wordpress).\nYour docroot %v may be incorrect - looking in directory %v, error=%v", app.Docroot, fullPath, err)
 			}
-			app.AppType = appType
+			app.Type = appType
 
 			prov, _ := app.GetProvider()
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -50,37 +50,37 @@ var ConfigCommand = &cobra.Command{
 			provider = args[0]
 		}
 
-		c, err := ddevapp.NewApp(appRoot, provider)
+		app, err := ddevapp.NewApp(appRoot, provider)
 		if err != nil {
 			util.Failed("Could not create new config: %v", err)
 		}
 
 		// If they have not given us any flags, we prompt for full info. Otherwise, we assume they're in control.
 		if siteName == "" && docrootRelPath == "" && pantheonEnvironment == "" && appType == "" {
-			err = c.PromptForConfig()
+			err = app.PromptForConfig()
 			if err != nil {
 				util.Failed("There was a problem configuring your application: %v", err)
 			}
 		} else { // In this case we have to validate the provided items, or set to sane defaults
 
 			// Let them know if we're replacing the config.yaml
-			c.WarnIfConfigReplace()
+			app.WarnIfConfigReplace()
 
-			// c.Name gets set to basename if not provided, or set to sitneName if provided
-			if c.Name != "" && siteName == "" { // If we already have a c.Name and no siteName, leave c.Name alone
+			// app.Name gets set to basename if not provided, or set to siteName if provided
+			if app.Name != "" && siteName == "" { // If we already have a c.Name and no siteName, leave c.Name alone
 				// Sorry this is empty but it makes the logic clearer.
 			} else if siteName != "" { // if we have a siteName passed in, use it for c.Name
-				c.Name = siteName
+				app.Name = siteName
 			} else { // No siteName passed, c.Name not set: use c.Name from the directory
 				// nolint: vetshadow
 				pwd, err := os.Getwd()
 				util.CheckErr(err)
-				c.Name = path.Base(pwd)
+				app.Name = path.Base(pwd)
 			}
 
 			// docrootRelPath must exist
 			if docrootRelPath != "" {
-				c.Docroot = docrootRelPath
+				app.Docroot = docrootRelPath
 				if _, err = os.Stat(docrootRelPath); os.IsNotExist(err) {
 					util.Failed("The docroot provided (%v) does not exist", docrootRelPath)
 				}
@@ -93,8 +93,8 @@ var ConfigCommand = &cobra.Command{
 				util.Failed("apptype must be drupal7, drupal8, or wordpress")
 			}
 
-			foundAppType, err := ddevapp.DetermineAppType(c.Docroot)
-			fullPath, _ := filepath.Abs(c.Docroot)
+			foundAppType, err := ddevapp.DetermineAppType(app.Docroot)
+			fullPath, _ := filepath.Abs(app.Docroot)
 			if err == nil && (appType == "" || appType == foundAppType) { // Found an app, matches passed-in or no apptype passed
 				appType = foundAppType
 				util.Success("Found a %s codebase at %s", foundAppType, fullPath)
@@ -103,11 +103,11 @@ var ConfigCommand = &cobra.Command{
 			} else if appType != "" && err == nil && foundAppType != appType { // apptype was passed, app was found, but not the same type
 				util.Warning("You have specified an apptype of %s but an app of type %s was discovered in %s", appType, foundAppType, fullPath)
 			} else {
-				util.Failed("Failed to determine app type (drupal7/drupal8/wordpress).\nYour docroot %v may be incorrect - looking in directory %v, error=%v", c.Docroot, fullPath, err)
+				util.Failed("Failed to determine app type (drupal7/drupal8/wordpress).\nYour docroot %v may be incorrect - looking in directory %v, error=%v", app.Docroot, fullPath, err)
 			}
-			c.AppType = appType
+			app.AppType = appType
 
-			prov, _ := c.GetProvider()
+			prov, _ := app.GetProvider()
 
 			if provider == "pantheon" {
 				pantheonProvider := prov.(*ddevapp.PantheonProvider)
@@ -119,13 +119,13 @@ var ConfigCommand = &cobra.Command{
 			// But pantheon *does* validate "Name"
 			err = prov.Validate()
 			if err != nil {
-				util.Failed("Failed to validate sitename %v and environment %v with provider %v: %v", c.Name, pantheonEnvironment, provider, err)
+				util.Failed("Failed to validate sitename %v and environment %v with provider %v: %v", app.Name, pantheonEnvironment, provider, err)
 			} else {
-				util.Success("Using pantheon sitename '%s' and environment '%s'.", c.Name, pantheonEnvironment)
+				util.Success("Using pantheon sitename '%s' and environment '%s'.", app.Name, pantheonEnvironment)
 			}
 
 		}
-		err = c.Write()
+		err = app.WriteConfig()
 		if err != nil {
 			util.Failed("Could not write ddev config file: %v", err)
 		}

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -94,9 +94,9 @@ var ConfigCommand = &cobra.Command{
 			}
 
 			foundAppType, appTypeErr := ddevapp.DetermineAppType(app.Docroot)
-			fullPath, err := filepath.Abs(app.Docroot)
-			if err != nil {
-				util.Failed("Failed to get absolute path to Docroot %s: %v", app.Docroot, err)
+			fullPath, pathErr := filepath.Abs(app.Docroot)
+			if pathErr != nil {
+				util.Failed("Failed to get absolute path to Docroot %s: %v", app.Docroot, pathErr)
 			}
 			if appTypeErr == nil && (appType == "" || appType == foundAppType) { // Found an app, matches passed-in or no apptype passed
 				appType = foundAppType

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -50,7 +50,7 @@ var ConfigCommand = &cobra.Command{
 			provider = args[0]
 		}
 
-		c, err := ddevapp.NewConfig(appRoot, provider)
+		c, err := ddevapp.NewApp(appRoot, provider)
 		if err != nil {
 			util.Failed("Could not create new config: %v", err)
 		}

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -107,7 +107,7 @@ func TestDescribeAppFunction(t *testing.T) {
 		assert.EqualValues(v.Dir, desc["approot"].(string))
 
 		out, _ := json.Marshal(desc)
-		assert.Contains(string(out), app.URL())
+		assert.Contains(string(out), app.GetURL())
 		assert.Contains(string(out), app.GetName())
 		assert.Contains(string(out), "\"router_status\":\"healthy\"")
 		assert.Contains(string(out), ddevapp.RenderHomeRootedDir(v.Dir))

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -15,19 +15,19 @@ var DevListCmd = &cobra.Command{
 	Short: "List applications",
 	Long:  `List applications.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		sites := ddevapp.GetApps()
+		apps := ddevapp.GetApps()
 		var appDescs []map[string]interface{}
 
-		if len(sites) < 1 {
+		if len(apps) < 1 {
 			output.UserOut.Println("There are no running ddev applications.")
 			os.Exit(0)
 		}
 
 		table := ddevapp.CreateAppTable()
-		for _, site := range sites {
-			desc, err := site.Describe()
+		for _, app := range apps {
+			desc, err := app.Describe()
 			if err != nil {
-				util.Failed("Failed to describe site %s: %v", site.GetName(), err)
+				util.Failed("Failed to describe site %s: %v", app.GetName(), err)
 			}
 			appDescs = append(appDescs, desc)
 			ddevapp.RenderAppRow(table, desc)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -38,7 +38,7 @@ func TestDevList(t *testing.T) {
 
 		// Look for standard items in the regular ddev list output
 		assert.Contains(string(out), v.Name)
-		assert.Contains(string(out), app.URL())
+		assert.Contains(string(out), app.GetURL())
 		assert.Contains(string(out), app.GetType())
 		assert.Contains(string(out), ddevapp.RenderHomeRootedDir(app.GetAppRoot()))
 

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -40,7 +40,7 @@ func TestDevList(t *testing.T) {
 		assert.Contains(string(out), v.Name)
 		assert.Contains(string(out), app.URL())
 		assert.Contains(string(out), app.GetType())
-		assert.Contains(string(out), ddevapp.RenderHomeRootedDir(app.AppRoot()))
+		assert.Contains(string(out), ddevapp.RenderHomeRootedDir(app.GetAppRoot()))
 
 		// Look through list results in json for this site.
 		found := false
@@ -54,8 +54,8 @@ func TestDevList(t *testing.T) {
 				assert.Contains(item["httpurl"], app.HostName())
 				assert.Contains(item["httpsurl"], app.HostName())
 				assert.EqualValues(app.GetType(), item["type"])
-				assert.EqualValues(ddevapp.RenderHomeRootedDir(app.AppRoot()), item["shortroot"])
-				assert.EqualValues(app.AppRoot(), item["approot"])
+				assert.EqualValues(ddevapp.RenderHomeRootedDir(app.GetAppRoot()), item["shortroot"])
+				assert.EqualValues(app.GetAppRoot(), item["approot"])
 				break
 			}
 		}

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -56,7 +56,7 @@ func appImport(skipConfirmation bool) {
 	}
 
 	util.Success("Successfully Imported.")
-	util.Success("Your application can be reached at: %s", app.URL())
+	util.Success("Your application can be reached at: %s", app.GetURL())
 }
 
 func init() {

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -42,7 +42,7 @@ var DdevRestartCmd = &cobra.Command{
 		}
 
 		util.Success("Successfully restarted %s", app.GetName())
-		util.Success("Your application can be reached at: %s", app.URL())
+		util.Success("Your application can be reached at: %s", app.GetURL())
 	},
 }
 

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -29,7 +29,7 @@ func TestDevRestart(t *testing.T) {
 		}
 
 		assert.Contains(string(out), "Your application can be reached at")
-		assert.Contains(string(out), app.URL())
+		assert.Contains(string(out), app.GetURL())
 
 		cleanup()
 	}
@@ -71,7 +71,7 @@ func TestDevRestartJSON(t *testing.T) {
 
 		// Go ahead and look for normal strings within the json output.
 		assert.Contains(string(out), "Your application can be reached at")
-		assert.Contains(string(out), app.URL())
+		assert.Contains(string(out), app.GetURL())
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -63,7 +63,7 @@ func handleSequelProCommand(appLocation string) (string, error) {
 	}
 	dbPublishPort := fmt.Sprint(dockerutil.GetPublishedPort(dbPrivatePort, db))
 
-	tmpFilePath := filepath.Join(app.AppRoot(), ".ddev/sequelpro.spf")
+	tmpFilePath := filepath.Join(app.GetAppRoot(), ".ddev/sequelpro.spf")
 	tmpFile, err := os.Create(tmpFilePath)
 	if err != nil {
 		output.UserOut.Fatalln(err)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -109,7 +109,7 @@ func (app *DdevApp) WriteConfig() error {
 	}
 
 	cfgbytes = append(cfgbytes, []byte(HookTemplate)...)
-	switch app.AppType {
+	switch app.Type {
 	case "drupal8":
 		cfgbytes = append(cfgbytes, []byte(Drupal8Hooks)...)
 	case "drupal7":
@@ -170,7 +170,7 @@ func (app *DdevApp) ReadConfig() error {
 	app.DataDir = filepath.Join(dirPath, "mysql")
 	app.ImportDir = filepath.Join(dirPath, "import-db")
 
-	app.setSiteSettingsPaths(app.AppType)
+	app.setSiteSettingsPaths(app.Type)
 
 	return err
 }
@@ -191,7 +191,7 @@ func (app *DdevApp) PromptForConfig() error {
 	app.WarnIfConfigReplace()
 
 	for {
-		err := app.appNamePrompt()
+		err := app.promptForName()
 
 		if err == nil {
 			break
@@ -235,9 +235,9 @@ func (app *DdevApp) ValidateConfig() error {
 	}
 
 	// validate apptype
-	match = IsAllowedAppType(app.AppType)
+	match = IsAllowedAppType(app.Type)
 	if !match {
-		return fmt.Errorf("'%s' is not a valid apptype", app.AppType)
+		return fmt.Errorf("'%s' is not a valid apptype", app.Type)
 	}
 
 	return nil
@@ -291,7 +291,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	templateVars := map[string]string{
 		"name":        app.Name,
 		"plugin":      "ddev",
-		"appType":     app.AppType,
+		"appType":     app.Type,
 		"mailhogport": appports.GetPort("mailhog"),
 		"dbaport":     appports.GetPort("dba"),
 		"dbport":      appports.GetPort("db"),
@@ -302,7 +302,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 }
 
 // Define an application name.
-func (app *DdevApp) appNamePrompt() error {
+func (app *DdevApp) promptForName() error {
 	provider, err := app.GetProvider()
 	if err != nil {
 		return err
@@ -360,7 +360,7 @@ func (app *DdevApp) ConfigExists() bool {
 	return true
 }
 
-// appTypePrompt handles the AppType workflow.
+// appTypePrompt handles the Type workflow.
 func (app *DdevApp) appTypePrompt() error {
 	provider, err := app.GetProvider()
 	if err != nil {
@@ -379,21 +379,21 @@ func (app *DdevApp) appTypePrompt() error {
 	if err == nil {
 		// If we found an application type just set it and inform the user.
 		util.Success("Found a %s codebase at %s.", appType, filepath.Join(app.AppRoot, app.Docroot))
-		app.AppType = appType
-		return provider.ValidateField("AppType", app.AppType)
+		app.Type = appType
+		return provider.ValidateField("Type", app.Type)
 	}
-	typePrompt = fmt.Sprintf("%s (%s)", typePrompt, app.AppType)
+	typePrompt = fmt.Sprintf("%s (%s)", typePrompt, app.Type)
 
 	for IsAllowedAppType(appType) != true {
 		fmt.Printf(typePrompt + ": ")
-		appType = strings.ToLower(util.GetInput(app.AppType))
+		appType = strings.ToLower(util.GetInput(app.Type))
 
 		if IsAllowedAppType(appType) != true {
 			output.UserOut.Errorf("'%s' is not a valid application type. Allowed application types are: %s\n", appType, strings.Join(AllowedAppTypes, ", "))
 		}
-		app.AppType = appType
+		app.Type = appType
 	}
-	return provider.ValidateField("AppType", app.AppType)
+	return provider.ValidateField("Type", app.Type)
 }
 
 // IsAllowedAppType determines if a given string exists in the AllowedAppTypes slice.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -34,27 +34,6 @@ var AllowedAppTypes = []string{"drupal7", "drupal8", "wordpress"}
 // Regexp pattern to determine if a hostname is valid per RFC 1123.
 var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
 
-// Config defines the yaml config file format for ddev applications
-type Config struct {
-	APIVersion            string               `yaml:"APIVersion"`
-	Name                  string               `yaml:"name"`
-	AppType               string               `yaml:"type"`
-	Docroot               string               `yaml:"docroot"`
-	WebImage              string               `yaml:"webimage"`
-	DBImage               string               `yaml:"dbimage"`
-	DBAImage              string               `yaml:"dbaimage"`
-	ConfigPath            string               `yaml:"-"`
-	AppRoot               string               `yaml:"-"`
-	Platform              string               `yaml:"-"`
-	Provider              string               `yaml:"provider,omitempty"`
-	DataDir               string               `yaml:"-"`
-	ImportDir             string               `yaml:"-"`
-	SiteSettingsPath      string               `yaml:"-"`
-	SiteLocalSettingsPath string               `yaml:"-"`
-	providerInstance      Provider             `yaml:"-"`
-	Commands              map[string][]Command `yaml:"hooks,omitempty"`
-}
-
 // Command defines commands to be run as pre/post hooks
 type Command struct {
 	Exec     string `yaml:"exec,omitempty"`

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -111,30 +111,6 @@ func NewConfig(AppRoot string, provider string) (*Config, error) {
 	return c, nil
 }
 
-// GetProvider returns a pointer to the provider instance interface.
-func (c *Config) GetProvider() (Provider, error) {
-	if c.providerInstance != nil {
-		return c.providerInstance, nil
-	}
-
-	var provider Provider
-	err := fmt.Errorf("unknown provider type: %s", c.Provider)
-
-	switch c.Provider {
-	case "pantheon":
-		provider = &PantheonProvider{}
-		err = provider.Init(c)
-	case DefaultProviderName:
-		provider = &DefaultProvider{}
-		err = nil
-	default:
-		provider = &DefaultProvider{}
-		// Use the default error from above.
-	}
-	c.providerInstance = provider
-	return c.providerInstance, err
-}
-
 // GetPath returns the path to an application config file specified by filename.
 func (c *Config) GetPath(filename string) string {
 	return filepath.Join(c.AppRoot, ".ddev", filename)
@@ -274,9 +250,9 @@ func (c *Config) Validate() error {
 	}
 
 	// validate hostname
-	match := hostRegex.MatchString(c.Hostname())
+	match := hostRegex.MatchString(c.GetHostname())
 	if !match {
-		return fmt.Errorf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", c.Hostname())
+		return fmt.Errorf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", c.GetHostname())
 	}
 
 	// validate apptype
@@ -293,8 +269,8 @@ func (c *Config) DockerComposeYAMLPath() string {
 	return c.GetPath("docker-compose.yaml")
 }
 
-// Hostname returns the hostname to the app controlled by this config.
-func (c *Config) Hostname() string {
+// GetHostname returns the hostname to the app controlled by this config.
+func (c *Config) GetHostname() string {
 	return c.Name + "." + version.DDevTLD
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -40,7 +40,7 @@ type Command struct {
 	ExecHost string `yaml:"exec-host,omitempty"`
 }
 
-// Provider in the interface which all provider plugins must implement.
+// Provider is the interface which all provider plugins must implement.
 type Provider interface {
 	Init(app *DdevApp) error
 	ValidateField(string, string) error
@@ -51,7 +51,7 @@ type Provider interface {
 	GetBackup(string) (fileLocation string, importPath string, err error)
 }
 
-// NewApp creates a new Config struct with defaults set and overridden by any existing config.yml.
+// NewApp creates a new DdevApp struct with defaults set and overridden by any existing config.yml.
 func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	// Set defaults.
 	app := &DdevApp{}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -95,7 +95,7 @@ func (app *DdevApp) GetConfigPath(filename string) string {
 	return filepath.Join(app.AppRoot, ".ddev", filename)
 }
 
-// Write the app configuration to the .ddev folder.
+// WriteConfig writes the app configuration into the .ddev folder.
 func (app *DdevApp) WriteConfig() error {
 
 	err := PrepDdevDirectory(filepath.Dir(app.ConfigPath))

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -104,7 +104,6 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	// Create an  app
 	app, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 	app.Name = util.RandString(32)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -26,7 +26,7 @@ func TestNewConfig(t *testing.T) {
 	defer testcommon.Chdir(testDir)()
 
 	// Load a new Config
-	newConfig, err := NewConfig(testDir, DefaultProviderName)
+	newConfig, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 
 	// Ensure the config uses specified defaults.
@@ -37,13 +37,13 @@ func TestNewConfig(t *testing.T) {
 	newConfig.Name = util.RandString(32)
 	newConfig.AppType = "drupal8"
 
-	// Write the newConfig.
+	// WriteConfig the newConfig.
 	err = newConfig.Write()
 	assert.NoError(err)
 	_, err = os.Stat(newConfig.ConfigPath)
 	assert.NoError(err)
 
-	loadedConfig, err := NewConfig(testDir, DefaultProviderName)
+	loadedConfig, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 	assert.Equal(newConfig.Name, loadedConfig.Name)
 	assert.Equal(newConfig.AppType, loadedConfig.AppType)
@@ -71,7 +71,7 @@ func TestPrepDirectory(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	config, err := NewConfig(testDir, DefaultProviderName)
+	config, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 
 	// Prep the directory.
@@ -89,7 +89,7 @@ func TestHostName(t *testing.T) {
 	testDir := testcommon.CreateTmpDir("TestHostName")
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
-	config, err := NewConfig(testDir, DefaultProviderName)
+	config, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 	config.Name = util.RandString(32)
 
@@ -105,12 +105,12 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	defer testcommon.Chdir(testDir)()
 
 	// Create a config
-	config, err := NewConfig(testDir, DefaultProviderName)
+	config, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 	config.Name = util.RandString(32)
 	config.AppType = AllowedAppTypes[0]
 
-	// Write a config to create/prep necessary directories.
+	// WriteConfig a config to create/prep necessary directories.
 	err = config.Write()
 	assert.NoError(err)
 
@@ -149,7 +149,7 @@ func TestConfigCommand(t *testing.T) {
 
 	// Create the ddevapp we'll use for testing.
 	// This will not return an error, since there is no existing config.
-	config, err := NewConfig(testDir, DefaultProviderName)
+	config, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 
 	// Randomize some values to use for Stdin during testing.
@@ -186,7 +186,7 @@ func TestConfigCommand(t *testing.T) {
 func TestRead(t *testing.T) {
 	assert := asrt.New(t)
 
-	// This closely resembles the values one would have from NewConfig()
+	// This closely resembles the values one would have from NewApp()
 	c := &Config{
 		ConfigPath: filepath.Join("testdata", "config.yaml"),
 		AppRoot:    "testdata",
@@ -251,7 +251,7 @@ func TestWrite(t *testing.T) {
 	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestConfigWrite")
 
-	// This closely resembles the values one would have from NewConfig()
+	// This closely resembles the values one would have from NewApp()
 	c := &Config{
 		ConfigPath: filepath.Join(testDir, "config.yaml"),
 		AppRoot:    testDir,
@@ -264,7 +264,7 @@ func TestWrite(t *testing.T) {
 		Provider:   DefaultProviderName,
 	}
 
-	err := c.Write()
+	err := c.WriteConfig()
 	assert.NoError(err)
 
 	out, err := ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))
@@ -273,7 +273,7 @@ func TestWrite(t *testing.T) {
 	assert.Contains(string(out), `exec: "drush cr"`)
 
 	c.AppType = "wordpress"
-	err = c.Write()
+	err = c.WriteConfig()
 	assert.NoError(err)
 
 	out, err = ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -35,7 +35,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(app.WebImage, version.WebImg+":"+version.WebTag)
 	assert.Equal(app.DBAImage, version.DBAImg+":"+version.DBATag)
 	app.Name = util.RandString(32)
-	app.AppType = "drupal8"
+	app.Type = "drupal8"
 
 	// WriteConfig the newConfig.
 	err = app.WriteConfig()
@@ -46,7 +46,7 @@ func TestNewConfig(t *testing.T) {
 	loadedConfig, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 	assert.Equal(app.Name, loadedConfig.Name)
-	assert.Equal(app.AppType, loadedConfig.AppType)
+	assert.Equal(app.Type, loadedConfig.Type)
 
 }
 
@@ -108,7 +108,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	app, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 	app.Name = util.RandString(32)
-	app.AppType = AllowedAppTypes[0]
+	app.Type = AllowedAppTypes[0]
 
 	// WriteConfig a config to create/prep necessary directories.
 	err = app.WriteConfig()
@@ -128,7 +128,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	assert.NoError(err)
 	contentString := string(composeBytes)
 	assert.Contains(contentString, app.Platform)
-	assert.Contains(contentString, app.AppType)
+	assert.Contains(contentString, app.Type)
 }
 
 // TestConfigCommand tests the interactive config options.
@@ -175,7 +175,7 @@ func TestConfigCommand(t *testing.T) {
 
 	// Ensure values were properly set on the config struct.
 	assert.Equal(name, config.Name)
-	assert.Equal("drupal8", config.AppType)
+	assert.Equal("drupal8", config.Type)
 	assert.Equal("docroot", config.Docroot)
 	err = PrepDdevDirectory(testDir)
 	assert.NoError(err)
@@ -208,7 +208,7 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(app.DBImage, version.DBImg+":"+version.DBTag)
 
 	// Values defined in file, we should have values from file
-	assert.Equal(app.AppType, "drupal8")
+	assert.Equal(app.Type, "drupal8")
 	assert.Equal(app.WebImage, "test/testimage:latest")
 }
 
@@ -223,7 +223,7 @@ func TestValidate(t *testing.T) {
 		Name:    "TestValidate",
 		AppRoot: cwd,
 		Docroot: "testdata",
-		AppType: "wordpress",
+		Type:    "wordpress",
 	}
 
 	err = app.ValidateConfig()
@@ -241,9 +241,9 @@ func TestValidate(t *testing.T) {
 	assert.EqualError(err, fmt.Sprintf("no directory could be found at %s. Please enter a valid docroot in your configuration", filepath.Join(cwd, app.Docroot)))
 
 	app.Docroot = "testdata"
-	app.AppType = "potato"
+	app.Type = "potato"
 	err = app.ValidateConfig()
-	assert.EqualError(err, fmt.Sprintf("'%s' is not a valid apptype", app.AppType))
+	assert.EqualError(err, fmt.Sprintf("'%s' is not a valid apptype", app.Type))
 }
 
 // TestWriteConfig tests writing config values to file
@@ -260,7 +260,7 @@ func TestWriteConfig(t *testing.T) {
 		WebImage:   version.WebImg + ":" + version.WebTag,
 		DBImage:    version.DBImg + ":" + version.DBTag,
 		DBAImage:   version.DBAImg + ":" + version.DBATag,
-		AppType:    "drupal8",
+		Type:       "drupal8",
 		Provider:   DefaultProviderName,
 	}
 
@@ -272,7 +272,7 @@ func TestWriteConfig(t *testing.T) {
 	assert.Contains(string(out), "TestWrite")
 	assert.Contains(string(out), `exec: "drush cr"`)
 
-	app.AppType = "wordpress"
+	app.Type = "wordpress"
 	err = app.WriteConfig()
 	assert.NoError(err)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -198,9 +198,9 @@ func TestRead(t *testing.T) {
 		Provider:   DefaultProviderName,
 	}
 
-	err := c.Read()
+	err := c.ReadConfig()
 	if err != nil {
-		t.Fatalf("Unable to c.Read(), err: %v", err)
+		t.Fatalf("Unable to c.ReadConfig(), err: %v", err)
 	}
 
 	// Values not defined in file, we should still have default values

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -83,7 +83,7 @@ func TestPrepDirectory(t *testing.T) {
 	assert.NoError(err)
 }
 
-// TestHostName tests that the TestSite.Hostname() field returns the hostname as expected.
+// TestHostName tests that the config.GetHostname() field returns the hostname as expected.
 func TestHostName(t *testing.T) {
 	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestHostName")
@@ -233,7 +233,7 @@ func TestValidate(t *testing.T) {
 
 	c.Name = "Invalid!"
 	err = c.Validate()
-	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", c.Hostname()))
+	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", c.GetHostname()))
 
 	c.Name = "valid"
 	c.Docroot = "invalid"

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -89,11 +89,11 @@ func TestHostName(t *testing.T) {
 	testDir := testcommon.CreateTmpDir("TestHostName")
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
-	config, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
-	config.Name = util.RandString(32)
+	app.Name = util.RandString(32)
 
-	assert.Equal(config.Hostname(), config.Name+"."+version.DDevTLD)
+	assert.Equal(app.GetHostname(), app.Name+"."+version.DDevTLD)
 }
 
 // TestWriteDockerComposeYaml tests the writing of a docker-compose.yaml file.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -26,27 +26,27 @@ func TestNewConfig(t *testing.T) {
 	defer testcommon.Chdir(testDir)()
 
 	// Load a new Config
-	newConfig, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 
 	// Ensure the config uses specified defaults.
-	assert.Equal(newConfig.APIVersion, CurrentAppVersion)
-	assert.Equal(newConfig.DBImage, version.DBImg+":"+version.DBTag)
-	assert.Equal(newConfig.WebImage, version.WebImg+":"+version.WebTag)
-	assert.Equal(newConfig.DBAImage, version.DBAImg+":"+version.DBATag)
-	newConfig.Name = util.RandString(32)
-	newConfig.AppType = "drupal8"
+	assert.Equal(app.APIVersion, CurrentAppVersion)
+	assert.Equal(app.DBImage, version.DBImg+":"+version.DBTag)
+	assert.Equal(app.WebImage, version.WebImg+":"+version.WebTag)
+	assert.Equal(app.DBAImage, version.DBAImg+":"+version.DBATag)
+	app.Name = util.RandString(32)
+	app.AppType = "drupal8"
 
 	// WriteConfig the newConfig.
-	err = newConfig.Write()
+	err = app.WriteConfig()
 	assert.NoError(err)
-	_, err = os.Stat(newConfig.ConfigPath)
+	_, err = os.Stat(app.ConfigPath)
 	assert.NoError(err)
 
 	loadedConfig, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
-	assert.Equal(newConfig.Name, loadedConfig.Name)
-	assert.Equal(newConfig.AppType, loadedConfig.AppType)
+	assert.Equal(app.Name, loadedConfig.Name)
+	assert.Equal(app.AppType, loadedConfig.AppType)
 
 }
 
@@ -104,31 +104,31 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	// Create a config
-	config, err := NewApp(testDir, DefaultProviderName)
+	// Create an  app
+	app, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
-	config.Name = util.RandString(32)
-	config.AppType = AllowedAppTypes[0]
+	app.Name = util.RandString(32)
+	app.AppType = AllowedAppTypes[0]
 
 	// WriteConfig a config to create/prep necessary directories.
-	err = config.Write()
+	err = app.WriteConfig()
 	assert.NoError(err)
 
 	// After the config has been written and directories exist, the write should work.
-	err = config.WriteDockerComposeConfig()
+	err = app.WriteDockerComposeConfig()
 	assert.NoError(err)
 
 	// Ensure we can read from the file and that it's a regular file with the expected name.
-	fileinfo, err := os.Stat(config.DockerComposeYAMLPath())
+	fileinfo, err := os.Stat(app.DockerComposeYAMLPath())
 	assert.NoError(err)
 	assert.False(fileinfo.IsDir())
-	assert.Equal(fileinfo.Name(), filepath.Base(config.DockerComposeYAMLPath()))
+	assert.Equal(fileinfo.Name(), filepath.Base(app.DockerComposeYAMLPath()))
 
-	composeBytes, err := ioutil.ReadFile(config.DockerComposeYAMLPath())
+	composeBytes, err := ioutil.ReadFile(app.DockerComposeYAMLPath())
 	assert.NoError(err)
 	contentString := string(composeBytes)
-	assert.Contains(contentString, config.Platform)
-	assert.Contains(contentString, config.AppType)
+	assert.Contains(contentString, app.Platform)
+	assert.Contains(contentString, app.AppType)
 }
 
 // TestConfigCommand tests the interactive config options.
@@ -182,12 +182,12 @@ func TestConfigCommand(t *testing.T) {
 
 }
 
-// TestRead tests reading config values from file and fallback to defaults for values not exposed.
-func TestRead(t *testing.T) {
+// TestReadConfig tests reading config values from file and fallback to defaults for values not exposed.
+func TestReadConfig(t *testing.T) {
 	assert := asrt.New(t)
 
 	// This closely resembles the values one would have from NewApp()
-	c := &Config{
+	app := &DdevApp{
 		ConfigPath: filepath.Join("testdata", "config.yaml"),
 		AppRoot:    "testdata",
 		APIVersion: CurrentAppVersion,
@@ -198,18 +198,18 @@ func TestRead(t *testing.T) {
 		Provider:   DefaultProviderName,
 	}
 
-	err := c.ReadConfig()
+	err := app.ReadConfig()
 	if err != nil {
 		t.Fatalf("Unable to c.ReadConfig(), err: %v", err)
 	}
 
 	// Values not defined in file, we should still have default values
-	assert.Equal(c.Name, "TestRead")
-	assert.Equal(c.DBImage, version.DBImg+":"+version.DBTag)
+	assert.Equal(app.Name, "TestRead")
+	assert.Equal(app.DBImage, version.DBImg+":"+version.DBTag)
 
 	// Values defined in file, we should have values from file
-	assert.Equal(c.AppType, "drupal8")
-	assert.Equal(c.WebImage, "test/testimage:latest")
+	assert.Equal(app.AppType, "drupal8")
+	assert.Equal(app.WebImage, "test/testimage:latest")
 }
 
 // TestValidate tests validation of configuration values.
@@ -219,40 +219,40 @@ func TestValidate(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(err)
 
-	c := &Config{
+	app := &DdevApp{
 		Name:    "TestValidate",
 		AppRoot: cwd,
 		Docroot: "testdata",
 		AppType: "wordpress",
 	}
 
-	err = c.ValidateConfig()
+	err = app.ValidateConfig()
 	if err != nil {
-		t.Fatalf("Failed to c.ValidateConfig(), err=%v", err)
+		t.Fatalf("Failed to app.ValidateConfig(), err=%v", err)
 	}
 
-	c.Name = "Invalid!"
-	err = c.ValidateConfig()
-	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", c.GetHostname()))
+	app.Name = "Invalid!"
+	err = app.ValidateConfig()
+	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", app.GetHostname()))
 
-	c.Name = "valid"
-	c.Docroot = "invalid"
-	err = c.ValidateConfig()
-	assert.EqualError(err, fmt.Sprintf("no directory could be found at %s. Please enter a valid docroot in your configuration", filepath.Join(cwd, c.Docroot)))
+	app.Name = "valid"
+	app.Docroot = "invalid"
+	err = app.ValidateConfig()
+	assert.EqualError(err, fmt.Sprintf("no directory could be found at %s. Please enter a valid docroot in your configuration", filepath.Join(cwd, app.Docroot)))
 
-	c.Docroot = "testdata"
-	c.AppType = "potato"
-	err = c.ValidateConfig()
-	assert.EqualError(err, fmt.Sprintf("'%s' is not a valid apptype", c.AppType))
+	app.Docroot = "testdata"
+	app.AppType = "potato"
+	err = app.ValidateConfig()
+	assert.EqualError(err, fmt.Sprintf("'%s' is not a valid apptype", app.AppType))
 }
 
-// TestWrite tests writing config values to file
-func TestWrite(t *testing.T) {
+// TestWriteConfig tests writing config values to file
+func TestWriteConfig(t *testing.T) {
 	assert := asrt.New(t)
 	testDir := testcommon.CreateTmpDir("TestConfigWrite")
 
 	// This closely resembles the values one would have from NewApp()
-	c := &Config{
+	app := &DdevApp{
 		ConfigPath: filepath.Join(testDir, "config.yaml"),
 		AppRoot:    testDir,
 		APIVersion: CurrentAppVersion,
@@ -264,7 +264,7 @@ func TestWrite(t *testing.T) {
 		Provider:   DefaultProviderName,
 	}
 
-	err := c.WriteConfig()
+	err := app.WriteConfig()
 	assert.NoError(err)
 
 	out, err := ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))
@@ -272,8 +272,8 @@ func TestWrite(t *testing.T) {
 	assert.Contains(string(out), "TestWrite")
 	assert.Contains(string(out), `exec: "drush cr"`)
 
-	c.AppType = "wordpress"
-	err = c.WriteConfig()
+	app.AppType = "wordpress"
+	err = app.WriteConfig()
 	assert.NoError(err)
 
 	out, err = ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -71,15 +71,15 @@ func TestPrepDirectory(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	config, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 
 	// Prep the directory.
-	err = PrepDdevDirectory(filepath.Dir(config.ConfigPath))
+	err = PrepDdevDirectory(filepath.Dir(app.ConfigPath))
 	assert.NoError(err)
 
 	// Read directory info an ensure it exists.
-	_, err = os.Stat(filepath.Dir(config.ConfigPath))
+	_, err = os.Stat(filepath.Dir(app.ConfigPath))
 	assert.NoError(err)
 }
 
@@ -147,8 +147,8 @@ func TestConfigCommand(t *testing.T) {
 	}
 
 	// Create the ddevapp we'll use for testing.
-	// This will not return an error, since there is no existing config.
-	config, err := NewApp(testDir, DefaultProviderName)
+	// This will not return an error, since there is no existing configuration.
+	app, err := NewApp(testDir, DefaultProviderName)
 	assert.NoError(err)
 
 	// Randomize some values to use for Stdin during testing.
@@ -163,7 +163,7 @@ func TestConfigCommand(t *testing.T) {
 	util.SetInputScanner(scanner)
 
 	restoreOutput := testcommon.CaptureUserOut()
-	err = config.PromptForConfig()
+	err = app.PromptForConfig()
 	assert.NoError(err, t)
 	out := restoreOutput()
 
@@ -172,10 +172,10 @@ func TestConfigCommand(t *testing.T) {
 	assert.Contains(out, fmt.Sprintf("No directory could be found at %s", filepath.Join(testDir, invalidDir)))
 	assert.Contains(out, fmt.Sprintf("'%s' is not a valid application type", invalidAppType))
 
-	// Ensure values were properly set on the config struct.
-	assert.Equal(name, config.Name)
-	assert.Equal("drupal8", config.Type)
-	assert.Equal("docroot", config.Docroot)
+	// Ensure values were properly set on the app struct.
+	assert.Equal(name, app.Name)
+	assert.Equal("drupal8", app.Type)
+	assert.Equal("docroot", app.Docroot)
 	err = PrepDdevDirectory(testDir)
 	assert.NoError(err)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -226,23 +226,23 @@ func TestValidate(t *testing.T) {
 		AppType: "wordpress",
 	}
 
-	err = c.Validate()
+	err = c.ValidateConfig()
 	if err != nil {
-		t.Fatalf("Failed to c.Validate(), err=%v", err)
+		t.Fatalf("Failed to c.ValidateConfig(), err=%v", err)
 	}
 
 	c.Name = "Invalid!"
-	err = c.Validate()
+	err = c.ValidateConfig()
 	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", c.GetHostname()))
 
 	c.Name = "valid"
 	c.Docroot = "invalid"
-	err = c.Validate()
+	err = c.ValidateConfig()
 	assert.EqualError(err, fmt.Sprintf("no directory could be found at %s. Please enter a valid docroot in your configuration", filepath.Join(cwd, c.Docroot)))
 
 	c.Docroot = "testdata"
 	c.AppType = "potato"
-	err = c.Validate()
+	err = c.ValidateConfig()
 	assert.EqualError(err, fmt.Sprintf("'%s' is not a valid apptype", c.AppType))
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -46,11 +46,9 @@ const SiteConfigMissing = ".ddev/config.yaml missing"
 // SiteStopped defines the string used to denote when a site is in the stopped state.
 const SiteStopped = "stopped"
 
-// DdevApp is the struct that represents a ddev app, including its config
+// DdevApp is the struct that represents a ddev app, mostly its config
 // from config.yaml.
 type DdevApp struct {
-	AppConfig *Config
-
 	APIVersion            string               `yaml:"APIVersion"`
 	Name                  string               `yaml:"name"`
 	AppType               string               `yaml:"type"`
@@ -869,7 +867,7 @@ func (app *DdevApp) Down(removeData bool) error {
 			}
 		}
 		// Check that app.DataDir is a directory that is safe to remove.
-		err = validateDataDirRemoval(app.AppConfig)
+		err = validateDataDirRemoval(app)
 		if err != nil {
 			return fmt.Errorf("failed to remove data directories: %v", err)
 		}
@@ -1048,8 +1046,8 @@ func restoreApp(app *DdevApp, siteName string) error {
 }
 
 // validateDataDirRemoval validates that dataDir is a safe filepath to be removed by ddev.
-func validateDataDirRemoval(config *Config) error {
-	dataDir := config.DataDir
+func validateDataDirRemoval(app *DdevApp) error {
+	dataDir := app.DataDir
 	unsafeFilePathErr := fmt.Errorf("filepath: %s unsafe for removal", dataDir)
 	// Check for an empty filepath
 	if dataDir == "" {
@@ -1067,7 +1065,7 @@ func validateDataDirRemoval(config *Config) error {
 	// Get the last element of dataDir and use it to check that there is something after GlobalDdevDir.
 	lastPathElem := filepath.Base(dataDir)
 	nextLastPathElem := filepath.Base(filepath.Dir(dataDir))
-	if lastPathElem == ".ddev" || nextLastPathElem != config.Name || lastPathElem == "" {
+	if lastPathElem == ".ddev" || nextLastPathElem != app.Name || lastPathElem == "" {
 		return unsafeFilePathErr
 	}
 	return nil

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -51,7 +51,7 @@ const SiteStopped = "stopped"
 type DdevApp struct {
 	APIVersion            string               `yaml:"APIVersion"`
 	Name                  string               `yaml:"name"`
-	AppType               string               `yaml:"type"`
+	Type                  string               `yaml:"type"`
 	Docroot               string               `yaml:"docroot"`
 	WebImage              string               `yaml:"webimage"`
 	DBImage               string               `yaml:"dbimage"`
@@ -70,7 +70,7 @@ type DdevApp struct {
 
 // GetType returns the application type as a (lowercase) string
 func (app *DdevApp) GetType() string {
-	return strings.ToLower(app.AppType)
+	return strings.ToLower(app.Type)
 }
 
 // Init populates DdevApp config based on the current working directory.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -931,7 +931,7 @@ func (app *DdevApp) AddHostsEntry() error {
 
 	_, err = osexec.Command("sudo", "-h").Output()
 	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
-		util.Warning("You must manually add the following entry to your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname %s %s", dockerIP, app.HostName(), app.HostName(), dockerIP)
+		util.Warning("You must manually add the following entry to your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname %s %s'", dockerIP, app.HostName(), app.HostName(), dockerIP)
 		return nil
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -151,8 +151,8 @@ func (app *DdevApp) Describe() (map[string]interface{}, error) {
 		dbinfo["published_port"] = fmt.Sprint(dockerutil.GetPublishedPort(dbPrivatePort, db))
 		appDesc["dbinfo"] = dbinfo
 
-		appDesc["mailhog_url"] = app.URL() + ":" + appports.GetPort("mailhog")
-		appDesc["phpmyadmin_url"] = app.URL() + ":" + appports.GetPort("dba")
+		appDesc["mailhog_url"] = app.GetURL() + ":" + appports.GetPort("mailhog")
+		appDesc["phpmyadmin_url"] = app.GetURL() + ":" + appports.GetPort("dba")
 	}
 
 	appDesc["router_status"] = GetRouterStatus()
@@ -275,7 +275,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string) error {
 	}
 
 	if app.GetType() == "wordpress" {
-		util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", app.URL())
+		util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", app.GetURL())
 	}
 
 	err = fileutil.PurgeDirectory(dbPath)
@@ -675,7 +675,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_DOCROOT":         app.Docroot,
 		"DDEV_DATADIR":         app.DataDir,
 		"DDEV_IMPORTDIR":       app.ImportDir,
-		"DDEV_URL":             app.URL(),
+		"DDEV_URL":             app.GetURL(),
 		"DDEV_HOSTNAME":        app.HostName(),
 		"DDEV_UID":             "",
 		"DDEV_GID":             "",
@@ -816,7 +816,7 @@ func (app *DdevApp) CreateSettingsFile() error {
 			drushConfig.IsDrupal8 = true
 		}
 
-		drupalConfig.DeployURL = app.URL()
+		drupalConfig.DeployURL = app.GetURL()
 		err = config.WriteDrupalConfig(drupalConfig, settingsFilePath)
 		if err != nil {
 			return err
@@ -830,7 +830,7 @@ func (app *DdevApp) CreateSettingsFile() error {
 	case "wordpress":
 		output.UserOut.Printf("Generating %s file for database connection.", fileName)
 		wpConfig := model.NewWordpressConfig()
-		wpConfig.DeployURL = app.URL()
+		wpConfig.DeployURL = app.GetURL()
 		err := config.WriteWordpressConfig(wpConfig, settingsFilePath)
 		if err != nil {
 			return err
@@ -893,8 +893,8 @@ func (app *DdevApp) Down(removeData bool) error {
 	return err
 }
 
-// URL returns the URL for a given application.
-func (app *DdevApp) URL() string {
+// GetURL returns the URL for an app.
+func (app *DdevApp) GetURL() string {
 	return "http://" + app.GetHostname()
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -78,7 +78,7 @@ func (l *DdevApp) GetType() string {
 // Init populates DdevApp config based on the current working directory.
 // It does not start the containers.
 func (l *DdevApp) Init(basePath string) error {
-	config, err := NewConfig(basePath, "")
+	config, err := NewApp(basePath, "")
 
 	// Save config to l.AppConfig so we can capture and display the site's
 	// status regardless of its validity
@@ -582,7 +582,7 @@ func (l *DdevApp) Start() error {
 		return err
 	}
 
-	// Write docker-compose.yaml (if it doesn't exist).
+	// WriteConfig docker-compose.yaml (if it doesn't exist).
 	// If the user went through the `ddev config` process it will be written already, but
 	// we also do it here in the case of a manually created `.ddev/config.yaml` file.
 	err = l.WriteDockerComposeConfig()
@@ -1085,18 +1085,18 @@ func validateDataDirRemoval(config *Config) error {
 }
 
 // GetProvider returns a pointer to the provider instance interface.
-func (c *Config) GetProvider() (Provider, error) {
-	if c.providerInstance != nil {
-		return c.providerInstance, nil
+func (app *DdevApp) GetProvider() (Provider, error) {
+	if app.providerInstance != nil {
+		return app.providerInstance, nil
 	}
 
 	var provider Provider
-	err := fmt.Errorf("unknown provider type: %s", c.Provider)
+	err := fmt.Errorf("unknown provider type: %s", app.Provider)
 
-	switch c.Provider {
+	switch app.Provider {
 	case "pantheon":
 		provider = &PantheonProvider{}
-		err = provider.Init(c)
+		err = provider.Init(app)
 	case DefaultProviderName:
 		provider = &DefaultProvider{}
 		err = nil
@@ -1104,6 +1104,6 @@ func (c *Config) GetProvider() (Provider, error) {
 		provider = &DefaultProvider{}
 		// Use the default error from above.
 	}
-	c.providerInstance = provider
-	return c.providerInstance, err
+	app.providerInstance = provider
+	return app.providerInstance, err
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -98,6 +98,9 @@ func (app *DdevApp) Init(basePath string) error {
 		}
 		return nil
 	} else if strings.Contains(err.Error(), "could not find containers") {
+		// Init() is just putting together the DdevApp struct, the containers do
+		// not have to exist (app doesn't have to have been started, so the fact
+		// we didn't find any is not an error.
 		return nil
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -76,23 +76,25 @@ func (app *DdevApp) GetType() string {
 // Init populates DdevApp config based on the current working directory.
 // It does not start the containers.
 func (app *DdevApp) Init(basePath string) error {
-	app, err := NewApp(basePath, "")
+	newApp, err := NewApp(basePath, "")
 	if err != nil {
 		return err
 	}
 
-	err = app.ValidateConfig()
+	err = newApp.ValidateConfig()
 	if err != nil {
 		return err
 	}
 
-	web, err := app.FindContainerByType("web")
-	if err == nil {
-		containerApproot := web.Labels["com.ddev.approot"]
-		if containerApproot != app.AppRoot {
-			return fmt.Errorf("a web container in %s state already exists for %s that was created at %s", web.State, app.Name, containerApproot)
-		}
+	web, err := newApp.FindContainerByType("web")
+	if err != nil {
+		return err
 	}
+	containerApproot := web.Labels["com.ddev.approot"]
+	if containerApproot != newApp.AppRoot {
+		return fmt.Errorf("a web container in %s state already exists for %s that was created at %s", web.State, app.Name, containerApproot)
+	}
+	*app = *newApp
 
 	return nil
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -394,7 +394,7 @@ func TestDdevLogs(t *testing.T) {
 	}
 }
 
-// TestProcessHooks tests execution of commands defined in config
+// TestProcessHooks tests execution of commands defined in config.yaml
 func TestProcessHooks(t *testing.T) {
 	assert := asrt.New(t)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -403,10 +403,10 @@ func TestProcessHooks(t *testing.T) {
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ProcessHooks", site.Name))
 
 		testcommon.ClearDockerEnv()
-		conf, err := ddevapp.NewApp(site.Dir, ddevapp.DefaultProviderName)
+		app, err := ddevapp.NewApp(site.Dir, ddevapp.DefaultProviderName)
 		assert.NoError(err)
 
-		conf.Commands = map[string][]ddevapp.Command{
+		app.Commands = map[string][]ddevapp.Command{
 			"hook-test": {
 				{
 					Exec: "pwd",
@@ -416,8 +416,6 @@ func TestProcessHooks(t *testing.T) {
 				},
 			},
 		}
-
-		app := &ddevapp.DdevApp{}
 
 		stdout := testcommon.CaptureUserOut()
 		err = app.ProcessHooks("hook-test")

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -403,7 +403,7 @@ func TestProcessHooks(t *testing.T) {
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ProcessHooks", site.Name))
 
 		testcommon.ClearDockerEnv()
-		conf, err := ddevapp.NewConfig(site.Dir, ddevapp.DefaultProviderName)
+		conf, err := ddevapp.NewApp(site.Dir, ddevapp.DefaultProviderName)
 		assert.NoError(err)
 
 		conf.Commands = map[string][]ddevapp.Command{
@@ -730,7 +730,7 @@ func TestListWithoutDir(t *testing.T) {
 	err = os.Chdir(testDir)
 	assert.NoError(err)
 
-	config, err := ddevapp.NewConfig(testDir, "")
+	config, err := ddevapp.NewApp(testDir, "")
 	assert.NoError(err)
 	config.Name = "junk"
 	config.AppType = "drupal7"

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -548,7 +548,7 @@ func TestDescribeMissingDirectory(t *testing.T) {
 
 	desc, err := app.Describe()
 	assert.NoError(err)
-	assert.Contains(desc["status"], ddevapp.SiteDirMissing, "Status did not include the phrase 'app directory missing' when describing a site with missing directories.")
+	assert.Contains(desc["status"], ddevapp.SiteDirMissing, "Status did not include the phrase '%s' when describing a site with missing directories.", ddevapp.SiteDirMissing)
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
 	assert.NoError(err)
@@ -728,7 +728,7 @@ func TestListWithoutDir(t *testing.T) {
 	err = os.Chdir(testDir)
 	assert.NoError(err)
 
-	app, err := ddevapp.NewApp(testDir, "")
+	app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
 	assert.NoError(err)
 	app.Name = "junk"
 	app.AppType = "drupal7"
@@ -766,7 +766,7 @@ func TestListWithoutDir(t *testing.T) {
 
 		ddevapp.RenderAppRow(table, desc)
 	}
-	assert.Contains(table.String(), fmt.Sprintf("app directory missing: %s", testDir))
+	assert.Contains(table.String(), fmt.Sprintf("%s: %s", ddevapp.SiteDirMissing, testDir))
 
 	err = app.Down(true)
 	assert.NoError(err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -518,8 +518,8 @@ func TestDescribe(t *testing.T) {
 		assert.NoError(err)
 		assert.EqualValues(desc["status"], ddevapp.SiteRunning)
 		assert.EqualValues(app.GetName(), desc["name"])
-		assert.EqualValues(ddevapp.RenderHomeRootedDir(app.AppRoot()), desc["shortroot"])
-		assert.EqualValues(app.AppRoot(), desc["approot"])
+		assert.EqualValues(ddevapp.RenderHomeRootedDir(app.GetAppRoot()), desc["shortroot"])
+		assert.EqualValues(app.GetAppRoot(), desc["approot"])
 
 		// Now stop it and test behavior.
 		err = app.Stop()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -41,7 +41,7 @@ var (
 			DBTarURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.tar.gz",
 			DBZipURL:                      "https://github.com/drud/drupal8/releases/download/v0.6.0/db.zip",
 			FullSiteTarballURL:            "https://github.com/drud/drupal8/releases/download/v0.6.0/site.tar.gz",
-			AppType:                       "drupal8",
+			Type:                          "drupal8",
 		},
 		{
 			Name:                          "TestMainPkgDrupalKickstart",
@@ -729,7 +729,7 @@ func TestListWithoutDir(t *testing.T) {
 	app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
 	assert.NoError(err)
 	app.Name = "junk"
-	app.AppType = "drupal7"
+	app.Type = "drupal7"
 	err = app.WriteConfig()
 	assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -417,12 +417,10 @@ func TestProcessHooks(t *testing.T) {
 			},
 		}
 
-		l := &ddevapp.DdevApp{
-			AppConfig: conf,
-		}
+		app := &ddevapp.DdevApp{}
 
 		stdout := testcommon.CaptureUserOut()
-		err = l.ProcessHooks("hook-test")
+		err = app.ProcessHooks("hook-test")
 		assert.NoError(err)
 		out := stdout()
 
@@ -730,15 +728,15 @@ func TestListWithoutDir(t *testing.T) {
 	err = os.Chdir(testDir)
 	assert.NoError(err)
 
-	config, err := ddevapp.NewApp(testDir, "")
+	app, err := ddevapp.NewApp(testDir, "")
 	assert.NoError(err)
-	config.Name = "junk"
-	config.AppType = "drupal7"
-	err = config.Write()
+	app.Name = "junk"
+	app.AppType = "drupal7"
+	err = app.WriteConfig()
 	assert.NoError(err)
 
 	// Do a start on the configured site.
-	app, err := ddevapp.GetActiveApp("")
+	app, err = ddevapp.GetActiveApp("")
 	assert.NoError(err)
 	err = app.Start()
 	assert.NoError(err)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -86,7 +86,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 
 	// Ensure values were properly set on the config struct.
 	assert.Equal(pantheonTestSiteName, config.Name)
-	assert.Equal("drupal8", config.AppType)
+	assert.Equal("drupal8", config.Type)
 	assert.Equal("docroot", config.Docroot)
 	err = PrepDdevDirectory(testDir)
 	assert.NoError(err)
@@ -153,7 +153,7 @@ func TestPantheonPull(t *testing.T) {
 	app, err := NewApp(siteDir, "pantheon")
 	assert.NoError(err)
 	app.Name = pantheonTestSiteName
-	app.AppType = "drupal8"
+	app.Type = "drupal8"
 	err = app.WriteConfig()
 	assert.NoError(err)
 

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -150,26 +150,26 @@ func TestPantheonPull(t *testing.T) {
 	err = os.Chdir(siteDir)
 	assert.NoError(err)
 
-	config, err := NewApp(siteDir, "pantheon")
+	app, err := NewApp(siteDir, "pantheon")
 	assert.NoError(err)
-	config.Name = pantheonTestSiteName
-	config.AppType = "drupal8"
-	err = config.Write()
+	app.Name = pantheonTestSiteName
+	app.AppType = "drupal8"
+	err = app.WriteConfig()
 	assert.NoError(err)
 
 	testcommon.ClearDockerEnv()
 
 	provider := PantheonProvider{}
-	err = provider.Init(config)
+	err = provider.Init(app)
 	assert.NoError(err)
 
 	provider.Sitename = pantheonTestSiteName
 	provider.EnvironmentName = pantheonTestEnvName
-	err = provider.Write(config.GetConfigPath("import.yaml"))
+	err = provider.Write(app.GetConfigPath("import.yaml"))
 	assert.NoError(err)
 
 	// Ensure we can do a pull on the configured site.
-	app, err := GetActiveApp("")
+	app, err = GetActiveApp("")
 	assert.NoError(err)
 	err = app.Import()
 	assert.NoError(err)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -46,7 +46,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	}
 
 	// Create the ddevapp we'll use for testing.
-	config, err := NewApp(testDir, "pantheon")
+	app, err := NewApp(testDir, "pantheon")
 	assert.NoError(err)
 
 	// Randomize some values to use for Stdin during testing.
@@ -69,12 +69,12 @@ func TestPantheonConfigCommand(t *testing.T) {
 	util.SetInputScanner(scanner)
 
 	restoreOutput := testcommon.CaptureUserOut()
-	err = config.PromptForConfig()
+	err = app.PromptForConfig()
 	assert.NoError(err, t)
 	out := restoreOutput()
 
 	// Get the provider interface and ensure it validates.
-	provider, err := config.GetProvider()
+	provider, err := app.GetProvider()
 	assert.NoError(err)
 	err = provider.Validate()
 	assert.NoError(err)
@@ -84,10 +84,10 @@ func TestPantheonConfigCommand(t *testing.T) {
 	assert.Contains(out, fmt.Sprintf("could not find a pantheon site named %s", invalidName))
 	assert.Contains(out, fmt.Sprintf("could not find an environment named '%s'", invalidEnvironment))
 
-	// Ensure values were properly set on the config struct.
-	assert.Equal(pantheonTestSiteName, config.Name)
-	assert.Equal("drupal8", config.Type)
-	assert.Equal("docroot", config.Docroot)
+	// Ensure values were properly set on the app struct.
+	assert.Equal(pantheonTestSiteName, app.Name)
+	assert.Equal("drupal8", app.Type)
+	assert.Equal("docroot", app.Docroot)
 	err = PrepDdevDirectory(testDir)
 	assert.NoError(err)
 }
@@ -106,12 +106,12 @@ func TestPantheonBackupLinks(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	config, err := NewApp(testDir, "pantheon")
+	app, err := NewApp(testDir, "pantheon")
 	assert.NoError(err)
-	config.Name = pantheonTestSiteName
+	app.Name = pantheonTestSiteName
 
 	provider := PantheonProvider{}
-	err = provider.Init(config)
+	err = provider.Init(app)
 	assert.NoError(err)
 
 	provider.Sitename = pantheonTestSiteName

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -46,7 +46,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	}
 
 	// Create the ddevapp we'll use for testing.
-	config, err := NewConfig(testDir, "pantheon")
+	config, err := NewApp(testDir, "pantheon")
 	assert.NoError(err)
 
 	// Randomize some values to use for Stdin during testing.
@@ -106,7 +106,7 @@ func TestPantheonBackupLinks(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	config, err := NewConfig(testDir, "pantheon")
+	config, err := NewApp(testDir, "pantheon")
 	assert.NoError(err)
 	config.Name = pantheonTestSiteName
 
@@ -150,7 +150,7 @@ func TestPantheonPull(t *testing.T) {
 	err = os.Chdir(siteDir)
 	assert.NoError(err)
 
-	config, err := NewConfig(siteDir, "pantheon")
+	config, err := NewApp(siteDir, "pantheon")
 	assert.NoError(err)
 	config.Name = pantheonTestSiteName
 	config.AppType = "drupal8"
@@ -165,7 +165,7 @@ func TestPantheonPull(t *testing.T) {
 
 	provider.Sitename = pantheonTestSiteName
 	provider.EnvironmentName = pantheonTestEnvName
-	err = provider.Write(config.GetPath("import.yaml"))
+	err = provider.Write(config.GetConfigPath("import.yaml"))
 	assert.NoError(err)
 
 	// Ensure we can do a pull on the configured site.

--- a/pkg/ddevapp/providerDefault.go
+++ b/pkg/ddevapp/providerDefault.go
@@ -6,7 +6,7 @@ import "os"
 type DefaultProvider struct{}
 
 // Init provides a no-op for the Init operation.
-func (p *DefaultProvider) Init(config *Config) error {
+func (p *DefaultProvider) Init(app *DdevApp) error {
 	return nil
 }
 

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -20,7 +20,7 @@ import (
 // PantheonProvider provides pantheon-specific import functionality.
 type PantheonProvider struct {
 	ProviderType     string                   `yaml:"provider"`
-	config           *Config                  `yaml:"-"`
+	app              *DdevApp                 `yaml:"-"`
 	Sitename         string                   `yaml:"site"`
 	site             pantheon.Site            `yaml:"-"`
 	siteEnvironments pantheon.EnvironmentList `yaml:"-"`
@@ -41,7 +41,7 @@ func (p *PantheonProvider) Init(app *DdevApp) error {
 	return err
 }
 
-// ValidateField provides field level validation for config settings. This is used any time a field is set via `ddev config` on the primary app config, and allows
+// ValidateField provides field level validation for config settings. This is used any time a field is set via `ddev app` on the primary app config, and allows
 // provider plugins to have additional validation for top level config settings.
 func (p *PantheonProvider) ValidateField(field, value string) error {
 	switch field {
@@ -57,7 +57,7 @@ func (p *PantheonProvider) ValidateField(field, value string) error {
 
 // SetSiteNameAndEnv sets the environment of the provider (dev/test/live)
 func (p *PantheonProvider) SetSiteNameAndEnv(environment string) {
-	p.Sitename = p.config.Name
+	p.Sitename = p.app.Name
 	p.EnvironmentName = environment
 }
 
@@ -132,7 +132,7 @@ func (p *PantheonProvider) prepDownloadDir() {
 func (p *PantheonProvider) getDownloadDir() string {
 	userDir, err := gohomedir.Dir()
 	util.CheckErr(err)
-	destDir := filepath.Join(userDir, ".ddev", "pantheon", p.config.Name)
+	destDir := filepath.Join(userDir, ".ddev", "pantheon", p.app.Name)
 	return destDir
 }
 

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -29,11 +29,10 @@ type PantheonProvider struct {
 }
 
 // Init handles loading data from saved config.
-func (p *PantheonProvider) Init(config *Config) error {
+func (p *PantheonProvider) Init(app *DdevApp) error {
 	var err error
-	p.config = config
 
-	configPath := config.GetPath("import.yaml")
+	configPath := app.GetConfigPath("import.yaml")
 	if fileutil.FileExists(configPath) {
 		err = p.Read(configPath)
 	}

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -41,8 +41,10 @@ func (p *PantheonProvider) Init(app *DdevApp) error {
 	return err
 }
 
-// ValidateField provides field level validation for config settings. This is used any time a field is set via `ddev app` on the primary app config, and allows
-// provider plugins to have additional validation for top level config settings.
+// ValidateField provides field level validation for config settings. This is
+// used any time a field is set via `ddev config` on the primary app config, and
+// allows provider plugins to have additional validation for top level config
+// settings.
 func (p *PantheonProvider) ValidateField(field, value string) error {
 	switch field {
 	case "Name":

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -32,6 +32,7 @@ type PantheonProvider struct {
 func (p *PantheonProvider) Init(app *DdevApp) error {
 	var err error
 
+	p.app = app
 	configPath := app.GetConfigPath("import.yaml")
 	if fileutil.FileExists(configPath) {
 		err = p.Read(configPath)

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -42,6 +42,7 @@ func GetApps() [](*DdevApp) {
 			if err != nil {
 				app.Name = siteContainer.Labels["com.ddev.site-name"]
 				app.AppType = siteContainer.Labels["com.ddev.app-type"]
+				app.AppRoot = siteContainer.Labels["com.ddev.approot"]
 			}
 			apps = append(apps, app)
 		}

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -40,8 +40,8 @@ func GetApps() [](*DdevApp) {
 			// Artificially populate sitename and apptype based on labels
 			// if site.Init() failed.
 			if err != nil {
-				site.AppConfig.Name = siteContainer.Labels["com.ddev.site-name"]
-				site.AppConfig.AppType = siteContainer.Labels["com.ddev.app-type"]
+				site.Name = siteContainer.Labels["com.ddev.site-name"]
+				site.AppType = siteContainer.Labels["com.ddev.app-type"]
 			}
 			apps = append(apps, site)
 		}

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -25,25 +25,25 @@ func GetApps() [](*DdevApp) {
 		"com.ddev.platform":          "ddev",
 		"com.docker.compose.service": "web",
 	}
-	sites, err := dockerutil.FindContainersByLabels(labels)
+	containers, err := dockerutil.FindContainersByLabels(labels)
 
 	if err == nil {
-		for _, siteContainer := range sites {
-			site := &DdevApp{}
+		for _, siteContainer := range containers {
+			app := &DdevApp{}
 			approot, ok := siteContainer.Labels["com.ddev.approot"]
 			if !ok {
 				break
 			}
 
-			err = site.Init(approot)
+			err = app.Init(approot)
 
 			// Artificially populate sitename and apptype based on labels
-			// if site.Init() failed.
+			// if app.Init() failed.
 			if err != nil {
-				site.Name = siteContainer.Labels["com.ddev.site-name"]
-				site.AppType = siteContainer.Labels["com.ddev.app-type"]
+				app.Name = siteContainer.Labels["com.ddev.site-name"]
+				app.AppType = siteContainer.Labels["com.ddev.app-type"]
 			}
-			apps = append(apps, site)
+			apps = append(apps, app)
 		}
 	}
 

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -41,7 +41,7 @@ func GetApps() [](*DdevApp) {
 			// if app.Init() failed.
 			if err != nil {
 				app.Name = siteContainer.Labels["com.ddev.site-name"]
-				app.AppType = siteContainer.Labels["com.ddev.app-type"]
+				app.Type = siteContainer.Labels["com.ddev.app-type"]
 				app.AppRoot = siteContainer.Labels["com.ddev.approot"]
 			}
 			apps = append(apps, app)

--- a/pkg/output/text_formatter.go
+++ b/pkg/output/text_formatter.go
@@ -207,7 +207,7 @@ func prefixFieldClashes(data log.Fields) {
 		data["fields.msg"] = m
 	}
 
-	if l, ok := data["level"]; ok {
-		data["fields.level"] = l
+	if level, ok := data["level"]; ok {
+		data["fields.level"] = level
 	}
 }

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -77,7 +77,7 @@ func TestServices(t *testing.T) {
 			assert.NoError(err)
 
 			for _, service := range ServiceFiles {
-				confdir := filepath.Join(app.AppRoot(), ".ddev")
+				confdir := filepath.Join(app.GetAppRoot(), ".ddev")
 				err = fileutil.CopyFile(filepath.Join(ServiceDir, service), filepath.Join(confdir, service))
 				assert.NoError(err)
 			}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -47,9 +47,9 @@ type TestSite struct {
 	HTTPProbeURI string
 	// DocrootBase is the subdirectory witin the site that is the root/index.php
 	DocrootBase string
-	// AppType is the type of application. This can be specified when a config file is not present
+	// Type is the type of application. This can be specified when a config file is not present
 	// for a test site.
-	AppType string
+	Type string
 }
 
 // Prepare downloads and extracts a site codebase to a temporary directory.
@@ -86,8 +86,8 @@ func (site *TestSite) Prepare() error {
 	// ignore app name defined in config file if present.
 	app.Name = site.Name
 
-	if app.AppType == "" {
-		app.AppType = site.AppType
+	if app.Type == "" {
+		app.Type = site.Type
 	}
 
 	err = app.WriteConfig()

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -80,7 +80,7 @@ func (site *TestSite) Prepare() error {
 
 	// Create a config object. Err is ignored as we may not have
 	// a config file to read in from a test site.
-	config, _ := ddevapp.NewConfig(site.Dir, "")
+	config, _ := ddevapp.NewApp(site.Dir, "")
 
 	// Set site name to the name we define for test sites. We'll
 	// ignore site name defined in config file if present.

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -78,19 +78,19 @@ func (site *TestSite) Prepare() error {
 		return fmt.Errorf("Failed to CopyDir from %s to %s, err=%v", cachedSrcDir, site.Dir, err)
 	}
 
-	// Create a config object. Err is ignored as we may not have
+	// Create an app. Err is ignored as we may not have
 	// a config file to read in from a test site.
-	config, _ := ddevapp.NewApp(site.Dir, "")
+	app, _ := ddevapp.NewApp(site.Dir, "")
 
-	// Set site name to the name we define for test sites. We'll
-	// ignore site name defined in config file if present.
-	config.Name = site.Name
+	// Set app name to the name we define for test sites. We'll
+	// ignore app name defined in config file if present.
+	app.Name = site.Name
 
-	if config.AppType == "" {
-		config.AppType = site.AppType
+	if app.AppType == "" {
+		app.AppType = site.AppType
 	}
 
-	err = config.Write()
+	err = app.WriteConfig()
 	if err != nil {
 		return errors.Errorf("Failed to write site config for site %s, dir %s, err: %v", site.Name, site.Dir, err)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

In #458 we already refactored the platform/plugin/local into ddevapp. The final step to finish that is to move the config members up as full members of the ddevapp. This PR does that move.

## Manual Testing Instructions:

Everything should work as it always have. Test it out.

There should be no impact of any kind on the end user.

## Automated Testing Overview:

There is no new functionality, and no new tests.

## Related Issue Link(s):

OP #458
Refactor into ddevapp https://github.com/drud/ddev/pull/561

## Release/Deployment notes:

