### PR TITLE
Create settings file when configuring project, fixes #692

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
       - run:
           command: ./.circleci/generate_artifacts.sh $ARTIFACTS
           name: tar/zip up artifacts and make hashes
+          no_output_timeout: "20m"
 
       - store_artifacts:
           path: /artifacts
@@ -79,6 +80,7 @@ jobs:
       - run:
           command: ./.circleci/generate_artifacts.sh $ARTIFACTS
           name: tar/zip up artifacts and make hashes
+          no_output_timeout: "20m"
 
       - store_artifacts:
           path: /artifacts
@@ -114,6 +116,7 @@ jobs:
       - run:
           command: ./.circleci/generate_artifacts.sh $ARTIFACTS
           name: tar/zip up artifacts and make hashes
+          no_output_timeout: "20m"
 
       - store_artifacts:
           path: /artifacts

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -165,7 +165,7 @@ var ConfigCommand *cobra.Command = &cobra.Command{
 
 		_, err = app.CreateSettingsFile()
 		if err != nil {
-			util.Failed("Could not write settings file: %w", err)
+			util.Failed("Could not write settings file: %v", err)
 		}
 
 		// If a provider is specified, prompt about whether to do an import after config.

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -163,10 +163,7 @@ var ConfigCommand *cobra.Command = &cobra.Command{
 			util.Failed("Could not write ddev config file: %v", err)
 		}
 
-		_, err = app.CreateSettingsFile()
-		if err != nil {
-			util.Failed("Could not write settings file: %w", err)
-		}
+		_,_ = app.CreateSettingsFile()
 
 		// If a provider is specified, prompt about whether to do an import after config.
 		switch provider {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -152,7 +152,10 @@ var ConfigCommand *cobra.Command = &cobra.Command{
 			} else {
 				util.Success("Using project name '%s' and environment '%s'.", app.Name, pantheonEnvironment)
 			}
-			_ = app.ConfigFileOverrideAction()
+			err = app.ConfigFileOverrideAction()
+			if err != nil {
+				util.Failed("Failed to run ConfigFileOverrideAction: %v", err)
+			}
 
 		}
 		err = app.WriteConfig()

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -163,7 +163,7 @@ var ConfigCommand *cobra.Command = &cobra.Command{
 			util.Failed("Could not write ddev config file: %v", err)
 		}
 
-		_,_ = app.CreateSettingsFile()
+		_, _ = app.CreateSettingsFile()
 
 		// If a provider is specified, prompt about whether to do an import after config.
 		switch provider {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -152,10 +152,7 @@ var ConfigCommand *cobra.Command = &cobra.Command{
 			} else {
 				util.Success("Using project name '%s' and environment '%s'.", app.Name, pantheonEnvironment)
 			}
-			err = app.ConfigFileOverrideAction()
-			if err != nil {
-				util.Failed("Failed to run ConfigFileOverrideAction: %v", err)
-			}
+			_ = app.ConfigFileOverrideAction()
 
 		}
 		err = app.WriteConfig()

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -163,7 +163,10 @@ var ConfigCommand *cobra.Command = &cobra.Command{
 			util.Failed("Could not write ddev config file: %v", err)
 		}
 
-		_, _ = app.CreateSettingsFile()
+		_, err = app.CreateSettingsFile()
+		if err != nil {
+			util.Failed("Could not write settings file: %w", err)
+		}
 
 		// If a provider is specified, prompt about whether to do an import after config.
 		switch provider {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -163,6 +163,11 @@ var ConfigCommand *cobra.Command = &cobra.Command{
 			util.Failed("Could not write ddev config file: %v", err)
 		}
 
+		_, err = app.CreateSettingsFile()
+		if err != nil {
+			util.Failed("Could not write settings file: %w", err)
+		}
+
 		// If a provider is specified, prompt about whether to do an import after config.
 		switch provider {
 		case ddevapp.DefaultProviderName:

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -57,6 +57,8 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not create %s directory under %s", testDocrootName, tmpdir)
 	}
+	err = os.MkdirAll(filepath.Join(tmpdir, testDocrootName, "sites", "default"), 0755)
+	assert.NoError(err)
 	_, err = os.OpenFile(filepath.Join(tmpdir, testDocrootName, "index.php"), os.O_RDONLY|os.O_CREATE, 0666)
 	assert.NoError(err)
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -94,9 +94,11 @@ func IsValidAppType(apptype string) bool {
 func (app *DdevApp) CreateSettingsFile() (string, error) {
 	app.SetApptypeSettingsPaths()
 
-	// If neither settings file options are set, then don't continue
+	// If neither settings file options are set, then don't continue. Return
+	// a nil error because this should not halt execution if the apptype
+	// does not have a settings definition.
 	if app.SiteLocalSettingsPath == "" && app.SiteSettingsPath == "" {
-		return "", fmt.Errorf("Neither SiteLocalSettingsPath nor SiteSettingsPath is set")
+		return "", nil
 	}
 
 	// Drupal and WordPress love to change settings files to be unwriteable.

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/util"
 	"os"
 	"path/filepath"
 )
@@ -98,6 +99,7 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	// a nil error because this should not halt execution if the apptype
 	// does not have a settings definition.
 	if app.SiteLocalSettingsPath == "" && app.SiteSettingsPath == "" {
+		util.Warning("Project type has no settings paths configured, so not creating settings file.")
 		return "", nil
 	}
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -125,7 +125,10 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	// just ignore.
 	if appFuncs, ok := appTypeMatrix[app.GetType()]; ok && appFuncs.settingsCreator != nil {
 		settingsPath, err := appFuncs.settingsCreator(app)
-		return settingsPath, err
+		if err != nil {
+			util.Warning("Unable to create settings file: %v", err)
+		}
+		return settingsPath, nil
 	}
 	return "", nil
 }

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -68,7 +68,7 @@ ini_set('session.cookie_lifetime', 2000000);
 func createBackdropSettingsFile(app *DdevApp) (string, error) {
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get Backdrop settings file path: %v", err)
+		return "", fmt.Errorf("Failed to get Backdrop settings file path: %v", err.Error())
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
@@ -76,7 +76,7 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 
 	err = writeBackdropSettingsFile(backdropConfig, settingsFilePath)
 	if err != nil {
-		return settingsFilePath, fmt.Errorf("Failed to write Backdrop settings file: %v", err)
+		return settingsFilePath, fmt.Errorf("Failed to write Backdrop settings file: %v", err.Error())
 	}
 
 	return settingsFilePath, nil

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -76,7 +76,7 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 
 	err = writeBackdropSettingsFile(backdropConfig, settingsFilePath)
 	if err != nil {
-		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err)
+		return settingsFilePath, fmt.Errorf("Failed to write Backdrop settings file: %v", err)
 	}
 
 	return settingsFilePath, nil

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -283,12 +283,8 @@ func (app *DdevApp) ImportDB(imPath string, extPath string) error {
 
 	_, err = app.CreateSettingsFile()
 	if err != nil {
-		// @todo: Use a typed error instead of relying on the text of the message.
-		if strings.Contains(err.Error(), "settings files already exist and are being managed") {
-			return fmt.Errorf("failed to write settings file for %s: %v", app.GetName(), err)
-		}
-		util.Warning("A custom settings file exists for your project, so ddev did not generate one.")
-		util.Warning("Run 'ddev describe' to find the database credentials for this project.")
+		util.Warning("A custom settings file exists for your application, so ddev did not generate one.")
+		util.Warning("Run 'ddev describe' to find the database credentials for this application.")
 	}
 
 	err = app.PostImportDBAction()

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -173,7 +173,7 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err.Error())
+		return "", fmt.Errorf("Failed to get Drupal 7 settings file path: %v", err.Error())
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
@@ -196,7 +196,7 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err.Error())
+		return "", fmt.Errorf("Failed to get Drupal 8 settings file path: %v", err.Error())
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
@@ -219,7 +219,7 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err.Error())
+		return "", fmt.Errorf("Failed to get Drupal 6 settings file path: %v", err.Error())
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -173,7 +173,7 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err)
+		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err.Error())
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
@@ -183,7 +183,7 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 
 	err = writeDrupal7SettingsFile(drupalConfig, settingsFilePath)
 	if err != nil {
-		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err)
+		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err.Error())
 	}
 
 	return settingsFilePath, nil
@@ -196,7 +196,7 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err)
+		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err.Error())
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
@@ -206,7 +206,7 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 
 	err = writeDrupal8SettingsFile(drupalConfig, settingsFilePath)
 	if err != nil {
-		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err)
+		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err.Error())
 	}
 
 	return settingsFilePath, nil
@@ -219,7 +219,7 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err)
+		return "", fmt.Errorf("Failed to get Drupal settings file path: %v", err.Error())
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
@@ -229,7 +229,7 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 
 	err = writeDrupal6SettingsFile(drupalConfig, settingsFilePath)
 	if err != nil {
-		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err)
+		return settingsFilePath, fmt.Errorf("Failed to write Drupal settings file: %v", err.Error())
 	}
 
 	return settingsFilePath, nil

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -30,7 +30,7 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($GLOBA
 func createTypo3SettingsFile(app *DdevApp) (string, error) {
 
 	if !fileutil.FileExists(app.SiteSettingsPath) {
-		return "", fmt.Errorf("TYPO3 does not seem to have been set up yet, missing LocalConfiguration.php (%s)", app.SiteLocalSettingsPath)
+		util.Warning("TYPO3 does not seem to have been set up yet, missing LocalConfiguration.php (%s)", app.SiteLocalSettingsPath)
 	}
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -35,13 +35,13 @@ func createTypo3SettingsFile(app *DdevApp) (string, error) {
 
 	settingsFilePath, err := app.DetermineSettingsPathLocation()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get TYPO3 AdditionalConfiguration.php file path: %v", err)
+		return "", fmt.Errorf("Failed to get TYPO3 AdditionalConfiguration.php file path: %v", err.Error())
 	}
 	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
 
 	err = writeTypo3SettingsFile(app)
 	if err != nil {
-		return settingsFilePath, fmt.Errorf("Failed to write TYPO3 AdditionalConfiguration.php file: %v", err)
+		return settingsFilePath, fmt.Errorf("Failed to write TYPO3 AdditionalConfiguration.php file: %v", err.Error())
 	}
 
 	return settingsFilePath, nil

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -130,7 +130,7 @@ Sets up WordPress vars and included files.
 wp-settings.php is typically included in wp-config.php. This check ensures it is not
 included again if this file is written to wp-config-local.php.
 */
-if (__FILE__ == "wp-config.php") {
+if (basename(__FILE__) == "wp-config.php") {
 	require_once(ABSPATH . '/wp-settings.php');
 }
 `


### PR DESCRIPTION
## The Problem/Issue/Bug:

See issue #692

## How this PR Solves The Problem:

After writing the project config, also write a settings files via `app.CreateSettingsFile()`

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

#692

## Release/Deployment notes:

* No obvious break changes come to mind.

## Remaining Tasks
* [x] Error Messages: As discussed in [the following review ](https://github.com/drud/ddev/pull/693#pullrequestreview-101537297), there are syntax errors when attempting to output the message beginning with “Could not write settings file” for Drupal 6, 7, 8, Backdrop, and TYPO3.
* [ ]  WordPress Local Settings:
	* [ ] We need to replicate the pattern used for Drupal by defaulting to wp-config.php if it doesn’t exist and falling back to generating wp-config-local.php if #ddev-generated is not found in wp-config.php.
	* [x] We need to fix the 500 error for WP by correcting the require_once() [syntax described here](https://github.com/drud/ddev/pull/693#issuecomment-370833403) .
	* [ ]  We need to append an inclusion of wp-config-local.php within the wp-config.php template [similar to how D8 does it]([https://github.com/drupal/drupal/blob/8.5.x/sites/default/default.settings.php#L785).
* [x] Backdrop: We need to ensure the error message for Backdrop doesn’t state Drupal.
* [ ] TYPO3:
  * [x]  Convert Error to Warning: It's not an error to not have LocalConfiguration.php (but we should util.Warning() it.
  * [ ] If AdditionalConfiguration.php does not exist, create the typo3conf directory if it doesn't exist and add our AdditionalConfiguration.php to it.
  * [ ] If typo3conf/LocalConfiguration.php didn't already exist, util.Warning() them that they have to do an install manually.
* [ ] Documentation: Any end-user documentation necessary to instruct users on this new workflow (@rickmanelius can address).
* [ ] Config => Start: File an issue to address [this use case](https://github.com/drud/ddev/pull/693#issuecomment-370893215) where an end-user may need the settings file generated at `ddev start` (@rickmanelius)
