### PR TITLE
Add Linux xdebug instructions, fixes #610

### DIFF
--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -8,7 +8,7 @@ All IDEs basically work the same: They listen on a port and react when they're c
 
 **Key facts:**
 * The debug server port on the IDE must be set to port 11011. Although the xdebug default is port 9000, that port often has conflicts for PHP developers, so 11011 is used with ddev.
-* An IP-address *alias* of 172.28.99.99 must be added to your workstation host's loopback address. On macOS this is done with the command `sudo ifconfig lo0 alias 172.28.99.99`. **This must currently be done after each reboot.**
+* An IP-address *alias* of 172.28.99.99 must be added to your workstation host's loopback address. On macOS this is done with the command `sudo ifconfig lo0 alias 172.28.99.99`. On Ubuntu 16.04 and probably other Linux variants, `sudo ifconfig docker0:0 172.28.99.99 up` **This must currently be done after each reboot.**
 
 For more background on XDebug see [XDebug documentation](https://xdebug.org/docs/remote). The intention here is that one won't have to understand XDebug to do debugging.
 
@@ -91,3 +91,17 @@ Before, beginning anything else, please set your Debugger Port to 11011. (Prefer
 6. Turn on debugging in Atom (Right-click->PHP Debug->Toggle Debugging)
 7. Turn on debugging in your browser using the browser extension.
 8. Visit a page that should trigger your breakpoint.
+
+An example configuration from [user contribution](https://github.com/drud/ddev/issues/610#issuecomment-359244922):
+```
+"php-debug":
+    AutoExpandLocals: true
+    DebugXDebugMessages: true
+    MaxDepth: 6
+    PathMaps: [
+      "/path/to/container/docroot;/path/to/host/docroot"
+    ]
+    PhpException: {}
+    ServerAddress: "172.28.99.99"
+    ServerPort: 11011
+```


### PR DESCRIPTION
## The Problem/Issue/Bug:

We didn't give instructions about linux usage with xdebug.

## How this PR Solves The Problem:

Adds the results in #610.

## Manual Testing Instructions:

Try xdebug with PHPStorm or another environment on a Linux machine, as described [here](https://github.com/rfay/ddev/blob/2fd36cf15e1ff7bbb9e9f4927f40b68c3bce8092/docs/users/step-debugging.md).

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
OP #610

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

