### PR TITLE
Typo3 support for ddev, fixes #570

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ ddev is an open source tool that makes it simple to get local PHP development en
 2. **Install ddev:** Options include [macOS homebrew](https://ddev.readthedocs.io/en/latest/#homebrew-macos) (recommended), an [install script](https://ddev.readthedocs.io/en/latest/#installation-script-linux-and-macos), or [a manually download](https://ddev.readthedocs.io/en/latest/#manual-installation-linux-and-macos).
 3. **Choose a CMS Quick Start Guide:** 
   - [WordPress](https://ddev.readthedocs.io/en/latest/users/cli-usage#wordpress-quickstart)
-  - [Drupal 7](https://ddev.readthedocs.io/en/latest/users/cli-usage#drupal-7-quickstart)
+  - [Drupal 6 and 7](https://ddev.readthedocs.io/en/latest/users/cli-usage#drupal-6/7-quickstart)
   - [Drupal 8](https://ddev.readthedocs.io/en/latest/users/cli-usage#drupal-8-quickstart)
+  - [TYPO3](https://ddev.readthedocs.io/en/latest/users/cli-usage#typo3-quickstart)
 
 Having trouble? See our [support options below](#support). Additionally, you may have trouble if [another local development tool is already using port 80 or 443](https://ddev.readthedocs.io/en/latest/#using-ddev-with-other-development-environments).
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -40,13 +40,13 @@ Your application can be reached at: http://example-wordpress-site.ddev.local
 
 Quickstart instructions regarding database imports can be found under [Database Imports](#database-imports).
 
-### Drupal 7 Quickstart
+### Drupal 6/7 Quickstart
 
-Beginning to use ddev with a Drupal 7 project is as simple as cloning the project's repository and checking out its directory.
+Beginning to use ddev with a Drupal 6 or 7 project is as simple as cloning the project's repository and checking out its directory.
 
 ```
-git clone https://github.com/user/my-drupal7-site
-cd my-drupal7-site
+git clone https://github.com/user/my-drupal-site
+cd my-drupal-site
 ```
 
 Now to start working with ddev. In your project's working directory, enter the following command:
@@ -55,19 +55,19 @@ Now to start working with ddev. In your project's working directory, enter the f
 ddev config
 ```
 
-_Note: ddev config will prompt you for a project name, docroot, and app type._
+_Note: ddev config will prompt you for a project name, docroot, and project type._
 
-After you've run `ddev config` you're ready to start running your project. Run ddev using a simple:
+After you've run `ddev config` you're ready to start running your project. Run ddev using:
 
 ```
 ddev start
 ``` 
 
-When running `ddev start` you should see output informing you that the project's environment is being started. If startup is successful, you'll see a message like the one below telling you where the project can be reached.
+While `ddev start` is running you will see output informing you that the project's environment is being started. When startup is complete, you'll see a message like the one below telling you where the project can be reached.
 
 ```
-Successfully started my-drupal7-site
-Your application can be reached at: http://my-drupal7-site.ddev.local
+Successfully started my-drupal-site
+Your application can be reached at: http://my-drupal-site.ddev.local
 ```
 
 Quickstart instructions for database imports can be found under [Database Imports](#database-imports).
@@ -111,6 +111,40 @@ After running `ddev start` you should see output informing you that the project'
 ```
 Successfully started my-drupal8-site
 Your application can be reached at: http://my-drupal8-site.ddev.local
+```
+
+### TYPO3 Quickstart
+
+To get started using ddev with a TYPO3 project, simply clone the project's repository and checkout its directory.
+
+```
+git clone https://github.com/example-user/example-typo3-site
+cd example-typo3-site
+```
+
+If necessary, run build steps that you may require, like `composer install` in the correct directory.
+
+_Note: ddev assumes that the files created by a site install have already been created, including the typo3conf, typo3temp, uploads, and fileadmin directories._
+
+From here we can start setting up ddev. In your project's working directory, enter the command:
+
+```
+ddev config
+```
+
+_Note: ddev config will prompt you for a project name, docroot, and project type._
+
+After you've run `ddev config`, you're ready to start running your project. To start running ddev, simply enter:
+
+```
+ddev start
+``` 
+
+`ddev start` will provide output informing you that the project's environment is being started. When startup is successful, you'll see a message like the one below telling you where the project can be reached.
+
+```
+Successfully started example-typo3-site
+Your application can be reached at: http://example-typo3-site.ddev.local
 ```
 
 ### Database Imports

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -89,6 +89,8 @@ func IsValidAppType(apptype string) bool {
 // CreateSettingsFile creates the settings file (like settings.php) for the
 // provided app is the apptype has a settingsCreator function.
 func (app *DdevApp) CreateSettingsFile() (string, error) {
+	app.SetApptypeSettingsPaths()
+
 	// If neither settings file options are set, then don't continue
 	if app.SiteLocalSettingsPath == "" && app.SiteSettingsPath == "" {
 		return "", fmt.Errorf("Neither SiteLocalSettingsPath nor SiteSettingsPath is set")

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -62,6 +62,9 @@ func init() {
 		"drupal6": {
 			createDrupal6SettingsFile, getDrupalUploadDir, getDrupal6Hooks, setDrupalSiteSettingsPaths, isDrupal6App, nil, drupal6ConfigOverrideAction, drupal6PostConfigAction,
 		},
+		"typo3": {
+			createTypo3SettingsFile, getTypo3UploadDir, getTypo3Hooks, setTypo3SiteSettingsPaths, isTypo3App, nil, nil, nil,
+		},
 	}
 }
 
@@ -86,8 +89,6 @@ func IsValidAppType(apptype string) bool {
 // CreateSettingsFile creates the settings file (like settings.php) for the
 // provided app is the apptype has a settingsCreator function.
 func (app *DdevApp) CreateSettingsFile() (string, error) {
-	app.SetApptypeSettingsPaths()
-
 	// If neither settings file options are set, then don't continue
 	if app.SiteLocalSettingsPath == "" && app.SiteSettingsPath == "" {
 		return "", fmt.Errorf("Neither SiteLocalSettingsPath nor SiteSettingsPath is set")

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -22,9 +22,16 @@ func TestWriteSettings(t *testing.T) {
 		"drupal7":   "sites/default/settings.php",
 		"drupal8":   "sites/default/settings.php",
 		"wordpress": "wp-config.php",
+		"typo3":     "typo3conf/AdditionalConfiguration.php",
 	}
 	dir := testcommon.CreateTmpDir("example")
-	err := os.MkdirAll(dir+"/sites/default", 0777)
+	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
+	assert.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(dir, "typo3conf"), 0777)
+	assert.NoError(t, err)
+
+	// typo3 wants LocalConfiguration.php to exist in the repo ahead of time.
+	err = ioutil.WriteFile(filepath.Join(dir, "typo3conf", "LocalConfiguration.php"), []byte("<?php\n"), 0644)
 	assert.NoError(t, err)
 
 	app, err := NewApp(dir, DefaultProviderName)

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -1,0 +1,150 @@
+package ddevapp
+
+import (
+	"fmt"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+	"github.com/drud/ddev/pkg/appports"
+	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/output"
+	"github.com/drud/ddev/pkg/util"
+	"os"
+	"path/filepath"
+)
+
+// Typo3Settings encapsulates all the configurations for a typo3 site.
+type Typo3Settings struct {
+	DeployName       string
+	DeployURL        string
+	DatabaseName     string
+	DatabaseUsername string
+	DatabasePassword string
+	DatabaseHost     string
+	DatabaseDriver   string
+	DatabasePort     string
+	DatabasePrefix   string
+	Signature        string
+}
+
+// NewTypo3Settings produces a Typo3Settings object with default.
+func NewTypo3Settings() *Typo3Settings {
+	return &Typo3Settings{
+		DatabaseName:     "db",
+		DatabaseUsername: "db",
+		DatabasePassword: "db",
+		DatabaseHost:     "db",
+		DatabaseDriver:   "mysql",
+		DatabasePort:     appports.GetPort("db"),
+		DatabasePrefix:   "",
+		Signature:        DdevFileSignature,
+	}
+}
+
+const typo3AdditionalConfigTemplate = `<?php
+{{ $config := . }}
+/**
+ {{ $config.Signature }}: Automatically generated Typo3 AdditionalConfiguration.php file.
+ ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ */
+
+$GLOBALS['TYPO3_CONF_VARS']['DB'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['DB'], [
+                    'database' => 'db',
+                    'host' => 'db',
+                    'password' => 'db',
+                    'user' => 'db',
+]);`
+
+// createTypo3SettingsFile creates the app's LocalConfiguration.php and
+// AdditionalConfiguration.php, adding things like database host, name, and
+// password. Returns the fullpath to settings file and error
+func createTypo3SettingsFile(app *DdevApp) (string, error) {
+
+	if !fileutil.FileExists(app.SiteSettingsPath) {
+		util.Failed("Typo3 does not seem to have been set up yet, missing LocalConfiguration.php (%s)", app.SiteLocalSettingsPath)
+	}
+
+	settingsFilePath, err := app.DetermineSettingsPathLocation()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get Typo3 AdditionalConfiguration.php file path: %v", err)
+	}
+	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
+
+	// Currently there isn't any customization done for the typo3 config, but
+	// we may want to do some kind of customization in the future.
+	typo3Config := NewTypo3Settings()
+
+	err = writeTypo3SettingsFile(app, typo3Config)
+	if err != nil {
+		return settingsFilePath, fmt.Errorf("Failed to write Typo3 settings file: %v", err)
+	}
+
+	return settingsFilePath, nil
+}
+
+// writeTypo3SettingsFile produces AdditionalSettings.php file
+// It's assumed that the LocalConfiguration.php must already exist, and we're
+// overriding the db config values in it.
+func writeTypo3SettingsFile(app *DdevApp, settings *Typo3Settings) error {
+
+	filePath := app.SiteLocalSettingsPath
+	tmpl, err := template.New("settings").Funcs(sprig.TxtFuncMap()).Parse(typo3AdditionalConfigTemplate)
+	if err != nil {
+		return err
+	}
+
+	// Ensure target directory is writable.
+	dir := filepath.Dir(filePath)
+	err = os.Chmod(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	err = tmpl.Execute(file, settings)
+	if err != nil {
+		return err
+	}
+	util.CheckClose(file)
+	return nil
+}
+
+// getTypo3UploadDir just returns a static upload files (public files) dir.
+// This can be made more sophisticated in the future, for example by adding
+// the directory to the ddev config.yaml.
+func getTypo3UploadDir(app *DdevApp) string {
+	// @todo: Check to see if this can be overridden in LocalConfiguration.php
+	return "uploads"
+}
+
+// Typo3Hooks adds a typo3-specific hooks example for post-import-db
+const Typo3Hooks = `
+#     - exec: "hostname"`
+
+// getTypo3Hooks for appending as byte array
+func getTypo3Hooks() []byte {
+	// We don't have anything new to add yet, so just use Typo37 version
+	return []byte(Typo3Hooks)
+}
+
+// setTypo3SiteSettingsPaths sets the paths to settings.php/settings.local.php
+// for templating.
+func setTypo3SiteSettingsPaths(app *DdevApp) {
+	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+	var settingsFilePath, localSettingsFilePath string
+	settingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "LocalConfiguration.php")
+	localSettingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "AdditionalConfiguration.php")
+	app.SiteSettingsPath = settingsFilePath
+	app.SiteLocalSettingsPath = localSettingsFilePath
+}
+
+// isTypoApp returns true if the app is of type typo3
+func isTypo3App(app *DdevApp) bool {
+	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "typo3")); err == nil {
+		return true
+	}
+	return false
+}

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -2,10 +2,8 @@ package ddevapp
 
 import (
 	"fmt"
-	"text/template"
+	"io/ioutil"
 
-	"github.com/Masterminds/sprig"
-	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
@@ -13,38 +11,8 @@ import (
 	"path/filepath"
 )
 
-// Typo3Settings encapsulates all the configurations for a typo3 site.
-type Typo3Settings struct {
-	DeployName       string
-	DeployURL        string
-	DatabaseName     string
-	DatabaseUsername string
-	DatabasePassword string
-	DatabaseHost     string
-	DatabaseDriver   string
-	DatabasePort     string
-	DatabasePrefix   string
-	Signature        string
-}
-
-// NewTypo3Settings produces a Typo3Settings object with default.
-func NewTypo3Settings() *Typo3Settings {
-	return &Typo3Settings{
-		DatabaseName:     "db",
-		DatabaseUsername: "db",
-		DatabasePassword: "db",
-		DatabaseHost:     "db",
-		DatabaseDriver:   "mysql",
-		DatabasePort:     appports.GetPort("db"),
-		DatabasePrefix:   "",
-		Signature:        DdevFileSignature,
-	}
-}
-
 const typo3AdditionalConfigTemplate = `<?php
-{{ $config := . }}
-/**
- {{ $config.Signature }}: Automatically generated Typo3 AdditionalConfiguration.php file.
+/** ` + DdevFileSignature + `: Automatically generated Typo3 AdditionalConfiguration.php file.
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
 
@@ -52,6 +20,7 @@ $GLOBALS['TYPO3_CONF_VARS']['DB'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['DB'
                     'database' => 'db',
                     'host' => 'db',
                     'password' => 'db',
+                    'port' => '3306',
                     'user' => 'db',
 ]);`
 
@@ -61,7 +30,7 @@ $GLOBALS['TYPO3_CONF_VARS']['DB'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['DB'
 func createTypo3SettingsFile(app *DdevApp) (string, error) {
 
 	if !fileutil.FileExists(app.SiteSettingsPath) {
-		util.Failed("Typo3 does not seem to have been set up yet, missing LocalConfiguration.php (%s)", app.SiteLocalSettingsPath)
+		return "", fmt.Errorf("Typo3 does not seem to have been set up yet, missing LocalConfiguration.php (%s)", app.SiteLocalSettingsPath)
 	}
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
@@ -70,32 +39,24 @@ func createTypo3SettingsFile(app *DdevApp) (string, error) {
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
-	// Currently there isn't any customization done for the typo3 config, but
-	// we may want to do some kind of customization in the future.
-	typo3Config := NewTypo3Settings()
-
-	err = writeTypo3SettingsFile(app, typo3Config)
+	err = writeTypo3SettingsFile(app)
 	if err != nil {
-		return settingsFilePath, fmt.Errorf("Failed to write Typo3 settings file: %v", err)
+		return settingsFilePath, fmt.Errorf("Failed to write Typo3 AdditionalConfiguration.php file: %v", err)
 	}
 
 	return settingsFilePath, nil
 }
 
-// writeTypo3SettingsFile produces AdditionalSettings.php file
+// writeTypo3SettingsFile produces AdditionalConfiguration.php file
 // It's assumed that the LocalConfiguration.php must already exist, and we're
 // overriding the db config values in it.
-func writeTypo3SettingsFile(app *DdevApp, settings *Typo3Settings) error {
+func writeTypo3SettingsFile(app *DdevApp) error {
 
 	filePath := app.SiteLocalSettingsPath
-	tmpl, err := template.New("settings").Funcs(sprig.TxtFuncMap()).Parse(typo3AdditionalConfigTemplate)
-	if err != nil {
-		return err
-	}
 
 	// Ensure target directory is writable.
 	dir := filepath.Dir(filePath)
-	err = os.Chmod(dir, 0755)
+	err := os.Chmod(dir, 0755)
 	if err != nil {
 		return err
 	}
@@ -104,7 +65,8 @@ func writeTypo3SettingsFile(app *DdevApp, settings *Typo3Settings) error {
 	if err != nil {
 		return err
 	}
-	err = tmpl.Execute(file, settings)
+	contents := []byte(typo3AdditionalConfigTemplate)
+	err = ioutil.WriteFile(filePath, contents, 0644)
 	if err != nil {
 		return err
 	}
@@ -116,7 +78,7 @@ func writeTypo3SettingsFile(app *DdevApp, settings *Typo3Settings) error {
 // This can be made more sophisticated in the future, for example by adding
 // the directory to the ddev config.yaml.
 func getTypo3UploadDir(app *DdevApp) string {
-	// @todo: Check to see if this can be overridden in LocalConfiguration.php
+	// @todo: Check to see if this gets overridden in LocalConfiguration.php
 	return "uploads"
 }
 

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -84,11 +84,11 @@ func getTypo3UploadDir(app *DdevApp) string {
 
 // Typo3Hooks adds a typo3-specific hooks example for post-import-db
 const Typo3Hooks = `
-#     - exec: "hostname"`
+#     - exec: "echo database was loaded"`
 
 // getTypo3Hooks for appending as byte array
 func getTypo3Hooks() []byte {
-	// We don't have anything new to add yet, so just use Typo37 version
+	// We don't have anything new to add yet.
 	return []byte(Typo3Hooks)
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

We want to officially detect and support typo3.

## How this PR Solves The Problem:

* Typo3 is detected
* Import-db and related actions work


## Manual Testing Instructions:

Spin up a few typo3 sites, and import the db for them. I would imagine we'll learn something along the way. 

The assumption (enforced by the code here) is that typo3 must already have been through an installation process and a typo3conf/LocalConfiguration.php has been created *by typo3*. On import-db, we add an AdditionalConfiguration.php that overrides the database credentials.

Typo3 creates many more files and has much more outside-the-db configuration than we've experienced before, so I'm not entirely sure what the result of that will be.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

Tests still being visualized.

## Related Issue Link(s):

OP #570 - "Official support for typo3"

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

It looks to me like typo3 is pretty specific about versions. For example. a database from 8.0.0 doesn't seem to work in 8.7.