### PR TITLE
docker-compose version check failure, fixes #711, fixes #737

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,8 +13,8 @@
 [[projects]]
   name = "github.com/Masterminds/semver"
   packages = ["."]
-  revision = "517734cc7d6470c0d07130e40fd40bdeb9bcd3fd"
-  version = "v1.3.1"
+  revision = "15d8430ab86497c5c0da827b748823945e1cf1e1"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/Masterminds/sprig"

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -29,14 +29,14 @@ var RootCmd = &cobra.Command{
 	Long:  "This Command Line Interface (CLI) gives you the ability to interact with the ddev to create a development environment.",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		ignores := []string{"list", "version", "describe", "config", "hostname"}
-		command := strings.Join(os.Args, " ")
+		command := strings.Join(os.Args[1:], " ")
 
 		output.LogSetUp()
 
 		// Skip docker validation for any command listed in "ignores"
 		for _, k := range ignores {
-			if strings.Contains(command, " "+k) {
-				break
+			if strings.Contains(command, k) {
+				return
 			}
 		}
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -28,7 +28,7 @@ var RootCmd = &cobra.Command{
 	Short: "A CLI for interacting with ddev.",
 	Long:  "This Command Line Interface (CLI) gives you the ability to interact with the ddev to create a development environment.",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		ignores := []string{"list", "version", "describe", "config", "hostname"}
+		ignores := []string{"version", "config", "hostname", "help", "auth-pantheon", "import-files"}
 		command := strings.Join(os.Args[1:], " ")
 
 		output.LogSetUp()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,10 +11,10 @@ var DdevVersion = "v0.3.0-dev" // Note that this is overridden by make
 // DockerVersionConstraint is the current minimum version of docker required for ddev.
 // See https://godoc.org/github.com/Masterminds/semver#hdr-Checking_Version_Constraints
 // for examples defining version constraints.
-var DockerVersionConstraint = ">= 17.05.0-ce"
+var DockerVersionConstraint = ">= 17.05.0-ce-alpha.1"
 
 // DockerComposeVersionConstraint is the current minimum version of docker-compose required for ddev.
-var DockerComposeVersionConstraint = ">= 1.10.0"
+var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 
 // WebImg defines the default web image used for applications.
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make

--- a/vendor/github.com/Masterminds/semver/version.go
+++ b/vendor/github.com/Masterminds/semver/version.go
@@ -64,14 +64,14 @@ func NewVersion(v string) (*Version, error) {
 	}
 
 	var temp int64
-	temp, err := strconv.ParseInt(m[1], 10, 32)
+	temp, err := strconv.ParseInt(m[1], 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing version segment: %s", err)
 	}
 	sv.major = temp
 
 	if m[2] != "" {
-		temp, err = strconv.ParseInt(strings.TrimPrefix(m[2], "."), 10, 32)
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[2], "."), 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing version segment: %s", err)
 		}
@@ -81,7 +81,7 @@ func NewVersion(v string) (*Version, error) {
 	}
 
 	if m[3] != "" {
-		temp, err = strconv.ParseInt(strings.TrimPrefix(m[3], "."), 10, 32)
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[3], "."), 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing version segment: %s", err)
 		}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#737: Docker-compose latest edge is 1.20.0-rc2. But [semver does not support versions with a pre unless the check has a pre](https://github.com/Masterminds/semver/issues/21). So our docker-compose version check was broken.

## How this PR Solves The Problem:

* Update the constraint to include a "pre" for both docker and docker-compose.
* Fix the logic about skipping pre-validation on commands like "version" and "hostname" to fix #711

## Manual Testing Instructions:

With latest edge docker-compose, try `ddev version`, `ddev hostname` with and without this. 

For brute-force testing, create a script called docker-compose in a location which is *not* normally in your $PATH (like ~/tmp) with this content:
```
#!/bin/bash
echo "0.5 "
```

```
export PATH=~/tmp:$PATH
```
and run `ddev start` and `ddev list`, which should fail with that content. Run `ddev version` and `ddev hostname something.ddev.local 127.0.0.1`, which should succeed with that content. Change the script to use other versions valid and invalid.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

I'm not sure how to make a test for this behavior, since it depends on the compiled ddev behavior so I don't have a way to override the version constraints cleanly.

## Related Issue Link(s):

OP #737 (docker-compose breaking everything)
OP #711 (ddev hostname shouldn't check docker)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

