### PR TITLE
Put web container internal port back to port 80

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= v1.2.1
+WebTag ?= v1.2.2
 DBImg ?= drud/mariadb-local
 DBTag ?=  v0.9.0
 RouterImage ?= drud/ddev-router

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -51,10 +51,10 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
-      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:8080,{{ .mailhogport }}
+      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,{{ .mailhogport }}
       # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
       # To expose an HTTPS port, define the port as securePort:containerPort.
-      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:8080
+      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .plugin }}

--- a/pkg/ddevapp/testdata/.ddev/nginx-site.conf
+++ b/pkg/ddevapp/testdata/.ddev/nginx-site.conf
@@ -11,8 +11,8 @@ map $http_x_forwarded_proto $fcgi_https {
 }
 
 server {
-    listen 8080; ## listen for ipv4; this line is default and implied
-    listen [::]:8080 default ipv6only=on; ## listen for ipv6
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
     # The NGINX_DOCROOT variable is substituted with
     # its value when the container is started.
     root $NGINX_DOCROOT;

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.2.1" // Note that this is overridden by make
+var WebTag = "v1.2.2" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

See https://github.com/drud/docker.nginx-php-fpm-local/pull/65

There was minor confusion (especially in the TYPO3 world) when nginx moved to port 8080. There were two problems:

* It was really hard to set the trustedHostPattern to something that worked
* Redirects from "typo3" to "typo3/" tended to pick up the 8080 port, so the redirect from http://typo3git.ddev.local/typo3 would be http://typo3git.ddev.local:8080/typo3/

It turns out that the redirect problem was completely a separate problem, and it's fixed in the [nginx-php-fpm-local](https://github.com/drud/docker.nginx-php-fpm-local/pull/65) PR drud/docker.nginx-php-fpm-local#65


## How this PR Solves The Problem:

* Switches the internal port back to port 80
* Introduces relative redirects to avoid getting the port mixed up in the redirect.

## Manual Testing Instructions:

* Normal usage with a variety of configured router_http_port and router_https_port
* With a router_http_port that is not the default 80, hit the admin section of typo3 site with something like http://typo3git.ddev.local/typo3 - it should work OK. Before this patch the redirect would have contained the port (80 now, 8080 previously) of nginx in the web container.  A related and simpler technique for a Drupal user is just to create a directory "junk" in the docroot and put an index.html in there, and then hit http://drupalsite.ddev.local:9999/junk and verify that your junk/index.html content shows.


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

