### PR TITLE
Support router_http_port and router_https_port in config.yaml, fixes #481

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -107,7 +107,7 @@ func TestDescribeAppFunction(t *testing.T) {
 		assert.EqualValues(v.Dir, desc["approot"].(string))
 
 		out, _ := json.Marshal(desc)
-		assert.Contains(string(out), app.GetURL())
+		assert.Contains(string(out), app.GetHTTPURL())
 		assert.Contains(string(out), app.GetName())
 		assert.Contains(string(out), "\"router_status\":\"healthy\"")
 		assert.Contains(string(out), ddevapp.RenderHomeRootedDir(v.Dir))

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -42,7 +42,7 @@ func TestDevList(t *testing.T) {
 
 		// Look for standard items in the regular ddev list output
 		assert.Contains(string(out), v.Name)
-		assert.Contains(string(out), app.GetURL())
+		assert.Contains(string(out), app.GetHTTPURL())
 		assert.Contains(string(out), app.GetType())
 		assert.Contains(string(out), ddevapp.RenderHomeRootedDir(app.GetAppRoot()))
 

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -56,7 +56,7 @@ func appImport(skipConfirmation bool) {
 	}
 
 	util.Success("Successfully Imported.")
-	util.Success("Your application can be reached at: %s", app.GetURL())
+	util.Success("Your project can be reached at: %s and %s", app.GetHTTPURL(), app.GetHTTPSURL())
 }
 
 func init() {

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -42,7 +42,7 @@ var DdevRestartCmd = &cobra.Command{
 		}
 
 		util.Success("Successfully restarted %s", app.GetName())
-		util.Success("Your application can be reached at: %s", app.GetURL())
+		util.Success("Your project can be reached at: %s and %s", app.GetHTTPURL(), app.GetHTTPSURL())
 	},
 }
 

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -28,8 +28,9 @@ func TestDevRestart(t *testing.T) {
 			assert.Fail("Could not find an active ddev configuration: %v", err)
 		}
 
-		assert.Contains(string(out), "Your application can be reached at")
-		assert.Contains(string(out), app.GetURL())
+		assert.Contains(string(out), "Your project can be reached at")
+		assert.Contains(string(out), app.GetHTTPURL())
+		assert.Contains(string(out), app.GetHTTPSURL())
 
 		cleanup()
 	}
@@ -70,8 +71,9 @@ func TestDevRestartJSON(t *testing.T) {
 		}
 
 		// Go ahead and look for normal strings within the json output.
-		assert.Contains(string(out), "Your application can be reached at")
-		assert.Contains(string(out), app.GetURL())
+		assert.Contains(string(out), "Your project can be reached at")
+		assert.Contains(string(out), app.GetHTTPURL())
+		assert.Contains(string(out), app.GetHTTPSURL())
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -31,10 +31,11 @@ provide a working environment for development.`,
 	},
 }
 
+// appStart is a convenience function to encapsulate startup functionality
 func appStart() {
 	app, err := ddevapp.GetActiveApp("")
 	if err != nil {
-		util.Failed("Failed to start: %v", err)
+		util.Failed("Failed to start project: %v", err)
 	}
 
 	output.UserOut.Printf("Starting environment for %s...", app.GetName())

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -45,19 +44,8 @@ func appStart() {
 		util.Failed("Failed to start %s: %v", app.GetName(), err)
 	}
 
-	var https bool
-	web, err := app.FindContainerByType("web")
-	if err == nil {
-		https = dockerutil.CheckForHTTPS(web)
-	}
-
-	urlString := fmt.Sprintf("http://%s", app.HostName())
-	if https {
-		urlString = fmt.Sprintf("%s\nhttps://%s", urlString, app.HostName())
-	}
-
 	util.Success("Successfully started %s", app.GetName())
-	util.Success("Your application can be reached at:\n%s", urlString)
+	util.Success("Your project can be reached at %s and %s", app.GetHTTPURL(), app.GetHTTPSURL())
 
 }
 func init() {

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -35,7 +35,7 @@ When running `ddev start` you should see output informing you that the project's
 
 ```
 Successfully started example-wordpress-site
-Your application can be reached at: http://example-wordpress-site.ddev.local
+Your project can be reached at: http://example-wordpress-site.ddev.local
 ```
 
 Quickstart instructions regarding database imports can be found under [Database Imports](#database-imports).
@@ -66,8 +66,8 @@ ddev start
 While `ddev start` is running you will see output informing you that the project's environment is being started. When startup is complete, you'll see a message like the one below telling you where the project can be reached.
 
 ```
-Successfully started my-drupal-site
-Your application can be reached at: http://my-drupal-site.ddev.local
+Successfully started my-drupal7-site
+Your project can be reached at: http://my-drupal7-site.ddev.local
 ```
 
 Quickstart instructions for database imports can be found under [Database Imports](#database-imports).
@@ -110,7 +110,7 @@ After running `ddev start` you should see output informing you that the project'
 
 ```
 Successfully started my-drupal8-site
-Your application can be reached at: http://my-drupal8-site.ddev.local
+Your project can be reached at: http://my-drupal8-site.ddev.local
 ```
 
 ### TYPO3 Quickstart
@@ -197,7 +197,7 @@ Creating local-drupal8-db
 Creating local-drupal8-web
 Waiting for the environment to become ready. This may take a couple of minutes...
 Successfully started drupal8
-Your application can be reached at: http://drupal8.ddev.local
+Your project can be reached at: http://drupal8.ddev.local
 ```
 
 And you can now visit your working project. Enjoy!

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -5,15 +5,35 @@ Things might go wrong!
 <a name="unable-listen"></a>
 ## Webserver ports are already occupied by another webserver
 
-If you get a message from ddev about a port conflict on port 80 or 443, like this:
+If you get a message from ddev about a port conflict, like this:
 
 ```
-Failed to start yoursite: Unable to listen on required ports, Localhost port 80 is in use
+Failed to start yoursite: Unable to listen on required ports, localhost port 80 is in use,
 ```
 
-it means that you have another webserver listening on port 80 (or 443, or both), and it needs to be stopped so that ddev can access the port. 
+it means that you have another webserver listening on the named port(s), and it needs to be stopped so that ddev can access the port. 
 
-Probably the most common reason for this is that Apache is running locally. It can often be stopped gracefully (but temporarily) with:
+You have two choices: 
+
+1. You can configure your project to use different ports
+2. You can stop the competing application.
+
+### Configuring your project to use non-conflicting ports
+
+To configure your project to use non-conflicting ports, edit the project's .ddev/config.yaml to add entries like `router_http_port: 8000` and `router_https_port: 8443` depending on your needs, then use `ddev start` again. For example, if you had a port conflict with a local apache http on port 80, you could add
+
+```
+router_http_port: 8000
+```
+
+to the config.yaml, and `ddev start`, and the project's http URL will change to http://yoursite.ddev.local:8000.
+
+
+### Fixing port conflicts by stopping the other application
+
+If you choose to do so you can also just stop the other application.
+
+Probably the most common conflicting application is Apache running locally. It can often be stopped gracefully (but temporarily) with:
 
 ```
 sudo apachectl stop

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -79,7 +79,7 @@ func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	if _, err := os.Stat(app.ConfigPath); !os.IsNotExist(err) {
 		err = app.ReadConfig()
 		if err != nil {
-			return app, fmt.Errorf("%v exists but cannot be read: %v", app.ConfigPath, err)
+			return app, fmt.Errorf("%v exists but cannot be read. It may be invalid due to a syntax error.: %v", app.ConfigPath, err)
 		}
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -26,6 +26,12 @@ const DefaultProviderName = "default"
 // DdevDefaultPHPVersion is the default PHP version, overridden by $DDEV_PHP_VERSION
 const DdevDefaultPHPVersion = "7.1"
 
+// DdevDefaultRouterHTTPPort is the starting router port, 80
+const DdevDefaultRouterHTTPPort = "80"
+
+// DdevDefaultRouterHTTPSPort is the starting https router port, 443
+const DdevDefaultRouterHTTPSPort = "443"
+
 // CurrentAppVersion sets the current YAML config file version.
 // We're not doing anything with AppVersion, so just default it to 1 for now.
 const CurrentAppVersion = "1"
@@ -60,6 +66,8 @@ func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	app.ConfigPath = app.GetConfigPath("config.yaml")
 	app.APIVersion = CurrentAppVersion
 	app.PHPVersion = DdevDefaultPHPVersion
+	app.RouterHTTPPort = DdevDefaultRouterHTTPPort
+	app.RouterHTTPSPort = DdevDefaultRouterHTTPSPort
 
 	// These should always default to the latest image/tag names from the Version package.
 	app.WebImage = version.WebImg + ":" + version.WebTag
@@ -163,6 +171,14 @@ func (app *DdevApp) ReadConfig() error {
 	}
 	if app.PHPVersion == "" {
 		app.PHPVersion = DdevDefaultPHPVersion
+	}
+
+	if app.RouterHTTPPort == "" {
+		app.RouterHTTPPort = DdevDefaultRouterHTTPPort
+	}
+
+	if app.RouterHTTPSPort == "" {
+		app.RouterHTTPSPort = DdevDefaultRouterHTTPSPort
 	}
 
 	if app.WebImage == "" {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -155,8 +155,8 @@ func (app *DdevApp) Describe() (map[string]interface{}, error) {
 		dbinfo["published_port"] = fmt.Sprint(dockerutil.GetPublishedPort(dbPrivatePort, db))
 		appDesc["dbinfo"] = dbinfo
 
-		appDesc["mailhog_url"] = app.GetHTTPURL() + ":" + appports.GetPort("mailhog")
-		appDesc["phpmyadmin_url"] = app.GetHTTPURL() + ":" + appports.GetPort("dba")
+		appDesc["mailhog_url"] = "http://" + app.GetHostname() + ":" + appports.GetPort("mailhog")
+		appDesc["phpmyadmin_url"] = "http://" + app.GetHostname() + ":" + appports.GetPort("dba")
 	}
 
 	appDesc["router_status"] = GetRouterStatus()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -740,7 +740,7 @@ func (app *DdevApp) Stop() error {
 		return err
 	}
 
-	return StopRouter()
+	return StopRouterIfNoContainers()
 }
 
 // Wait ensures that the app service containers are healthy.
@@ -832,7 +832,7 @@ func (app *DdevApp) Down(removeData bool) error {
 		}
 	}
 
-	err = StopRouter()
+	err = StopRouterIfNoContainers()
 	return err
 }
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -585,8 +585,8 @@ func TestRouterPortsCheck(t *testing.T) {
 	err = app.Start()
 	assert.NoError(err, "app.Start(%s) failed, err: %v", app.GetName(), err)
 
-	// Stop the router using code from StopRouter().
-	// StopRouter can't be used here because it checks to see if containers are running
+	// Stop the router using code from StopRouterIfNoContainers().
+	// StopRouterIfNoContainers can't be used here because it checks to see if containers are running
 	// and doesn't do its job as a result.
 	dest := ddevapp.RouterComposeYAMLPath()
 	_, _, err = dockerutil.ComposeCmd([]string{dest}, "-p", ddevapp.RouterProjectName, "down", "-v")

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -116,7 +116,8 @@ func StartDdevRouter() error {
 }
 
 // findDdevRouter usees FindContainerByLabels to get our router container and
-// return it
+// return it. This is currently unused but may be useful in the future.
+// nolint: deadcode
 func findDdevRouter() (docker.APIContainers, error) {
 	containerQuery := map[string]string{
 		"com.docker.compose.service": RouterProjectName,

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -59,7 +59,7 @@ func StartDdevRouter() error {
 	if _, err = os.Stat(certDir); os.IsNotExist(err) {
 		err = os.MkdirAll(certDir, 0755)
 		if err != nil {
-			return fmt.Errorf("unable to create directory for ddev router: %v", err)
+			return fmt.Errorf("unable to create directory for ddev certs: %v", err)
 		}
 	}
 

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"path/filepath"
 
-	"net"
 	"strings"
 
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -224,12 +223,7 @@ func determineRouterPorts() []string {
 func CheckRouterPorts() error {
 	routerPorts := determineRouterPorts()
 	for _, port := range routerPorts {
-		conn, err := net.Dial("tcp", ":"+port)
-		// We want an error (inability to connect), that's the success case.
-		// If we don't get one, return err. This will normally be "getsockopt: connection refused"
-		// For simplicity we're not actually studying the err value.
-		if err == nil {
-			_ = conn.Close()
+		if util.IsPortActive(port) {
 			return fmt.Errorf("localhost port %s is in use", port)
 		}
 	}

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -31,7 +31,10 @@ func TestPortOverride(t *testing.T) {
 		app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
 		assert.NoError(err)
 		app.RouterHTTPPort = strconv.Itoa(80 + i)
-		app.RouterHTTPSPort = strconv.Itoa(443 + i)
+		// Note that we start with port 453 instead of 443 here because Windows
+		// by default has port 445 occupied by NetBT (Netbios over TCP)
+		// So the test will fail because of that.
+		app.RouterHTTPSPort = strconv.Itoa(453 + i)
 		app.Name = "TestPortOverride-" + strconv.Itoa(i)
 		app.Type = "php"
 		err = app.WriteConfig()

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -1,0 +1,69 @@
+package ddevapp_test
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
+	asrt "github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+)
+
+// TestPortOverride makes sure that the router_http_port and router_https_port
+// config.yaml overrides work correctly.
+// It starts up 3 ddev projects, looks to see if the config is set right,
+// then tests to see that the right ports have been started up on the router.
+func TestPortOverride(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Try some different combinations of ports. The first (offset 0) will
+	// share ports with already-started test sites.
+	for i := 0; i < 3; i++ {
+		testDir := testcommon.CreateTmpDir("TestPortOverride")
+
+		// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+		defer testcommon.CleanupDir(testDir)
+		defer testcommon.Chdir(testDir)()
+
+		testcommon.ClearDockerEnv()
+
+		app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+		assert.NoError(err)
+		app.RouterHTTPPort = strconv.Itoa(80 + i)
+		app.RouterHTTPSPort = strconv.Itoa(443 + i)
+		app.Name = "TestPortOverride-" + strconv.Itoa(i)
+		app.Type = "php"
+		err = app.WriteConfig()
+		assert.NoError(err)
+		err = app.ReadConfig()
+		assert.NoError(err)
+
+		stringFound, err := fileutil.FgrepStringInFile(app.ConfigPath, "router_http_port: \""+app.RouterHTTPPort+"\"")
+		assert.NoError(err)
+		assert.True(stringFound)
+		stringFound, err = fileutil.FgrepStringInFile(app.ConfigPath, "router_https_port: \""+app.RouterHTTPSPort+"\"")
+		assert.NoError(err)
+		assert.True(stringFound)
+
+		// These ports will already be active if on the standard port, because
+		// the TestMain has started stuff up on the standard ports.
+		if i != 0 {
+			assert.False(util.IsPortActive(app.RouterHTTPPort))
+			assert.False(util.IsPortActive(app.RouterHTTPSPort))
+		}
+
+		err = app.Start()
+		assert.NoError(err)
+		err = app.Wait("web")
+		assert.NoError(err)
+		assert.True(util.IsPortActive(app.RouterHTTPPort))
+		assert.True(util.IsPortActive(app.RouterHTTPSPort))
+		// defer the app.Down so we have a more diverse set of tests. If we brought
+		// each down before testing the next that would be a more trivial test.
+		// Don't worry about the possible error case as this is just a test cleanup
+		// nolint: errcheck
+		defer app.Down(true)
+	}
+
+}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -33,6 +33,7 @@ services:
       - db
     links:
       - db:db
+    # ports is list of exposed *container* ports
     ports:
       - "80"
       - "{{ .mailhogport }}"
@@ -43,14 +44,16 @@ services:
       - DDEV_URL=$DDEV_URL
       - DOCROOT=$DDEV_DOCROOT
       - DDEV_PHP_VERSION=$DDEV_PHP_VERSION
+      - DDEV_ROUTER_HTTP_PORT=$DDEV_ROUTER_HTTP_PORT
+      - DDEV_ROUTER_HTTPS_PORT=$DDEV_ROUTER_HTTPS_PORT
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
-      - HTTP_EXPOSE=80,{{ .mailhogport }}
+      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,{{ .mailhogport }}
       # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
       # To expose an HTTPS port, define the port as securePort:containerPort.
-      - HTTPS_EXPOSE=443:80
+      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .plugin }}

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -129,7 +129,7 @@ func Cleanup(app *DdevApp) error {
 		}
 	}
 
-	err = StopRouter()
+	err = StopRouterIfNoContainers()
 	return err
 }
 

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -145,7 +145,7 @@ func createWordpressSettingsFile(app *DdevApp) (string, error) {
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 	wpConfig := NewWordpressConfig()
-	wpConfig.DeployURL = app.GetURL()
+	wpConfig.DeployURL = app.GetHTTPURL()
 	err := WriteWordpressConfig(wpConfig, settingsFilePath)
 	return settingsFilePath, err
 }
@@ -199,6 +199,6 @@ func isWordpressApp(app *DdevApp) bool {
 // wordpressPostImportDBAction just emits a warning about updating URLs as is
 // required with wordpress when running on a different URL.
 func wordpressPostImportDBAction(app *DdevApp) error {
-	util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", app.GetURL())
+	util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", app.GetHTTPURL())
 	return nil
 }

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -234,6 +234,8 @@ func ClearDockerEnv() {
 		"DDEV_IMPORTDIR",
 		"DDEV_DATADIR",
 		"DDEV_PHP_VERSION",
+		"DDEV_ROUTER_HTTP_PORT",
+		"DDEV_ROUTER_HTTPS_PORT",
 	}
 	for _, env := range envVars {
 		err := os.Unsetenv(env)

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -161,11 +161,15 @@ func IsPortActive(port string) bool {
 	oe, ok := err.(*net.OpError)
 	if ok {
 		syscallErr, ok := oe.Err.(*os.SyscallError)
-		if ok && syscallErr.Err == syscall.ECONNREFUSED {
+
+		// On Windows, WSAECONNREFUSED (10061) results instead of ECONNREFUSED. And golang doesn't seem to have it.
+		var WSAECONNREFUSED syscall.Errno = 10061
+
+		if ok && (syscallErr.Err == syscall.ECONNREFUSED || syscallErr.Err == WSAECONNREFUSED) {
 			return false
 		}
 	}
 	// Otherwise, hmm, something else happened. It's not a fatal or anything.
-	Warning("Failed to properly check port status: %v", oe)
+	Warning("Unable to properly check port status: %v", oe)
 	return false
 }

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/cheggaaa/pb"
@@ -145,4 +147,25 @@ func EnsureHTTPStatus(o *HTTPOptions) error {
 			return fmt.Errorf("timed out after %d seconds. Got status %d, wanted %d", o.Timeout, respCode, o.ExpectedStatus)
 		}
 	}
+}
+
+// IsPortActive checks to see if the given port on localhost is answering.
+func IsPortActive(port string) bool {
+	conn, err := net.Dial("tcp", ":"+port)
+	// If we were able to connect, something is listening on the port.
+	if err == nil {
+		_ = conn.Close()
+		return true
+	}
+	// If we get ECONNREFUSED the port is not active.
+	oe, ok := err.(*net.OpError)
+	if ok {
+		syscallErr, ok := oe.Err.(*os.SyscallError)
+		if ok && syscallErr.Err == syscall.ECONNREFUSED {
+			return false
+		}
+	}
+	// Otherwise, hmm, something else happened. It's not a fatal or anything.
+	Warning("Failed to properly check port status: %v", oe)
+	return false
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #481: We need to allow people to choose a different router port

## How this PR Solves The Problem:

New elements in config.yaml for each site allow the user to override router_http_port and router_https_port

## Manual Testing Instructions:

1. Stop the project and delete the .ddev/docker-compose.yml (New respect for an environment variable in the docker-compose.yml is required)
2. Add "router_http_port: 8080" to a site's config.yaml and `ddev start`. The correct URL should show everywhere that URLs are displayed.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

- [ ] Depending on how ddev-ui calculates or uses the URL in describe, it may have to add respect for the port number.