### PR TITLE
Support Backdrop CMS

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -193,11 +193,7 @@ ddev import-db --src=dumpfile.sql.gz
 
 For in-depth application monitoring, use the `ddev describe` command to see details about the status of your ddev app.
 
-**Note for Backdrop users:** In addition to importing a Backdrop database, you will need to put your Backdrop site's `active` configuration into `files/ddev_config/active`. Without these config files present, Backdrop will not run properly. If `files/ddev_config` is not where your project stores its config, you can replace the `ddev_config` directory with a symlink to whereever you store your config. An example of this command is as follows:
-
-```
-ln -s ../config ./files/ddev_config
-```
+**Note for Backdrop users:** In addition to importing a Backdrop database, you will need to extract a copy of your Backdrop site's configuration into the local `active` directory. The location for this directory can vary depending on the contents of your Backdrop `settings.php` file, but the default location is `[docroot]/files/config_[random letters and numbers]/active`. Please refer to the Backdrop documentation for more information on [moving your Backdrop site](https://backdropcms.org/user-guide/moving-backdrop-site) into the `ddev` environment.
 
 ## Getting Started
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -193,7 +193,7 @@ ddev import-db --src=dumpfile.sql.gz
 
 For in-depth application monitoring, use the `ddev describe` command to see details about the status of your ddev app.
 
-**Note for Backdrop users:** In addition to importing a Backdrop database, you will need to put your Backdrop site's `active` configuration into `files/ddev_config/active`. Without these config files present, Backdrop will not run properly. If `files/ddev_config` is not where your project stores it's config, you can replace the `ddev_config` directory with a symlink to whereever you store your config. An example of this command is as follows:
+**Note for Backdrop users:** In addition to importing a Backdrop database, you will need to put your Backdrop site's `active` configuration into `files/ddev_config/active`. Without these config files present, Backdrop will not run properly. If `files/ddev_config` is not where your project stores its config, you can replace the `ddev_config` directory with a symlink to whereever you store your config. An example of this command is as follows:
 
 ```
 ln -s ../config ./files/ddev_config

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -147,6 +147,36 @@ Successfully started example-typo3-site
 Your application can be reached at: http://example-typo3-site.ddev.local
 ```
 
+### Backdrop Quickstart
+
+To get started with Backdrop, clone the project repository and navigate to the project directory.
+
+```
+git clone https://github.com/example-user/example-backdrop-site
+cd example-backdrop-site
+```
+
+To set up ddev for your project, enter the command:
+
+```
+ddev config
+```
+
+_Note: ddev config will prompt you for a project name, docroot, and project type._
+
+After you've run `ddev config`, you're ready to start running your project. To start running ddev, simply enter:
+
+```
+ddev start
+``` 
+
+`ddev start` will provide output informing you that the project's environment is being started. When startup is successful, you'll see a message like the one below telling you where the project can be reached.
+
+```
+Successfully started example-backdrop-site
+Your application can be reached at: http://example-backdrop-site.ddev.local
+```
+
 ### Database Imports
 
 **Important:** Before importing any databases for your project, please remove its' wp-config.php if using WordPress - or settings.php file in the case of Drupal 7/8, if present. 
@@ -163,6 +193,11 @@ ddev import-db --src=dumpfile.sql.gz
 
 For in-depth application monitoring, use the `ddev describe` command to see details about the status of your ddev app.
 
+**Note for Backdrop users:** In addition to importing a Backdrop database, you will need to put your Backdrop site's `active` configuration into `files/ddev_config/active`. Without these config files present, Backdrop will not run properly. If `files/ddev_config` is not where your project stores it's config, you can replace the `ddev_config` directory with a symlink to whereever you store your config. An example of this command is as follows:
+
+```
+ln -s ../config ./files/ddev_config
+```
 
 ## Getting Started
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -66,7 +66,7 @@ func init() {
 			createTypo3SettingsFile, getTypo3UploadDir, getTypo3Hooks, setTypo3SiteSettingsPaths, isTypo3App, nil, nil, nil,
 		},
 		"backdrop": {
-			createBackdropSettingsFile, getBackdropUploadDir, getBackdropHooks, setBackdropSiteSettingsPaths, isBackdropApp, nil, nil, nil,
+			createBackdropSettingsFile, getBackdropUploadDir, getBackdropHooks, setBackdropSiteSettingsPaths, isBackdropApp, backdropPostImportDBAction, nil, nil,
 		},
 	}
 }

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -66,7 +66,7 @@ func init() {
 			createTypo3SettingsFile, getTypo3UploadDir, getTypo3Hooks, setTypo3SiteSettingsPaths, isTypo3App, nil, nil, nil,
 		},
 		"backdrop": {
-			createBackdropSettingsFile, getBackdropUploadDir, getBackdropHooks, setBackdropSiteSettingsPaths, isBackdropApp, nil,
+			createBackdropSettingsFile, getBackdropUploadDir, getBackdropHooks, setBackdropSiteSettingsPaths, isBackdropApp, nil, nil, nil,
 		},
 	}
 }

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -65,6 +65,9 @@ func init() {
 		"typo3": {
 			createTypo3SettingsFile, getTypo3UploadDir, getTypo3Hooks, setTypo3SiteSettingsPaths, isTypo3App, nil, nil, nil,
 		},
+		"backdrop": {
+			createBackdropSettingsFile, getBackdropUploadDir, getBackdropHooks, setBackdropSiteSettingsPaths, isBackdropApp, nil,
+		},
 	}
 }
 

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -1,12 +1,13 @@
 package ddevapp_test
 
 import (
-	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/testcommon"
-	asrt "github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // TestApptypeDetection does a simple test of various filesystem setups to make
@@ -19,6 +20,7 @@ func TestApptypeDetection(t *testing.T) {
 		"drupal7":   "misc/ajax.js",
 		"drupal8":   "core/scripts/drupal.sh",
 		"wordpress": "wp-login.php",
+		"backdrop":  "core/scripts/backdrop.sh",
 	}
 
 	for expectedType, expectedPath := range fileLocations {

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -52,9 +52,6 @@ const backdropTemplate = `<?php
 $database = 'mysql://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@{{ $config.DatabaseHost }}/{{ $config.DatabaseName }}';
 $database_prefix = '{{ $config.DatabasePrefix }}';
 
-$config_directories['active'] = 'files/ddev_config/active';
-$config_directories['staging'] = 'files/ddev_config/staging';
-
 $settings['update_free_access'] = FALSE;
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 $settings['backdrop_drupal_compatibility'] = TRUE;

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -75,7 +75,7 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
-	backdropConfig := NewBackdropsettings()
+	backdropConfig := NewBackdropSettings()
 
 	err = writeBackdropSettingsFile(backdropConfig, settingsFilePath)
 	if err != nil {

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -1,0 +1,143 @@
+package ddevapp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+	"github.com/drud/ddev/pkg/appports"
+	"github.com/drud/ddev/pkg/output"
+	"github.com/drud/ddev/pkg/util"
+)
+
+type BackdropSettings struct {
+	DatabaseName     string
+	DatabaseUsername string
+	DatabasePassword string
+	DatabaseHost     string
+	DatabaseDriver   string
+	DatabasePort     string
+	DatabasePrefix   string
+	HashSalt         string
+	Signature        string
+}
+
+// NewBackdropSettings produces a BackdropSettings object with default values.
+func NewBackdropsettings() *BackdropSettings {
+	return &BackdropSettings{
+		DatabaseName:     "db",
+		DatabaseUsername: "db",
+		DatabasePassword: "db",
+		DatabaseHost:     "db",
+		DatabaseDriver:   "mysql",
+		DatabasePort:     appports.GetPort("db"),
+		DatabasePrefix:   "",
+		HashSalt:         util.RandString(64),
+		Signature:        DdevSettingsFileSignature,
+	}
+}
+
+const backdropTemplate = `<?php
+{{ $config := . }}
+/**
+ {{ $config.Signature }}: Automatically generated Backdrop settings.php file.
+ ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ */
+
+$database = 'mysql://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@{{ $config.DatabaseHost }}/{{ $config.DatabaseName }}';
+$database_prefix = '{{ $config.DatabasePrefix }}';
+
+$config_directories['active'] = 'files/config_' . md5($database) . '/active';
+$config_directories['staging'] = 'files/config_' . md5($database) . '/staging';
+
+$settings['update_free_access'] = FALSE;
+$settings['hash_salt'] = '{{ $config.HashSalt }}';
+$settings['backdrop_drupal_compatibility'] = TRUE;
+
+ini_set('session.gc_probability', 1);
+ini_set('session.gc_divisor', 100);
+ini_set('session.gc_maxlifetime', 200000);
+ini_set('session.cookie_lifetime', 2000000);
+
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+
+`
+
+// createBackdropSettingsFile creates the app's settings.php or equivalent,
+// adding things like database host, name, and password.
+// Returns the full path to the settings file and err.
+func createBackdropSettingsFile(app *DdevApp) (string, error) {
+	settingsFilePath, err := app.DetermineSettingsPathLocation()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get Backdrop settings file path: %v", err)
+	}
+	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
+
+	backdropConfig := NewBackdropsettings()
+
+	err = writeBackdropSettingsFile(backdropConfig, settingsFilePath)
+	if err != nil {
+		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err)
+	}
+
+	return settingsFilePath, nil
+}
+
+// writeBackdropSettingsFile dynamically produces a valid settings.php file by
+// combining a configuration object with a data-driven template.
+func writeBackdropSettingsFile(settings *BackdropSettings, filePath string) error {
+	tmpl, err := template.New("settings").Funcs(sprig.TxtFuncMap()).Parse(backdropTemplate)
+	if err != nil {
+		return err
+	}
+
+	// Ensure target directory is writable.
+	dir := filepath.Dir(filePath)
+	err = os.Chmod(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	err = tmpl.Execute(file, settings)
+	if err != nil {
+		return err
+	}
+	util.CheckClose(file)
+	return nil
+}
+
+// getBackdropUploadDir returns the path to the directory where uploaded files are
+// stored.
+func getBackdropUploadDir(app *DdevApp) string {
+	return "files"
+}
+
+// getBackdropHooks for appending as byte array.
+func getBackdropHooks() []byte {
+	backdropHooks := `
+#      - exec: "drush cc all"`
+	return []byte(backdropHooks)
+}
+
+// setBackdropSiteSettingsPaths sets the paths to settings.php for templating.
+func setBackdropSiteSettingsPaths(app *DdevApp) {
+	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, "settings.php")
+	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, "settings.local.php")
+}
+
+// isBackdropApp returns true if the app is of type "backdrop".
+func isBackdropApp(app *DdevApp) bool {
+	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "core/scripts/backdrop.sh")); err == nil {
+		return true
+	}
+	return false
+}

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -62,11 +62,6 @@ ini_set('session.gc_probability', 1);
 ini_set('session.gc_divisor', 100);
 ini_set('session.gc_maxlifetime', 200000);
 ini_set('session.cookie_lifetime', 2000000);
-
-if (file_exists(__DIR__ . '/settings.local.php')) {
-  include __DIR__ . '/settings.local.php';
-}
-
 `
 
 // createBackdropSettingsFile creates the app's settings.php or equivalent,

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -125,8 +125,7 @@ func getBackdropHooks() []byte {
 // setBackdropSiteSettingsPaths sets the paths to settings.php for templating.
 func setBackdropSiteSettingsPaths(app *DdevApp) {
 	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
-	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, "settings.php")
-	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, "settings.local.php")
+	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, "settings.local.php")
 }
 
 // isBackdropApp returns true if the app is of type "backdrop".

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -52,8 +52,8 @@ const backdropTemplate = `<?php
 $database = 'mysql://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@{{ $config.DatabaseHost }}/{{ $config.DatabaseName }}';
 $database_prefix = '{{ $config.DatabasePrefix }}';
 
-$config_directories['active'] = 'files/config_' . md5($database) . '/active';
-$config_directories['staging'] = 'files/config_' . md5($database) . '/staging';
+$config_directories['active'] = 'files/ddev_config/active';
+$config_directories['staging'] = 'files/ddev_config/staging';
 
 $settings['update_free_access'] = FALSE;
 $settings['hash_salt'] = '{{ $config.HashSalt }}';

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -136,3 +136,10 @@ func isBackdropApp(app *DdevApp) bool {
 	}
 	return false
 }
+
+// backdropPostImportDBAction emits a warning about moving configuration into place
+// appropriately in order for Backdrop to function properly.
+func backdropPostImportDBAction(app *DdevApp) error {
+	util.Warning("Backdrop sites require your config JSON files to be located in your site's \"active\" configuration directory. Please refer to the Backdrop documentation (https://backdropcms.org/user-guide/moving-backdrop-site) for more information about this process.")
+	return nil
+}

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -12,6 +12,7 @@ import (
 	"github.com/drud/ddev/pkg/util"
 )
 
+// BackdropSettings holds database connection details for Backdrop.
 type BackdropSettings struct {
 	DatabaseName     string
 	DatabaseUsername string
@@ -25,7 +26,7 @@ type BackdropSettings struct {
 }
 
 // NewBackdropSettings produces a BackdropSettings object with default values.
-func NewBackdropsettings() *BackdropSettings {
+func NewBackdropSettings() *BackdropSettings {
 	return &BackdropSettings{
 		DatabaseName:     "db",
 		DatabaseUsername: "db",

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -35,10 +35,12 @@ func NewBackdropsettings() *BackdropSettings {
 		DatabasePort:     appports.GetPort("db"),
 		DatabasePrefix:   "",
 		HashSalt:         util.RandString(64),
-		Signature:        DdevSettingsFileSignature,
+		Signature:        DdevFileSignature,
 	}
 }
 
+// Note that this template will almost always be used for settings.local.php
+// because Backdrop ships with it's own default settings.php.
 const backdropTemplate = `<?php
 {{ $config := . }}
 /**

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -2,7 +2,10 @@ package ddevapp
 
 import (
 	"fmt"
+<<<<<<< HEAD
 	"io/ioutil"
+=======
+>>>>>>> Fix typo
 
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/appports"
@@ -321,7 +324,7 @@ func isDrupal7App(app *DdevApp) bool {
 	return false
 }
 
-// isDrupal8App returns true if the app of of type drupal8
+// isDrupal8App returns true if the app is of type drupal8
 func isDrupal8App(app *DdevApp) bool {
 	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "core/scripts/drupal.sh")); err == nil {
 		return true

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -2,10 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
-<<<<<<< HEAD
 	"io/ioutil"
-=======
->>>>>>> Fix typo
 
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/appports"

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -23,7 +23,6 @@ func TestWriteSettings(t *testing.T) {
 		"drupal8":   "sites/default/settings.php",
 		"wordpress": "wp-config.php",
 		"typo3":     "typo3conf/AdditionalConfiguration.php",
-		"backdrop":  "settings.local.php",
 	}
 	dir := testcommon.CreateTmpDir("example")
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -23,6 +23,7 @@ func TestWriteSettings(t *testing.T) {
 		"drupal8":   "sites/default/settings.php",
 		"wordpress": "wp-config.php",
 		"typo3":     "typo3conf/AdditionalConfiguration.php",
+		"backdrop":  "settings.local.php",
 	}
 	dir := testcommon.CreateTmpDir("example")
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Needs more ~cowbell~ Backdrop support

## How this PR Solves The Problem:

Adds backdrop support

## Manual Testing Instructions:

Download a Backdrop tarball, use the build artifact, and stand up a site. We're looking for parity with 

## Automated Testing Overview:

None yet, but WIP.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/571

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

* Backdrop ships with a settings.php included, so we probably shouldn't overwrite that under any circumstances. Right now, the settings file generation doesn't actually do anything. I was thinking that for backdrop, maybe we should generate a settings.local.php instead? The default settings.php includes settings.local.php OOTB if it exists, so that would be a relatively straightforward way to handle this.
* I clicked around a bit in the Backdrop interface, and everything seemed to work. It did prompt me to go through the utf8mb4 conversion though. Is there something we can do to avoid that? Maybe create the default database differently in our db container?
* Drush support is still up in the air.