### PR TITLE
Add ddevapp tests for drupal6, backdrop, TYPO3, fixes #617 Pull on 2018-03-6 #TRIVIALREVIEW

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -40,7 +40,7 @@ func TestDevLogs(t *testing.T) {
 		cleanup := v.Chdir()
 
 		confByte := []byte("<?php trigger_error(\"Fatal error\", E_USER_ERROR);")
-		err := ioutil.WriteFile(filepath.Join(v.Dir, v.DocrootBase, "index.php"), confByte, 0644)
+		err := ioutil.WriteFile(filepath.Join(v.Dir, v.Docroot, "index.php"), confByte, 0644)
 		assert.NoError(err)
 
 		o := util.NewHTTPOptions("http://127.0.0.1/index.php")

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -27,7 +27,7 @@ var (
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		HTTPProbeURI:                  "wp-admin/setup-config.php",
-		DocrootBase:                   "htdocs",
+		Docroot:                       "htdocs",
 	},
 	}
 )

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -28,6 +28,7 @@ var (
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		HTTPProbeURI:                  "wp-admin/setup-config.php",
 		Docroot:                       "htdocs",
+		Type:                          "wordpress",
 	},
 	}
 )

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -430,6 +430,12 @@ func TestDdevExec(t *testing.T) {
 func TestDdevLogs(t *testing.T) {
 	assert := asrt.New(t)
 
+	// Skip test because on Windows because the CaptureUserOut() hangs, at least
+	// sometimes.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test TestDdevLogs on Windows")
+	}
+
 	app := &ddevapp.DdevApp{}
 
 	for _, site := range TestSites {
@@ -684,10 +690,10 @@ func TestRouterPortsCheck(t *testing.T) {
 // TestCleanupWithoutCompose ensures app containers can be properly cleaned up without a docker-compose config file present.
 func TestCleanupWithoutCompose(t *testing.T) {
 	assert := asrt.New(t)
+
 	// Skip test because we can't rename folders while they're in use if running on Windows.
 	if runtime.GOOS == "windows" {
-		log.Println("Skipping test TestCleanupWithoutCompose on Windows")
-		t.Skip()
+		t.Skip("Skipping test TestCleanupWithoutCompose on Windows")
 	}
 
 	site := TestSites[0]

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -64,6 +64,24 @@ var (
 			DocrootBase:                   "",
 			Type:                          "drupal6",
 		},
+		{
+			Name:                          "TestPkgBackdrop",
+			SourceURL:                     "https://github.com/backdrop/backdrop/archive/1.9.2.tar.gz",
+			ArchiveInternalExtractionPath: "backdrop-1.9.2/",
+			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/backdrop_db.tar.gz",
+			FullSiteTarballURL:            "",
+			DocrootBase:                   "",
+			Type:                          "backdrop",
+		},
+		{
+			Name:                          "TestPkgTypo3",
+			SourceURL:                     "https://typo3.azureedge.net/typo3/8.7.10/typo3_src-8.7.10.tar.gz",
+			ArchiveInternalExtractionPath: "typo3_src-8.7.10/",
+			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/typo3git_db.tar.gz",
+			FullSiteTarballURL:            "",
+			DocrootBase:                   "",
+			Type:                          "typo3",
+		},
 	}
 )
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -32,7 +32,8 @@ var (
 			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_db.tar.gz",
-			DocrootBase:                   "htdocs",
+			Docroot:                       "htdocs",
+			Type:                          "wordpress",
 		},
 		{
 			Name:                          "TestPkgDrupal8",
@@ -44,7 +45,7 @@ var (
 			DBZipURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/drupal8_db.zip",
 			FullSiteTarballURL:            "",
 			Type:                          "drupal8",
-			DocrootBase:                   "",
+			Docroot:                       "",
 		},
 		{
 			Name:                          "TestPkgDrupal7", // Drupal Kickstart on D7
@@ -53,7 +54,8 @@ var (
 			FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
 			FullSiteTarballURL:            "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/site.tar.gz",
-			DocrootBase:                   "docroot",
+			Docroot:                       "docroot",
+			Type:                          "drupal7",
 		},
 		{
 			Name:                          "TestPkgDrupal6",
@@ -61,7 +63,7 @@ var (
 			ArchiveInternalExtractionPath: "drupal-6.38/",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/drupal6_db.tar.gz",
 			FullSiteTarballURL:            "",
-			DocrootBase:                   "",
+			Docroot:                       "",
 			Type:                          "drupal6",
 		},
 		{
@@ -70,7 +72,7 @@ var (
 			ArchiveInternalExtractionPath: "backdrop-1.9.2/",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/backdrop_db.tar.gz",
 			FullSiteTarballURL:            "",
-			DocrootBase:                   "",
+			Docroot:                       "",
 			Type:                          "backdrop",
 		},
 		{
@@ -79,7 +81,7 @@ var (
 			ArchiveInternalExtractionPath: "typo3_src-8.7.10/",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/typo3git_db.tar.gz",
 			FullSiteTarballURL:            "",
-			DocrootBase:                   "",
+			Docroot:                       "",
 			Type:                          "typo3",
 		},
 	}
@@ -372,6 +374,7 @@ func TestDdevImportFiles(t *testing.T) {
 		if site.FullSiteTarballURL != "" {
 			_, siteTarPath, err := testcommon.GetCachedArchive(site.Name, "local-site-tar", "", site.FullSiteTarballURL)
 			assert.NoError(err)
+			// TODO: This is totally Drupal-only, and has to be fixed when we do file import for new CMSs
 			err = app.ImportFiles(siteTarPath, "docroot/sites/default/files")
 			assert.NoError(err)
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -76,8 +77,16 @@ func TestMain(m *testing.M) {
 		log.Fatalf("ddevapp tests require no sites running. You have %v site(s) running.", count)
 	}
 
-	if os.Getenv("GOTEST_SHORT") != "" {
-		TestSites = []testcommon.TestSite{TestSites[0]}
+	// If GOTEST_SHORT is an integer, then use it as index for a single usage
+	// in the array. Any value can be used, it will default to just using the
+	// first site in the array.
+	gotestShort := os.Getenv("GOTEST_SHORT")
+	if gotestShort != "" {
+		useSite := 0
+		if site, err := strconv.Atoi(gotestShort); err == nil && site >= 0 && site < len(TestSites) {
+			useSite = site
+		}
+		TestSites = []testcommon.TestSite{TestSites[useSite]}
 	}
 
 	for i := range TestSites {

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -23,7 +23,8 @@ var (
 			Name:                          "TestServicesDrupal8",
 			SourceURL:                     "https://github.com/drud/drupal8/archive/v0.6.0.tar.gz",
 			ArchiveInternalExtractionPath: "drupal8-0.6.0/",
-			Type: "drupal8",
+			Docroot: "docroot",
+			Type:    "drupal8",
 		},
 	}
 	ServiceFiles []string

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -45,8 +45,8 @@ type TestSite struct {
 	Dir string
 	// HTTPProbeURI is the URI that can be probed to look for a working web container
 	HTTPProbeURI string
-	// DocrootBase is the subdirectory witin the site that is the root/index.php
-	DocrootBase string
+	// Docroot is the subdirectory witin the site that is the root/index.php
+	Docroot string
 	// Type is the type of application. This can be specified when a config file is not present
 	// for a test site.
 	Type string
@@ -85,9 +85,10 @@ func (site *TestSite) Prepare() error {
 	// Set app name to the name we define for test sites. We'll
 	// ignore app name defined in config file if present.
 	app.Name = site.Name
-
-	if app.Type == "" {
-		app.Type = site.Type
+	app.Docroot = site.Docroot
+	app.Type = app.DetectAppType()
+	if app.Type != site.Type {
+		return errors.Errorf("Detected apptype does not match provided apptype")
 	}
 
 	err = app.WriteConfig()

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -97,6 +97,7 @@ func TestValidTestSite(t *testing.T) {
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		Docroot:                       "htdocs",
+		Type:                          "wordpress",
 	}
 
 	// Create a testsite and ensure the prepare() method extracts files into a temporary directory.

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -96,7 +96,7 @@ func TestValidTestSite(t *testing.T) {
 		ArchiveInternalExtractionPath: "wordpress-0.4.0/",
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
-		DocrootBase:                   "htdocs",
+		Docroot:                       "htdocs",
 	}
 
 	// Create a testsite and ensure the prepare() method extracts files into a temporary directory.
@@ -106,7 +106,7 @@ func TestValidTestSite(t *testing.T) {
 		t.FailNow()
 	}
 	assert.NotNil(ts.Dir, "Directory is set.")
-	docroot := filepath.Join(ts.Dir, ts.DocrootBase)
+	docroot := filepath.Join(ts.Dir, ts.Docroot)
 	dirStat, err := os.Stat(docroot)
 	assert.NoError(err, "Docroot exists after prepare()")
 	if err != nil {

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// DownloadFile retreives a file.
+// DownloadFile retrieves a file.
 func DownloadFile(fp string, url string, progressBar bool) (err error) {
 	// Create the file
 	out, err := os.Create(fp)


### PR DESCRIPTION
## The Problem/Issue/Bug:

We didn't add the full suite of tests for d6/backdrop/TYPO3 when implementing those and it's time.

This is not intended to solve the fact that we don't currently use any of the sites that we spin up with ddev, or see if they're working. That problem is deferred to https://github.com/drud/ddev/issues/677

## How this PR Solves The Problem:

This PR simply fills in test tarballs and related info for other CMSs, and does some minor improvements to the testing process. New tarballs are provided in the new repo set up for their storage.

## Manual Testing Instructions:

Look at the Circleci test results and make sure everything is being hit. 

## Related Issue Link(s):

Fixes #617 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

