### PR TITLE
Switch restart to 'no' for main containers, fixes #676

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -11,7 +11,7 @@ services:
     volumes:
       - "${DDEV_IMPORTDIR}:/db"
       - "${DDEV_DATADIR}:/var/lib/mysql"
-    restart: always
+    restart: "no"
     ports:
       - "3306"
     labels:
@@ -28,7 +28,7 @@ services:
     image: $DDEV_WEBIMAGE
     volumes:
       - "../:/var/www/html:cached"
-    restart: always
+    restart: "no"
     depends_on:
       - db
     links:
@@ -64,7 +64,7 @@ services:
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
-    restart: always
+    restart: "no"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .plugin }}
@@ -173,7 +173,7 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./certs:/etc/nginx/certs:cached
-    restart: always
+    restart: "always"
 networks:
    default:
      external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -173,7 +173,7 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./certs:/etc/nginx/certs:cached
-    restart: "always"
+    restart: "no"
 networks:
    default:
      external:


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #676: Our web and db containers never do recover when a restart happens, so restarting them just obscures the cause. This PR changes the restart for the "working" containers from "always" to "no".

@mglaman also points out the unexpected side-effect of the current restart: always policy: A machine reboot or docker restart results in stopped projects magically starting unexpectedly. 

This change should result in more predictable ddev container behavior.

## How this PR Solves The Problem:

Failing containers won't restart any more.

## Manual Testing Instructions:

ddev ssh into the web container. `killall supervisord`. This will ruin the container, and it will show up as unhealthy in a bit, but won't restart.

ddev ssh -s db into the db container. `killall mysqld`. This will ruin the container, and it will stop, and it will show up as stopped in `ddev list`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #676

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

