### PR TITLE
[BUGFIX] fix typo in install instruction output for bash completion

### DIFF
--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -61,7 +61,7 @@ if which brew &&  [ -f `brew --prefix`/etc/bash_completion ]; then
     printf "${GREEN}Installed ddev bash completions in $bash_completion_dir${RESET}\n"
     rm /tmp/ddev_bash_completion.sh
 else
-	printf "${YELLOW}Bash completion for ddev was not installed. You may manually install /tmp/ddev_bash_completions.sh in your bash_completions.d directory.${RESET}\n"
+	printf "${YELLOW}Bash completion for ddev was not installed. You may manually install /tmp/ddev_bash_completion.sh in your bash_completions.d directory.${RESET}\n"
 fi
 
 rm /tmp/$TARBALL /tmp/$SHAFILE


### PR DESCRIPTION
## The Problem/Issue/Bug:
instruction for installing bash completion shows wrong filename "ddev_bash_completions.sh"
## How this PR Solves The Problem:
change filename in output to "ddev_bash_completion.sh"
## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

