### PR TITLE
Add docker images to artifacts for #501

### DIFF
--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -8,7 +8,11 @@ BASE_DIR=$PWD
 sudo mkdir $ARTIFACTS && sudo chmod 777 $ARTIFACTS
 export VERSION=$(git describe --tags --always --dirty)
 
+# Make sure we have all our docker images, and save them in a tarball
 $BASE_DIR/bin/linux/ddev version | awk '/drud\// {print $2;}' >/tmp/images.txt
+for item in $(cat /tmp/images.txt); do
+  docker pull $item
+done
 docker save -o /tmp/docker_images.tar $(cat /tmp/images.txt)
 
 # Generate and place the extra items like images and autocomplete
@@ -20,18 +24,18 @@ done
 
 # Generate macOS tarball/zipball
 cd $BASE_DIR/bin/darwin/darwin_amd64
-tar -czf $ARTIFACTS/ddev_macos.$VERSION.tar.gz ddev ddev_bash_completion.sh
-zip $ARTIFACTS/ddev_macos.$VERSION.zip ddev ddev_bash_completion.sh
+tar -czf $ARTIFACTS/ddev_macos.$VERSION.tar.gz ddev ddev_bash_completion.sh docker_images.tar
+zip $ARTIFACTS/ddev_macos.$VERSION.zip ddev ddev_bash_completion.sh docker_images.tar
 
 # Generate linux tarball/zipball
 cd $BASE_DIR/bin/linux
-tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev ddev_bash_completion.sh
-zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev ddev_bash_completion.sh
+tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev ddev_bash_completion.sh docker_images.tar
+zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev ddev_bash_completion.sh docker_images.tar
 
 # generate windows tarball/zipball
 cd $BASE_DIR/bin/windows/windows_amd64
-tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe ddev_bash_completion.sh
-zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
+tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe ddev_bash_completion.sh docker_images.tar
+zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh docker_images.tar
 
 # Create the sha256 files
 cd $ARTIFACTS

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -14,6 +14,7 @@ for item in $(cat /tmp/images.txt); do
   docker pull $item
 done
 docker save -o $ARTIFACTS/ddev_docker_images.$VERSION.tar $(cat /tmp/images.txt)
+gzip $ARTIFACTS/ddev_docker_images.$VERSION.tar
 
 # Generate and place extra items like autocomplete
 bin/linux/ddev_gen_autocomplete
@@ -38,6 +39,6 @@ zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
 
 # Create the sha256 files
 cd $ARTIFACTS
-for item in *.tar.gz *.zip ddev_docker_images.$VERSION.tar; do
+for item in *.tar.gz *.zip ddev_docker_images.$VERSION.tar.gz; do
   sha256sum $item > $item.sha256.txt
 done

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -8,10 +8,14 @@ BASE_DIR=$PWD
 sudo mkdir $ARTIFACTS && sudo chmod 777 $ARTIFACTS
 export VERSION=$(git describe --tags --always --dirty)
 
-# Generate and place the autocomplete
+$BASE_DIR/bin/linux/ddev version | awk '/drud\// {print $2;}' >/tmp/images.txt
+docker save -o /tmp/docker_images.tar $(cat /tmp/images.txt)
+
+# Generate and place the extra items like images and autocomplete
 bin/linux/ddev_gen_autocomplete
 for dir in bin/darwin/darwin_amd64 bin/linux bin/windows/windows_amd64; do
   cp bin/ddev_bash_completion.sh $dir
+  cp /tmp/docker_images.tar $dir
 done
 
 # Generate macOS tarball/zipball

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -13,32 +13,31 @@ $BASE_DIR/bin/linux/ddev version | awk '/drud\// {print $2;}' >/tmp/images.txt
 for item in $(cat /tmp/images.txt); do
   docker pull $item
 done
-docker save -o /tmp/docker_images.tar $(cat /tmp/images.txt)
+docker save -o $ARTIFACTS/ddev_docker_images.$VERSION.tar $(cat /tmp/images.txt)
 
-# Generate and place the extra items like images and autocomplete
+# Generate and place extra items like autocomplete
 bin/linux/ddev_gen_autocomplete
 for dir in bin/darwin/darwin_amd64 bin/linux bin/windows/windows_amd64; do
   cp bin/ddev_bash_completion.sh $dir
-  cp /tmp/docker_images.tar $dir
 done
 
 # Generate macOS tarball/zipball
 cd $BASE_DIR/bin/darwin/darwin_amd64
-tar -czf $ARTIFACTS/ddev_macos.$VERSION.tar.gz ddev ddev_bash_completion.sh docker_images.tar
-zip $ARTIFACTS/ddev_macos.$VERSION.zip ddev ddev_bash_completion.sh docker_images.tar
+tar -czf $ARTIFACTS/ddev_macos.$VERSION.tar.gz ddev ddev_bash_completion.sh
+zip $ARTIFACTS/ddev_macos.$VERSION.zip ddev ddev_bash_completion.sh
 
 # Generate linux tarball/zipball
 cd $BASE_DIR/bin/linux
-tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev ddev_bash_completion.sh docker_images.tar
-zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev ddev_bash_completion.sh docker_images.tar
+tar -czf $ARTIFACTS/ddev_linux.$VERSION.tar.gz ddev ddev_bash_completion.sh
+zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev ddev_bash_completion.sh
 
 # generate windows tarball/zipball
 cd $BASE_DIR/bin/windows/windows_amd64
-tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe ddev_bash_completion.sh docker_images.tar
-zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh docker_images.tar
+tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe ddev_bash_completion.sh
+zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
 
 # Create the sha256 files
 cd $ARTIFACTS
-for item in *.tar.gz *.zip; do
+for item in *.tar.gz *.zip ddev_docker_images.$VERSION.tar; do
   sha256sum $item > $item.sha256.txt
 done

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -14,10 +14,10 @@ for dir in bin/darwin/darwin_amd64 bin/linux bin/windows/windows_amd64; do
   cp bin/ddev_bash_completion.sh $dir
 done
 
-# Generate OSX tarball/zipball
+# Generate macOS tarball/zipball
 cd $BASE_DIR/bin/darwin/darwin_amd64
-tar -czf $ARTIFACTS/ddev_osx.$VERSION.tar.gz ddev ddev_bash_completion.sh
-zip $ARTIFACTS/ddev_osx.$VERSION.zip ddev ddev_bash_completion.sh
+tar -czf $ARTIFACTS/ddev_macos.$VERSION.tar.gz ddev ddev_bash_completion.sh
+zip $ARTIFACTS/ddev_macos.$VERSION.zip ddev ddev_bash_completion.sh
 
 # Generate linux tarball/zipball
 cd $BASE_DIR/bin/linux

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -19,7 +19,7 @@ URL="https://github.com/drud/ddev/releases/download/$LATEST_VERSION"
 
 if [[ "$OS" == "Darwin" ]]; then
     SHACMD="shasum -a 256"
-    FILEBASE="ddev_osx"
+    FILEBASE="ddev_macos"
 elif [[ "$OS" == "Linux" ]]; then
     SHACMD="sha256sum"
     FILEBASE="ddev_linux"

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -64,8 +64,6 @@ else
 	printf "${YELLOW}Bash completion for ddev was not installed. You may manually install /tmp/ddev_bash_completions.sh in your bash_completions.d directory.${RESET}\n"
 fi
 
-docker load -i /tmp/docker_images.tar
-
 rm /tmp/$TARBALL /tmp/$SHAFILE
 
 printf "${GREEN}ddev is now installed. Run \"ddev\" to verify your installation and see usage.${RESET}\n"

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -64,6 +64,8 @@ else
 	printf "${YELLOW}Bash completion for ddev was not installed. You may manually install /tmp/ddev_bash_completions.sh in your bash_completions.d directory.${RESET}\n"
 fi
 
+docker load -i /tmp/docker_images.tar
+
 rm /tmp/$TARBALL /tmp/$SHAFILE
 
 printf "${GREEN}ddev is now installed. Run \"ddev\" to verify your installation and see usage.${RESET}\n"


### PR DESCRIPTION
## The Problem/Issue/Bug:

For OP #501 one of the things we want is to prevent the initial docker pull that happens initially, so bundle all the containers in the artifacts we provide. 

## How this PR Solves The Problem:

* Change "osx" to "macos" in artifact names
* Add ddev_docker_images.tar to the artifacts, so all can be downloaded at once.

## Manual Testing Instructions:

* Delete your drud containers any way you like
* Use the install script to install ddev
* Download the ddev_docker_images.tar
* Load the images with `docker load -i /path/to/ddev_docker_images.tar`
* Verify with `docker images | grep drud` that the new images were loaded
* When you do your first "ddev start" nothing should have to be pulled.

This didn't fully work out as I had hoped. I had been planning to put the images into the download tarball, but that resulted in a tarball over 1G, which would be an unacceptable download for many people. Instead, the docker images are in a separate tarball.

We should consider whether the script should prompt about downloading it, or ask if it's already available.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #501  - turnkey install for sprints.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

