### PR TITLE
Add failsafe so we don't blow away the repository when import-files on D6/TYPO3/Backdrop

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -430,6 +430,10 @@ func (app *DdevApp) ImportFiles(imPath string, extPath string) error {
 		uploadDir = "wp-content/uploads"
 	}
 
+	if uploadDir == "" {
+		util.Failed("No upload directory has been specified for the project type %s", app.GetType())
+	}
+
 	destPath := filepath.Join(app.GetAppRoot(), app.GetDocroot(), uploadDir)
 
 	// parent of destination dir should exist


### PR DESCRIPTION
## The Problem/Issue/Bug:

Currently, if someone uses import-files on Backdrop, TYPO3, or Drupal6, ddev will destroy the entire approot. Nothing will be left.

This is a result of us never implementing import-files support for those CMSs, and of course, a rather catastrophic coding failure.

## How this PR Solves The Problem:

Check to see if the files directory has been set, and if it has not, halt the operation.

This is a stopgap solution only, intended to stop the bleeding. The actual solution will be done in https://github.com/drud/ddev/issues/666 but I didn't want to wait for that.

## Manual Testing Instructions:

Run ddev import-files on D6 with and without this. Make a tarball of your directory first!

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

