### PR TITLE
Harden Drupal version detection #545

### DIFF
--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
+	"io/ioutil"
 )
 
 // TestApptypeDetection does a simple test of various filesystem setups to make
@@ -16,9 +17,6 @@ func TestApptypeDetection(t *testing.T) {
 	assert := asrt.New(t)
 
 	fileLocations := map[string]string{
-		"drupal6":   "misc/ahah.js",
-		"drupal7":   "misc/ajax.js",
-		"drupal8":   "core/scripts/drupal.sh",
 		"wordpress": "wp-login.php",
 		"backdrop":  "core/scripts/backdrop.sh",
 	}
@@ -43,4 +41,82 @@ func TestApptypeDetection(t *testing.T) {
 		assert.EqualValues(expectedType, foundType)
 	}
 
+}
+
+// Tests Drupal 6 apptype detection
+func TestDrupal6AppTypeDetection(t *testing.T) {
+	assert := asrt.New(t)
+
+	testDir := testcommon.CreateTmpDir("TestApptype")
+
+	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
+
+	// Drupal file comment.
+	fileDoc := []byte("<?php\n\n/**\n* @file\n* The PHP page that serves all page requests on a Drupal installation.\n*\n* The routines here dispatch control to the appropriate handler, which then\n* prints the appropriate page.\n*\n* All Drupal code is released under the GNU General Public License.\n* See COPYRIGHT.txt and LICENSE.txt.\n*/")
+	err := ioutil.WriteFile(filepath.Join(testDir, "index.php"), fileDoc, 0644)
+	assert.NoError(err)
+
+	// Drupal version identifier.
+	err = os.MkdirAll(filepath.Join(testDir, filepath.Dir("misc/ahah.js")), 0777)
+	assert.NoError(err)
+	_, err = os.OpenFile(filepath.Join(testDir, "misc/ahah.js"), os.O_RDONLY|os.O_CREATE, 0666)
+	assert.NoError(err)
+
+	app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+	assert.NoError(err)
+
+	foundType := app.DetectAppType()
+	assert.EqualValues("drupal6", foundType)
+}
+
+// Tests Drupal 7 apptype detection
+func TestDrupal7AppTypeDetection(t *testing.T) {
+	assert := asrt.New(t)
+
+	testDir := testcommon.CreateTmpDir("TestApptype")
+
+	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
+
+	// Drupal file comment.
+	fileDoc := []byte("<?php\n\n/**\n* @file\n* The PHP page that serves all page requests on a Drupal installation.\n*\n* The routines here dispatch control to the appropriate handler, which then\n* prints the appropriate page.\n*\n* All Drupal code is released under the GNU General Public License.\n* See COPYRIGHT.txt and LICENSE.txt.\n*/")
+	err := ioutil.WriteFile(filepath.Join(testDir, "index.php"), fileDoc, 0644)
+	assert.NoError(err)
+
+	app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+	assert.NoError(err)
+
+	foundType := app.DetectAppType()
+	assert.EqualValues("drupal7", foundType)
+}
+
+// Tests Drupal 8 apptype detection
+func TestDrupal8AppTypeDetection(t *testing.T) {
+	assert := asrt.New(t)
+
+	testDir := testcommon.CreateTmpDir("TestApptype")
+
+	// testcommon.Chdir()() and CleanupDir() checks their own errors (and exit)
+	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
+
+	// Drupal file comment.
+	fileDoc := []byte("/**\n* @file\n* The PHP page that serves all page requests on a Drupal installation.\n*\n* All Drupal code is released under the GNU General Public License.\n* See COPYRIGHT.txt and LICENSE.txt files in the \"core\" directory.\n*/")
+	err := ioutil.WriteFile(filepath.Join(testDir, "index.php"), fileDoc, 0644)
+	assert.NoError(err)
+
+	// Drupal version identifier.
+	err = os.MkdirAll(filepath.Join(testDir, filepath.Dir("core/composer.json")), 0777)
+	assert.NoError(err)
+	_, err = os.OpenFile(filepath.Join(testDir, "core/composer.json"), os.O_RDONLY|os.O_CREATE, 0666)
+	assert.NoError(err)
+
+	app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+	assert.NoError(err)
+
+	foundType := app.DetectAppType()
+	assert.EqualValues("drupal8", foundType)
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -12,6 +12,7 @@ import (
 
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 )
 
@@ -386,26 +387,44 @@ func setDrupalSiteSettingsPaths(app *DdevApp) {
 	app.SiteLocalSettingsPath = localSettingsFilePath
 }
 
+func isDrupalApp(app *DdevApp) bool {
+	file, err := os.Open(filepath.Join(app.AppRoot, app.Docroot, "index.php"))
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+	buffer := make([]byte, 3178)
+	file.Read(buffer)
+
+	return strings.Index(string(buffer), "Drupal") > -1
+}
+
 // isDrupal7App returns true if the app is of type drupal7
 func isDrupal7App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "misc/ajax.js")); err == nil {
-		return true
+	if isDrupalApp(app) {
+		if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "core/composer.json")); err != nil {
+			return true
+		}
 	}
 	return false
 }
 
 // isDrupal8App returns true if the app is of type drupal8
 func isDrupal8App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "core/scripts/drupal.sh")); err == nil {
-		return true
+	if isDrupalApp(app) {
+		if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "core/composer.json")); err == nil {
+			return true
+		}
 	}
 	return false
 }
 
 // isDrupal6App returns true if the app is of type Drupal6
 func isDrupal6App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "misc/ahah.js")); err == nil {
-		return true
+	if isDrupalApp(app) {
+		if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "misc/ahah.js")); err == nil {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -392,10 +392,13 @@ func isDrupalApp(app *DdevApp) bool {
 	if err != nil {
 		return false
 	}
-	defer file.Close()
 	buffer := make([]byte, 3178)
-	file.Read(buffer)
-
+	_, err = file.Read(buffer)
+	if err != nil {
+		_ = file.Close()
+		return false
+	}
+	_ = file.Close()
 	return strings.Index(string(buffer), "Drupal") > -1
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Detecting the Drupal version can be weak if wrong docroot chosen.

## How this PR Solves The Problem:

There must be an `index.php` and contain the word "Drupal", then follow structure patterns.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

