### PR TITLE
Add intl extension for TYPO3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= v0.9.1
+WebTag ?= v0.9.2
 DBImg ?= drud/mariadb-local
 DBTag ?= v0.7.1
 RouterImage ?= drud/ddev-router

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.9.1" // Note that this is overridden by make
+var WebTag = "v0.9.2" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

TYPO3 requires the intl extension

## How this PR Solves The Problem:

The container already has the intl extension in v0.9.2, so we should use that version.

## Manual Testing Instructions:

No user facing changes other than the extension being installed. `php -i | grep intl` should return some things in the container.

## Automated Testing Overview:

No automated test changes.

## Related Issue Link(s):

https://github.com/drud/ddev/issues/634

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

