### PR TITLE
Improve json output of hostname command to give explicit results

### DIFF
--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -49,6 +49,10 @@ var HostNameCmd = &cobra.Command{
 			rawResult["error"] = "WRITEERROR"
 			rawResult["full_error"] = fmt.Sprintf("%v", err)
 			output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("Could not write hosts file: %v", err))
+		} else {
+			rawResult["error"] = "SUCCESS"
+			rawResult["detail"] = "hostname added to hosts file"
+			output.UserOut.WithField("raw", rawResult).Info("")
 		}
 	},
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

ddev-ui needed better output from the `ddev hostname x y -j` command, so it could determine what had actually happened (and prevent some extra permission escalation).

This changes the ddev hostname json output like this:

```
ddev hostname "d7git.ddev.local" 127.0.0.1  -j
{
    "level": "info",
    "msg": "",
    "raw": {
        "detail": "hostname already exists in hosts file",
        "error": "SUCCESS"
    },
    "time": "2018-01-29T18:19:43-07:00"
}
rfay@Randy-Air:~/go/src/github.com/drud/ddev$ ddev hostname "d9git.ddev.local" 127.0.0.1  -j
{
    "level": "fatal",
    "msg": "Could not write hosts file: open /etc/hosts: permission denied",
    "raw": {
        "error": "WRITERROR",
        "full_error": "open /etc/hosts: permission denied"
    },
    "time": "2018-01-29T18:19:57-07:00"
}
```

## How this PR Solves The Problem:

## Manual Testing Instructions:

* Use `ddev hostname -j somename 127.0.0.1` where "somename" exists already and where it doesn't, and with sudo and without.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

