### PR TITLE
Disable xdebug by default for 6x speed improvement fixes #664

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= v1.1.0
+WebTag ?= 20180308_disable_xdebug_by_default
 DBImg ?= drud/mariadb-local
 DBTag ?= v0.8.0
 RouterImage ?= drud/ddev-router

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -58,7 +58,7 @@ func TestDevLogs(t *testing.T) {
 
 		assert.NoError(err)
 		assert.Contains(string(out), "Server started")
-		assert.Contains(string(out), "PHP message: PHP Stack trace:")
+		assert.Contains(string(out), "PHP Fatal error:")
 
 		cleanup()
 	}

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -1,12 +1,13 @@
 <h1>Step-debugging with ddev and xdebug</h1>
 
-Every ddev project is automatically configured with xdebug so that popular IDEs can do step-debugging of PHP code.
+Every ddev project is automatically configured with xdebug so that popular IDEs can do step-debugging of PHP code. It is disabled by default for performance reasons, so you'll need to enable it in your config.yaml.
 
 xdebug is a server-side tool: It is installed automatically on the container and you do *not* need to install it on your workstation. All you have to do on your workstation is to add an extra IP address (below) and perhaps add a browser extension or bookmark.
 
 All IDEs basically work the same: They listen on a port and react when they're contacted there. So IDEs other than those listed here should work fine, if listening on port 11011.
 
 **Key facts:**
+* You need to explicitly enable xdebug in your config.yaml as a post-start step.
 * The debug server port on the IDE must be set to port 11011. Although the xdebug default is port 9000, that port often has conflicts for PHP developers, so 11011 is used with ddev.
 * An IP-address *alias* of 172.28.99.99 must be added to your workstation host's loopback address. On macOS this is done with the command `sudo ifconfig lo0 alias 172.28.99.99`. On Ubuntu 16.04 and probably other Linux variants, `sudo ifconfig docker0:0 172.28.99.99 up` **This must currently be done after each reboot.**
 
@@ -15,6 +16,17 @@ For more background on XDebug see [XDebug documentation](https://xdebug.org/docs
 For each IDE the link to their documentation is provided, and the skeleton steps required are listed here.
 
 ## Setup Instructions
+
+### Enable or disable xdebug in your config.yaml
+
+Use a post-start hook to enable or disable xdebug on startup:
+
+```
+hooks:
+    post-start:
+      - exec: enable_xdebug
+```
+
 
 * [PHPStorm](#phpstorm)
 * [NetBeans](#netbeans)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.1.0" // Note that this is overridden by make
+var WebTag = "20180308_disable_xdebug_by_default" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

I think this will fix #664 "TYPO3 environment extremely slow"

From https://github.com/drud/docker.nginx-php-fpm-local/pull/57 description of the container change:

People complain that ddev is slow. It was.

If we turn off xdebug by default it's 6x faster. 

I was always wrong about its impact

d8 web-based install:

macOS 10.13.3 8GB memory MacBook Pro (Retina, 13-inch, Early 2015
Processor: 2.7 GHz Intel Core i5
Docker 17.09.0-ce-mac35 (19611) default 2CPU, 2GB memory

Test: Install d8 8.5 HEAD via gui/web. "Install site"
with xdebug on: 12:34 
with xdebug off (phpdismod xdebug +killall -1 php-fpm): 2:08

6x faster

## How this PR Solves The Problem:

## Manual Testing Instructions:

Delete your .config.yaml (or delete the web image line) and delete your docker-compose.yaml
ddev start.
Try things out.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

nginx container PR: https://github.com/drud/docker.nginx-php-fpm-local/pull/57
#664: Discussion of slow TYPO3 environment

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

