### PR TITLE
Don't remove settings.local.php when removing database, fixes #478 PULL 2018-03-06 #TRIVIALREVIEW

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -788,7 +788,6 @@ func (app *DdevApp) DetermineSettingsPathLocation() (string, error) {
 // Down stops the docker containers for the project in current directory.
 func (app *DdevApp) Down(removeData bool) error {
 	app.DockerEnv()
-	settingsFilePath := app.SiteSettingsPath
 
 	// Remove all the containers and volumes for app.
 	err := Cleanup(app)
@@ -798,24 +797,10 @@ func (app *DdevApp) Down(removeData bool) error {
 
 	// Remove data/database if we need to.
 	if removeData {
-		if fileutil.FileExists(settingsFilePath) {
-			signatureFound, err := fileutil.FgrepStringInFile(settingsFilePath, DdevFileSignature)
-			util.CheckErr(err) // Really can't happen as we already checked for the file existence
-			if signatureFound {
-				err = os.Chmod(settingsFilePath, 0644)
-				if err != nil {
-					return err
-				}
-				err = os.Remove(settingsFilePath)
-				if err != nil {
-					return err
-				}
-			}
-		}
 		// Check that app.DataDir is a directory that is safe to remove.
 		err = validateDataDirRemoval(app)
 		if err != nil {
-			return fmt.Errorf("failed to remove data directories: %v", err)
+			return fmt.Errorf("failed to remove data/database directories: %v", err)
 		}
 		// mysql data can be set to read-only on linux hosts. PurgeDirectory ensures files
 		// are writable before we attempt to remove them.


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #478 

We used to try to delete the settings.php or settings.local.php when deleting database (`ddev remove --remove-data`) but this isn't necessary and can just create confusion. 

It also doesn't make sense to delete the settings file just because we're dropping the database.

## How this PR Solves The Problem:

## Manual Testing Instructions:

* Create a Drupal site and use it
* check that Drupal has done its silly thing and set sites/default to 0444.
* `ddev rm --remove-data` and look for no error.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #478 


## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

