### PR TITLE
Remove special windows handling for docker-compose.exe since it has a typo anyway

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 
@@ -336,9 +335,6 @@ func CheckDockerVersion(versionConstraint string) error {
 // relies on docker-compose being somewhere in the user's $PATH.
 func CheckDockerCompose(versionConstraint string) error {
 	executableName := "docker-compose"
-	if runtime.GOOS == "Windows" {
-		executableName = "docker-compose.exe"
-	}
 
 	path, err := exec.LookPath(executableName)
 	if err != nil {


### PR DESCRIPTION

## The Problem/Issue/Bug:

I happened to notice in code (which I should have noticed when I reviewed) that 'Windows' is capitalized in the docker-compose version check, which means that code was never executed, which means we must not need it. So this PR removes that if that changes 'docker-compose' to 'docker-compose.exe'. 

Before this can be pulled it must be manually tested on Windows.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

