### PR TITLE
Update docs for remove (and project/site) fixes #599, for #526

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 ![ddev logo](images/ddev_logo.png)
 
-ddev is an open source tool that makes it dead simple to get local PHP development environments up and running within minutes. It's powerful and flexible as a result of its per-project environment configurations, which can be extended, version controlled, and shared. In short, ddev aims to allow development teams to use Docker in their workflow without the complexities of bespoke configuration.
+ddev is an open source tool that makes it simple to get local PHP development environments up and running in minutes. It's powerful and flexible as a result of its per-project environment configurations, which can be extended, version controlled, and shared. In short, ddev aims to allow development teams to use Docker in their workflow without the complexities of bespoke configuration.
 
 ## Getting Started
 
-1. **Check System Requirements:** We support recent versions of macOS, Windows 10, and select Linux distributions that will run docker. ([more info here](https://ddev.readthedocs.io/en/latest/#system-requirements)).
+1. **Check System Requirements:** We support recent versions of macOS, Windows 10, and select Linux distributions that will run docker (ddev requires Docker and docker-compose). ([more info here](https://ddev.readthedocs.io/en/latest/#system-requirements)). 
 2. **Install ddev:** Options include [macOS homebrew](https://ddev.readthedocs.io/en/latest/#homebrew-macos) (recommended), an [install script](https://ddev.readthedocs.io/en/latest/#installation-script-linux-and-macos), or [a manually download](https://ddev.readthedocs.io/en/latest/#manual-installation-linux-and-macos).
 3. **Choose a CMS Quick Start Guide:** 
   - [WordPress](https://ddev.readthedocs.io/en/latest/users/cli-usage#wordpress-quickstart)
@@ -30,7 +30,7 @@ Having trouble? See our [support options below](#support). Additionally, you may
 Just running `ddev` will show you all the commands.
 
 ## Support
-If you're having trouble using ddev, please use these resources to get help with your issue:
+If you're having trouble using ddev, please use these resources to get help:
 
 1. Please review the [ddev Documentation](https://ddev.readthedocs.io) to ensure your question isn't answered there.
 2. Review the [ddev issue queue](https://github.com/drud/ddev/issues) to see if an issue similar to yours already exists.
@@ -41,4 +41,4 @@ If you're having trouble using ddev, please use these resources to get help with
 Interested in contributing to ddev? We would love your suggestions, contributions, and help! Please review our [Guidelines for Contributing](https://github.com/drud/ddev/blob/master/CONTRIBUTING.md), then [create an issue](https://github.com/drud/ddev/issues/new) or open a pull request!
 
 ## Addititional Information
-* **Roadmap:** The [ddev roadmap is publicly available](https://github.com/drud/ddev/wiki/roadmap) and managed by @rickmanelius. Additional requests should be added to the [ddev issue queue](https://github.com/drud/ddev/issues).
+* **Roadmap:** The [ddev roadmap](https://github.com/drud/ddev/wiki/roadmap) is managed by @rickmanelius. We love your input! Make requests in the [ddev issue queue](https://github.com/drud/ddev/issues).

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,7 @@
 - docker-compose 1.10.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
 - OS Support 
   - macOS Sierra and higher (macOS 10.12 and higher)
-  - Linux (See [Linux notes](users/linux_notes.md))
-    * Ubuntu 16.04 LTS
-    * Debian Jessie
-    * Fedora 25
+  - Linux (See [Linux notes](users/linux_notes.md)): Most recent Linux distributions which can run Docker are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+
   - Windows 10 Pro
 
 We are open to expanding this list to include additional OSs as well as improve our existing support for the ones listed above. Please [let us know](https://github.com/drud/ddev/issues/new) if you hit an issue!

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,9 @@
 
 ## System Requirements
 
-- [Docker](https://www.docker.com/community-edition) version 17.05 or greater
-- OS Support
+- [Docker](https://www.docker.com/community-edition) version 17.05 or higher
+- docker-compose 1.10.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
+- OS Support 
   - macOS Sierra and higher (macOS 10.12 and higher)
   - Linux (See [Linux notes](users/linux_notes.md))
     * Ubuntu 16.04 LTS

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,9 @@
 We are open to expanding this list to include additional OSs as well as improve our existing support for the ones listed above. Please [let us know](https://github.com/drud/ddev/issues/new) if you hit an issue!
 
 ### Using ddev with other development environments
-ddev requires ports 80 and 443 to be available for use on your system when sites are running. If you are using another local development environment alongside ddev, please ensure the other environment is turned off or otherwise not occupying ports 80 and 443.
+ddev requires ports 80 and 443 to be available for use on your system when projects are running. If you are using another local development environment alongside ddev, please ensure the other environment is turned off or otherwise not occupying ports 80 and 443.
 
-If you need to use another environment after using ddev, simply ensure all of your ddev sites are stopped or removed. ddev only occupies system ports when at least one site is running.
+If you need to use another environment after using ddev, just stop or remove all of your ddev projects. ddev only occupies system ports when at least one project is running.
 
 ## Installation
 ### Homebrew - macOS

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -1,113 +1,85 @@
 <h1>Using the ddev command line interface (CLI)</h1>
 
-Type `ddev` in a terminal to see the available ddev commands:
+Type `ddev` or `ddev -h`in a terminal windows to see the available ddev commands. There are commands to configure a project, start, stop, remove, describe, etc. Each command also has help. For example, `ddev describe -h`.
 
-```
-➜  ddev
-This Command Line Interface (CLI) gives you the ability to interact with the ddev to create a local development environment.
-
-Usage:
-  ddev [command]
-
-Available Commands:
-  config       Create or modify a ddev application config in the current directory
-  describe     Get a detailed description of a running ddev site.
-  exec         Execute a shell command in the container for a service. Uses the web service by default.
-  hostname     Manage your hostfile entries.
-  import-db    Import the database of an existing site to the local dev environment.
-  import-files Import the uploaded files directory of an existing site to the default public upload directory of your application.
-  list         List applications that exist locally
-  logs         Get the logs from your running services.
-  restart      Restart the local development environment for a site.
-  remove       Remove an application's local services.
-  sequelpro    Easily connect local site to sequelpro
-  ssh          Starts a shell session in the container for a service. Uses the web service by default.
-  start        Start the local development environment for a site.
-  stop         Stop an application's local services.
-  version      print ddev version and component versions
-
-Use "ddev [command] --help" for more information about a command.
-```
 
 ## Quickstart Guides
 
-You can start using ddev with any site just by running a few commands.
+You can start using ddev by running just a few commands. Below are quickstart instructions WordPress, Drupal 7, and Drupal 8.
 
-Below are quickstart instructions Wordpress, Drupal 7, and Drupal 8.
+**Prerequisites:** If you do not have ddev already on your machine, please follow the [installation instructions](../index.md#installation) before beginning the quickstart tutorials.  You'll need *docker* and *docker-compose* to use ddev.
 
-**Prerequisites:** If you do not have ddev already on your machine, please follow the [installation instructions](../index.md#installation) before beginning the quickstart tutorials. 
-
-### Wordpress Quickstart
-To get started using ddev with a Wordpress site, simply clone the site's repository and checkout its directory.
+### WordPress Quickstart
+To get started using ddev with a WordPress project, simply clone the project's repository and checkout its directory.
 
 ```
-git clone https://github.com/user/worpress-site
-cd wordpress-site
+git clone https://github.com/example-user/example-wordpress-site
+cd example-wordpress-site
 ```
 
-From here we can start setting up ddev. Inside of your site's working directory, enter the command:
+From here we can start setting up ddev. Inside your project's working directory, enter the command:
 
 ```
 ddev config
 ```
 
-_Note: ddev config will prompt you for a site name, docroot, and app type._
+_Note: ddev config will prompt you for a project name, docroot, and app type._
 
-After you've run `ddev config`, you're ready to start running your site. To start running ddev, simply enter:
+After you've run `ddev config`, you're ready to start running your project. To start running ddev, simply enter:
 
 ```
 ddev start
 ``` 
 
-When running `ddev start` you should see output informing you that the site's environment is being started. If startup is successful, you'll see a message like the one below telling you where the site can be reached.
+When running `ddev start` you should see output informing you that the project's environment is being started. If startup is successful, you'll see a message like the one below telling you where the project can be reached.
 
 ```
-Successfully started wordpress-site
-Your application can be reached at: http://wordpress-site.ddev.local
+Successfully started example-wordpress-site
+Your application can be reached at: http://example-wordpress-site.ddev.local
 ```
 
-Quickstart instructions regarding database imports, can be found under [Database Imports](#database-imports).
+Quickstart instructions regarding database imports can be found under [Database Imports](#database-imports).
 
 ### Drupal 7 Quickstart
 
-Beginning to use ddev with a Drupal 7 site is as simple as cloning the site's repository and checking out its directory.
+Beginning to use ddev with a Drupal 7 project is as simple as cloning the project's repository and checking out its directory.
 
 ```
 git clone https://github.com/user/my-drupal7-site
 cd my-drupal7-site
 ```
 
-Now to start working with ddev. Inside of your site's working directory, enter the following command:
+Now to start working with ddev. In your project's working directory, enter the following command:
 
 ```
 ddev config
 ```
 
-_Note: ddev config will prompt you for a site name, docroot, and app type._
+_Note: ddev config will prompt you for a project name, docroot, and app type._
 
-After you've run `ddev config` you're ready to start running your site. Run ddev using a simple:
+After you've run `ddev config` you're ready to start running your project. Run ddev using a simple:
 
 ```
 ddev start
 ``` 
 
-When running `ddev start` you should see output informing you that the site's environment is being started. If startup is successful, you'll see a message like the one below telling you where the site can be reached.
+When running `ddev start` you should see output informing you that the project's environment is being started. If startup is successful, you'll see a message like the one below telling you where the project can be reached.
 
 ```
 Successfully started my-drupal7-site
 Your application can be reached at: http://my-drupal7-site.ddev.local
 ```
 
-Quickstart instructions regarding database imports, can be found under [Database Imports](#database-imports).
+Quickstart instructions for database imports can be found under [Database Imports](#database-imports).
 
 ### Drupal 8 Quickstart
 
-You can get started with Drupal 8 sites on ddev either by cloning a git repository or using a new or existing composer project.
+You can get started with Drupal 8 projects on ddev either by cloning a git repository or using a new or existing composer project.
 
 **Git Clone Example**
 
 ```
-git clone https://github.com/user/my-drupal8-site
+git clone https://github.com/example-user/my-drupal8-site
 cd my-drupal8-site
 ```
 
@@ -120,21 +92,21 @@ cd my-drupal8-site
 
 _You can find more information on composer and how to use it [here](https://github.com/drupal-composer/drupal-project)._
 
-The next step is to configure ddev. Inside of your site's working directory, enter the following command:
+The next step is to configure ddev. In your project's working directory, enter the following command:
 
 ```
 ddev config
 ```
 
-_Note: ddev config will prompt you for a site name, docroot, and app type._
+_Note: ddev config will prompt you for a project name, docroot, and app type._
 
-After you've run `ddev config` you're ready to start running your site. Run ddev using a simple:
+After you've run `ddev config` you're ready to start up your project. Run ddev using:
 
 ```
 ddev start
 ``` 
 
-When running `ddev start` you should see output informing you that the site's environment is being started. If startup is successful, you'll see a message like the one below telling you where the site can be reached.
+After running `ddev start` you should see output informing you that the project's environment is being started. If startup is successful, you'll see a message like the one below telling you where the project can be reached.
 
 ```
 Successfully started my-drupal8-site
@@ -143,13 +115,11 @@ Your application can be reached at: http://my-drupal8-site.ddev.local
 
 ### Database Imports
 
-**Important:** Before importing any databases for your site, please remove its' wp-config.php if using Worpress - or settings.php file in the case of Drupal 7/8, if present. 
+**Important:** Before importing any databases for your project, please remove its' wp-config.php if using WordPress - or settings.php file in the case of Drupal 7/8, if present. 
 
-_ddev will create its own wp_config.php or settings.php file automatically._
+_ddev will create a wp_config.php or settings.php file automatically if one does not exist. If you already have one you'll need to set the database credentials (user=db, password=db, host=db, database=db)._
 
-We're happy to say that importing a database into a site running on ddev is painless. 
-
-Database imports can be accomplished using one command. And we currently offer support for several file types. Including: **.sql, sql.gz, tar, tar.gz, and zip**.
+Import a database with just one command; We offer support for several file formats, including: **.sql, sql.gz, tar, tar.gz, and zip**.
 
 Here's an example of a database import using ddev:
 
@@ -157,14 +127,12 @@ Here's an example of a database import using ddev:
 ddev import-db --src=dumpfile.sql.gz
 ```
 
-The `import-db` command will produce output so you can monitor the progress of the database import. 
-
-For more in depth application monitoring, use the `ddev describe` command to see details about the status of your ddev app.
+For in-depth application monitoring, use the `ddev describe` command to see details about the status of your ddev app.
 
 
 ## Getting Started
 
-Check out the git repository for the site you want to work on. `cd` into the directory and run `ddev config` and follow the prompts.
+Check out the git repository for the project you want to work on. `cd` into the directory and run `ddev config` and follow the prompts.
 
 ```
 $ cd ~/Projects
@@ -183,9 +151,9 @@ Docroot Location: web
 Found a drupal8 codebase at /Users/username/Projects/drupal8/web
 ```
 
-Configuration files have now been created for your site. (Available for inspection/modification at .ddev/ddev.yaml).
+Configuration files have now been created for your project. (Take a look at the file on the project's .ddev/ddev.yaml file).
 
-Now that the configuration has been created, you can start your site with `ddev start` (still from within the project working directory):
+Now that the configuration has been created, you can start your project with `ddev start` (still from within the project working directory):
 
 ```
 $ ddev start
@@ -198,24 +166,29 @@ Successfully started drupal8
 Your application can be reached at: http://drupal8.ddev.local
 ```
 
-And you can now visit your working site. Enjoy!
+And you can now visit your working project. Enjoy!
 
-## Listing site information
+## Listing project information
 
-To see a list of your current sites you can use `ddev list`.
+To see a list of your current projects you can use `ddev list`.
 
 ```
 ➜  ddev list
-1 local site found.
-NAME     TYPE     LOCATION                 URL                        STATUS
-drupal8  drupal8  ~/Projects/ddev/drupal8  http://drupal8.ddev.local  running
+NAME     TYPE     LOCATION             URL(s)                      STATUS
+drupal8  drupal8  ~/workspace/drupal8  http://drupal8.ddev.local   running
+                                       https://drupal8.ddev.local
 ```
 
-You can also see more detailed information about a site by running `ddev describe` from its working directory. You can also run `ddev describe [site-name]` from any location to see the detailed information for a running site.
+You can also see more detailed information about a project by running `ddev describe` from its working directory. You can also run `ddev describe [project-name]` from any location to see the detailed information for a running project.
 
 ```
-NAME     TYPE     LOCATION                 URL                        STATUS
-drupal8  drupal8  ~/Projects/ddev/drupal8  http://drupal8.ddev.local  running
+NAME     TYPE     LOCATION             URL(s)                      STATUS
+drupal8  drupal8  ~/workspace/drupal8  http://drupal8.ddev.local   running
+                                       https://drupal8.ddev.local
+
+Project Information
+-----------------
+PHP version:	7.0
 
 MySQL Credentials
 -----------------
@@ -224,22 +197,24 @@ Password:     	db
 Database name:	db
 Host:         	db
 Port:         	3306
-To connect to mysql from your host machine, use port 32894 on 127.0.0.1
-For example: mysql --host 127.0.0.1 --port 32894
+To connect to mysql from your host machine, use port 32768 on 127.0.0.1.
+For example: mysql --host=127.0.0.1 --port=32768 --user=db --password=db --database=db
 
 Other Services
 --------------
 MailHog:   	http://drupal8.ddev.local:8025
 phpMyAdmin:	http://drupal8.ddev.local:8036
+
+DDEV ROUTER STATUS: healthy
 ```
 
-## Importing assets for an existing site
+## Importing assets for an existing project
 
-An important aspect of local web development is the ability to have a precise recreation of the site you are working on locally, including up-to-date database contents and static assets such as uploaded images and files. ddev provides functionality to help with importing assets to your local environment with two commands.
+An important aspect of local web development is the ability to have a precise recreation of the project you are working on locally, including up-to-date database contents and static assets such as uploaded images and files. ddev provides functionality to help with importing assets to your local environment with two commands.
 
 ### Importing a database
 
-The `ddev import-db` command is provided for importing the MySQL database for a site. Running this command will provide a prompt for you to specify the location of your database import.
+The `ddev import-db` command is provided for importing the MySQL database for a project. Running this command will provide a prompt for you to specify the location of your database import.
 
 ```
 ➜  ddev import-db
@@ -251,7 +226,7 @@ Generating settings.php file for database connection.
 Successfully imported database for drupal8
 ```
 
-A database connection file will be generated for your site if one does not exist (`settings.php` for Drupal, `wp-config.php` for WordPress). If you have already created a connection file, you will need to ensure your connection credentials match the ones provided in `ddev describe`.
+A database connection file will be generated for your project if one does not exist (`settings.php` for Drupal, `wp-config.php` for WordPress). If you have already created a connection file, you will need to ensure your connection credentials match the ones provided in `ddev describe`.
 
 <h4>Supported file types</h4>
 
@@ -279,10 +254,12 @@ Successfully imported database for drupal8
 ```
 
 <h4>Non-interactive usage</h4>
-If you want to use import-db without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag.
+If you want to use import-db without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag. Example:
+
+`ddev import-db --src=/tmp/mydb.sql.gz`
 
 ### Importing static file assets
-The `ddev import-files` command is provided for importing the static file assets for a site, such as uploaded images and documents. Running this command will provide a prompt for you to specify the location of your asset import. The assets will then be imported to the default public upload directory of the platform for the site. For Drupal sites, this is the "sites/default/files" directory. For WordPress sites, this is the "wp-content/uploads" directory. 
+The `ddev import-files` command is provided for importing the static file assets for a project, such as uploaded images and documents. Running this command will provide a prompt for you to specify the location of your asset import. The assets will then be imported to the default public upload directory of the platform for the project. For Drupal projects, this is the "sites/default/files" directory. For WordPress projects, this is the "wp-content/uploads" directory. 
 
 ```
 ➜  ddev import-files
@@ -314,13 +291,15 @@ Successfully imported files for drupal8
 ```
 
 <h4>Non-interactive usage</h4>
-If you want to use import-files without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag.
+If you want to use import-files without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag. Example:
 
-## Interacting with your Site
-ddev provides several commands to facilitate interacting with your site in the development environment. These commands can be run within the working directory of your project while the site is running in ddev. 
+`ddev import-files --src=/tmp/files.tgz`
+
+## Interacting with your project
+ddev provides several commands to facilitate interacting with your project in the development environment. These commands can be run within the working directory of your project while the project is running in ddev. 
 
 ### Executing Commands in Containers
-The `ddev exec` command allows you to run shell commands in the container for a ddev service. By default, commands are executed on the web service container, in the docroot path of your site. This allows you to use [the developer tools included in the web container](developer-tools.md). For example, to run the Drush CLI in the web container, you would run `ddev exec drush status`.
+The `ddev exec` command allows you to run shell commands in the container for a ddev service. By default, commands are executed on the web service container, in the docroot path of your project. This allows you to use [the developer tools included in the web container](developer-tools.md). For example, to run the Drush CLI in the web container, you would run `ddev exec drush status`.
 
 To run a shell command in the container for a different service, use the `--service` flag at the beginning of your exec command to specify the service the command should be run against. For example, to run the mysql client in the database, container, you would run `ddev exec --service db mysql`.
 
@@ -334,11 +313,11 @@ The `ddev logs` command allows you to easily retrieve error logs from the web se
 
 Additional logging can be accessed by using `ddev ssh` to manually review the log files you are after. The web server stores access logs at `/var/log/nginx/access.log`, and PHP-FPM logs at `/var/log/php7.0-fpm.log`.
 
-## Stopping a site
-You can stop a site's containers without losing data by using `ddev stop` in the working directory of the site. You can also stop any running site's containers by providing the site name as an argument, e.g. `ddev stop <sitename>`.
+## Stopping a project
+You can stop a project's containers without losing data by using `ddev stop` in the working directory of the project. You can also stop any running project's containers by providing the project name as an argument, e.g. `ddev stop <projectname>`.
 
-## Removing a site
-You can remove a site's containers by running `ddev remove` in the working directory of the site. You can also remove any running site's containers by providing the site name as an argument, e.g. `ddev remove <sitename>`. **Note:** `ddev remove` is destructive. It will remove all containers for the site, destroying database contents in the process. Your project code base and files will not be affected.
+## Removing a project
+You can remove a project's containers by running `ddev remove` in the working directory of the project. You can also remove any running project's containers by providing the project name as an argument, e.g. `ddev remove <projectname>`. `ddev remove` is *not* destructive. It removes the docker containers but does not remove the database for the project, so you can easily have many configured projects with databases loaded, but with no docker containers wasted on unused projects. Your project code base and files are never affected by `ddev remove`. When you want to remove the imported database for a project, use `ddev remove --remove-data` instead of just `ddev remove`, and the database files will also be destroyed.
 
 ## ddev Command Auto-Completion
 ddev bash auto-completion is available. If you have installed ddev via homebrew (on macOS) it will already be installed. Otherwise, you can download the [latest release](https://github.com/drud/ddev/releases) tarball for your platform and the ddev_bash_completions.sh inside it can be installed wherever your bash_completions.d is. For example, `cp ddev_bash_completions.sh /etc/bash_completion.d/ddev`

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -50,7 +50,7 @@ $databases['default']['default'] = array(
   'password' => "db",
   'host' => "127.0.0.1",
   'driver' => "mysql",
-  'port' => <YOUR_project_DB_PORT>,
+  'port' => <YOUR_PROJECT_DB_PORT>,
   'prefix' => "",
 );
 ```

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -14,32 +14,32 @@ These tools can be accessed for single commands using [`ddev exec <command>`](cl
 ### Email Capture and Review
 [MailHog](https://github.com/mailhog/MailHog) is a mail catcher which is configured to capture and display emails sent by PHP in the development environment.
 
-Its web interface can be accessed at its default port after your site has been started. e.g.:
+Its web interface can be accessed at its default port after your project has been started. e.g.:
 ```
 http://mysite.ddev.local:8025
 ```
 
 Please note this will not intercept emails if your application is configured to use SMTP or a 3rd-party ESP integration. If you are using SMTP for outgoing mail handling ([Swiftmailer](https://www.drupal.org/project/swiftmailer) or [SMTP](https://www.drupal.org/project/smtp) modules for example), update your application configuration to use `localhost` on port `1025` as the SMTP server locally in order to use MailHog.
 
-MailHog provides several [configuration options](https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md). If you need to alter its configuration, you can do so by adding the desired environment variable to the `environment` section for the web container in the `.ddev/docker-compose.yaml` for your site.
+MailHog provides several [configuration options](https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md). If you need to alter its configuration, you can do so by adding the desired environment variable to the `environment` section for the web container in the `.ddev/docker-compose.yaml` for your project.
 
 ## Using Development Tools on the Host Machine
-It is possible in many cases to use development tools installed on your host machine on a site provisioned by ddev. Tools that interact with files and require no database connection, such as Git or Composer, can be run from the host machine against the code base for a ddev site with no additional configuration necessary.
+It is possible in many cases to use development tools installed on your host machine on a project provisioned by ddev. Tools that interact with files and require no database connection, such as Git or Composer, can be run from the host machine against the code base for a ddev project with no additional configuration necessary.
 
 ### Database Connections from the Host
-If you need to connect to the database of your site from the host machine, run `ddev describe` to retrieve the Database connection information. The last line of the database credentials will provide your host connection info, similar to this:
+If you need to connect to the database of your project from the host machine, run `ddev describe` to retrieve the Database connection information. The last line of the database credentials will provide your host connection info, similar to this:
 
 ```
 To connect to mysql from your host machine, use port 32838 on 127.0.0.1
 For example: mysql --host 127.0.0.1 --port 32838
 ```
 
-The port referenced is unique per running site, and randomly chosen from available ports on your system when `ddev start` is ran.
+The port referenced is unique per running project, and randomly chosen from available ports on your system when `ddev start` is ran.
 
-**Note:** The host database port is likely to change any time a site is stopped/removed and then later started again.
+**Note:** The host database port is likely to change any time a project is stopped/removed and then later started again.
 
 ### Using Drush Installation on Host Machine
-If you have Drush installed on your host system, you can use it to interact with a ddev site by defining a `drush.settings.php` file at the docroot of your code base, and referencing it from your `settings.php` file. The `drush.settings.php` file should look similar to below, using the host port information for your site retrieved from `ddev describe`:
+If you have Drush installed on your host system, you can use it to interact with a ddev project by defining a `drush.settings.php` file at the docroot of your code base, and referencing it from your `settings.php` file. The `drush.settings.php` file should look similar to below, using the host port information for your project retrieved from `ddev describe`:
 
 ```
 <?php
@@ -50,7 +50,7 @@ $databases['default']['default'] = array(
   'password' => "db",
   'host' => "127.0.0.1",
   'driver' => "mysql",
-  'port' => <YOUR_SITE_DB_PORT>,
+  'port' => <YOUR_project_DB_PORT>,
   'prefix' => "",
 );
 ```
@@ -65,4 +65,4 @@ if (!empty($_SERVER["argv"]) && strpos($_SERVER["argv"][0], "drush") && empty($_
 }
 ```
 
-These configuration files are auto-generated for you if you run [`ddev import-db`](cli-usage.md#import-db) on a site with no existing settings file.
+These configuration files are auto-generated for you if you run [`ddev import-db`](cli-usage.md#import-db) on a project with no existing settings file.

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -1,6 +1,6 @@
 <h1> Additional Service Configurations for ddev</h1>
 
-Site environments in ddev can be extended to provide additional services. This is achieved by adding docker compose files to a project's .ddev directory that defines the added service(s). This page provides configurations for services that are ready to be added to your project with minimal setup.
+ddev projects can be extended to provide additional services. This is achieved by adding docker-compose files to a project's .ddev directory that defines the added service(s). This page provides configurations for services that are ready to be added to your project with minimal setup.
 
 If you need a service not provided here, see [Defining an additional service with Docker Compose](custom-compose-files.md)
 
@@ -16,6 +16,6 @@ This recipe adds an Apache Solr 5.4 container to a project. It will setup a solr
 
 **Interacting with Apache Solr**
 
-- The Solr admin interface will be accessible at http://<sitename>.ddev.local:8983
-- The host connection for apache solr will be <sitename>.ddev.local
+- The Solr admin interface will be accessible at http://<projectname>.ddev.local:8983
+- The host connection for apache solr will be <projectname>.ddev.local
 - The Solr core will be "dev"

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -9,7 +9,7 @@ Under the hood, ddev uses docker-compose to define and run the multiple containe
 ## Conventions for defining additional services
 When defining additional services for your project, it is recommended to follow these conventions to ensure your service is handled by ddev the same way the default services are.
 
-- Containers should be follow the naming convention `ddev-[sitename]-[servicename]`
+- Containers should be follow the naming convention `ddev-[projectname]-[servicename]`
 
 - Containers should be provided the following labels:
 

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -14,13 +14,13 @@ A collection of vetted service configurations is available in the [Additional Se
 If you need to create a service configuration for your project, see [Defining an additional service with Docker Compose](custom-compose-files.md)
 
 ## Providing custom nginx configuration
-The default web container for ddev uses NGINX as the web server. A default configuration is provided in the web container that should work for most Drupal 7+ and WordPress sites. Some sites may require custom configuration, for example to support a module or plugin requiring special rules. To accommodate these needs, ddev provides a way to replace the default configuration with a custom version.
+The default web container for ddev uses NGINX as the web server. A default configuration is provided in the web container that should work for most Drupal 7+ and WordPress projects. Some projects may require custom configuration, for example to support a module or plugin requiring special rules. To accommodate these needs, ddev provides a way to replace the default configuration with a custom version.
 
-- Run `ddev config` for the site if it has not been used with ddev before.
-- Create a file named "nginx-site.conf" in the ".ddev" directory for your site.
+- Run `ddev config` for the project if it has not been used with ddev before.
+- Create a file named "nginx-site.conf" in the ".ddev" directory for your project.
 - Add your configurations to the "nginx-site.conf" file. You can optionally use the [default NGINX configuration provided by ddev](https://github.com/drud/docker.nginx-php-fpm-local/blob/master/files/etc/nginx/nginx-site.conf) as a reference or starting point. [Additional configuration examples](https://www.nginx.com/resources/wiki/start/#other-examples) and documentation are available at the [nginx wiki](https://www.nginx.com/resources/wiki/)
-- **NOTE:** The "root" statement in the server block must be `root $NGINX_DOCROOT;` in order to ensure the path for NGINX to serve the site from is correct.
-- Save your configuration file and run `dev start` to start the site environment. If you encounter issues with your configuration or the site fails to start, use `ddev logs` to inspect the logs for possible NGINX configuration errors.
+- **NOTE:** The "root" statement in the server block must be `root $NGINX_DOCROOT;` in order to ensure the path for NGINX to serve the project from is correct.
+- Save your configuration file and run `dev start` to start the project environment. If you encounter issues with your configuration or the project fails to start, use `ddev logs` to inspect the logs for possible NGINX configuration errors.
 
 ## Overriding default container images
 The default container images provided by ddev are defined in the `config.yaml` file in the `.ddev` folder of your project. This means that _defining_ an alternative image for default services is as simple as changing the image definition in `config.yaml`. In practice, however, ddev currently has certain expectations and assumptions for what the web and database containers provide. At this time, it is recommended that the default container projects be referenced or used as a starting point for developing an alternative image. If you encounter difficulties integrating alternative images, please [file an issue and let us know](https://github.com/drud/ddev/issues/new).

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -1,6 +1,6 @@
 <h1>Extending ddev Commands</h1>
 
-Certain ddev commands provide hooks to run tasks before or after the main command executes. These tasks can be defined in the config.yaml for your site, and allow for you to automate setup tasks specific to your site. To define command tasks in your configuration, specify the desired command hook as a subfield to `hooks`, then provide a list of tasks to run.
+Certain ddev commands provide hooks to run tasks before or after the main command executes. These tasks can be defined in the config.yaml for your project, and allow for you to automate setup tasks specific to your project. To define command tasks in your configuration, specify the desired command hook as a subfield to `hooks`, then provide a list of tasks to run.
 
 Example:
 
@@ -12,8 +12,8 @@ hooks:
 
 ## Supported Command Hooks
 
-- `pre-start`: Hooks into "ddev start". Execute tasks before the site environment starts. **Note:** Only `exec-host` tasks can be run successfully for pre-start. See Supported Tasks below for more info.
-- `post-start`: Hooks into "ddev start". Execute tasks after the site environment has started
+- `pre-start`: Hooks into "ddev start". Execute tasks before the project environment starts. **Note:** Only `exec-host` tasks can be run successfully for pre-start. See Supported Tasks below for more info.
+- `post-start`: Hooks into "ddev start". Execute tasks after the project environment has started
 - `pre-import-db`: Hooks into "ddev import-db". Execute tasks before database import
 - `post-import-db`: Hooks into "ddev import-db". Execute tasks after database import
 - `pre-import-files`: Hooks into "ddev import-files". Execute tasks before files are imported
@@ -37,7 +37,7 @@ hooks:
 
 Example:
 
-_Use wp-cli to replace the production URL with development URL in the database of a WordPress site_
+_Use wp-cli to replace the production URL with development URL in the database of a WordPress project_
 
 ```
 hooks:
@@ -51,7 +51,7 @@ Value: string providing the command to run. Commands requiring user interaction 
 
 Example:
 
-_Run "composer install" from your system before starting the site (composer would nee to be installed on your system)_
+_Run "composer install" from your system before starting the project (composer would nee to be installed on your system)_
 
 ```
 hooks:
@@ -68,7 +68,7 @@ hooks:
     - exec: "wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db"
     - exec: "wp core install --url=http://mysite.ddev.local --title=MySite --admin_user=admin --admin_email=admin@mail.test"
   post-import-db:
-    # Update the URL of your site throughout your database after import
+    # Update the URL of your project throughout your database after import
     - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
 ```
 
@@ -82,7 +82,7 @@ hooks:
     # Generate a one-time login link for the admin account.
     - exec: "drush uli 1"
   post-import-db:
-    # Set the site name
+    # Set the project name
     - exec: "drush vset site_name MyDevSite"
     # Enable the environment indicator module
     - exec: "drush en -y environment_indicator"

--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -1,12 +1,12 @@
 <h1>Pantheon Hosting Provider Integration</h1>
 
-ddev provides an integration with the [Pantheon Website Management Platform](https://pantheon.io/), which allows for Pantheon users to quickly and easily download and provision a site from Pantheon in a local ddev-managed environment.
+ddev provides an integration with the [Pantheon Website Management Platform](https://pantheon.io/), which allows for Pantheon users to quickly and easily download and provision a project from Pantheon in a local ddev-managed environment.
 
 ddev's Pantheon integration pulls an existing backup from an existing Pantheon site/environment into your local system so you can develop locally. Of course that means you must already have a Pantheon site with a backup in order to use it.
 
 ## Quick Start
 
-If you have ddev installed, and have an active Pantheon account with an active WordPress, Drupal 7, or Drupal 8 site, you can follow this quick start guide to spin up a pantheon site locally.
+If you have ddev installed, and have an active Pantheon account with an active WordPress, Drupal 7, or Drupal 8 site, you can follow this quick start guide to spin up a pantheon project locally.
 
 1. Authenticate with Pantheon.
 
@@ -16,19 +16,19 @@ If you have ddev installed, and have an active Pantheon account with an active W
 
 2. Choose a Pantheon site and environment you want to use with ddev.
 
-3. Get a copy of the site codebase from Pantheon. We recommend enabling the "Git Connection Mode" if not already enabled, and using `git clone` to check out the code locally.
+3. Get a copy of the project codebase from Pantheon. We recommend enabling the "Git Connection Mode" if not already enabled, and using `git clone` to check out the code locally.
 
-4. Create a new backup of the site. This can be done by navigating to Backups->Backup Log->Create New Backup. _Note: this must be done every time you want the latest state of your Pantheon environment provisioned locally._
+4. Create a new backup of the Pantheon site. This can be done by navigating to Backups->Backup Log->Create New Backup. _Note: this must be done every time you want the latest state of your Pantheon environment provisioned locally._
 
 5. Configure the local checkout for ddev.
 
-    a. Navigate in your terminal to your checkout of the site codebase.
+    a. Navigate in your terminal to your checkout of the project codebase.
 
     b. Run `ddev config pantheon`. When asked for the project name you must use the exact name of the Pantheon project.
 
     c. Configuration prompts will allow you to choose a Pantheon environment, suggesting "dev" as the default.
 
-6. Run `ddev pull`. The ddev environment will spin up, download the latest backup from Pantheon, and import the database and files into the ddev environment. You should now be able to access the site locally.
+6. Run `ddev pull`. The ddev environment will spin up, download the latest backup from Pantheon, and import the database and files into the ddev environment. You should now be able to access the project locally.
 
 ## Requirements
 
@@ -44,15 +44,15 @@ This step only needs to be completed once for your system. We recommend that you
 
 ## Usage
 
-### Configuring a Pantheon Site for Imports
+### Configuring a Pantheon project for Imports
 
-After you copy your Pantheon site’s codebase locally, you can use `ddev config pantheon` to generate the necessary configuration files for ddev. In addition to the prompts the `ddev config` command provides for any new site, you will also be asked to specify which Pantheon environment you wish to pull your file and database assets from. These environments are usually "live", "test", or "dev". If you wish to later change the Pantheon environment you wish to sync from, you can do so by editing the `import.yaml` file in the `.ddev` directory for your site.
+After you copy your Pantheon project’s codebase locally, you can use `ddev config pantheon` to generate the necessary configuration files for ddev. In addition to the prompts the `ddev config` command provides for any new project, you will also be asked to specify which Pantheon environment you wish to pull your file and database assets from. These environments are usually "live", "test", or "dev". If you wish to later change the Pantheon environment you wish to sync from, you can do so by editing the `import.yaml` file in the `.ddev` directory for your project.
 
 ### Imports
 
 Running `ddev pull` will connect to Pantheon through their API to find the latest versions of the database and files backups from the specified environment. If new versions are available on Pantheon, they are downloaded and stored in ~/.ddev/pantheon. If the stored copies there are the latest copies, ddev will use these cached copies instead of downloading them again.
 
-_**Note for WordPress Users:** In order for your local site to load file assets from your local environment rather than the Pantheon environment it was pulled from, the URL of the site must be changed in the database by performing a search and replace. ddev provides an example `wp search-replace` as a post-pull hook in the config.yaml for your site. It is recommended to populate and uncomment this example so that replacement is done any time a backup is pulled from Pantheon._
+_**Note for WordPress Users:** In order for your local project to load file assets from your local environment rather than the Pantheon environment it was pulled from, the URL of the project must be changed in the database by performing a search and replace. ddev provides an example `wp search-replace` as a post-pull hook in the config.yaml for your project. It is recommended to populate and uncomment this example so that replacement is done any time a backup is pulled from Pantheon._
 
 ## Troubleshooting
 

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -1,6 +1,6 @@
 <h1>Step-debugging with ddev and xdebug</h1>
 
-Every ddev site is automatically configured with xdebug so that popular IDEs can do step-debugging of PHP code.
+Every ddev project is automatically configured with xdebug so that popular IDEs can do step-debugging of PHP code.
 
 xdebug is a server-side tool: It is installed automatically on the container and you do *not* need to install it on your workstation. All you have to do on your workstation is to add an extra IP address (below) and perhaps add a browser extension or bookmark.
 
@@ -46,7 +46,7 @@ PHPStorm [run/debug configurations](https://www.jetbrains.com/help/phpstorm/2017
 1. Make sure your "Debug port" is set to 11011 in preferences.
 2. Under the "Run" menu select "Edit configurations"
 3. Click the "+" in the upper left and choose "PHP Web Application" to create a configuration. Give it a reasonable name.
-4. Create a "server" for the site. (Screenshot below)
+4. Create a "server" for the project. (Screenshot below)
 5. Add file mappings for the docroot of the server. If your repo has the main code in the root of the repo, that will map to /var/www/html. If it's in a docroot directory, it would map to /var/www/html/docroot.
 6. Set an appropriate breakpoint.
 7. Start debugging by clicking the "debug" button, which will launch a page in your browser.
@@ -67,11 +67,11 @@ Before, beginning anything else, please set your Debugger Port to 11011. (Prefer
 
 ![Netbeans Debugging Port](images/netbeans_debugger_port.png)
 
-1. Create a PHP project that relates to your site repository. (File->New Project->PHP Application with Existing Sources)
+1. Create a PHP project that relates to your project repository. (File->New Project->PHP Application with Existing Sources)
 2. Under "Run as", choose "Local web site (running on local web server)".
-3. Under "Name and Location", give the sources folder of the **docroot/webroot** of your site.
+3. Under "Name and Location", give the sources folder of the **docroot/webroot** of your project.
 ![Netbeans project name and location](images/netbeans_project_name_location.png)
-4. Under "Run configuration" the project URL to the full URL of your dev site, for example http://drud-d8.ddev.local/, and choose the index file.
+4. Under "Run configuration" the project URL to the full URL of your dev project, for example http://drud-d8.ddev.local/, and choose the index file.
 ![Netbeans run configuration](images/netbeans_project_run_configuration.png)
 5. Set a breakpoint.
 6. Click the "Debug" button.


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #599 pointed out that we had inaccuracies about the use of the "remove" command. The help is right, but the docs were wrong. This fixes that.
* On a casual read-through I also edited some usage for clarity.
* For #526 (changing usage of "site" and "app" to "project" I changed "site" to "project" in a number of cases. 
* For #597 make sure it's clear that docker-compose is required.

## How this PR Solves The Problem:

## Manual Testing Instructions:

Read the docs.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

- #599: Inaccuracies about `ddev remove`
- #526: Change "site" to "project"
- #597: Make sure docker-compose requirement is explicit.


