### PR TITLE
Add Config docroot detection, fixes #663

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -32,7 +32,7 @@ var appType string
 var showConfigLocation bool
 
 // ConfigCommand represents the `ddev config` command
-var ConfigCommand = &cobra.Command{
+var ConfigCommand *cobra.Command = &cobra.Command{
 	Use:   "config [provider]",
 	Short: "Create or modify a ddev project configuration in the current directory",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -107,7 +107,10 @@ var ConfigCommand = &cobra.Command{
 				if _, err = os.Stat(docrootRelPath); os.IsNotExist(err) {
 					util.Failed("The docroot provided (%v) does not exist", docrootRelPath)
 				}
+			} else if !cmd.Flags().Changed("docroot") {
+				app.Docroot = ddevapp.DiscoverDefaultDocroot(app)
 			}
+
 			// pantheonEnvironment must be appropriate, and can only be used with pantheon provider.
 			if provider != "pantheon" && pantheonEnvironment != "" {
 				util.Failed("--pantheon-environment can only be used with pantheon provider, for example 'ddev config pantheon --pantheon-environment=dev --docroot=docroot'")

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -43,6 +43,7 @@ func TestConfigDescribeLocation(t *testing.T) {
 
 }
 
+// TestConfigWithSitenameFlagDetectsDocroot tests docroot detected when flags passed.
 func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	assert := asrt.New(t)
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -53,10 +53,12 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	defer testcommon.CleanupDir(tmpdir)
 	defer testcommon.Chdir(tmpdir)()
 	// Create a document root folder.
-	err := os.MkdirAll(filepath.Join(tmpdir, filepath.Join(testDocrootName)), 0755)
+	err := os.MkdirAll(filepath.Join(tmpdir, testDocrootName), 0755)
 	if err != nil {
 		t.Errorf("Could not create %s directory under %s", testDocrootName, tmpdir)
 	}
+	_, err = os.OpenFile(filepath.Join(tmpdir, testDocrootName, "index.php"), os.O_RDONLY|os.O_CREATE, 0666)
+	assert.NoError(err)
 
 	expectedPath := "web/core/scripts/drupal.sh"
 	err = os.MkdirAll(filepath.Join(tmpdir, filepath.Dir(expectedPath)), 0777)

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
 )
 
 // TestConfigDescribeLocation tries out the --show-config-location flag.
@@ -39,4 +41,32 @@ func TestConfigDescribeLocation(t *testing.T) {
 	assert.Error(err)
 	assert.Contains(string(out), "No project configuration currently exists")
 
+}
+
+func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Create a temporary directory and switch to it.
+	testDocrootName := "web"
+	tmpdir := testcommon.CreateTmpDir("config-with-sitename")
+	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
+	// Create a document root folder.
+	err := os.MkdirAll(filepath.Join(tmpdir, filepath.Join(testDocrootName)), 0755)
+	if err != nil {
+		t.Errorf("Could not create %s directory under %s", testDocrootName, tmpdir)
+	}
+
+	expectedPath := "web/core/scripts/drupal.sh"
+	err = os.MkdirAll(filepath.Join(tmpdir, filepath.Dir(expectedPath)), 0777)
+	assert.NoError(err)
+
+	_, err = os.OpenFile(filepath.Join(tmpdir, expectedPath), os.O_RDONLY|os.O_CREATE, 0666)
+	assert.NoError(err)
+
+	// Create a config
+	args := []string{"config", "--sitename=config-with-sitename"}
+	out, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(string(out), "Found a drupal8 codebase")
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -354,6 +354,18 @@ func (app *DdevApp) promptForName() error {
 	return provider.ValidateField("Name", app.Name)
 }
 
+// An array of default docroot locations to look for.
+func AvailableDocrootLocations() []string {
+	return []string{
+		"web/public",
+		"web",
+		"docroot",
+		"htdocs",
+		"_www",
+		"public",
+	}
+}
+
 // Determine the document root.
 func (app *DdevApp) docrootPrompt() error {
 	provider, err := app.GetProvider()
@@ -368,7 +380,7 @@ func (app *DdevApp) docrootPrompt() error {
 	// Provide use the app.Docroot as the default docroot option.
 	var defaultDocroot = app.Docroot
 	if defaultDocroot == "" {
-		for _, docroot := range []string{"web", "docroot", "htdocs", "_www", "public"} {
+		for _, docroot := range AvailableDocrootLocations() {
 			if _, err := os.Stat(docroot); err == nil {
 				defaultDocroot = docroot
 				break
@@ -378,6 +390,8 @@ func (app *DdevApp) docrootPrompt() error {
 	// If there is a default docroot, display it in the prompt.
 	if defaultDocroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
+	} else {
+		docrootPrompt = fmt.Sprintf("%s (current directory)", docrootPrompt)
 	}
 
 	fmt.Print(docrootPrompt + ": ")

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -354,7 +354,7 @@ func (app *DdevApp) promptForName() error {
 	return provider.ValidateField("Name", app.Name)
 }
 
-// An array of default docroot locations to look for.
+// AvailableDocrootLocations returns an of default docroot locations to look for.
 func AvailableDocrootLocations() []string {
 	return []string{
 		"web/public",

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -365,12 +365,22 @@ func (app *DdevApp) docrootPrompt() error {
 	output.UserOut.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your application root (%s)", app.AppRoot)
 	output.UserOut.Println("You may leave this value blank if your site files are in the application root")
 	var docrootPrompt = "Docroot Location"
+	// Provide use the app.Docroot as the default docroot option.
+	var defaultDocroot = app.Docroot;
 	if app.Docroot != "" {
-		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, app.Docroot)
+		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
+	} else {
+		// If the app.Docroot was not defined, help discover a possible default.
+		for _, docroot := range []string{"web", "docroot", "htdocs"} {
+			if _, err := os.Stat(docroot); err == nil {
+				defaultDocroot = docroot;
+				break;
+			}
+		}
 	}
 
 	fmt.Print(docrootPrompt + ": ")
-	app.Docroot = util.GetInput(app.Docroot)
+	app.Docroot = util.GetInput(defaultDocroot)
 
 	// Ensure the docroot exists. If it doesn't, prompt the user to verify they entered it correctly.
 	fullPath := filepath.Join(app.AppRoot, app.Docroot)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -372,7 +372,10 @@ func DiscoverDefaultDocroot(app *DdevApp) string {
 	var defaultDocroot = app.Docroot
 	if defaultDocroot == "" {
 		for _, docroot := range AvailableDocrootLocations() {
-			if _, err := os.Stat(docroot); err == nil {
+			if _, err := os.Stat(docroot); err != nil {
+				continue
+			}
+			if fileutil.FileExists(docroot + "/index.php") {
 				defaultDocroot = docroot
 				break
 			}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -368,7 +368,7 @@ func (app *DdevApp) docrootPrompt() error {
 	// Provide use the app.Docroot as the default docroot option.
 	var defaultDocroot = app.Docroot
 	if defaultDocroot == "" {
-		for _, docroot := range []string{"web", "docroot", "htdocs"} {
+		for _, docroot := range []string{"web", "docroot", "htdocs", "_www", "public"} {
 			if _, err := os.Stat(docroot); err == nil {
 				defaultDocroot = docroot
 				break

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -375,7 +375,7 @@ func DiscoverDefaultDocroot(app *DdevApp) string {
 			if _, err := os.Stat(docroot); err != nil {
 				continue
 			}
-			if fileutil.FileExists(docroot + "/index.php") {
+			if fileutil.FileExists(filepath.Join(docroot, "index.php")) {
 				defaultDocroot = docroot
 				break
 			}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -366,15 +366,15 @@ func (app *DdevApp) docrootPrompt() error {
 	output.UserOut.Println("You may leave this value blank if your site files are in the application root")
 	var docrootPrompt = "Docroot Location"
 	// Provide use the app.Docroot as the default docroot option.
-	var defaultDocroot = app.Docroot;
+	var defaultDocroot = app.Docroot
 	if app.Docroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
 	} else {
 		// If the app.Docroot was not defined, help discover a possible default.
 		for _, docroot := range []string{"web", "docroot", "htdocs"} {
 			if _, err := os.Stat(docroot); err == nil {
-				defaultDocroot = docroot;
-				break;
+				defaultDocroot = docroot
+				break
 			}
 		}
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -367,16 +367,17 @@ func (app *DdevApp) docrootPrompt() error {
 	var docrootPrompt = "Docroot Location"
 	// Provide use the app.Docroot as the default docroot option.
 	var defaultDocroot = app.Docroot
-	if app.Docroot != "" {
-		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
-	} else {
-		// If the app.Docroot was not defined, help discover a possible default.
+	if defaultDocroot == "" {
 		for _, docroot := range []string{"web", "docroot", "htdocs"} {
 			if _, err := os.Stat(docroot); err == nil {
 				defaultDocroot = docroot
 				break
 			}
 		}
+	}
+	// If there is a default docroot, display it in the prompt.
+	if defaultDocroot != "" {
+		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
 	}
 
 	fmt.Print(docrootPrompt + ": ")

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -366,6 +366,21 @@ func AvailableDocrootLocations() []string {
 	}
 }
 
+// DiscoverDefaultDocroot returns the default docroot directory.
+func DiscoverDefaultDocroot(app *DdevApp) string {
+	// Provide use the app.Docroot as the default docroot option.
+	var defaultDocroot = app.Docroot
+	if defaultDocroot == "" {
+		for _, docroot := range AvailableDocrootLocations() {
+			if _, err := os.Stat(docroot); err == nil {
+				defaultDocroot = docroot
+				break
+			}
+		}
+	}
+	return defaultDocroot
+}
+
 // Determine the document root.
 func (app *DdevApp) docrootPrompt() error {
 	provider, err := app.GetProvider()
@@ -377,16 +392,7 @@ func (app *DdevApp) docrootPrompt() error {
 	output.UserOut.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your application root (%s)", app.AppRoot)
 	output.UserOut.Println("You may leave this value blank if your site files are in the application root")
 	var docrootPrompt = "Docroot Location"
-	// Provide use the app.Docroot as the default docroot option.
-	var defaultDocroot = app.Docroot
-	if defaultDocroot == "" {
-		for _, docroot := range AvailableDocrootLocations() {
-			if _, err := os.Stat(docroot); err == nil {
-				defaultDocroot = docroot
-				break
-			}
-		}
-	}
+	var defaultDocroot = DiscoverDefaultDocroot(app)
 	// If there is a default docroot, display it in the prompt.
 	if defaultDocroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -212,6 +212,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		if err != nil {
 			t.Errorf("Could not create %s directory under %s", testDocrootName, testDir)
 		}
+		os.OpenFile(filepath.Join(testDir, filepath.Join(testDocrootName), "index.php"), os.O_RDONLY|os.O_CREATE, 0664)
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
@@ -241,7 +242,59 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		err = PrepDdevDirectory(testDir)
 		assert.NoError(err)
 	}
+}
 
+// TestConfigCommandDocrootDetection asserts the default docroot is detected and has index.php.
+// The `web` docroot check is before `docroot` this verifies the directory with an
+// existing index.php is selected.
+func TestConfigCommandDocrootDetectionIndexVerification(t *testing.T) {
+	// Set up tests and give ourselves a working directory.
+	assert := asrt.New(t)
+
+	testDir := testcommon.CreateTmpDir("TestConfigCommand_testDocrootIndex")
+
+	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
+
+	// Create a document root folder.
+	err := os.MkdirAll(filepath.Join(testDir, filepath.Join("web")), 0755)
+	if err != nil {
+		t.Errorf("Could not create %s directory under %s", "web", testDir)
+	}
+	err = os.MkdirAll(filepath.Join(testDir, filepath.Join("docroot")), 0755)
+	if err != nil {
+		t.Errorf("Could not create %s directory under %s", "docroot", testDir)
+	}
+	os.OpenFile(filepath.Join(testDir, "docroot", "index.php"), os.O_RDONLY|os.O_CREATE, 0664)
+
+	// Create the ddevapp we'll use for testing.
+	// This will not return an error, since there is no existing configuration.
+	app, err := NewApp(testDir, DefaultProviderName)
+	assert.NoError(err)
+
+	// Randomize some values to use for Stdin during testing.
+	name := strings.ToLower(util.RandString(16))
+
+	// Create an example input buffer that writes the site name, accepts the
+	// default document root and provides a valid app type.
+	input := fmt.Sprintf("%s\n\ndrupal8", name)
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	util.SetInputScanner(scanner)
+
+	restoreOutput := testcommon.CaptureStdOut()
+	err = app.PromptForConfig()
+	assert.NoError(err, t)
+	out := restoreOutput()
+
+	assert.Contains(out, fmt.Sprintf("Docroot Location (%s)", "docroot"))
+
+	// Ensure values were properly set on the app struct.
+	assert.Equal(name, app.Name)
+	assert.Equal("drupal8", app.Type)
+	assert.Equal("docroot", app.Docroot)
+	err = PrepDdevDirectory(testDir)
+	assert.NoError(err)
 }
 
 // TestReadConfig tests reading config values from file and fallback to defaults for values not exposed.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -201,7 +201,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 
 	testMatrix := AvailableDocrootLocations()
 	for _, testDocrootName := range testMatrix {
-		testDir := testcommon.CreateTmpDir("TestConfigCommand_" + testDocrootName)
+		testDir := testcommon.CreateTmpDir("TestConfigCommand_" + filepath.Join(testDocrootName))
 
 		// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
 		defer testcommon.CleanupDir(testDir)
@@ -210,7 +210,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		// Create a document root folder.
 		err := os.MkdirAll(filepath.Join(testDir, testDocrootName), 0644)
 		if err != nil {
-			t.Errorf("Could not create %s directory under %s", testDocrootName, testDir)
+			t.Errorf("Could not create %s directory under %s", filepath.Join(testDocrootName), testDir)
 		}
 
 		// Create the ddevapp we'll use for testing.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -199,7 +199,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 
-	testMatrix := []string{"web", "docroot", "htdocs"};
+	testMatrix := []string{"web", "docroot", "htdocs"}
 	for _, testDocrootName := range testMatrix {
 		testDir := testcommon.CreateTmpDir("TestConfigCommand_" + testDocrootName)
 
@@ -223,7 +223,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 
 		// Create an example input buffer that writes the site name, accepts the
 		// default document root and provides a valid app type.
-		input := fmt.Sprintf("%s\n\ndrupal8", name);
+		input := fmt.Sprintf("%s\n\ndrupal8", name)
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -227,8 +227,13 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
+		restoreOutput := testcommon.CaptureUserOut()
 		err = app.PromptForConfig()
 		assert.NoError(err, t)
+		out := restoreOutput()
+
+		assert.Contains(out, testDir)
+		assert.Contains(out, fmt.Sprintf("Docroot Location (%s)", testDocrootName))
 
 		// Ensure values were properly set on the app struct.
 		assert.Equal(name, app.Name)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -208,7 +208,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		defer testcommon.Chdir(testDir)()
 
 		// Create a document root folder.
-		err := os.MkdirAll(filepath.Join(testDir, testDocrootName), 0644)
+		err := os.MkdirAll(filepath.Join(testDir, filepath.Join(testDocrootName)), 0755)
 		if err != nil {
 			t.Errorf("Could not create %s directory under %s", testDocrootName, testDir)
 		}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -199,7 +199,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 
-	testMatrix := []string{"web", "docroot", "htdocs"}
+	testMatrix := []string{"web", "docroot", "htdocs", "_www", "public"}
 	for _, testDocrootName := range testMatrix {
 		testDir := testcommon.CreateTmpDir("TestConfigCommand_" + testDocrootName)
 
@@ -227,7 +227,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
-		restoreOutput := testcommon.CaptureUserOut()
+		restoreOutput := testcommon.CaptureStdOut()
 		err = app.PromptForConfig()
 		assert.NoError(err, t)
 		out := restoreOutput()

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -200,8 +200,8 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 	assert := asrt.New(t)
 
 	testMatrix := AvailableDocrootLocations()
-	for _, testDocrootName := range testMatrix {
-		testDir := testcommon.CreateTmpDir("TestConfigCommand_" + filepath.Join(testDocrootName))
+	for index, testDocrootName := range testMatrix {
+		testDir := testcommon.CreateTmpDir(fmt.Sprintf("TestConfigCommand_%v", index))
 
 		// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
 		defer testcommon.CleanupDir(testDir)
@@ -210,7 +210,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		// Create a document root folder.
 		err := os.MkdirAll(filepath.Join(testDir, testDocrootName), 0644)
 		if err != nil {
-			t.Errorf("Could not create %s directory under %s", filepath.Join(testDocrootName), testDir)
+			t.Errorf("Could not create %s directory under %s", testDocrootName, testDir)
 		}
 
 		// Create the ddevapp we'll use for testing.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -232,7 +232,6 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		assert.NoError(err, t)
 		out := restoreOutput()
 
-		assert.Contains(out, testDir)
 		assert.Contains(out, fmt.Sprintf("Docroot Location (%s)", testDocrootName))
 
 		// Ensure values were properly set on the app struct.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -199,7 +199,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 
-	testMatrix := []string{"web", "docroot", "htdocs", "_www", "public"}
+	testMatrix := AvailableDocrootLocations()
 	for _, testDocrootName := range testMatrix {
 		testDir := testcommon.CreateTmpDir("TestConfigCommand_" + testDocrootName)
 
@@ -208,7 +208,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		defer testcommon.Chdir(testDir)()
 
 		// Create a document root folder.
-		err := os.Mkdir(filepath.Join(testDir, testDocrootName), 0644)
+		err := os.MkdirAll(filepath.Join(testDir, testDocrootName), 0644)
 		if err != nil {
 			t.Errorf("Could not create %s directory under %s", testDocrootName, testDir)
 		}


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #663 - Our users would love to have docroot detected for them during `ddev config`.

## How this PR Solves The Problem:

Check if any of the following directories exist and default to the first one found

* web
* docroot
* htdocs
* _www (legacy Platform.sh)
* public

## Manual Testing Instructions:

Run `ddev config` and see that the docroot discovery re-uses `app.Docroot` or detects an existing directory if present.

## Automated Testing Overview:

Added `TestConfigCommandDocrootDetection` which tests automatic detection of `web`, `htdocs`, and `docroot`.

## Related Issue Link(s):

#663

## Release/Deployment notes:


