### PR TITLE
Add postImportDBAction capability to apptype matrix

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -288,10 +288,9 @@ func (app *DdevApp) ImportDB(imPath string, extPath string) error {
 		util.Warning("Run 'ddev describe' to find the database credentials for this application.")
 	}
 
-	// @todo: We need a post-import warning hook for this
-	// instead of putting it inline here.
-	if app.GetType() == "wordpress" {
-		util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", app.GetURL())
+	err = app.PostImportDBAction()
+	if err != nil {
+		return fmt.Errorf("failed to execute PostImportDBAction: %v", err)
 	}
 
 	err = fileutil.PurgeDirectory(dbPath)

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -195,3 +195,10 @@ func isWordpressApp(app *DdevApp) bool {
 	}
 	return false
 }
+
+// wordpressPostImportDBAction just emits a warning about updating URLs as is
+// required with wordpress when running on a different URL.
+func wordpressPostImportDBAction(app *DdevApp) error {
+	util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", app.GetURL())
+	return nil
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

One of the one-off things we do is a special warning about fixing the URL stuff when importing a wordpress database. This PR pulls that out of inline code and into the apptype matrix, adding a simple function to wordpress.go to handle it.

## Manual Testing Instructions:

Import a db into a wordpress site. You should get the warning. Import into a Drupal site and you should not get the warning.

## Automated Testing Overview:

I didn't add any testing as there was no behavior change. However, I'm open to testing ideas.

## Related Issue Link(s):

The main tracking here is the base-level PR in #574.
The OP is #535 
I *think* this is the last thing that absolutely must be done for #535, although I expect we'll learn something from our first *new* apptypes.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

