### PR TITLE
Make circleci install current stable Docker-ce

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -26,9 +26,9 @@ sudo add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
-sudo apt-get update
-sudo apt-get install docker-ce
+sudo apt-get update -qq
+sudo apt-get install -qq docker-ce
 
 # docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.19.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -s -L "https://github.com/docker/compose/releases/download/1.20.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -14,6 +14,21 @@ wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.linux-amd64.tar.gz &&
 sudo tar -C /usr/local -xzf /tmp/golang.tgz
 
 
+# Remove existing docker
+sudo apt-get remove docker docker-engine docker.io
+sudo apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+sudo apt-get update
+sudo apt-get install docker-ce
+
 # docker-compose
 sudo curl -s -L "https://github.com/docker/compose/releases/download/1.19.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: NORMAL Circle VM setup - tools, docker, golang
 
       - run:
-          command: echo "go version:$(go version) docker version=$(docker --version) docker-compose version=$(docker-compose --version) HOME=$HOME USER=$(whoami) PWD=$PWD"
+          command: printf "go version:$(go version)\ndocker version=$(docker --version)\ndocker-compose version=$(docker-compose --version)\nHOME=$HOME USER=$(whoami) PWD=$PWD"
           name: Installed tool versions
 
       # Now build using the regular ddev-only technique - this results in a fully clean set of executables.


### PR DESCRIPTION
## The Problem/Issue/Bug:

We were blindsided by a change made in Docker-ce stable linux in recent (near) release. We really want to be testing with current stable as that is the most likely thing people will be using.

## How this PR Solves The Problem:

Use docker's documented technique to install: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce-1

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

