### PR TITLE
Docs: Remove special linux filesystem instructions, add docker-ce post-install, fixes #754

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,11 @@
 
 ## System Requirements
 
-- [Docker](https://www.docker.com/community-edition) version 17.05 or higher
+- [Docker](https://www.docker.com/community-edition) version 17.05 or higher. Linux users make sure you do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
 - docker-compose 1.10.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
 - OS Support
   - macOS Sierra and higher (macOS 10.12 and higher but it probably runs anywhere docker runs)
-  - Linux (See [Linux notes](users/linux_notes.md)): Most recent Linux distributions which can run Docker are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+
+  - Linux: Most recent Linux distributions which can run Docker are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
   - Windows 10 Pro
 
 We are open to expanding this list to include additional OSs as well as improve our existing support for the ones listed above. Please [let us know](https://github.com/drud/ddev/issues/new) if you hit an issue!

--- a/docs/users/linux_notes.md
+++ b/docs/users/linux_notes.md
@@ -1,5 +1,0 @@
-<h1>Linux Notes</h1>
-
-On Linux there are minor behavior differences due to the significant architecture differences of Docker for Linux.
-
-* File mounts are direct on Linux, and Docker always mounts file systems as user uid 1000. As a result, if you are **not** using the default Linux user 1000 and you need to create files using the web server, you may need to make directories in your file system writable by all users. For example `find sites/default/files -type d | xargs chmod ugo+rwx`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,6 @@ pages:
       - 'Defining Custom Services': 'users/extend/custom-compose-files.md'
     - 'Integration with Hosting Providers':
       - 'Pantheon': 'users/providers/pantheon.md'
-    - 'Notes for Linux Users': 'users/linux_notes.md'
     - 'Troubleshooting': 'users/troubleshooting.md'
   - 'Developer Documentation':
     - 'Building, Testing, and Contributing': 'developers/building-contributing.md'


### PR DESCRIPTION
## The Problem/Issue/Bug:

Since #745 we Linux users don't have the writability problems they once had with files. 

However, #754 reminds us that Linux users need to do the required docker-ce setup steps.

## How this PR Solves The Problem:

Out with the old, in with the new. Docs only

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

