### PR TITLE
Change "app" and "application" to "project" in user-facing docs/output, fixes #526

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -45,7 +45,7 @@ var ConfigCommand = &cobra.Command{
 		provider := ddevapp.DefaultProviderName
 
 		if len(args) > 1 {
-			output.UserOut.Fatal("Invalid argument detected. Please use 'ddev config' or 'ddev config [provider]' to configure a site.")
+			output.UserOut.Fatal("Invalid argument detected. Please use 'ddev config' or 'ddev config [provider]' to configure a project.")
 		}
 
 		if len(args) == 1 {
@@ -173,14 +173,16 @@ var ConfigCommand = &cobra.Command{
 func init() {
 	validAppTypes := strings.Join(ddevapp.GetValidAppTypes(), ", ")
 	apptypeUsage := fmt.Sprintf("Provide the project type (one of %s). This is autodetected and this flag is necessary only to override the detection.", validAppTypes)
+	projectNameUsage := fmt.Sprintf("Provide the project name of project to configure (normally the same as the last part of directory name)")
 
-	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", "Provide the sitename of site to configure (normally the same as the directory name)")
-	ConfigCommand.Flags().StringVarP(&docrootRelPath, "docroot", "", "", "Provide the relative docroot of the site, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory")
+	ConfigCommand.Flags().StringVarP(&siteName, "projectname", "", "", projectNameUsage)
+	ConfigCommand.Flags().StringVarP(&docrootRelPath, "docroot", "", "", "Provide the relative docroot of the project, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory")
 	ConfigCommand.Flags().StringVarP(&pantheonEnvironment, "pantheon-environment", "", "", "Choose the environment for a Pantheon site (dev/test/prod) (Pantheon-only)")
 	ConfigCommand.Flags().StringVarP(&appType, "projecttype", "", "", apptypeUsage)
 	// apptype flag is there for backwards compatibility.
 	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
 	ConfigCommand.Flags().BoolVarP(&showConfigLocation, "show-config-location", "", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
+	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", projectNameUsage+" This is the same as projectname and is included only for backwards compatibility")
 
 	RootCmd.AddCommand(ConfigCommand)
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -183,8 +183,10 @@ func init() {
 	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
 	ConfigCommand.Flags().BoolVarP(&showConfigLocation, "show-config-location", "", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
 	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", projectNameUsage+" This is the same as projectname and is included only for backwards compatibility")
-	ConfigCommand.Flags().MarkDeprecated("sitename", "The sitename flag is deprecated in favor of --projectname")
-	ConfigCommand.Flags().MarkDeprecated("apptype", "The apptype flag is deprecated in favor of --projecttype")
+	err := ConfigCommand.Flags().MarkDeprecated("sitename", "The sitename flag is deprecated in favor of --projectname")
+	util.CheckErr(err)
+	err = ConfigCommand.Flags().MarkDeprecated("apptype", "The apptype flag is deprecated in favor of --projecttype")
+	util.CheckErr(err)
 
 	RootCmd.AddCommand(ConfigCommand)
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -183,6 +183,8 @@ func init() {
 	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
 	ConfigCommand.Flags().BoolVarP(&showConfigLocation, "show-config-location", "", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
 	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", projectNameUsage+" This is the same as projectname and is included only for backwards compatibility")
+	ConfigCommand.Flags().MarkDeprecated("sitename", "The sitename flag is deprecated in favor of --projectname")
+	ConfigCommand.Flags().MarkDeprecated("apptype", "The apptype flag is deprecated in favor of --projecttype")
 
 	RootCmd.AddCommand(ConfigCommand)
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -82,7 +82,7 @@ var ConfigCommand = &cobra.Command{
 		if siteName == "" && docrootRelPath == "" && pantheonEnvironment == "" && appType == "" {
 			err = app.PromptForConfig()
 			if err != nil {
-				util.Failed("There was a problem configuring your application: %v", err)
+				util.Failed("There was a problem configuring your project: %v", err)
 			}
 		} else { // In this case we have to validate the provided items, or set to sane defaults
 
@@ -127,9 +127,9 @@ var ConfigCommand = &cobra.Command{
 				appType = detectedApptype
 				util.Success("Found a %s codebase at %s", detectedApptype, fullPath)
 			} else if appType != "" { // apptype was passed, but we found no app at all
-				util.Warning("You have specified an apptype of %s but no app of that type is found in %s", appType, fullPath)
+				util.Warning("You have specified a project type of %s but no project of that type is found in %s", appType, fullPath)
 			} else if appType != "" && detectedApptype != appType { // apptype was passed, app was found, but not the same type
-				util.Warning("You have specified an apptype of %s but an app of type %s was discovered in %s", appType, detectedApptype, fullPath)
+				util.Warning("You have specified a project type of %s but a project of type %s was discovered in %s", appType, detectedApptype, fullPath)
 			}
 			app.Type = appType
 

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -12,14 +12,14 @@ import (
 
 // DescribeCommand represents the `ddev config` command
 var DescribeCommand = &cobra.Command{
-	Use:   "describe [sitename]",
-	Short: "Get a detailed description of a running ddev site.",
-	Long: `Get a detailed description of a running ddev site. Describe provides basic
-information about a ddev site, including its name, location, url, and status.
+	Use:   "describe [projectname]",
+	Short: "Get a detailed description of a running ddev project.",
+	Long: `Get a detailed description of a running ddev project. Describe provides basic
+information about a ddev project, including its name, location, url, and status.
 It also provides details for MySQL connections, and connection information for
 additional services like MailHog and phpMyAdmin. You can run 'ddev describe' from
-a site directory to stop that site, or you can specify a site to describe by
-running 'ddev stop <sitename>.`,
+a project directory to stop that project, or you can specify a project to describe by
+running 'ddev stop <projectname>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var siteName string
 
@@ -33,17 +33,17 @@ running 'ddev stop <sitename>.`,
 
 		site, err := ddevapp.GetActiveApp(siteName)
 		if err != nil {
-			util.Failed("Unable to find any active site named %s: %v", siteName, err)
+			util.Failed("Unable to find any active project named %s: %v", siteName, err)
 		}
 
 		// Do not show any describe output if we can't find the site.
 		if site.SiteStatus() == ddevapp.SiteNotFound {
-			util.Failed("no site found. have you run 'ddev start'?")
+			util.Failed("no project found. have you run 'ddev start'?")
 		}
 
 		desc, err := site.Describe()
 		if err != nil {
-			util.Failed("Failed to describe site %s: %v", err)
+			util.Failed("Failed to describe project %s: %v", err)
 		}
 
 		renderedDesc, err := renderAppDescribe(desc)

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -26,13 +26,13 @@ func TestDescribeBadArgs(t *testing.T) {
 	args := []string{"describe"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "Please specify a site name or change directories")
+	assert.Contains(string(out), "Please specify a project name or change directories")
 
 	// Ensure we get a failure if we run a describe on a named application which does not exist.
 	args = []string{"describe", util.RandString(16)}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "Unable to find any active site")
+	assert.Contains(string(out), "Unable to find any active project")
 
 	// Ensure we get a failure if using too many arguments.
 	args = []string{"describe", util.RandString(16), util.RandString(16)}

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -30,11 +30,11 @@ var DdevExecCmd = &cobra.Command{
 		}
 
 		if strings.Contains(app.SiteStatus(), ddevapp.SiteNotFound) {
-			util.Failed("App not currently running. Try 'ddev start'.")
+			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 
 		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
-			util.Failed("App is stopped. Run 'ddev start' to start the environment.")
+			util.Failed("Project is stopped. Run 'ddev start' to start the environment.")
 		}
 
 		app.DockerEnv()

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -15,11 +15,11 @@ var dbExtPath string
 // ImportDBCmd represents the `ddev import-db` command.
 var ImportDBCmd = &cobra.Command{
 	Use:   "import-db",
-	Short: "Import the database of an existing site to the dev environment.",
-	Long: `Import the database of an existing site to the development environment.
+	Short: "Import the database of an existing project to the dev environment.",
+	Long: `Import the database of an existing project to the development environment.
 The database can be provided as a SQL dump in a .sql, .sql.gz, .zip, .tgz, or .tar.gz
 format. For the zip and tar formats, the path to a .sql file within the archive
-can be provided if it is not located at the top-level of the archive.`,
+can be provided if it is not located at the top level of the archive.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()
@@ -35,7 +35,7 @@ can be provided if it is not located at the top-level of the archive.`,
 		}
 
 		if app.SiteStatus() != ddevapp.SiteRunning {
-			util.Failed("The site is not running. The site must be running in order to import a database.")
+			util.Failed("The project is not running. The project must be running in order to import a database.")
 		}
 
 		err = app.ImportDB(dbSource, dbExtPath)

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -15,9 +15,9 @@ var fileExtPath string
 // ImportFileCmd represents the `ddev import-db` command.
 var ImportFileCmd = &cobra.Command{
 	Use:   "import-files",
-	Short: "Import the uploaded files directory of an existing site to the default public upload directory of your application.",
+	Short: "Import the uploaded files directory of an existing site to the default public upload directory of your project.",
 	Long: `Import the uploaded files directory of an existing site to the default public
-upload directory of your application. The files can be provided as a directory
+upload directory of your project. The files can be provided as a directory
 path or an archive in .tar, .tar.gz, .tgz, or .zip format. For the .zip and tar formats,
 the path to a directory within the archive can be provided if it is not located at the
 top-level of the archive. If the destination directory exists, it will be replaced with

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -15,8 +15,8 @@ var fileExtPath string
 // ImportFileCmd represents the `ddev import-db` command.
 var ImportFileCmd = &cobra.Command{
 	Use:   "import-files",
-	Short: "Import the uploaded files directory of an existing site to the default public upload directory of your project.",
-	Long: `Import the uploaded files directory of an existing site to the default public
+	Short: "Import the uploaded files directory of an existing project to the default public upload directory of your project.",
+	Long: `Import the uploaded files directory of an existing project to the default public
 upload directory of your project. The files can be provided as a directory
 path or an archive in .tar, .tar.gz, .tgz, or .zip format. For the .zip and tar formats,
 the path to a directory within the archive can be provided if it is not located at the

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -14,15 +14,15 @@ var continuous bool
 // DevListCmd represents the list command
 var DevListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List applications",
-	Long:  `List applications.`,
+	Short: "List projects",
+	Long:  `List projects.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for {
 			apps := ddevapp.GetApps()
 			var appDescs []map[string]interface{}
 
 			if len(apps) < 1 {
-				output.UserOut.Println("There are no running ddev applications.")
+				output.UserOut.Println("There are no running ddev projects.")
 			} else {
 				table := ddevapp.CreateAppTable()
 				for _, app := range apps {

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -28,7 +28,7 @@ var DevListCmd = &cobra.Command{
 				for _, app := range apps {
 					desc, err := app.Describe()
 					if err != nil {
-						util.Failed("Failed to describe site %s: %v", app.GetName(), err)
+						util.Failed("Failed to describe project %s: %v", app.GetName(), err)
 					}
 					appDescs = append(appDescs, desc)
 					ddevapp.RenderAppRow(table, desc)
@@ -47,6 +47,6 @@ var DevListCmd = &cobra.Command{
 }
 
 func init() {
-	DevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, site information will be emitted once per second")
+	DevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted once per second")
 	RootCmd.AddCommand(DevListCmd)
 }

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -63,7 +63,7 @@ func TestDevList(t *testing.T) {
 				break
 			}
 		}
-		assert.True(found, "Failed to find site %s in ddev list -j", v.Name)
+		assert.True(found, "Failed to find project %s in ddev list -j", v.Name)
 
 	}
 

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -26,11 +26,11 @@ var DdevLogsCmd = &cobra.Command{
 		}
 
 		if strings.Contains(app.SiteStatus(), ddevapp.SiteNotFound) {
-			util.Failed("App not currently running. Try 'ddev start'.")
+			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 
 		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
-			util.Failed("App is stopped. Run 'ddev start' to start the environment.")
+			util.Failed("Project is stopped. Run 'ddev start' to start the environment.")
 		}
 
 		err = app.Logs(serviceType, follow, timestamp, tail)

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -29,7 +29,7 @@ func TestDevLogsNoConfig(t *testing.T) {
 	args := []string{"logs"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "Please specify a site name or change directories")
+	assert.Contains(string(out), "Please specify a project name or change directories")
 }
 
 // TestDevLogs tests that the Dev logs functionality is working.

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -36,7 +36,7 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 		}
 
 		if app.SiteStatus() == ddevapp.SiteNotFound {
-			util.Failed("App not currently running. Try 'ddev start'.")
+			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 
 		err = app.Down(removeData)
@@ -44,11 +44,11 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 			util.Failed("Failed to remove %s: %s", app.GetName(), err)
 		}
 
-		util.Success("Successfully removed the %s application.", app.GetName())
+		util.Success("Successfully removed the %s project.", app.GetName())
 	},
 }
 
 func init() {
-	DdevRemoveCmd.Flags().BoolVarP(&removeData, "remove-data", "R", false, "Remove stored application data (MySQL, logs, etc.)")
+	DdevRemoveCmd.Flags().BoolVarP(&removeData, "remove-data", "R", false, "Remove stored project data (MySQL, logs, etc.)")
 	RootCmd.AddCommand(DdevRemoveCmd)
 }

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -10,12 +10,12 @@ var removeData bool
 
 // DdevRemoveCmd represents the remove command
 var DdevRemoveCmd = &cobra.Command{
-	Use:     "remove [sitename]",
+	Use:     "remove [projectname]",
 	Aliases: []string{"rm"},
-	Short:   "Remove the development environment for a site.",
-	Long: `Remove the development environment for a site. You can run 'ddev remove'
-from a site directory to remove that site, or you can specify a site to remove
-by running 'ddev remove <sitename>'. By default, remove is a non-destructive operation and will
+	Short:   "Remove the development environment for a project.",
+	Long: `Remove the development environment for a project. You can run 'ddev remove'
+from a project directory to remove that project, or you can specify a project to remove
+by running 'ddev remove <projectname>'. By default, remove is a non-destructive operation and will
 leave database contents intact. Remove never touches your code or files directories.
 
 To remove database contents, you may use the --remove-data flag with remove.`,

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -13,8 +13,8 @@ import (
 // DdevRestartCmd rebuilds an apps settings
 var DdevRestartCmd = &cobra.Command{
 	Use:   "restart",
-	Short: "Restart the development environment for a site.",
-	Long:  `Restart stops the containers for site's environment and starts them back up again.`,
+	Short: "Restart the development environment for a project.",
+	Long:  `Restart stops the containers for project and starts them back up again.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()
@@ -30,7 +30,7 @@ var DdevRestartCmd = &cobra.Command{
 			util.Failed("Failed to restart: %v", err)
 		}
 
-		output.UserOut.Printf("Restarting environment for %s...", app.GetName())
+		output.UserOut.Printf("Restarting project %s...", app.GetName())
 		err = app.Stop()
 		if err != nil {
 			util.Failed("Failed to restart %s: %v", app.GetName(), err)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -73,7 +73,7 @@ func TestGetActiveAppRoot(t *testing.T) {
 	assert := asrt.New(t)
 
 	_, err := ddevapp.GetActiveAppRoot("")
-	assert.Contains(err.Error(), "Please specify a site name or change directories")
+	assert.Contains(err.Error(), "Please specify a project name or change directories")
 
 	_, err = ddevapp.GetActiveAppRoot("potato")
 	assert.Error(err)

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -27,7 +27,7 @@ var SequelproLoc = "/Applications/sequel pro.app"
 var DdevSequelproCmd = &cobra.Command{
 	Use:   "sequelpro",
 	Short: "Easily connect a dev site to sequelpro",
-	Long:  `A helper command for easily using sequelpro (OSX database browser) with a running ddev app.`,
+	Long:  `A helper command for easily using sequelpro (OSX database browser) with a running DDEV-Local project.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
 			output.UserOut.Fatalf("invalid arguments to sequelpro command: %v", args)

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -26,8 +26,8 @@ var SequelproLoc = "/Applications/sequel pro.app"
 // DdevSequelproCmd represents the sequelpro command
 var DdevSequelproCmd = &cobra.Command{
 	Use:   "sequelpro",
-	Short: "Connect a project database to sequelpro",
-	Long:  `A helper command for using sequelpro (macOS database browser) with a running DDEV-Local project.`,
+	Short: "Connect sequelpro to a project database",
+	Long:  `A helper command for using sequelpro (macOS database browser) with a running DDEV-Local project's database'.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
 			output.UserOut.Fatalf("invalid arguments to sequelpro command: %v", args)

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -26,8 +26,8 @@ var SequelproLoc = "/Applications/sequel pro.app"
 // DdevSequelproCmd represents the sequelpro command
 var DdevSequelproCmd = &cobra.Command{
 	Use:   "sequelpro",
-	Short: "Easily connect a dev site to sequelpro",
-	Long:  `A helper command for easily using sequelpro (OSX database browser) with a running DDEV-Local project.`,
+	Short: "Connect a project database to sequelpro",
+	Long:  `A helper command for using sequelpro (macOS database browser) with a running DDEV-Local project.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
 			output.UserOut.Fatalf("invalid arguments to sequelpro command: %v", args)
@@ -49,7 +49,7 @@ func handleSequelProCommand(appLocation string) (string, error) {
 	}
 
 	if app.SiteStatus() != ddevapp.SiteRunning {
-		return "", errors.New("site is not running. The site must be running to create a Sequel Pro connection")
+		return "", errors.New("project is not running. The project must be running to create a Sequel Pro connection")
 	}
 
 	db, err := app.FindContainerByType("db")

--- a/cmd/ddev/cmd/sequelpro_test.go
+++ b/cmd/ddev/cmd/sequelpro_test.go
@@ -50,6 +50,6 @@ func TestSequelproBadApp(t *testing.T) {
 	// Ensure it fails if we run outside of an application root.
 	_, err := handleSequelProCommand(SequelproLoc)
 	assert.Error(err)
-	assert.Contains(err.Error(), "unable to determine the application")
+	assert.Contains(err.Error(), "unable to determine the project")
 
 }

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -20,11 +20,11 @@ var DdevSSHCmd = &cobra.Command{
 		}
 
 		if strings.Contains(app.SiteStatus(), ddevapp.SiteNotFound) {
-			util.Failed("App not currently running. Try 'ddev start'.")
+			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 
 		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
-			util.Failed("App is stopped. Run 'ddev start' to start the environment.")
+			util.Failed("Project is stopped. Run 'ddev start' to start the environment.")
 		}
 
 		app.DockerEnv()

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -14,9 +14,9 @@ import (
 var StartCmd = &cobra.Command{
 	Use:     "start",
 	Aliases: []string{"add"},
-	Short:   "Start the development environment for a site.",
+	Short:   "Start a ddev project.",
 	Long: `Start initializes and configures the web server and database containers to
-provide a working environment for development.`,
+provide a local development environment.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -34,7 +34,7 @@ to stop by running 'ddev stop <sitename>.`,
 			util.Failed("Failed to stop containers for %s: %v", app.GetName(), err)
 		}
 
-		util.Success("Application has been stopped.")
+		util.Success("Project has been stopped.")
 	},
 }
 

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -8,16 +8,16 @@ import (
 
 // DdevStopCmd represents the stop command
 var DdevStopCmd = &cobra.Command{
-	Use:   "stop [sitename]",
-	Short: "Stop the development environment for a site.",
-	Long: `Stop the development environment for a site. You can run 'ddev stop'
-from a site directory to stop that site, or you can specify a running site
-to stop by running 'ddev stop <sitename>.`,
+	Use:   "stop [projectname]",
+	Short: "Stop the development environment for a project.",
+	Long: `Stop the development environment for a project. You can run 'ddev stop'
+from a project directory to stop that project, or you can specify a running project
+to stop by running 'ddev stop <projectname>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var siteName string
 
 		if len(args) > 1 {
-			util.Failed("Too many arguments provided. Please use 'ddev stop' or 'ddev stop [sitename]'")
+			util.Failed("Too many arguments provided. Please use 'ddev stop' or 'ddev stop [projectname]'")
 		}
 
 		if len(args) == 1 {

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -23,7 +23,7 @@ From here we can start setting up ddev. Inside your project's working directory,
 ddev config
 ```
 
-_Note: ddev config will prompt you for a project name, docroot, and app type._
+_Note: ddev config will prompt you for a project name, docroot, and project type._
 
 After you've run `ddev config`, you're ready to start running your project. To start running ddev, simply enter:
 
@@ -98,7 +98,7 @@ The next step is to configure ddev. In your project's working directory, enter t
 ddev config
 ```
 
-_Note: ddev config will prompt you for a project name, docroot, and app type._
+_Note: ddev config will prompt you for a project name, docroot, and project type._
 
 After you've run `ddev config` you're ready to start up your project. Run ddev using:
 
@@ -124,7 +124,7 @@ cd example-typo3-site
 
 If necessary, run build steps that you may require, like `composer install` in the correct directory.
 
-_Note: ddev assumes that the files created by a site install have already been created, including the typo3conf, typo3temp, uploads, and fileadmin directories._
+_Note: ddev assumes that the files created by a TYPO3 install have already been created, including the typo3conf, typo3temp, uploads, and fileadmin directories._
 
 From here we can start setting up ddev. In your project's working directory, enter the command:
 
@@ -191,9 +191,9 @@ Here's an example of a database import using ddev:
 ddev import-db --src=dumpfile.sql.gz
 ```
 
-For in-depth application monitoring, use the `ddev describe` command to see details about the status of your ddev app.
+For in-depth application monitoring, use the `ddev describe` command to see details about the status of your ddev project.
 
-**Note for Backdrop users:** In addition to importing a Backdrop database, you will need to extract a copy of your Backdrop site's configuration into the local `active` directory. The location for this directory can vary depending on the contents of your Backdrop `settings.php` file, but the default location is `[docroot]/files/config_[random letters and numbers]/active`. Please refer to the Backdrop documentation for more information on [moving your Backdrop site](https://backdropcms.org/user-guide/moving-backdrop-site) into the `ddev` environment.
+**Note for Backdrop users:** In addition to importing a Backdrop database, you will need to extract a copy of your Backdrop project's configuration into the local `active` directory. The location for this directory can vary depending on the contents of your Backdrop `settings.php` file, but the default location is `[docroot]/files/config_[random letters and numbers]/active`. Please refer to the Backdrop documentation for more information on [moving your Backdrop site](https://backdropcms.org/user-guide/moving-backdrop-site) into the `ddev` environment.
 
 ## Getting Started
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -210,7 +210,7 @@ Once completed, your configuration will be written to /Users/username/Projects/d
 
 Project name (drupal8):
 
-The docroot is the directory from which your site is served. This is a relative path from your application root (/Users/username/Projects/drupal8)
+The docroot is the directory from which your site is served. This is a relative path from your project root (/Users/username/Projects/drupal8)
 You may leave this value blank if your site files are in the application root
 Docroot Location: web
 Found a drupal8 codebase at /Users/username/Projects/drupal8/web

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -21,7 +21,7 @@ When defining additional services for your project, it is recommended to follow 
 
   - `com.ddev.container-type: [servicename]`
 
-- Exposing ports for service: you can expose the port for a service to be accessible as `sitename.ddev.local:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
+- Exposing ports for service: you can expose the port for a service to be accessible as `projectname.ddev.local:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
 
   - Define only the internal port in the `ports` section for docker-compose. The `hostPort:containerPort` convention normally used to expose ports in docker should not be used here, since we are leveraging the ddev router to expose the ports.
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -203,7 +203,7 @@ func (app *DdevApp) ReadConfig() error {
 // WarnIfConfigReplace just messages user about whether config is being replaced or created
 func (app *DdevApp) WarnIfConfigReplace() {
 	if app.ConfigExists() {
-		util.Warning("You are reconfiguring the app at %s. \nThe existing configuration will be updated and replaced.", app.AppRoot)
+		util.Warning("You are reconfiguring the project at %s. \nThe existing configuration will be updated and replaced.", app.AppRoot)
 	} else {
 		util.Success("Creating a new ddev project config in the current directory (%s)", app.AppRoot)
 		util.Success("Once completed, your configuration will be written to %s\n", app.ConfigPath)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -362,8 +362,8 @@ func (app *DdevApp) docrootPrompt() error {
 	}
 
 	// Determine the document root.
-	output.UserOut.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your application root (%s)", app.AppRoot)
-	output.UserOut.Println("You may leave this value blank if your site files are in the application root")
+	output.UserOut.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your project root (%s)", app.AppRoot)
+	output.UserOut.Println("You may leave this value blank if your site files are in the project root")
 	var docrootPrompt = "Docroot Location"
 	if app.Docroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, app.Docroot)
@@ -397,7 +397,7 @@ func (app *DdevApp) appTypePrompt() error {
 		return err
 	}
 	validAppTypes := strings.Join(GetValidAppTypes(), ", ")
-	typePrompt := fmt.Sprintf("Application Type [%s]", validAppTypes)
+	typePrompt := fmt.Sprintf("Project Type [%s]", validAppTypes)
 
 	// First, see if we can auto detect what kind of site it is so we can set a sane default.
 
@@ -412,7 +412,7 @@ func (app *DdevApp) appTypePrompt() error {
 	appType := strings.ToLower(util.GetInput(detectedAppType))
 
 	for !IsValidAppType(appType) {
-		output.UserOut.Errorf("'%s' is not a valid application type. Allowed application types are: %s\n", appType, validAppTypes)
+		output.UserOut.Errorf("'%s' is not a valid project type. Allowed project types are: %s\n", appType, validAppTypes)
 
 		fmt.Printf(typePrompt + ": ")
 		appType = strings.ToLower(util.GetInput(appType))

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -182,7 +182,7 @@ func TestConfigCommand(t *testing.T) {
 		// Ensure we have expected vales in output.
 		assert.Contains(out, testDir)
 		assert.Contains(out, fmt.Sprintf("No directory could be found at %s", filepath.Join(testDir, invalidDir)))
-		assert.Contains(out, fmt.Sprintf("'%s' is not a valid application type", invalidAppType))
+		assert.Contains(out, fmt.Sprintf("'%s' is not a valid project type", invalidAppType))
 
 		// Ensure values were properly set on the app struct.
 		assert.Equal(name, app.Name)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -949,7 +949,7 @@ func GetActiveAppRoot(siteName string) (string, error) {
 
 		webContainer, err := dockerutil.FindContainerByLabels(labels)
 		if err != nil {
-			return "", fmt.Errorf("could not find a site named '%s'. Run 'ddev list' to see currently active sites", siteName)
+			return "", fmt.Errorf("could not find a project named '%s'. Run 'ddev list' to see currently active projects", siteName)
 		}
 
 		siteDir, ok = webContainer.Labels["com.ddev.approot"]

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -937,7 +937,7 @@ func GetActiveAppRoot(siteName string) (string, error) {
 		}
 		_, err = CheckForConf(siteDir)
 		if err != nil {
-			return "", fmt.Errorf("Could not find a site in %s. Have you run 'ddev config'? Please specify a site name or change directories: %s", siteDir, err)
+			return "", fmt.Errorf("Could not find a project in %s. Have you run 'ddev config'? Please specify a project name or change directories: %s", siteDir, err)
 		}
 	} else {
 		var ok bool

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -287,8 +287,8 @@ func (app *DdevApp) ImportDB(imPath string, extPath string) error {
 		if strings.Contains(err.Error(), "settings files already exist and are being managed") {
 			return fmt.Errorf("failed to write settings file for %s: %v", app.GetName(), err)
 		}
-		util.Warning("A custom settings file exists for your application, so ddev did not generate one.")
-		util.Warning("Run 'ddev describe' to find the database credentials for this application.")
+		util.Warning("A custom settings file exists for your project, so ddev did not generate one.")
+		util.Warning("Run 'ddev describe' to find the database credentials for this project.")
 	}
 
 	err = app.PostImportDBAction()
@@ -734,7 +734,7 @@ func (app *DdevApp) Stop() error {
 	}
 
 	if strings.Contains(app.SiteStatus(), SiteDirMissing) || strings.Contains(app.SiteStatus(), SiteConfigMissing) {
-		return fmt.Errorf("ddev can no longer find your application files at %s. If you would like to continue using ddev to manage this site please restore your files to that directory. If you would like to remove this site from ddev, you may run 'ddev remove %s'", app.GetAppRoot(), app.GetName())
+		return fmt.Errorf("ddev can no longer find your project files at %s. If you would like to continue using ddev to manage this project please restore your files to that directory. If you would like to remove this site from ddev, you may run 'ddev remove %s'", app.GetAppRoot(), app.GetName())
 	}
 
 	_, _, err := dockerutil.ComposeCmd(app.ComposeFiles(), "stop")
@@ -820,7 +820,7 @@ func (app *DdevApp) Down(removeData bool) error {
 		// mysql data can be set to read-only on linux hosts. PurgeDirectory ensures files
 		// are writable before we attempt to remove them.
 		if !fileutil.FileExists(app.DataDir) {
-			util.Warning("No application data to remove")
+			util.Warning("No project data/database to remove")
 		} else {
 			err := fileutil.PurgeDirectory(app.DataDir)
 			if err != nil {
@@ -831,7 +831,7 @@ func (app *DdevApp) Down(removeData bool) error {
 			if err != nil {
 				return fmt.Errorf("failed to remove data directory %s: %v", app.DataDir, err)
 			}
-			util.Success("Application data removed")
+			util.Success("Project data/database removed")
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -565,7 +565,7 @@ func TestDdevStopMissingDirectory(t *testing.T) {
 
 	out := app.Stop()
 	assert.Error(out)
-	assert.Contains(out.Error(), "If you would like to continue using ddev to manage this site please restore your files to that directory.")
+	assert.Contains(out.Error(), "If you would like to continue using ddev to manage this project please restore your files to that directory.")
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)
 	assert.NoError(err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -243,7 +243,7 @@ func TestStartWithoutDdevConfig(t *testing.T) {
 
 	_, err = ddevapp.GetActiveApp("")
 	assert.Error(err)
-	assert.Contains(err.Error(), "Could not find a site")
+	assert.Contains(err.Error(), "Could not find a project")
 }
 
 // TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #526: We're trying to use "project" everywhere when talking about a ddev site/app/whatever, in our docs and whenever ddev interacts with the user. This PR attempts to do that.

## Manual Testing Instructions:

Use ddev. Look at the output. Review the docs.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #526 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

