### PR TITLE
Bump web container version to demonstrate quieting keepalive, fixes #494 #TRIVIALREVIEW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= v1.0.0
+WebTag ?= 20180228_quiet_keepalive
 DBImg ?= drud/mariadb-local
 DBTag ?= v0.7.1
 RouterImage ?= drud/ddev-router

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.0.0" // Note that this is overridden by make
+var WebTag = "20180228_quiet_keepalive" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #494: Our `ddev logs` output was swamped by "closed keepalive" messages, and php-fpm messages weren't reported.

## How this PR Solves The Problem:

https://github.com/drud/docker.nginx-php-fpm-local/pull/52 

* Quiets the keepalive messages
* Starts to tail both nginx and fpm logs
* Adds tests for these behaviors.

## Manual Testing Instructions:

* `ddev config`
Make sure your .ddev/confg.yaml has `webimage: drud/nginx-php-fpm-local:20180228_quiet_keepalive`
* `ddev start`
* `ddev logs`

## Related Issue Link(s):

OP #494 
Web container PR https://github.com/drud/docker.nginx-php-fpm-local/pull/52 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

