### PR TITLE
Make drupal 7 and drupal 8 settings distinct, recover settings[hash_salt], fixes #647

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -50,17 +50,17 @@ var appTypeMatrix map[string]AppTypeFuncs
 func init() {
 	appTypeMatrix = map[string]AppTypeFuncs{
 		"php": {},
+		"drupal6": {
+			createDrupal6SettingsFile, getDrupalUploadDir, getDrupal6Hooks, setDrupalSiteSettingsPaths, isDrupal6App, nil, drupal6ConfigOverrideAction, drupal6PostConfigAction,
+		},
 		"drupal7": {
-			createDrupalSettingsFile, getDrupalUploadDir, getDrupal7Hooks, setDrupalSiteSettingsPaths, isDrupal7App, nil, drupal7ConfigOverrideAction, nil,
+			createDrupal7SettingsFile, getDrupalUploadDir, getDrupal7Hooks, setDrupalSiteSettingsPaths, isDrupal7App, nil, drupal7ConfigOverrideAction, nil,
 		},
 		"drupal8": {
-			createDrupalSettingsFile, getDrupalUploadDir, getDrupal8Hooks, setDrupalSiteSettingsPaths, isDrupal8App, nil, nil, nil,
+			createDrupal8SettingsFile, getDrupalUploadDir, getDrupal8Hooks, setDrupalSiteSettingsPaths, isDrupal8App, nil, nil, nil,
 		},
 		"wordpress": {
 			createWordpressSettingsFile, getWordpressUploadDir, getWordpressHooks, setWordpressSiteSettingsPaths, isWordpressApp, wordpressPostImportDBAction, nil, nil,
-		},
-		"drupal6": {
-			createDrupal6SettingsFile, getDrupalUploadDir, getDrupal6Hooks, setDrupalSiteSettingsPaths, isDrupal6App, nil, drupal6ConfigOverrideAction, drupal6PostConfigAction,
 		},
 		"typo3": {
 			createTypo3SettingsFile, getTypo3UploadDir, getTypo3Hooks, setTypo3SiteSettingsPaths, isTypo3App, nil, nil, nil,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -234,6 +234,21 @@ func TestDdevImportDB(t *testing.T) {
 			path := filepath.Join(testDir, "testdata", file)
 			err = app.ImportDB(path, "")
 			assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", path, err)
+
+			settingsPath := filepath.Join(site.DocrootBase, "sites", "default", "settings.local.php")
+
+			// Make sure that the settings.local.php had correct hash_salt format
+			drupalHashSalt, err := fileutil.FgrepStringInFile(settingsPath, "$drupal_hash_salt")
+			assert.NoError(err)
+			settingsHashSalt, err := fileutil.FgrepStringInFile(settingsPath, "settings['hash_salt']")
+			assert.NoError(err)
+
+			switch site.Type {
+			case "drupal7":
+				assert.True(!settingsHashSalt && drupalHashSalt)
+			case "drupal8":
+				assert.True(!drupalHashSalt && settingsHashSalt)
+			}
 		}
 
 		if site.DBTarURL != "" {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -25,6 +25,14 @@ import (
 var (
 	TestSites = []testcommon.TestSite{
 		{
+			Name:                          "TestMainPkgWordpress",
+			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
+			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+			DocrootBase:                   "htdocs",
+		},
+		{
 			Name:                          "TestMainPkgDrupal8",
 			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.4.0.tar.gz",
 			ArchiveInternalExtractionPath: "drupal-8.4.0/",
@@ -44,14 +52,6 @@ var (
 			DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
 			FullSiteTarballURL:            "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/site.tar.gz",
 			DocrootBase:                   "docroot",
-		},
-		{
-			Name:                          "TestMainPkgWordpress",
-			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
-			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
-			DocrootBase:                   "htdocs",
 		},
 	}
 )

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -27,7 +27,6 @@ type DrupalSettings struct {
 	DatabasePort     string
 	DatabasePrefix   string
 	HashSalt         string
-	IsDrupal8        bool
 	Signature        string
 }
 
@@ -41,7 +40,6 @@ func NewDrupalSettings() *DrupalSettings {
 		DatabaseDriver:   "mysql",
 		DatabasePort:     appports.GetPort("db"),
 		DatabasePrefix:   "",
-		IsDrupal8:        false,
 		HashSalt:         util.RandString(64),
 		Signature:        DdevFileSignature,
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Drupal8-specific config values got lost in the appmatrix refactor, we need to get them back. The most obvious was the loss of `$settings["hash_salt"]`

## How this PR Solves The Problem:

* Splits the d7 and d8 config sections. 
* Uses the right one for the detected apptype
* Removes IsDrupal8 from the config struct

I'm not happy with the very, very not-DRY way we're doing Drupal and Backdrop settings creation. Loads of code and it's all repeated. However, it's what we've decided to go with for now, and this just does it again.  Maybe sometime when we're feeling more pure we can fiddle with it and clean it up.

## Manual Testing Instructions:

* Do a ddev import-db on a d7 and d8 site, and verify the settings.local.php that gets created.

## Related Issue Link(s):

OP #647 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

