### PR TITLE
Multi-hostname support, fixes #620

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/output"
@@ -65,6 +66,9 @@ func renderAppDescribe(desc map[string]interface{}) (string, error) {
 	output = output + "\n\nProject Information\n-----------------\n"
 	siteInfo := uitable.New()
 	siteInfo.AddRow("PHP version:", desc["php_version"])
+	if len(desc["hostnames"].([]string)) > 1 {
+		siteInfo.AddRow("Hostnames", strings.Join(desc["hostnames"].([]string), ", "))
+	}
 	output = output + fmt.Sprint(siteInfo)
 
 	// Only show extended status for running sites.

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -66,9 +66,7 @@ func renderAppDescribe(desc map[string]interface{}) (string, error) {
 	output = output + "\n\nProject Information\n-----------------\n"
 	siteInfo := uitable.New()
 	siteInfo.AddRow("PHP version:", desc["php_version"])
-	if len(desc["hostnames"].([]string)) > 1 {
-		siteInfo.AddRow("Hostnames", strings.Join(desc["hostnames"].([]string), ", "))
-	}
+	siteInfo.AddRow("URLs:", strings.Join(desc["urls"].([]string), ", "))
 	output = output + fmt.Sprint(siteInfo)
 
 	// Only show extended status for running sites.

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/version"
 	"path/filepath"
 	"testing"
 
@@ -48,7 +49,7 @@ func TestDevLogs(t *testing.T) {
 		// Because php display_errors = On the error results in a 200 anyway.
 		o.ExpectedStatus = 200
 		o.Timeout = 30
-		o.Headers["Host"] = v.Name + ".ddev.local"
+		o.Headers["Host"] = v.Name + "." + version.DDevTLD
 		err = util.EnsureHTTPStatus(o)
 		assert.NoError(err)
 

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -56,7 +57,7 @@ func appImport(skipConfirmation bool) {
 	}
 
 	util.Success("Successfully Imported.")
-	util.Success("Your project can be reached at: %s and %s", app.GetHTTPURL(), app.GetHTTPSURL())
+	util.Success("Your project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
 }
 
 func init() {

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -42,7 +43,7 @@ var DdevRestartCmd = &cobra.Command{
 		}
 
 		util.Success("Successfully restarted %s", app.GetName())
-		util.Success("Your project can be reached at: %s and %s", app.GetHTTPURL(), app.GetHTTPSURL())
+		util.Success("Your project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
 	},
 }
 

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -29,9 +29,7 @@ func TestDevRestart(t *testing.T) {
 		}
 
 		assert.Contains(string(out), "Your project can be reached at")
-		assert.Contains(string(out), app.GetHTTPURL())
-		assert.Contains(string(out), app.GetHTTPSURL())
-
+		assert.Contains(string(out), strings.Join(app.GetAllURLs(), ", "))
 		cleanup()
 	}
 }
@@ -71,10 +69,7 @@ func TestDevRestartJSON(t *testing.T) {
 		}
 
 		// Go ahead and look for normal strings within the json output.
-		assert.Contains(string(out), "Your project can be reached at")
-		assert.Contains(string(out), app.GetHTTPURL())
-		assert.Contains(string(out), app.GetHTTPSURL())
-
+		assert.Contains(string(out), strings.Join(app.GetAllURLs(), ", "))
 		cleanup()
 	}
 }

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -46,7 +47,7 @@ func appStart() {
 	}
 
 	util.Success("Successfully started %s", app.GetName())
-	util.Success("Your project can be reached at %s and %s", app.GetHTTPURL(), app.GetHTTPSURL())
+	util.Success("Your project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
 
 }
 func init() {

--- a/docs/users/extend/additional-hostnames.md
+++ b/docs/users/extend/additional-hostnames.md
@@ -1,0 +1,15 @@
+<h1> Additional Project Hostnames</h1>
+
+Add additional hostnames to a project in the project's .ddev/config.yaml:
+
+```
+name: mysite
+
+additional_hostnames:
+- extraname
+- fr.mysite
+- es.mysite
+- it.mysite
+```
+
+This configuration would result in working hostnames of mysite.ddev.local, extraname.ddev.local, fr.mysite.ddev.local, es.mysite.ddev.local, and it.mysite.ddev.local (with full http and https URLs for each).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ pages:
     - 'Using Developer Tools with ddev': 'users/developer-tools.md'
     - 'PHP Step Debugging': 'users/step-debugging.md'
     - 'Extending ddev':
+      - 'Additional Project Hostnames': 'users/extend/additional-hostnames.md'
       - 'Extending and Customizing Environments': 'users/extend/customization-extendibility.md'
       - 'Additional Services': 'users/extend/additional-services.md'
       - 'Defining Custom Services': 'users/extend/custom-compose-files.md'

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -118,7 +118,8 @@ func getBackdropUploadDir(app *DdevApp) string {
 // getBackdropHooks for appending as byte array.
 func getBackdropHooks() []byte {
 	backdropHooks := `
-#      - exec: "drush cc all"`
+#  post-import-db:
+#    - exec: "drush cc all"`
 	return []byte(backdropHooks)
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -279,9 +279,18 @@ func (app *DdevApp) DockerComposeYAMLPath() string {
 	return app.GetConfigPath("docker-compose.yaml")
 }
 
-// GetHostname returns the hostname of the app.
+// GetHostname returns the primary hostname of the app.
 func (app *DdevApp) GetHostname() string {
 	return app.Name + "." + version.DDevTLD
+}
+
+// GetHostnames() returns an array of all the configured hostnames.
+func (app *DdevApp) GetHostnames() []string {
+	nameList := app.GetHostname()
+	if app.AdditionalNames != "" {
+		nameList = nameList + "," + app.AdditionalNames
+	}
+	return strings.Split(nameList, ",")
 }
 
 // WriteDockerComposeConfig writes a docker-compose.yaml to the app configuration directory.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -291,7 +291,7 @@ func (app *DdevApp) GetHostnames() []string {
 	nameList = append(nameList, app.GetHostname())
 
 	for _, name := range app.AdditionalHostnames {
-		nameList = append(nameList, name)
+		nameList = append(nameList, name+"."+version.DDevTLD)
 	}
 	return nameList
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -286,11 +286,14 @@ func (app *DdevApp) GetHostname() string {
 
 // GetHostnames returns an array of all the configured hostnames.
 func (app *DdevApp) GetHostnames() []string {
-	nameList := app.GetHostname()
-	if app.AdditionalNames != "" {
-		nameList = nameList + "," + app.AdditionalNames
+
+	var nameList []string
+	nameList = append(nameList, app.GetHostname())
+
+	for _, name := range app.AdditionalHostnames {
+		nameList = append(nameList, name)
 	}
-	return strings.Split(nameList, ",")
+	return nameList
 }
 
 // WriteDockerComposeConfig writes a docker-compose.yaml to the app configuration directory.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -284,7 +284,7 @@ func (app *DdevApp) GetHostname() string {
 	return app.Name + "." + version.DDevTLD
 }
 
-// GetHostnames() returns an array of all the configured hostnames.
+// GetHostnames returns an array of all the configured hostnames.
 func (app *DdevApp) GetHostnames() []string {
 	nameList := app.GetHostname()
 	if app.AdditionalNames != "" {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -117,7 +117,7 @@ func (app *DdevApp) WriteConfig() error {
 	}
 
 	// Append hook information and sample hook suggestions.
-	cfgbytes = append(cfgbytes, []byte(HookTemplate)...)
+	cfgbytes = append(cfgbytes, []byte(ConfigInstructions)...)
 	cfgbytes = append(cfgbytes, app.GetHookDefaultComments()...)
 
 	err = ioutil.WriteFile(app.ConfigPath, cfgbytes, 0644)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -386,7 +386,7 @@ func TestWriteConfig(t *testing.T) {
 	out, err := ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))
 	assert.NoError(err)
 	assert.Contains(string(out), "TestWrite")
-	assert.Contains(string(out), `exec: "drush cr"`)
+	assert.Contains(string(out), `exec: drush cr`)
 
 	app.Type = "wordpress"
 	err = app.WriteConfig()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -52,6 +52,7 @@ const DdevFileSignature = "#ddev-generated"
 type DdevApp struct {
 	APIVersion            string               `yaml:"APIVersion"`
 	Name                  string               `yaml:"name"`
+	AdditionalNames       string               `yaml:"additional_names"`
 	Type                  string               `yaml:"type"`
 	Docroot               string               `yaml:"docroot"`
 	PHPVersion            string               `yaml:"php_version"`
@@ -734,6 +735,11 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_ROUTER_HTTPS_PORT":        app.RouterHTTPSPort,
 	}
 
+	// additional_names should be comma-delimited set of additional FQDN.
+	if app.AdditionalNames != "" {
+		// TODO: Warn people about additional names in use.
+		envVars["DDEV_HOSTNAME"] = app.GetHostname() + "," + app.AdditionalNames
+	}
 	// Only set values if they don't already exist in env.
 	for k, v := range envVars {
 		if os.Getenv(k) == "" {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -52,7 +52,6 @@ const DdevFileSignature = "#ddev-generated"
 type DdevApp struct {
 	APIVersion            string               `yaml:"APIVersion"`
 	Name                  string               `yaml:"name"`
-	AdditionalHostnames   []string             `yaml:"additional_hostnames"`
 	Type                  string               `yaml:"type"`
 	Docroot               string               `yaml:"docroot"`
 	PHPVersion            string               `yaml:"php_version"`
@@ -61,6 +60,7 @@ type DdevApp struct {
 	DBAImage              string               `yaml:"dbaimage"`
 	RouterHTTPPort        string               `yaml:"router_http_port"`
 	RouterHTTPSPort       string               `yaml:"router_https_port"`
+	AdditionalHostnames   []string             `yaml:"additional_hostnames"`
 	ConfigPath            string               `yaml:"-"`
 	AppRoot               string               `yaml:"-"`
 	Platform              string               `yaml:"-"`

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -739,7 +739,7 @@ func (app *DdevApp) DockerEnv() {
 
 	if len(app.AdditionalHostnames) > 0 {
 		// TODO: Warn people about additional names in use.
-		envVars["DDEV_HOSTNAME"] = app.GetHostname() + "," + strings.Join(app.AdditionalHostnames, ",")
+		envVars["DDEV_HOSTNAME"] = strings.Join(app.GetHostnames(), ",")
 	}
 	// Only set values if they don't already exist in env.
 	for k, v := range envVars {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -129,6 +129,7 @@ func (app *DdevApp) Describe() (map[string]interface{}, error) {
 	appDesc := make(map[string]interface{})
 
 	appDesc["name"] = app.GetName()
+	appDesc["hostnames"] = app.GetHostnames()
 	appDesc["status"] = app.SiteStatus()
 	appDesc["type"] = app.GetType()
 	appDesc["approot"] = app.GetAppRoot()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -237,9 +237,7 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 
 	for _, site := range TestSites {
-		switchDir := site.Chdir()
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStartMultipleHostnames", site.Name))
-
 		testcommon.ClearDockerEnv()
 
 		err := app.Init(site.Dir)
@@ -250,8 +248,6 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		err = app.WriteConfig()
 		assert.NoError(err)
 
-		//err = app.Down(false)
-		//assert.NoError(err)
 		err = app.Start()
 		assert.NoError(err)
 
@@ -277,11 +273,10 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 			assert.NoError(err)
 		}
 
-		err = app.Down(false)
+		err = app.Stop()
 		assert.NoError(err)
 
 		runTime()
-		switchDir()
 	}
 }
 
@@ -309,6 +304,19 @@ func TestStartWithoutDdevConfig(t *testing.T) {
 // TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.
 func TestGetApps(t *testing.T) {
 	assert := asrt.New(t)
+
+	// Start the apps.
+	for _, site := range TestSites {
+		testcommon.ClearDockerEnv()
+		app := &ddevapp.DdevApp{}
+
+		err := app.Init(site.Dir)
+		assert.NoError(err)
+
+		err = app.Start()
+		assert.NoError(err)
+	}
+
 	apps := ddevapp.GetApps()
 	assert.Equal(len(apps), len(TestSites))
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -351,11 +351,15 @@ func getDrupalUploadDir(app *DdevApp) string {
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db
 const Drupal8Hooks = `
-#     - exec: "drush cr"`
+# post-import-db:
+#   - exec: drush cr
+#   - exec: drush updb
+`
 
 // Drupal7Hooks adds a d7-specific hooks example for post-import-db
 const Drupal7Hooks = `
-#     - exec: "drush cc all"`
+#  post-import-db:
+#    - exec: "drush cc all"`
 
 // getDrupal7Hooks for appending as byte array
 func getDrupal7Hooks() []byte {

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -89,15 +89,46 @@ networks:
       name: ddev_default
 `
 
-// HookTemplate is used to add example hooks usage
-const HookTemplate = `
-# Certain ddev commands can be extended to run tasks before or after the ddev
-# command is executed.
+// ConfigInstructions is used to add example hooks usage
+const ConfigInstructions = `
+# Key features of ddev's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides 
+#   http://projectname.ddev.local and https://projectname.ddev.local
+
+# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "7.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2"
+
+# You can delete the webimage, dbimage, dbaimage lines to use the defaults
+# in ddev.
+
+# webimage: <docker_image>  # nginx/php docker image. 
+# dbimage: <docker_image>  # mariadb docker image. 
+# dbaimage: <docker_image>
+
+# router_http_port: <port>  # Port to be used for http (defaults to port 80)
+# router_https_port: <port> # Port for https (defaults to 443)
+
+# additional_hostnames[]  # For example, 
+#   additional_hostnames["name1.ddev.local", "othername.some.other.domain"]
+#   would provide http and https URLs for "name1.ddev.local"
+#   and "othername.some.other.domain".
+#   This can also be written in yaml array syntax:
+#   additional_hostnames:
+#   - name1.ddev.local
+#   - othername.some.other.domain
+
+# provider: default # Currently either "default" or "pantheon"
+#
+# Many ddev commands can be extended to run tasks after the ddev command is
+# executed.
 # See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more
 # information on the commands that can be extended and the tasks you can define
-# for them.
-# hooks:
-#   post-import-db:`
+# for them. Example:
+#hooks:`
 
 // SequelproTemplate is the template for Sequelpro config.
 var SequelproTemplate = `<?xml version="1.0" encoding="UTF-8"?>

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -112,14 +112,11 @@ const ConfigInstructions = `
 # router_http_port: <port>  # Port to be used for http (defaults to port 80)
 # router_https_port: <port> # Port for https (defaults to 443)
 
-# additional_hostnames[]  # For example, 
-#   additional_hostnames["name1.ddev.local", "othername.some.other.domain"]
-#   would provide http and https URLs for "name1.ddev.local"
-#   and "othername.some.other.domain".
-#   This can also be written in yaml array syntax:
-#   additional_hostnames:
-#   - name1.ddev.local
-#   - othername.some.other.domain
+#additional_hostnames:
+# - somename
+# - someothername
+# would provide http and https URLs for "somename.ddev.local"
+# and "someothername.ddev.local".
 
 # provider: default # Currently either "default" or "pantheon"
 #

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -84,7 +84,8 @@ func getTypo3UploadDir(app *DdevApp) string {
 
 // Typo3Hooks adds a TYPO3-specific hooks example for post-import-db
 const Typo3Hooks = `
-#     - exec: "echo database was loaded"`
+#  post-start:
+#    - exec: "composer install -d /var/www/html"`
 
 // getTypo3Hooks for appending as byte array
 func getTypo3Hooks() []byte {

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -55,10 +55,10 @@ func NewWordpressConfig() *WordpressConfig {
 
 // wordPressHooks adds a wp-specific hooks example for post-import-db
 const wordPressHooks = `
-    # Un-comment and enter the production url and local url
-    # to replace in your database after import.
-	#post-import-db:
-    #  - exec: "wp search-replace <production-url> <local-url>"`
+# Un-comment and enter the production url and local url
+# to replace in your database after import.
+#post-import-db:
+#  - exec: "wp search-replace <production-url> <local-url>"`
 
 // getWordpressHooks for appending as byte array
 func getWordpressHooks() []byte {

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -57,7 +57,8 @@ func NewWordpressConfig() *WordpressConfig {
 const wordPressHooks = `
     # Un-comment and enter the production url and local url
     # to replace in your database after import.
-    # - exec: "wp search-replace <production-url> <local-url>"`
+	#post-import-db:
+    #  - exec: "wp search-replace <production-url> <local-url>"`
 
 // getWordpressHooks for appending as byte array
 func getWordpressHooks() []byte {

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -50,6 +50,9 @@ type TestSite struct {
 	// Type is the type of application. This can be specified when a config file is not present
 	// for a test site.
 	Type string
+	// Safe200URL is a string of a url that can be accessed for testing a site
+	// that has not yet been installed
+	Safe200URL string
 }
 
 // Prepare downloads and extracts a site codebase to a temporary directory.

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -127,6 +127,7 @@ func EnsureHTTPStatus(o *HTTPOptions) error {
 					// Log expected vs. actual if we do not get a match.
 					output.UserOut.WithFields(log.Fields{
 						"URL":      o.URL,
+						"headers":  o.Headers,
 						"expected": o.ExpectedStatus,
 						"got":      resp.StatusCode,
 					}).Info("HTTP Status code matched expectations")
@@ -134,8 +135,9 @@ func EnsureHTTPStatus(o *HTTPOptions) error {
 				}
 
 				// Log expected vs. actual if we do not get a match.
-				log.WithFields(log.Fields{
+				output.UserOut.WithFields(log.Fields{
 					"URL":      o.URL,
+					"headers":  o.Headers,
 					"expected": o.ExpectedStatus,
 					"got":      resp.StatusCode,
 				}).Info("HTTP Status could not be matched")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -38,7 +38,7 @@ var DBATag = "v0.2.0"
 var RouterImage = "drud/ddev-router" // Note that this is overridden by make
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.4.3" // Note that this is overridden by make
+var RouterTag = "v0.5.0" // Note that this is overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

We need to support multiple hostnames for multisite applications for #620 

## How this PR Solves The Problem:

Unlimited hostnames.

From the config.yaml self-documentation:
```
#additional_hostnames:
# - somename
# - someothername
# would provide http and https URLs for "somename.ddev.local"
# and "someothername.ddev.local".
```

## Manual Testing Instructions:

* Delete your .ddev/docker-compose.yaml
* Optionally run `ddev config` for the extra documentation it will put in config.yaml
* Add some additional_hostnames to your project, use `ddev start` and `ddev describe` to explore and hit them.


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #620 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

