### PR TITLE
Updated build-tools to 1.5.3

### DIFF
--- a/build-tools/Makefile.example
+++ b/build-tools/Makefile.example
@@ -8,11 +8,11 @@ PKG := github.com/drud/repo_name
 # Docker repo for a push
 # DOCKER_REPO ?= drud/docker_repo_name
 
-# Upstream repo used in the Dockerfile
+# Upstream repo optionally used in the Dockerfile
 # UPSTREAM_REPO ?= full/upstream-docker-repo
 
 # Top-level directories to build
-SRC_DIRS := files drudapi secrets utils
+SRC_DIRS := pkg cmd
 
 # Version variables to replace in build, The variable VERSION is automatically pulled from git committish so it doesn't have to be added
 # These are replaced in the $(PKG).version package.
@@ -26,16 +26,14 @@ SRC_DIRS := files drudapi secrets utils
 # DOCKER_ARGS =
 
 # VERSION can be set by
-  # Default: git tag
-  # make command line: make VERSION=0.9.0
-# It can also be explicitly set in the Makefile as commented out below.
+	# Default: git tag
+	# make command line: make VERSION=0.9.0
 
-# This version-strategy uses git tags to set the version string
-# VERSION can be overridden on make commandline: make VERSION=0.9.1 push
+# Normally VERSION is derived from git committish/tag.
+# VERSION can be overridden on make commandline: make push VERSION=0.9.1
+# Using the git committish means we can always tie code to container or binary.
 VERSION := $(shell git describe --tags --always --dirty)
-#
-# This version-strategy uses a manual value to set the version string
-#VERSION := 1.2.3
+
 
 # Each section of the Makefile is included from standard components below.
 # If you need to override one, import its contents below and comment out the
@@ -49,5 +47,5 @@ include build-tools/makefile_components/base_test_go.mak
 #include build-tools/makefile_components/base_test_python.mak
 
 
-# Additional targets can be added here
+# Additional targets can be added below.
 # Also, existing targets can be overridden by copying and customizing them.

--- a/build-tools/makefile_components/base_build_python-docker.mak
+++ b/build-tools/makefile_components/base_build_python-docker.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 PWD := $(shell pwd)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.2.0
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.2
 
 all: VERSION.txt build
 

--- a/build-tools/makefile_components/base_test_go.mak
+++ b/build-tools/makefile_components/base_test_go.mak
@@ -11,10 +11,10 @@ test: build
 	@mkdir -p $(GOTMP)/{src/$(PKG),pkg,bin,std/linux}
 	@echo "Testing $(SRC_AND_UNDER) with TESTARGS=$(TESTARGS)"
 	@docker run -t --rm  -u $(shell id -u):$(shell id -g)                 \
-	    -v $(PWD)/$(GOTMP):/go                                                 \
-	    -v $(PWD):/go/src/$(PKG)                                          \
-	    -v $(PWD)/bin/linux:/go/bin                                     \
-	    -v $(PWD)/$(GOTMP)/std/linux:/usr/local/go/pkg/linux_amd64_static  \
+	    -v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+	    -v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+	    -v $(PWD)/bin/linux:/go/bin$(DOCKERMOUNTFLAG)                                     \
+	    -v $(PWD)/$(GOTMP)/std/linux:/usr/local/go/pkg/linux_amd64_static$(DOCKERMOUNTFLAG)  \
 	    -e CGO_ENABLED=0	\
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -95,14 +95,14 @@ func TestServices(t *testing.T) {
 					"com.docker.compose.service": serviceName,
 				}
 
-				container, err := dockerutil.FindContainerByLabels(labels)
+				container, findErr := dockerutil.FindContainerByLabels(labels)
 				assert.NoError(err)
-				if err != nil {
-					t.Fatalf("Could not find running container for service %s. Skipping remainder of test.", serviceName)
+				if findErr != nil {
+					t.Fatalf("Could not find running container for service %s. Skipping remainder of test: %v", serviceName, findErr)
 				}
 				name := dockerutil.ContainerName(container)
-				check, err := testcommon.ContainerCheck(name, "running")
-				assert.NoError(err)
+				check, runcheckErr := testcommon.ContainerCheck(name, "running")
+				assert.NoError(runcheckErr)
 				assert.True(check, serviceName, "container is running")
 
 				// check container env for HTTP_EXPOSE ports to check
@@ -120,8 +120,8 @@ func TestServices(t *testing.T) {
 							o := util.NewHTTPOptions("http://127.0.0.1:" + string(port.PublicPort))
 							o.ExpectedStatus = 200
 							o.Timeout = 30
-							err = util.EnsureHTTPStatus(o)
-							assert.NoError(err)
+							runcheckErr = util.EnsureHTTPStatus(o)
+							assert.NoError(runcheckErr)
 						}
 					}
 				}


### PR DESCRIPTION

## The Problem/Issue/Bug:

It's time to move to golang v1.9.3, this brings in the new build-tools that does that. https://github.com/drud/build-tools/releases/tag/1.5.3

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

