### PR TITLE
Regression fix: Improve --show-config-location

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -62,11 +62,22 @@ var ConfigCommand = &cobra.Command{
 		// Support the show-config-location flag.
 		if showConfigLocation {
 			activeApp, err := ddevapp.GetActiveApp("")
-			if err != nil && activeApp.ConfigPath != "" && activeApp.ConfigExists() {
-				util.Success("The project config location is %s", activeApp.ConfigPath)
+			if err != nil {
+				if strings.Contains(err.Error(), "Have you run 'ddev config'") {
+					util.Failed("No project configuration currently exists")
+				} else {
+					util.Failed("Failed to access project configuration: %v", err)
+				}
+			}
+			if activeApp.ConfigPath != "" && activeApp.ConfigExists() {
+				rawResult := make(map[string]interface{})
+				rawResult["configpath"] = activeApp.ConfigPath
+				rawResult["approot"] = activeApp.AppRoot
+
+				friendlyMsg := fmt.Sprintf("The project config location is %s", activeApp.ConfigPath)
+				output.UserOut.WithField("raw", rawResult).Print(friendlyMsg)
 				return
 			}
-			util.Failed("No project configuration currently exists")
 		}
 
 		// If they have not given us any flags, we prompt for full info. Otherwise, we assume they're in control.

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"path"
-
 	"path/filepath"
 
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -100,7 +98,7 @@ var ConfigCommand = &cobra.Command{
 				// nolint: vetshadow
 				pwd, err := os.Getwd()
 				util.CheckErr(err)
-				app.Name = path.Base(pwd)
+				app.Name = filepath.Base(pwd)
 			}
 
 			// docrootRelPath must exist

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -13,7 +13,7 @@ func TestConfigDescribeLocation(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Create a temporary directory and switch to it.
-	tmpdir := testcommon.CreateTmpDir("config_show_location")
+	tmpdir := testcommon.CreateTmpDir("config-show-location")
 	defer testcommon.CleanupDir(tmpdir)
 	defer testcommon.Chdir(tmpdir)()
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+)
+
+// TestConfigDescribeLocation tries out the --show-config-location flag.
+func TestConfigDescribeLocation(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Create a temporary directory and switch to it.
+	tmpdir := testcommon.CreateTmpDir("config_show_location")
+	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
+
+	// Create a config
+	args := []string{"config", "--docroot=."}
+	out, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(string(out), "Found a php codebase")
+
+	// Now see if we can detect it
+	args = []string{"config", "--show-config-location"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(string(out), tmpdir)
+
+	// Now try it in a directory that doesn't have a config
+	tmpdir = testcommon.CreateTmpDir("config_show_location")
+	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
+
+	args = []string{"config", "--show-config-location"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.Error(err)
+	assert.Contains(string(out), "No project configuration currently exists")
+
+}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -972,14 +972,13 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 		return app, err
 	}
 
-	// Ignore app.Init() error (unless malformed config.yaml), since app.Init()
-	// fails if no directory found.
+	// Mostly ignore app.Init() error, since app.Init() fails if no directory found. Some errors should be handled though.
 	// We already were successful with *finding* the app, and if we get an
 	// incomplete one we have to add to it.
 	err = app.Init(activeAppRoot)
-	if err != nil && strings.Contains(err.Error(), "config.yaml exists but cannot be read.") {
-		return app, err
-	}
+	if err != nil && (strings.Contains(err.Error(), "is not a valid hostname") || strings.Contains(err.Error(), "is not a valid apptype") || strings.Contains(err.Error(), "config.yaml exists but cannot be read.")) {
+    return app, err
+  }
 
 	if app.Name == "" || app.DataDir == "" {
 		err = restoreApp(app, siteName)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -977,8 +977,8 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 	// incomplete one we have to add to it.
 	err = app.Init(activeAppRoot)
 	if err != nil && (strings.Contains(err.Error(), "is not a valid hostname") || strings.Contains(err.Error(), "is not a valid apptype") || strings.Contains(err.Error(), "config.yaml exists but cannot be read.")) {
-    return app, err
-  }
+		return app, err
+	}
 
 	if app.Name == "" || app.DataDir == "" {
 		err = restoreApp(app, siteName)


### PR DESCRIPTION
## The Problem/Issue/Bug:

At the very end of the --show-config-location add-on in https://github.com/drud/ddev/pull/618 I seem to have added a reverse piece of logic which made it not work at all.

* Fix that, to make `ddev config --show-config-location work again`
* Add a "raw" section so that ddev-ui can more easily parse the return information.
* Fix a bug I discovered where a sitename containing underscores would result in a very misleading error "no sitename provided", and where that wasn't even shown when `ddev config` was run with args.

## Manual Testing Instructions:

* Verify `ddev config --show-config-location` and `ddev config --show-config-location -j` in both configured and unconfigured directories (or subdirectories)
* Verify behavior of `ddev start` and related when an invalid "name" (especially underscores) is provided in .ddev/config.yaml. I ran into this problem when a test did a `ddev config --docroot=.` and used the standard test directory name, which had underscores.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

This adds a test for `ddev config --show-config-location`

## Related Issue Link(s):

Related https://github.com/drud/ddev/issues/514 on validating the project name earlier.
