### PR TITLE
Add generic apptype detection using apptype approach in #574

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -93,20 +93,18 @@ var ConfigCommand = &cobra.Command{
 				util.Failed("apptype must be drupal7, drupal8, or wordpress")
 			}
 
-			foundAppType, appTypeErr := ddevapp.DetermineAppType(app.Docroot)
+			foundAppType := app.DetectAppType()
 			fullPath, pathErr := filepath.Abs(app.Docroot)
 			if pathErr != nil {
 				util.Failed("Failed to get absolute path to Docroot %s: %v", app.Docroot, pathErr)
 			}
-			if appTypeErr == nil && (appType == "" || appType == foundAppType) { // Found an app, matches passed-in or no apptype passed
+			if appType == "" || appType == foundAppType { // Found an app, matches passed-in or no apptype passed
 				appType = foundAppType
 				util.Success("Found a %s codebase at %s", foundAppType, fullPath)
-			} else if appType != "" && appTypeErr != nil { // apptype was passed, but we found no app at all
+			} else if appType != "" { // apptype was passed, but we found no app at all
 				util.Warning("You have specified an apptype of %s but no app of that type is found in %s", appType, fullPath)
-			} else if appType != "" && appTypeErr == nil && foundAppType != appType { // apptype was passed, app was found, but not the same type
+			} else if appType != "" && foundAppType != appType { // apptype was passed, app was found, but not the same type
 				util.Warning("You have specified an apptype of %s but an app of type %s was discovered in %s", appType, foundAppType, fullPath)
-			} else {
-				util.Failed("Failed to determine app type (drupal7/drupal8/wordpress).\nYour docroot %v may be incorrect - looking in directory %v, error=%v", app.Docroot, fullPath, appTypeErr)
 			}
 			app.Type = appType
 
@@ -120,7 +118,7 @@ var ConfigCommand = &cobra.Command{
 				pantheonProvider.SetSiteNameAndEnv(pantheonEnvironment)
 			}
 			// But pantheon *does* validate "Name"
-			appTypeErr = prov.Validate()
+			appTypeErr := prov.Validate()
 			if appTypeErr != nil {
 				util.Failed("Failed to validate sitename %v and environment %v with provider %v: %v", app.Name, pantheonEnvironment, provider, appTypeErr)
 			} else {

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -45,8 +45,6 @@ func init() {
 		"wordpress": {
 			createWordpressSettingsFile, getWordpressUploadDir, getWordpressHooks, setWordpressSiteSettingsPaths, isWordpressApp,
 		},
-		"backdrop": {},
-		"typo3":    {},
 	}
 }
 

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -1,0 +1,43 @@
+package ddevapp_test
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestApptypeDetection does a simple test of various filesystem setups to make
+// sure the expected apptype is returned.
+func TestApptypeDetection(t *testing.T) {
+	assert := asrt.New(t)
+
+	fileLocations := map[string]string{
+		"drupal7":   "scripts/drupal.sh",
+		"drupal8":   "core/scripts/drupal.sh",
+		"wordpress": "wp-login.php",
+	}
+
+	for expectedType, expectedPath := range fileLocations {
+		testDir := testcommon.CreateTmpDir("TestApptype")
+
+		// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+		defer testcommon.CleanupDir(testDir)
+		defer testcommon.Chdir(testDir)()
+
+		err := os.MkdirAll(filepath.Join(testDir, filepath.Dir(expectedPath)), 0777)
+		assert.NoError(err)
+
+		_, err = os.OpenFile(filepath.Join(testDir, expectedPath), os.O_RDONLY|os.O_CREATE, 0666)
+		assert.NoError(err)
+
+		app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+		assert.NoError(err)
+
+		foundType := app.DetectAppType()
+		assert.EqualValues(expectedType, foundType)
+	}
+
+}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -405,33 +404,6 @@ func PrepDdevDirectory(dir string) error {
 	}
 
 	return nil
-}
-
-// DetermineAppType uses some predetermined file checks to determine if an app
-// is of any of the known types
-func DetermineAppType(basePath string) (string, error) {
-	defaultLocations := map[string]string{
-		"scripts/drupal.sh":      "drupal7",
-		"core/scripts/drupal.sh": "drupal8",
-		"wp-settings.php":        "wordpress",
-	}
-
-	for k, v := range defaultLocations {
-		fp := filepath.Join(basePath, k)
-		log.WithFields(log.Fields{
-			"file": fp,
-		}).Debug("Looking for app fingerprint.")
-		if _, err := os.Stat(fp); err == nil {
-			log.WithFields(log.Fields{
-				"file": fp,
-				"app":  v,
-			}).Debug("Found app fingerprint.")
-
-			return v, nil
-		}
-	}
-
-	return "", errors.New("DetermineAppType() couldn't determine app's type")
 }
 
 // validateCommandYaml validates command hooks and tasks defined in hooks for config.yaml

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -369,31 +369,24 @@ func (app *DdevApp) appTypePrompt() error {
 	typePrompt := fmt.Sprintf("Application Type [%s]", validAppTypes)
 
 	// First, see if we can auto detect what kind of site it is so we can set a sane default.
-	absDocroot := filepath.Join(app.AppRoot, app.Docroot)
-	log.WithFields(log.Fields{
-		"Location": absDocroot,
-	}).Debug("Attempting to auto-determine application type")
 
-	appType := app.DetectAppType()
-	// If the detected appType is php, we'll ask them to confirm,
+	detectedAppType := app.DetectAppType()
+	// If the detected detectedAppType is php, we'll ask them to confirm,
 	// otherwise go with it.
-	if appType != "php" {
-		// If we found an application type just set it and inform the user.
-		util.Success("Found a %s codebase at %s.", appType, filepath.Join(app.AppRoot, app.Docroot))
-		app.Type = appType
-		return provider.ValidateField("Type", app.Type)
-	}
-	typePrompt = fmt.Sprintf("%s (%s)", typePrompt, app.Type)
+	// If we found an application type just set it and inform the user.
+	util.Success("Found a %s codebase at %s.", detectedAppType, filepath.Join(app.AppRoot, app.Docroot))
+	typePrompt = fmt.Sprintf("%s (%s)", typePrompt, detectedAppType)
+
+	fmt.Printf(typePrompt + ": ")
+	appType := strings.ToLower(util.GetInput(detectedAppType))
 
 	for !IsValidAppType(appType) {
-		fmt.Printf(typePrompt + ": ")
-		appType = strings.ToLower(util.GetInput(app.Type))
+		output.UserOut.Errorf("'%s' is not a valid application type. Allowed application types are: %s\n", appType, validAppTypes)
 
-		if !IsValidAppType(appType) {
-			output.UserOut.Errorf("'%s' is not a valid application type. Allowed application types are: %s\n", appType, validAppTypes)
-		}
-		app.Type = appType
+		fmt.Printf(typePrompt + ": ")
+		appType = strings.ToLower(util.GetInput(appType))
 	}
+	app.Type = appType
 	return provider.ValidateField("Type", app.Type)
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -374,8 +374,10 @@ func (app *DdevApp) appTypePrompt() error {
 		"Location": absDocroot,
 	}).Debug("Attempting to auto-determine application type")
 
-	appType, err := DetermineAppType(absDocroot)
-	if err == nil {
+	appType := app.DetectAppType()
+	// If the detected appType is php, we'll ask them to confirm,
+	// otherwise go with it.
+	if appType != "php" {
 		// If we found an application type just set it and inform the user.
 		util.Success("Found a %s codebase at %s.", appType, filepath.Join(app.AppRoot, app.Docroot))
 		app.Type = appType

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -234,7 +234,7 @@ func setDrupalSiteSettingsPaths(app *DdevApp) {
 
 // isDrupal7App returns true if the app is of type drupal7
 func isDrupal7App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.Docroot, "scripts/drupal.sh")); err == nil {
+	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "scripts/drupal.sh")); err == nil {
 		return true
 	}
 	return false
@@ -242,7 +242,7 @@ func isDrupal7App(app *DdevApp) bool {
 
 // isDrupal8App returns true if the app of of type drupal8
 func isDrupal8App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.Docroot, "core/scripts/drupal.sh")); err == nil {
+	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "core/scripts/drupal.sh")); err == nil {
 		return true
 	}
 	return false

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -6,6 +6,7 @@ import (
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
+
 	"os"
 	"path/filepath"
 	"text/template"
@@ -229,4 +230,20 @@ func setDrupalSiteSettingsPaths(app *DdevApp) {
 	localSettingsFilePath = filepath.Join(settingsFileBasePath, "sites", "default", "settings.local.php")
 	app.SiteSettingsPath = settingsFilePath
 	app.SiteLocalSettingsPath = localSettingsFilePath
+}
+
+// isDrupal7App returns true if the app is of type drupal7
+func isDrupal7App(app *DdevApp) bool {
+	if _, err := os.Stat(filepath.Join(app.Docroot, "scripts/drupal.sh")); err == nil {
+		return true
+	}
+	return false
+}
+
+// isDrupal8App returns true if the app of of type drupal8
+func isDrupal8App(app *DdevApp) bool {
+	if _, err := os.Stat(filepath.Join(app.Docroot, "core/scripts/drupal.sh")); err == nil {
+		return true
+	}
+	return false
 }

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -187,3 +187,11 @@ func setWordpressSiteSettingsPaths(app *DdevApp) {
 	app.SiteSettingsPath = settingsFilePath
 	app.SiteLocalSettingsPath = localSettingsFilePath
 }
+
+// isWordpressApp returns true if the app of of type wordpress
+func isWordpressApp(app *DdevApp) bool {
+	if _, err := os.Stat(filepath.Join(app.Docroot, "wp-login.php")); err == nil {
+		return true
+	}
+	return false
+}

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -190,7 +190,7 @@ func setWordpressSiteSettingsPaths(app *DdevApp) {
 
 // isWordpressApp returns true if the app of of type wordpress
 func isWordpressApp(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.Docroot, "wp-login.php")); err == nil {
+	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "wp-login.php")); err == nil {
 		return true
 	}
 	return false


### PR DESCRIPTION
## The Problem/Issue/Bug:

Apptype detection is done inline in existing code, which makes it hard to maintain. We're now moving all types of app-specific logic into its own file in ddevapp. This PR does that for drupal, wordpress, and php. 

This builds on https://github.com/drud/ddev/pull/574 (generic, extensible apptype handling)

## How this PR Solves The Problem:

* Add an appTypeDetect member to the appTypeMatrix,
* Implement the members for drupal and wordpress
* Create the master user DetectAppType()

## Manual Testing Instructions:

Try it out on some sites. Note that only drupal7, drupal8, and wordpress (and the default "php") are currently implemented.

## Automated Testing Overview:

This adds one test for detection and updates previous tests.

## Related Issue Link(s):

#574 is the basic PR, with much background.
OP: #535 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

