### PR TITLE
Surf build.sh needs to update any images that may be cached

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,8 @@ echo "Warning: deleting all docker containers and deleting ~/.ddev/Test*"
 if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
 	docker rm -f $(docker ps -aq)
 fi
+# Update all images that may have changed
+docker images |grep -v REPOSITORY | awk '{print $1":"$2 }' | xargs -L1 docker pull
 rm -rf ~/.ddev/Test*
 
 echo "Running tests..."


### PR DESCRIPTION
## The Problem/Issue/Bug:

When we push a new version of a docker image and keep the tag the same, our surf testbots never update, so may cause tests to fail because the new image is not brought down.

## How this PR Solves The Problem:

At the beginning of the test cycle in build.sh we update existing images with a `docker pull`

## Manual Testing Instructions:

Try running build.sh. You have to have surf though. I think this is a pretty simple and low risk approach.

Really I think that just reviewing the surf results on this PR is good enough.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

