### PR TITLE
Upgrade golang to 1.10 for testing, docker-compose 1.19

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -8,14 +8,12 @@ set -x
 sudo apt-get update -qq
 sudo apt-get install -qq mysql-client realpath zip
 
-go version
-
 # golang of the version we want
-sudo apt-get remove -qq golang &&
-wget -q -O /tmp/golang.tgz https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz &&
-cd /tmp && tar -xf golang.tgz &&
-sudo rm -rf /usr/local/go && sudo mv go /usr/local
+sudo apt-get remove -qq golang && sudo rm -rf /usr/local/go &&
+wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.linux-amd64.tar.gz &&
+sudo tar -C /usr/local -xzf /tmp/golang.tgz
+
 
 # docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.16.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -s -L "https://github.com/docker/compose/releases/download/1.19.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -14,14 +14,16 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-func TestDevLogsBadArgs(t *testing.T) {
+// TestDevLogsNoConfig tests what happens with when running "ddev logs" when
+// the directory has not been configured (and no project name is given)
+func TestDevLogsNoConfig(t *testing.T) {
 	assert := asrt.New(t)
 
 	testDir := testcommon.CreateTmpDir("no-valid-ddev-config")
 
 	err := os.Chdir(testDir)
 	if err != nil {
-		t.Skip("Could not change to temporary directory %s: %v", testDir, err)
+		t.Skipf("Could not change to temporary directory %s: %v", testDir, err)
 	}
 
 	args := []string{"logs"}


### PR DESCRIPTION
## The Problem/Issue/Bug:

It's time to upgrade to golang 1.10.

I'm actually forced to this by #657 where I have a weird problem that can't be reproduced on mac or windows, and only occurs with go 1.9 on Ubuntu 14.04, or that's the conclusion I'm coming to. It builds clean on Ubuntu 14.04 with go 1.10, so I'd rather just do this upgrade than chase it. After this goes in, I'll rebase that one.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

