### PR TITLE
Improve regexp so "." regex class includes newline in test

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -768,7 +769,7 @@ func TestListWithoutDir(t *testing.T) {
 	// testDir on Windows has backslashes in it, resulting in invalid regexp
 	// Remove them and use ., which is good enough.
 	testDirSafe := strings.Replace(testDir, "\\", ".", -1)
-	assert.Regexp(ddevapp.SiteDirMissing+".*"+testDirSafe, table.String())
+	assert.Regexp(regexp.MustCompile("(?s)"+ddevapp.SiteDirMissing+".*"+testDirSafe), table.String())
 
 	err = app.Down(true)
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

This is another try at https://github.com/drud/ddev/pull/593, which seems to behave differently at various times. I did in fact make a mistake in the regexp in that pull, assuming that by default "." would include newline, and it doesn't by default. This fixes it. Note that this issue is currently bedeviling https://github.com/drud/ddev/pull/596, at least some of the time.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

