### PR TITLE
Update maintained badge to 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ddev
-[![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) [![Go Report Card](https://goreportcard.com/badge/github.com/drud/ddev)](https://goreportcard.com/report/github.com/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2017.svg)
+[![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) [![Go Report Card](https://goreportcard.com/badge/github.com/drud/ddev)](https://goreportcard.com/report/github.com/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2018.svg)
 
 ![ddev logo](images/ddev_logo.png)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noted that our badges/shields on  on https://github.com/drud/ddev/blob/master/README.md were looking pretty sad. It turns out the badge year seems to have to be updated periodically (like now). The Circleci failing shield is apparently a result of my experimentation with local config files, so it should be fixed with a successful build shortly. 

View the results at https://github.com/rfay/ddev/blob/20180104_fix_maintained_status/README.md

![ddev_readme_md_at_master_ _drud_ddev](https://user-images.githubusercontent.com/112444/34584900-cb2beade-f15a-11e7-98d1-5246df5e2ab0.png)


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


  