### PR TITLE
Fix docker constraint typo

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var DdevVersion = "v0.3.0-dev" // Note that this is overridden by make
 // DockerVersionConstraint is the current minimum version of docker required for ddev.
 // See https://godoc.org/github.com/Masterminds/semver#hdr-Checking_Version_Constraints
 // for examples defining version constraints.
-var DockerVersionConstraint = ">= 17.05.0-ce-alpha.1"
+var DockerVersionConstraint = ">= 17.05.0-ce-alpha1"
 
 // DockerComposeVersionConstraint is the current minimum version of docker-compose required for ddev.
 var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noticed in the Drupal #mentoring channel that somebody actually had Docker 17.05 and they got the bogus warning 

```
$ ddev start
The docker version currently installed does not meet ddev's requirements: 17.5.0-ce is less than 17.05.0-ce-alpha.1
```

Although we really don't want people using docker that old, still the comparison should be correct, and the typo fix here should accomplish that.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

