### PR TITLE
Remove parsing of invited_by_id because it breaks and we don't use it, fixes #645

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
-  packages = [".","winterm"]
+  packages = [
+    ".",
+    "winterm"
+  ]
   revision = "19f72df4d05d31cbe1c56bfc8045c96babff6c7e"
 
 [[projects]]
@@ -58,7 +61,35 @@
 [[projects]]
   branch = "master"
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonlog","pkg/jsonmessage","pkg/longpath","pkg/mount","pkg/pools","pkg/promise","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/versions",
+    "opts",
+    "pkg/archive",
+    "pkg/fileutils",
+    "pkg/homedir",
+    "pkg/idtools",
+    "pkg/ioutils",
+    "pkg/jsonlog",
+    "pkg/jsonmessage",
+    "pkg/longpath",
+    "pkg/mount",
+    "pkg/pools",
+    "pkg/promise",
+    "pkg/stdcopy",
+    "pkg/system",
+    "pkg/term",
+    "pkg/term/windows"
+  ]
   revision = "9be245f438f9fb2eaeb7891673b16aed9262a192"
 
 [[projects]]
@@ -74,10 +105,10 @@
   version = "v0.3.2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/drud/go-pantheon"
   packages = ["pkg/pantheon"]
-  revision = "46aa66408de88c1d78ff95e560aa60e25147c952"
+  revision = "f7e26d4cd016ab86d4cbed264309f17dfdd25655"
+  version = "v0.1.0"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -118,13 +149,27 @@
 [[projects]]
   branch = "master"
   name = "github.com/gosuri/uitable"
-  packages = [".","util/strutil","util/wordwrap"]
+  packages = [
+    ".",
+    "util/strutil",
+    "util/wordwrap"
+  ]
   revision = "36ee7e946282a3fb1cfecd476ddc9b35d8847e42"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "68e816d1c783414e79bc65b3994d9ab6b0a722ab"
 
 [[projects]]
@@ -201,13 +246,19 @@
 
 [[projects]]
   name = "github.com/opencontainers/image-spec"
-  packages = ["specs-go","specs-go/v1"]
+  packages = [
+    "specs-go",
+    "specs-go/v1"
+  ]
   revision = "ab7389ef9f50030c9b245bc16b981c7ddf192882"
   version = "v1.0.0"
 
 [[projects]]
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/system","libcontainer/user"]
+  packages = [
+    "libcontainer/system",
+    "libcontainer/user"
+  ]
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
@@ -250,7 +301,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b"
 
 [[projects]]
@@ -292,25 +346,42 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["pbkdf2","scrypt","ssh/terminal"]
+  packages = [
+    "pbkdf2",
+    "scrypt",
+    "ssh/terminal"
+  ]
   revision = "7d9177d70076375b9a59c8fde23d52d9c4a7ecd5"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
   revision = "8351a756f30f1297fe94bbf4b767ec589c6ea6d0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "062cd7e4e68206d8bab9b18396626e855c992658"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
 
 [[projects]]
@@ -322,6 +393,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "25c7be4cfa247fa46582ee64ea5cae9c66b43af42d26f935b04bcc93a344a5da"
+  inputs-digest = "184fa914c923f63ed78adaf9f77216e2cf07a0650691ffaba1d9277084b55750"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/drud/go-pantheon/pkg/pantheon/site.go
+++ b/vendor/github.com/drud/go-pantheon/pkg/pantheon/site.go
@@ -8,12 +8,13 @@ import (
 
 // Site is a representation of a deployed pantheon site.
 type Site struct {
-	Archived    bool   `json:"archived"`
-	ID          string `json:"id"`
-	InvitedByID string `json:"invited_by_id"`
-	Key         string `json:"key"`
-	Role        string `json:"role"`
-	Site        struct {
+	Archived bool   `json:"archived"`
+	ID       string `json:"id"`
+	// invited_by_id seems to fail for some sites and we don't use it, so ignoring it here.
+	//InvitedByID string `json:"invited_by_id"`
+	Key  string `json:"key"`
+	Role string `json:"role"`
+	Site struct {
 		Created         jsonInt64 `json:"created"`
 		CreatedByUserID string    `json:"created_by_user_id"`
 		Framework       string    `json:"framework"`


### PR DESCRIPTION
## The Problem/Issue/Bug:

The invited_by_id field is apparently not always what we expect, and we don't use it. So stop parsing/using it.

This PR brings in v0.1.0 of go-pantheon, which just ignores the invited_by_id, https://github.com/drud/go-pantheon/pull/14

OP: #645 

## How this PR Solves The Problem:

## Manual Testing Instructions:

Basically we only know one person who can reproduce this. He's tested it. It's probably good to go. We don't know what the bad json looks like.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

