### PR TITLE
Add support for drupal6 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= v0.9.0
+WebTag ?= v0.9.1
 DBImg ?= drud/mysql-local-57
 DBTag ?= v0.6.3
 RouterImage ?= drud/ddev-router

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -127,6 +127,10 @@ var ConfigCommand = &cobra.Command{
 			} else {
 				util.Success("Using project name '%s' and environment '%s'.", app.Name, pantheonEnvironment)
 			}
+			err = app.ConfigFileOverrideAction()
+			if err != nil {
+				util.Failed("Failed to run ConfigFileOverrideAction: %v", err)
+			}
 
 		}
 		err = app.WriteConfig()

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -38,7 +38,6 @@ var ConfigCommand = &cobra.Command{
 		appRoot, err := os.Getwd()
 		if err != nil {
 			util.Failed("Could not determine current working directory: %v", err)
-
 		}
 
 		provider := ddevapp.DefaultProviderName

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"path"
 
@@ -89,8 +90,10 @@ var ConfigCommand = &cobra.Command{
 			if provider != "pantheon" && pantheonEnvironment != "" {
 				util.Failed("--pantheon-environment can only be used with pantheon provider, for example 'ddev config pantheon --pantheon-environment=dev --docroot=docroot'")
 			}
-			if appType != "" && appType != "drupal7" && appType != "drupal8" && appType != "wordpress" {
-				util.Failed("apptype must be drupal7, drupal8, or wordpress")
+
+			if !ddevapp.IsValidAppType(appType) {
+				validAppTypes := strings.Join(ddevapp.GetValidAppTypes(), ", ")
+				util.Failed("apptype must be one of %s", validAppTypes)
 			}
 
 			foundAppType := app.DetectAppType()
@@ -120,9 +123,9 @@ var ConfigCommand = &cobra.Command{
 			// But pantheon *does* validate "Name"
 			appTypeErr := prov.Validate()
 			if appTypeErr != nil {
-				util.Failed("Failed to validate sitename %v and environment %v with provider %v: %v", app.Name, pantheonEnvironment, provider, appTypeErr)
+				util.Failed("Failed to validate project name %v and environment %v with provider %v: %v", app.Name, pantheonEnvironment, provider, appTypeErr)
 			} else {
-				util.Success("Using pantheon sitename '%s' and environment '%s'.", app.Name, pantheonEnvironment)
+				util.Success("Using project name '%s' and environment '%s'.", app.Name, pantheonEnvironment)
 			}
 
 		}

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -189,6 +189,4 @@ func (app *DdevApp) PostConfigAction() error {
 	// In the future if these get more specialized we may want to add this explicitly
 	// to the apptype matrix instead of doing it here.
 	return genericPostConfigAction(app)
-
-	return nil
 }

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -22,6 +22,10 @@ type appTypeDetect func(app *DdevApp) bool
 // required actions on Wordpress.
 type postImportDBAction func(app *DdevApp) error
 
+// configOverrideAction allows a particular apptype to override elements
+// of the config for that apptype. Key example is drupal6 needing php56
+type configOverrideAction func(app *DdevApp) error
+
 // AppTypeFuncs struct defines the functions that can be called (if populated)
 // for a given appType.
 type AppTypeFuncs struct {
@@ -31,6 +35,7 @@ type AppTypeFuncs struct {
 	apptypeSettingsPaths
 	appTypeDetect
 	postImportDBAction
+	configOverrideAction
 }
 
 // appTypeMatrix is a static map that defines the various functions to be called
@@ -42,13 +47,16 @@ func init() {
 	appTypeMatrix = map[string]AppTypeFuncs{
 		"php": {},
 		"drupal7": {
-			createDrupalSettingsFile, getDrupalUploadDir, getDrupal7Hooks, setDrupalSiteSettingsPaths, isDrupal7App, nil,
+			createDrupalSettingsFile, getDrupalUploadDir, getDrupal7Hooks, setDrupalSiteSettingsPaths, isDrupal7App, nil, drupal7ConfigOverrideAction,
 		},
 		"drupal8": {
-			createDrupalSettingsFile, getDrupalUploadDir, getDrupal8Hooks, setDrupalSiteSettingsPaths, isDrupal8App, nil,
+			createDrupalSettingsFile, getDrupalUploadDir, getDrupal8Hooks, setDrupalSiteSettingsPaths, isDrupal8App, nil, nil,
 		},
 		"wordpress": {
-			createWordpressSettingsFile, getWordpressUploadDir, getWordpressHooks, setWordpressSiteSettingsPaths, isWordpressApp, wordpressPostImportDBAction,
+			createWordpressSettingsFile, getWordpressUploadDir, getWordpressHooks, setWordpressSiteSettingsPaths, isWordpressApp, wordpressPostImportDBAction, nil,
+		},
+		"drupal6": {
+			createDrupal6SettingsFile, getDrupalUploadDir, getDrupal6Hooks, setDrupalSiteSettingsPaths, isDrupal6App, nil, drupal6ConfigOverrideAction,
 		},
 	}
 }
@@ -152,6 +160,16 @@ func (app *DdevApp) PostImportDBAction() error {
 
 	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.postImportDBAction != nil {
 		return appFuncs.postImportDBAction(app)
+	}
+
+	return nil
+}
+
+// ConfigFileOverrideAction gives a chance for an apptype to override any element
+// of config.yaml that it needs to.
+func (app *DdevApp) ConfigFileOverrideAction() error {
+	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.configOverrideAction != nil {
+		return appFuncs.configOverrideAction(app)
 	}
 
 	return nil

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -186,5 +186,9 @@ func (app *DdevApp) PostConfigAction() error {
 		return appFuncs.postConfigAction(app)
 	}
 
+	// In the future if these get more specialized we may want to add this explicitly
+	// to the apptype matrix instead of doing it here.
+	return genericPostConfigAction(app)
+
 	return nil
 }

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -15,7 +15,8 @@ func TestApptypeDetection(t *testing.T) {
 	assert := asrt.New(t)
 
 	fileLocations := map[string]string{
-		"drupal7":   "scripts/drupal.sh",
+		"drupal6":   "misc/ahah.js",
+		"drupal7":   "misc/ajax.js",
 		"drupal8":   "core/scripts/drupal.sh",
 		"wordpress": "wp-login.php",
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -122,7 +122,18 @@ func (app *DdevApp) WriteConfig() error {
 		return err
 	}
 
-	return provider.Write(app.GetConfigPath("import.yaml"))
+	err = provider.Write(app.GetConfigPath("import.yaml"))
+	if err != nil {
+		return err
+	}
+
+	// Allow app-specific post-config action
+	err = app.PostConfigAction()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ReadConfig reads app configuration from a specified location on disk, falling

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -213,6 +213,11 @@ func (app *DdevApp) PromptForConfig() error {
 		return err
 	}
 
+	err = app.ConfigFileOverrideAction()
+	if err != nil {
+		return err
+	}
+
 	err = app.providerInstance.PromptForConfig()
 
 	return err

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -139,7 +139,7 @@ func TestConfigCommand(t *testing.T) {
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {"drupal6", "5.6"},
-		"drupal7phpversion": {"drupal7", "7.0"},
+		"drupal7phpversion": {"drupal7", "7.1"},
 		"drupal8phpversion": {"drupal8", "7.1"},
 	}
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -134,51 +134,64 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 func TestConfigCommand(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
-	testDir := testcommon.CreateTmpDir("TestConfigCommand")
 
-	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
-	defer testcommon.CleanupDir(testDir)
-	defer testcommon.Chdir(testDir)()
-
-	// Create a docroot folder.
-	err := os.Mkdir(filepath.Join(testDir, "docroot"), 0644)
-	if err != nil {
-		t.Errorf("Could not create docroot directory under %s", testDir)
+	const apptypePos = 0
+	const phpVersionPos = 1
+	testMatrix := map[string][]string{
+		"drupal6phpversion": {"drupal6", "5.6"},
+		"drupal7phpversion": {"drupal7", "7.0"},
+		"drupal8phpversion": {"drupal8", "7.1"},
 	}
 
-	// Create the ddevapp we'll use for testing.
-	// This will not return an error, since there is no existing configuration.
-	app, err := NewApp(testDir, DefaultProviderName)
-	assert.NoError(err)
+	for testName, testValues := range testMatrix {
 
-	// Randomize some values to use for Stdin during testing.
-	name := strings.ToLower(util.RandString(16))
-	invalidDir := strings.ToLower(util.RandString(16))
-	invalidAppType := strings.ToLower(util.RandString(8))
+		testDir := testcommon.CreateTmpDir("TestConfigCommand_" + testName)
 
-	// This is a bit hard to follow, but we create an example input buffer that writes the sitename, a (invalid) document root, a valid document root,
-	// an invalid app type, and finally a valid app type (drupal8)
-	input := fmt.Sprintf("%s\n%s\ndocroot\n%s\ndrupal8", name, invalidDir, invalidAppType)
-	scanner := bufio.NewScanner(strings.NewReader(input))
-	util.SetInputScanner(scanner)
+		// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+		defer testcommon.CleanupDir(testDir)
+		defer testcommon.Chdir(testDir)()
 
-	restoreOutput := testcommon.CaptureUserOut()
-	err = app.PromptForConfig()
-	assert.NoError(err, t)
-	out := restoreOutput()
+		// Create a docroot folder.
+		err := os.Mkdir(filepath.Join(testDir, "docroot"), 0644)
+		if err != nil {
+			t.Errorf("Could not create docroot directory under %s", testDir)
+		}
 
-	// Ensure we have expected vales in output.
-	assert.Contains(out, testDir)
-	assert.Contains(out, fmt.Sprintf("No directory could be found at %s", filepath.Join(testDir, invalidDir)))
-	assert.Contains(out, fmt.Sprintf("'%s' is not a valid application type", invalidAppType))
+		// Create the ddevapp we'll use for testing.
+		// This will not return an error, since there is no existing configuration.
+		app, err := NewApp(testDir, DefaultProviderName)
+		assert.NoError(err)
 
-	// Ensure values were properly set on the app struct.
-	assert.Equal(name, app.Name)
-	assert.Equal("drupal8", app.Type)
-	assert.Equal("docroot", app.Docroot)
-	err = PrepDdevDirectory(testDir)
-	assert.NoError(err)
+		// Randomize some values to use for Stdin during testing.
+		name := strings.ToLower(util.RandString(16))
+		invalidDir := strings.ToLower(util.RandString(16))
+		invalidAppType := strings.ToLower(util.RandString(8))
 
+		// Create an example input buffer that writes the sitename, an invalid
+		// document root, a valid document root,
+		// an invalid app type, and finally a valid app type (from test matrix)
+		input := fmt.Sprintf("%s\n%s\ndocroot\n%s\n%s", name, invalidDir, invalidAppType, testValues[apptypePos])
+		scanner := bufio.NewScanner(strings.NewReader(input))
+		util.SetInputScanner(scanner)
+
+		restoreOutput := testcommon.CaptureUserOut()
+		err = app.PromptForConfig()
+		assert.NoError(err, t)
+		out := restoreOutput()
+
+		// Ensure we have expected vales in output.
+		assert.Contains(out, testDir)
+		assert.Contains(out, fmt.Sprintf("No directory could be found at %s", filepath.Join(testDir, invalidDir)))
+		assert.Contains(out, fmt.Sprintf("'%s' is not a valid application type", invalidAppType))
+
+		// Ensure values were properly set on the app struct.
+		assert.Equal(name, app.Name)
+		assert.Equal(testValues[apptypePos], app.Type)
+		assert.Equal("docroot", app.Docroot)
+		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion)
+		err = PrepDdevDirectory(testDir)
+		assert.NoError(err)
+	}
 }
 
 // TestReadConfig tests reading config values from file and fallback to defaults for values not exposed.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -44,9 +44,9 @@ const SiteConfigMissing = ".ddev/config.yaml missing"
 // SiteStopped defines the string used to denote when a site is in the stopped state.
 const SiteStopped = "stopped"
 
-// DdevSettingsFileSignature is the text we use to detect whether a settings file is managed by us.
-// If this string is found, we assume we can replace/update the settings file.
-const DdevSettingsFileSignature = "#ddev-generated"
+// DdevFileSignature is the text we use to detect whether a settings file is managed by us.
+// If this string is found, we assume we can replace/update the file.
+const DdevFileSignature = "#ddev-generated"
 
 // DdevApp is the struct that represents a ddev app, mostly its config
 // from config.yaml.
@@ -772,7 +772,7 @@ func (app *DdevApp) DetermineSettingsPathLocation() (string, error) {
 	for _, loc := range possibleLocations {
 		// If the file is found we need to check for a signature to determine if it's safe to use.
 		if fileutil.FileExists(loc) {
-			signatureFound, err := fileutil.FgrepStringInFile(loc, DdevSettingsFileSignature)
+			signatureFound, err := fileutil.FgrepStringInFile(loc, DdevFileSignature)
 			util.CheckErr(err) // Really can't happen as we already checked for the file existence
 
 			if signatureFound {
@@ -801,7 +801,7 @@ func (app *DdevApp) Down(removeData bool) error {
 	// Remove data/database if we need to.
 	if removeData {
 		if fileutil.FileExists(settingsFilePath) {
-			signatureFound, err := fileutil.FgrepStringInFile(settingsFilePath, DdevSettingsFileSignature)
+			signatureFound, err := fileutil.FgrepStringInFile(settingsFilePath, DdevFileSignature)
 			util.CheckErr(err) // Really can't happen as we already checked for the file existence
 			if signatureFound {
 				err = os.Chmod(settingsFilePath, 0644)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -292,7 +292,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string) error {
 	if err != nil {
 		// @todo: Use a typed error instead of relying on the text of the message.
 		if strings.Contains(err.Error(), "settings files already exist and are being managed") {
-			return fmt.Errorf("failed to write configuration file for %s: %v", app.GetName(), err)
+			return fmt.Errorf("failed to write settings file for %s: %v", app.GetName(), err)
 		}
 		util.Warning("A custom settings file exists for your application, so ddev did not generate one.")
 		util.Warning("Run 'ddev describe' to find the database credentials for this application.")

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -2,6 +2,8 @@ package ddevapp
 
 import (
 	"fmt"
+	"io/ioutil"
+
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/output"
@@ -346,4 +348,137 @@ func drupal7ConfigOverrideAction(app *DdevApp) error {
 func drupal6ConfigOverrideAction(app *DdevApp) error {
 	app.PHPVersion = "5.6"
 	return nil
+}
+
+// dtNginxConfig provides an nginx config override for Drupal 6
+const d6NginxConfig = `
+# Set https to 'on' if x-forwarded-proto is https
+map $http_x_forwarded_proto $fcgi_https {
+    default off;
+    https on;
+}
+
+server {
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
+    # The NGINX_DOCROOT variable is substituted with
+    # its value when the container is started.
+    root $NGINX_DOCROOT;
+    index index.php index.htm index.html;
+
+    # Make site accessible from http://localhost/
+    server_name _;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /var/log/nginx/error.log info;
+    access_log /var/log/nginx/error.log;
+
+    location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to index.html
+        try_files $uri @rewrite;
+
+    }
+
+    location @rewrite {
+        rewrite ^/(.*)$ /index.php?q=$1;
+    }
+
+    # Handle image styles for Drupal 7+
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on socket
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors on;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 240;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+    }
+
+    # Expire rules for static content
+    # Feed
+    location ~* \.(?:rss|atom)$ {
+        expires 1h;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to /.well-known/ is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    ## Regular private file serving (i.e. handled by Drupal).
+    location ^~ /system/files/ {
+        ## For not signaling a 404 in the error log whenever the
+        ## system/files directory is accessed add the line below.
+        ## Note that the 404 is the intended behavior.
+        log_not_found off;
+        access_log off;
+        expires 30d;
+        try_files $uri @rewrite;
+    }
+
+    ## provide a health check endpoint
+    location /healthcheck {
+        access_log off;
+        return 200;
+    }
+
+    error_page 400 401 /40x.html;
+    location = /40x.html {
+            root   /usr/share/nginx/html;
+    }
+
+}
+`
+
+// drupal6PostConfigAction allows us to override the nginx config for d6, since
+// the default is oriented around d7/d8.
+func drupal6PostConfigAction(app *DdevApp) error {
+	// Write a nginx-site.conf
+	filePath := app.GetConfigPath("nginx-site.conf")
+
+	// If the file exists, respect it, give a warning message that we're not doing it.
+	if _, err := os.Stat(filePath); err == nil {
+		util.Warning("The file %s already exists, so not creating a Drupal 6 version of it.", filePath)
+		return nil
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filePath, []byte(d6NginxConfig), 0644)
+	if err != nil {
+		return err
+	}
+	util.CheckClose(file)
+	return nil
+
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -107,6 +107,28 @@ if (!empty($_SERVER["argv"]) && strpos($_SERVER["argv"][0], "drush") && empty($_
 `
 )
 
+const (
+	drupal6Template = `<?php
+{{ $config := . }}
+/**
+ {{ $config.Signature }}: Automatically generated Drupal settings.php file.
+ ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ */
+
+$db_url = '{{ $config.DatabaseDriver }}://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@{{ $config.DatabaseHost }}:{{ $config.DatabasePort }}/{{ $config.DatabaseName }}';
+
+ini_set('session.gc_probability', 1);
+ini_set('session.gc_divisor', 100);
+ini_set('session.gc_maxlifetime', 200000);
+ini_set('session.cookie_lifetime', 2000000);
+
+// This determines whether or not drush should include a custom settings file which allows
+// it to work both within a docker container and natively on the host system.
+if (!empty($_SERVER["argv"]) && strpos($_SERVER["argv"][0], "drush") && empty($_ENV['DEPLOY_NAME'])) {
+  include __DIR__ . '../../../drush.settings.php';
+}
+`
+)
 const drushTemplate = `<?php
 {{ $config := . }}
 $databases['default']['default'] = array(
@@ -143,10 +165,60 @@ func createDrupalSettingsFile(app *DdevApp) (string, error) {
 	return settingsFilePath, nil
 }
 
+// createDrupal6SettingsFile creates the app's settings.php or equivalent,
+// adding things like database host, name, and password
+// Returns the fullpath to settings file and err
+func createDrupal6SettingsFile(app *DdevApp) (string, error) {
+
+	settingsFilePath, err := app.DetermineSettingsPathLocation()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err)
+	}
+	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
+
+	// Currently there isn't any customization done for the drupal config, but
+	// we may want to do some kind of customization in the future.
+	drupalConfig := NewDrupalSettings()
+
+	err = writeDrupal6SettingsFile(drupalConfig, settingsFilePath)
+	if err != nil {
+		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err)
+	}
+
+	return settingsFilePath, nil
+}
+
 // writeDrupalSettingsFile dynamically produces valid settings.php file by combining a configuration
 // object with a data-driven template.
 func writeDrupalSettingsFile(settings *DrupalSettings, filePath string) error {
 	tmpl, err := template.New("settings").Funcs(sprig.TxtFuncMap()).Parse(drupalTemplate)
+	if err != nil {
+		return err
+	}
+
+	// Ensure target directory is writable.
+	dir := filepath.Dir(filePath)
+	err = os.Chmod(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	err = tmpl.Execute(file, settings)
+	if err != nil {
+		return err
+	}
+	util.CheckClose(file)
+	return nil
+}
+
+// writeDrupal6SettingsFile dynamically produces valid settings.php file by combining a configuration
+// object with a data-driven template.
+func writeDrupal6SettingsFile(settings *DrupalSettings, filePath string) error {
+	tmpl, err := template.New("settings").Funcs(sprig.TxtFuncMap()).Parse(drupal6Template)
 	if err != nil {
 		return err
 	}
@@ -216,6 +288,12 @@ func getDrupal7Hooks() []byte {
 	return []byte(Drupal7Hooks)
 }
 
+// getDrupal6Hooks for appending as byte array
+func getDrupal6Hooks() []byte {
+	// We don't have anything new to add yet, so just use Drupal7 version
+	return []byte(Drupal7Hooks)
+}
+
 // getDrupal8Hooks for appending as byte array
 func getDrupal8Hooks() []byte {
 	return []byte(Drupal8Hooks)
@@ -234,7 +312,7 @@ func setDrupalSiteSettingsPaths(app *DdevApp) {
 
 // isDrupal7App returns true if the app is of type drupal7
 func isDrupal7App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "scripts/drupal.sh")); err == nil {
+	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "misc/ajax.js")); err == nil {
 		return true
 	}
 	return false
@@ -246,4 +324,26 @@ func isDrupal8App(app *DdevApp) bool {
 		return true
 	}
 	return false
+}
+
+// isDrupal6App returns true if the app is of type Drupal6
+func isDrupal6App(app *DdevApp) bool {
+	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "misc/ahah.js")); err == nil {
+		return true
+	}
+	return false
+}
+
+// drupal7ConfigOverrideAction overrides php_version for D6, since it is incompatible
+// with php7+
+func drupal7ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = "7.0"
+	return nil
+}
+
+// drupal6ConfigOverrideAction overrides php_version for D6, since it is incompatible
+// with php7+
+func drupal6ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = "5.6"
+	return nil
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -336,10 +336,9 @@ func isDrupal6App(app *DdevApp) bool {
 	return false
 }
 
-// drupal7ConfigOverrideAction overrides php_version for D6, since it is incompatible
-// with php7+
+// drupal7ConfigOverrideAction sets a safe php_version for D7
 func drupal7ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = "7.0"
+	app.PHPVersion = "7.1"
 	return nil
 }
 

--- a/pkg/ddevapp/genericapp.go
+++ b/pkg/ddevapp/genericapp.go
@@ -1,0 +1,30 @@
+package ddevapp
+
+import (
+	"os"
+
+	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/util"
+)
+
+// genericPostConfigAction is the default post-config, and will currently
+// remove an existing nginx-site.conf
+func genericPostConfigAction(app *DdevApp) error {
+	// If an nginx-site.conf exists that we generated, it should be removed by
+	// default
+	filePath := app.GetConfigPath("nginx-site.conf")
+
+	if fileutil.FileExists(filePath) {
+		signatureFound, err := fileutil.FgrepStringInFile(filePath, DdevFileSignature)
+		util.CheckErr(err) // Really can't happen as we already checked for the file existence
+
+		if signatureFound {
+			util.Warning("Removing ddev-generated %s", filePath)
+			err = os.Remove(filePath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -41,7 +41,7 @@ func TestWriteSettings(t *testing.T) {
 		assert.EqualValues(t, expectedSettingsFile, createdFile)
 		_, err = os.Stat(expectedSettingsFile)
 		assert.NoError(t, err)
-		signatureFound, err := fileutil.FgrepStringInFile(expectedSettingsFile, DdevSettingsFileSignature)
+		signatureFound, err := fileutil.FgrepStringInFile(expectedSettingsFile, DdevFileSignature)
 		assert.NoError(t, err)
 		assert.True(t, signatureFound)
 		err = os.Remove(expectedSettingsFile)

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -49,7 +49,7 @@ func NewWordpressConfig() *WordpressConfig {
 		NonceSalt:        util.RandString(64),
 		SecureAuthKey:    util.RandString(64),
 		SecureAuthSalt:   util.RandString(64),
-		Signature:        DdevSettingsFileSignature,
+		Signature:        DdevFileSignature,
 	}
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.9.0" // Note that this is overridden by make
+var WebTag = "v0.9.1" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mysql-local-57" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

We need support for drupal6

## How this PR Solves The Problem:

* Adds d6 detection
* Improves d7 detection
* Adds d6 settings creation
* Adds capability for an apptype to override config, so for d6 this means settings the php_version

## Manual Testing Instructions:

* Bring up a d6 site, review it.
* Review config.yaml
* Import a database and review settings.php or settings.local.php

## Automated Testing Overview:

* Tests are next here

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

After https://github.com/drud/docker.nginx-php-fpm-local/pull/47 makes it in we have to add a new commit with the new minor release on nginx-php-fpm-local
