### PR TITLE
Provide xz tarball of ddev_docker_images, fixes #724

### DIFF
--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -14,7 +14,8 @@ for item in $(cat /tmp/images.txt); do
   docker pull $item
 done
 docker save -o $ARTIFACTS/ddev_docker_images.$VERSION.tar $(cat /tmp/images.txt)
-gzip $ARTIFACTS/ddev_docker_images.$VERSION.tar
+gzip --keep $ARTIFACTS/ddev_docker_images.$VERSION.tar
+xz $ARTIFACTS/ddev_docker_images.$VERSION.tar
 
 # Generate and place extra items like autocomplete
 bin/linux/ddev_gen_autocomplete
@@ -39,6 +40,6 @@ zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
 
 # Create the sha256 files
 cd $ARTIFACTS
-for item in *.tar.gz *.zip ddev_docker_images.$VERSION.tar.gz; do
+for item in *.tar.gz *.zip ddev_docker_images.$VERSION.tar.gz ddev_docker_images.$VERSION.tar.xz; do
   sha256sum $item > $item.sha256.txt
 done


### PR DESCRIPTION
## The Problem/Issue/Bug:

#724 requests xz tarballs of ddev_docker_images, this adds that packaging.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

