### PR TITLE
Make ddev config work with args when no --apptype provided, fixes #616

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -32,7 +33,7 @@ var appType string
 // ConfigCommand represents the `ddev config` command
 var ConfigCommand = &cobra.Command{
 	Use:   "config [provider]",
-	Short: "Create or modify a ddev application config in the current directory",
+	Short: "Create or modify a ddev project configuration in the current directory",
 	Run: func(cmd *cobra.Command, args []string) {
 
 		appRoot, err := os.Getwd()
@@ -90,23 +91,23 @@ var ConfigCommand = &cobra.Command{
 				util.Failed("--pantheon-environment can only be used with pantheon provider, for example 'ddev config pantheon --pantheon-environment=dev --docroot=docroot'")
 			}
 
-			if !ddevapp.IsValidAppType(appType) {
+			if appType != "" && !ddevapp.IsValidAppType(appType) {
 				validAppTypes := strings.Join(ddevapp.GetValidAppTypes(), ", ")
 				util.Failed("apptype must be one of %s", validAppTypes)
 			}
 
-			foundAppType := app.DetectAppType()
+			detectedApptype := app.DetectAppType()
 			fullPath, pathErr := filepath.Abs(app.Docroot)
 			if pathErr != nil {
 				util.Failed("Failed to get absolute path to Docroot %s: %v", app.Docroot, pathErr)
 			}
-			if appType == "" || appType == foundAppType { // Found an app, matches passed-in or no apptype passed
-				appType = foundAppType
-				util.Success("Found a %s codebase at %s", foundAppType, fullPath)
+			if appType == "" || appType == detectedApptype { // Found an app, matches passed-in or no apptype passed
+				appType = detectedApptype
+				util.Success("Found a %s codebase at %s", detectedApptype, fullPath)
 			} else if appType != "" { // apptype was passed, but we found no app at all
 				util.Warning("You have specified an apptype of %s but no app of that type is found in %s", appType, fullPath)
-			} else if appType != "" && foundAppType != appType { // apptype was passed, app was found, but not the same type
-				util.Warning("You have specified an apptype of %s but an app of type %s was discovered in %s", appType, foundAppType, fullPath)
+			} else if appType != "" && detectedApptype != appType { // apptype was passed, app was found, but not the same type
+				util.Warning("You have specified an apptype of %s but an app of type %s was discovered in %s", appType, detectedApptype, fullPath)
 			}
 			app.Type = appType
 
@@ -148,10 +149,15 @@ var ConfigCommand = &cobra.Command{
 }
 
 func init() {
+	validAppTypes := strings.Join(ddevapp.GetValidAppTypes(), ", ")
+	apptypeUsage := fmt.Sprintf("Provide the project type (one of %s). This is autodetected and this flag is necessary only to override the detection.", validAppTypes)
+
 	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", "Provide the sitename of site to configure (normally the same as the directory name)")
 	ConfigCommand.Flags().StringVarP(&docrootRelPath, "docroot", "", "", "Provide the relative docroot of the site, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory")
 	ConfigCommand.Flags().StringVarP(&pantheonEnvironment, "pantheon-environment", "", "", "Choose the environment for a Pantheon site (dev/test/prod) (Pantheon-only)")
-	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", "Provide the app type (like wordpress or drupal7 or drupal8). This is normally autodetected and this flag is not necessary")
+	ConfigCommand.Flags().StringVarP(&appType, "projecttype", "", "", apptypeUsage)
+	// apptype flag is there for backwards compatibility.
+	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
 
 	RootCmd.AddCommand(ConfigCommand)
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -30,6 +30,9 @@ const fallbackPantheonEnvironment = "dev"
 // appType is the ddev app type, like drupal7/drupal8/wordpress
 var appType string
 
+// showConfigLocation if set causes the command to show the config location.
+var showConfigLocation bool
+
 // ConfigCommand represents the `ddev config` command
 var ConfigCommand = &cobra.Command{
 	Use:   "config [provider]",
@@ -54,6 +57,16 @@ var ConfigCommand = &cobra.Command{
 		app, err := ddevapp.NewApp(appRoot, provider)
 		if err != nil {
 			util.Failed("Could not create new config: %v", err)
+		}
+
+		// Support the show-config-location flag.
+		if showConfigLocation {
+			activeApp, err := ddevapp.GetActiveApp("")
+			if err != nil && activeApp.ConfigPath != "" && activeApp.ConfigExists() {
+				util.Success("The project config location is %s", activeApp.ConfigPath)
+				return
+			}
+			util.Failed("No project configuration currently exists")
 		}
 
 		// If they have not given us any flags, we prompt for full info. Otherwise, we assume they're in control.
@@ -158,6 +171,7 @@ func init() {
 	ConfigCommand.Flags().StringVarP(&appType, "projecttype", "", "", apptypeUsage)
 	// apptype flag is there for backwards compatibility.
 	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
+	ConfigCommand.Flags().BoolVarP(&showConfigLocation, "show-config-location", "", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
 
 	RootCmd.AddCommand(ConfigCommand)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

In the multi-CMS rework, I seem to have made it so you can't use `ddev config --docroot=.`, for example, without specifying the apptype (you have to do `ddev config --apptype=drupal6 --docroot=.`

This problem breaks ddev-ui (which does not provide --approot)

## How this PR Solves The Problem:

Check to see if appRoot is empty and if so detect. The detection was already there, but the failure here was higher up.

## Manual Testing Instructions:

* Run `ddev config --docroot=.` and see if it works. Try other combinations of things with ddev config. Look at `ddev config -h`.
* Test with ddev-ui. Without this patch, "add from repo" is nonfunctional. With this patch it should work OK.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #616

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

This adds a new flag --projectroot, which is the same as --approot. That should become the new standard. But since people don't use ddev config with flags, we should be ok.