### PR TITLE
add troubleshooting to toc, update mkdocs meta

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: ddev Documentation
-edit_uri: edit/master/docs/
+repo_url: https://github.com/drud/ddev
+repo_name: GitHub
+edit_uri: blob/master/docs/
 copyright: DRUD Technology, LLC
 theme: readthedocs
 extra_javascript:
@@ -20,5 +22,6 @@ pages:
     - 'Integration with Hosting Providers':
       - 'Pantheon': 'users/providers/pantheon.md'
     - 'Notes for Linux Users': 'users/linux_notes.md'
+    - 'Troubleshooting': 'users/troubleshooting.md'
   - 'Developer Documentation':
     - 'Building, Testing, and Contributing': 'developers/building-contributing.md'


### PR DESCRIPTION
## The Problem/Issue/Bug:
#630 - Troubleshooting doc missing from readthedocs site
#637 - Missing "Edit on Github" links on readthedocs pages, missing readthedocs footer

## How this PR Solves The Problem:

- The troubleshooting docs page was missing from the mkdocs.yml TOC. Adding it restores the missing page and fixes the link we provide in ddev that's currently broken
- Updates the mkdocs.yml metadata to get the "Edit on Github" links to show in readthedocs. From what I can tell, this update makes it a static link back to the ddev github page. The only examples of RTD sites I can find with more specific edit links are using RST. Similarly, any of the markdown driven sites I could find with the edit link were static to their repo homepages as well.


How it doesn't :( :

- readthedocs has a footer in the menu sidebar that pops-up, with links to EPUB, PDF versions of the site, and any available alternate versions of the docs. On our site, this pop-up is empty. This appears to be due to the workaround we implemented to resolve the broken docs search. I checked other sites with the search workaround and similarly found empty footer pop-ups. IMO, search is far more important than this footer menu, especially for our project. I don't believe the the PDF and EPUB options work for our project, and we only provide one version of our docs, so there are no other versions to navigate to. I propose that we accept the lost footer and keep the search.

## Manual Testing Instructions:


An alternate version of the docs site is temporarily online to preview this change: http://ddev.readthedocs.io/en/doc-fixes/

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

