### PR TITLE
Improve comments and signature on 'tail' options in ddev logs testing

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -643,7 +643,8 @@ func (app *DdevApp) ExecWithTty(service string, cmd ...string) error {
 }
 
 // Logs returns logs for a site's given container.
-func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tail string) error {
+// See docker.LogsOptions for more information about valid tailLines values.
+func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines string) error {
 	container, err := app.FindContainerByType(service)
 	if err != nil {
 		return err
@@ -659,8 +660,8 @@ func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tail stri
 		Timestamps:   timestamps,
 	}
 
-	if tail != "" {
-		logOpts.Tail = tail
+	if tailLines != "" {
+		logOpts.Tail = tailLines
 	}
 
 	client := dockerutil.GetDockerClient()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -384,7 +384,7 @@ func TestDdevLogs(t *testing.T) {
 		assert.Contains(out, "Database initialized")
 
 		stdout = testcommon.CaptureUserOut()
-		err = app.Logs("db", false, false, "2")
+		err = app.Logs("db", false, false, "")
 		assert.NoError(err)
 		out = stdout()
 		assert.Contains(out, "MySQL init process done. Ready for start up.")


### PR DESCRIPTION
There were a couple changes in #572 that were valuable separately from switching to mariadb. They've been cherry picked into this branch.