### PR TITLE
Add --continuous for ddev ui

### DIFF
--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	//"os"
 	"time"
 
 	"github.com/drud/ddev/pkg/ddevapp"

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
-	"os"
+	//"os"
+	"time"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
+
+var continuous bool
 
 // DevListCmd represents the list command
 var DevListCmd = &cobra.Command{
@@ -18,25 +21,34 @@ var DevListCmd = &cobra.Command{
 		apps := ddevapp.GetApps()
 		var appDescs []map[string]interface{}
 
-		if len(apps) < 1 {
-			output.UserOut.Println("There are no running ddev applications.")
-			os.Exit(0)
-		}
+		for {
 
-		table := ddevapp.CreateAppTable()
-		for _, app := range apps {
-			desc, err := app.Describe()
-			if err != nil {
-				util.Failed("Failed to describe site %s: %v", app.GetName(), err)
+			if len(apps) < 1 {
+				output.UserOut.Println("There are no running ddev applications.")
+			} else {
+				table := ddevapp.CreateAppTable()
+				for _, app := range apps {
+					desc, err := app.Describe()
+					if err != nil {
+						util.Failed("Failed to describe site %s: %v", app.GetName(), err)
+					}
+					appDescs = append(appDescs, desc)
+					ddevapp.RenderAppRow(table, desc)
+				}
+				output.UserOut.WithField("raw", appDescs).Print(table.String() + "\n" + ddevapp.RenderRouterStatus())
 			}
-			appDescs = append(appDescs, desc)
-			ddevapp.RenderAppRow(table, desc)
+
+			if !continuous {
+				break
+			}
+
+			time.Sleep(time.Second)
 		}
 
-		output.UserOut.WithField("raw", appDescs).Print(table.String() + "\n" + ddevapp.RenderRouterStatus())
 	},
 }
 
 func init() {
+	DevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, site information will be emitted once per second")
 	RootCmd.AddCommand(DevListCmd)
 }

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -18,10 +18,9 @@ var DevListCmd = &cobra.Command{
 	Short: "List applications",
 	Long:  `List applications.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		apps := ddevapp.GetApps()
-		var appDescs []map[string]interface{}
-
 		for {
+			apps := ddevapp.GetApps()
+			var appDescs []map[string]interface{}
 
 			if len(apps) < 1 {
 				output.UserOut.Println("There are no running ddev applications.")

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"encoding/json"
+	oexec "os/exec"
+	"time"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
@@ -63,4 +65,25 @@ func TestDevList(t *testing.T) {
 
 	}
 
+}
+
+// TestDdevListContinuous tests the --continuous flag for ddev list.
+func TestDdevListContinuous(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Execute "ddev list --continuous"
+	cmd := oexec.Command(DdevBin, "list", "--continuous")
+	err := cmd.Start()
+	assert.NoError(err)
+
+	// Take a snapshot of the output a little over one second apart.
+	output1 := cmd.CombinedOutput()
+	time.Sleep(time.Millisecond * 1020)
+	output2 := cmd.CombinedOutput()
+
+	// Kill the process we started.
+	cmd.Process.Kill()
+
+	// The two snapshots of output should be different.
+	assert.NotEqual(output1, output2)
 }

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"testing"
 
 	"encoding/json"
@@ -73,19 +74,20 @@ func TestDdevListContinuous(t *testing.T) {
 
 	// Execute "ddev list --continuous"
 	cmd := oexec.Command(DdevBin, "list", "--continuous")
+	var cmdOutput bytes.Buffer
+	cmd.Stdout = &cmdOutput
 	err := cmd.Start()
 	assert.NoError(err)
 
 	// Take a snapshot of the output a little over one second apart.
-	output1, err := cmd.CombinedOutput()
-	assert.NoError(err)
+	output1 := len(cmdOutput.Bytes())
 	time.Sleep(time.Millisecond * 1020)
-	output2, err := cmd.CombinedOutput()
-	assert.NoError(err)
+	output2 := len(cmdOutput.Bytes())
 
 	// Kill the process we started.
 	cmd.Process.Kill()
 
-	// The two snapshots of output should be different.
+	// The two snapshots of output should be different, and output2 should be larger.
 	assert.NotEqual(output1, output2)
+	assert.True((output2 > output1))
 }

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -85,7 +85,8 @@ func TestDdevListContinuous(t *testing.T) {
 	output2 := len(cmdOutput.Bytes())
 
 	// Kill the process we started.
-	cmd.Process.Kill()
+	err = cmd.Process.Kill()
+	assert.NoError(err)
 
 	// The two snapshots of output should be different, and output2 should be larger.
 	assert.NotEqual(output1, output2)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -73,7 +73,6 @@ func TestDevList(t *testing.T) {
 func TestDdevListContinuous(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping TestDdevListContinuous because Windows stdout capture doesn't work.")
-		return
 	}
 
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -72,7 +72,7 @@ func TestDevList(t *testing.T) {
 // TestDdevListContinuous tests the --continuous flag for ddev list.
 func TestDdevListContinuous(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip()
+		t.Skip("Skipping TestDdevListContinuous because Windows stdout capture doesn't work.")
 		return
 	}
 

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -77,9 +77,11 @@ func TestDdevListContinuous(t *testing.T) {
 	assert.NoError(err)
 
 	// Take a snapshot of the output a little over one second apart.
-	output1 := cmd.CombinedOutput()
+	output1, err := cmd.CombinedOutput()
+	assert.NoError(err)
 	time.Sleep(time.Millisecond * 1020)
-	output2 := cmd.CombinedOutput()
+	output2, err := cmd.CombinedOutput()
+	assert.NoError(err)
 
 	// Kill the process we started.
 	cmd.Process.Kill()

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"runtime"
 	"testing"
 
 	"encoding/json"
@@ -70,6 +71,11 @@ func TestDevList(t *testing.T) {
 
 // TestDdevListContinuous tests the --continuous flag for ddev list.
 func TestDdevListContinuous(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+		return
+	}
+
 	assert := asrt.New(t)
 
 	// Execute "ddev list --continuous"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The UI needs to be updated when the site list changes (https://github.com/drud/ddev/issues/552).

## How this PR Solves The Problem:

This PR adds a `--continuous` flag to `ddev list`. When set, ddev won't exit, and instead will re-emit site information after a hardcoded delay of 1 second. This works for both the standard table output and JSON output.

## Manual Testing Instructions:

* Run `ddev list` - should work as before
* Run `ddev list -j` - should work as before.
* Run `ddev list --continuous` -- should output table continuously. Open a separate terminal window and create a ddev environment, and you should see the output change as the site comes up.
* Run `ddev list --continuous -j` -- should output json continuously. Open a separate terminal window and create a ddev environment and you should see the output change as the site comes up.

## Automated Testing Overview:

WIP

## Related Issue Link(s):

https://github.com/drud/ddev/issues/552

## Release/Deployment notes:


