### PR TITLE
Fix TestListWithoutDir problem on Darwin

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -764,7 +764,11 @@ func TestListWithoutDir(t *testing.T) {
 
 		ddevapp.RenderAppRow(table, desc)
 	}
-	assert.Contains(table.String(), fmt.Sprintf("%s: %s", ddevapp.SiteDirMissing, testDir))
+
+	// testDir on Windows has backslashes in it, resulting in invalid regexp
+	// Remove them and use ., which is good enough.
+	testDirSafe := strings.Replace(testDir, "\\", ".", -1)
+	assert.Regexp(ddevapp.SiteDirMissing+".*"+testDirSafe, table.String())
 
 	err = app.Down(true)
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

On darwin it seems that the golang table can write out things breaking lines in a way that we don't expect. This may have to do with terminal width expectations, although I can demonstrate it a number of ways. I don't know why it happens on some commits and not on others.

This is the output on the failed assertion. You'll have to make it really wide to see what's happening. But we're listing both http and https URLs and in the process the table manager (with a super-wide appdir) is wrapping in a way that the assertion didn't expect.

	Error:		"NAME  TYPE     LOCATION                                                                                                                         URL(s)                   STATUS                                                                                                                                      
			junk  drupal7  /private/var/folders/7m/133fr9vn6b74srxz5t6t7bs00000gn/T/t-ddev-0bb2ed-2018-01-06T02.21.33Z/TestStartWithoutDdevConfig123986099  http://junk.ddev.local   app directory missing:                                                                                                                      
			                                                                                                                                                https://junk.ddev.local  /private/var/folders/7m/133fr9vn6b74srxz5t6t7bs00000gn/T/t-ddev-0bb2ed-2018-01-06T02.21.33Z/TestStartWithoutDdevConfig123986099             " does not contain "app directory missing: /private/var/folders/7m/133fr9vn6b74srxz5t6t7bs00000gn/T/t-ddev-0bb2ed-2018-01-06T02.21.33Z/TestStartWithoutDdevConfig123986099"


## How this PR Solves The Problem:

Change the rigid exact expectation to a regex instead.

## Manual Testing Instructions:

If this passes a few tests all is good.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

