### PR TITLE
Fix nightly build by removing clashing circle config stanza

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,10 @@ jobs:
           name: Artifact storage
 
   # nightly is triggered only with nightly_build_trigger.sh
+  # The approach is to build the tip of all related repositories, both
+  # ddev itself and the containers it relies on.
+  # It does a full build-and-test of nightly-build.mak (with containers)
+  # Then starts over and does a normal build with normal image tags.
   nightly_build:
     machine:
       image: circleci/classic:201711-01
@@ -64,19 +68,18 @@ jobs:
 
       - run:
           command: echo "go version:$(go version) docker version=$(docker --version) docker-compose version=$(docker-compose --version) HOME=$HOME USER=$(whoami) PWD=$PWD"
-          name: Installed tool versions
+          name: Show installed tool versions
 
       # The nightly build builds a ddev that can't be run elsewhere because the containers built in are not pushed.
       # Therefore we build this full nightly first, and then throw it away.
       - run:
           command: |
             make clean
-            export VERSION=nightly.$(date +%Y%m%d%H%M%S)
             export VERSION="$(git describe --tags --always --dirty)-nightly.$(date +%Y%m%d%H%M%S)"
             echo VERSION=$VERSION
             git submodule update --init && git submodule update --remote
-            make -f nightly_build.mak clean
-            make -f nightly_build.mak -s --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION DBATag=$VERSION WebTag=$VERSION RouterTag=$VERSION  NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG=$VERSION UPSTREAM_PHP_REPO_TAG=$VERSION
+            make -f nightly_build.mak clean  # Remove any existing binaries
+            make -f nightly_build.mak -s --print-directory VERSION=$VERSION DdevVersion=$VERSION DBTag=$VERSION DBATag=$VERSION WebTag=$VERSION RouterTag=$VERSION
           no_output_timeout: "20m"
           name: Run full nightly build
 
@@ -84,26 +87,23 @@ jobs:
           command: bin/linux/ddev version
           name:  nightly-build ddev version information
 
-      # Run the built-in ddev tests with the executables just built.
-      - run:
-          command: make -s test
-          name: ddev tests
-          no_output_timeout: "20m"
-
       - run: make -s gometalinter
 
-      # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
+      # Now build using the regular ddev-only technique - this results in a
+      # fully clean set of executables with expected tags. This should result
+      # in the normal artifacts we'd expect in a regular build.
+
       # Earlier process updated submodules so now we clean them up to continue.
       - run:
           command: |
             git submodule update --init &&
             make -s clean linux darwin windows
-          name: Build the ddev executables
+          name: Build the ddev executables normally, with normal image tags
 
       # Run the built-in ddev tests with the clean binaries just built.
       - run:
           command: make -s test
-          name: ddev tests
+          name: ddev tests, with normal clean ddev binaries (normal image tags)
           no_output_timeout: "20m"
 
       - run:


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our nightly build was broken by adding improved tests to the cmd/version_test.go. Instead of just using the in-code version information, the new tests actually ran ddev to get the version. Unfortunately, we had a redundant stanza of the .circleci/config.yml that tested the whole thing a second time with the special-tag executables but without overriding for comparison. Note that cmd's TestVersion was working fine in the first round of testing (when the proper variables were provided.)

I attempted to add more documentation to help everybody understand what's going on in the nightly_build stanza. 

As far as I can tell, the removed stanza had no reason to exist.

Testing: Use the instructions in .circleci/README.md to run a full nightly against this branch. Note that you have to enable testing against the fork where the branch lives to do this. I triggered on https://circleci.com/gh/rfay/ddev/298 