### PR TITLE
Fix missing port on urls at startup by fixing GetAllURLs()

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -879,7 +879,15 @@ func (app *DdevApp) GetHTTPSURL() string {
 func (app *DdevApp) GetAllURLs() []string {
 	var URLs []string
 	for _, name := range app.GetHostnames() {
-		URLs = append(URLs, "http://"+name, "https://"+name)
+		httpPort := ""
+		httpsPort := ""
+		if app.RouterHTTPPort != "80" {
+			httpPort = ":" + app.RouterHTTPPort
+		}
+		if app.RouterHTTPSPort != "443" {
+			httpsPort = ":" + app.RouterHTTPSPort
+		}
+		URLs = append(URLs, "http://"+name+httpPort, "https://"+name+httpsPort)
 	}
 	return URLs
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

In https://github.com/drud/ddev/issues/760 @rickmanelius discovered that the output on start/restart/pull did not have proper URLs if the router_http_port or router_https_port are set. (the port specification was missing).

## How this PR Solves The Problem:

Add the port specification in GetAllURLs().

With ports set to 8080/8443: 
```
$ ddev start
...
Successfully started montclair
Your project can be reached at http://montclair.ddev.local:8080, https://montclair.ddev.local:8443, http://www.montclair.ddev.local:8080, https://www.montclair.ddev.local:8443, http://www1.montclair.ddev.local:8080, https://www1.montclair.ddev.local:8443, http://www2.montclair.ddev.local:8080, https://www2.montclair.ddev.local:8443, http://en.montclair.ddev.local:8080, https://en.montclair.ddev.local:8443, http://fr.montclair.ddev.local:8080, https://fr.montclair.ddev.local:8443, http://es.montclair.ddev.local:8080, https://es.montclair.ddev.local:8443
```

With no ports set:
```
$ ddev start
...
Executing post-start commands...
--- Running host command: mkdir -p files/private ---
Running Command  Command=mkdir -p files/private

--- post-start host command succeeded ---

--- Running exec command: drush vset file_private_path files/private ---
file_private_path was set to "files/private".                        [success]
--- post-start exec command succeeded, output below ---

file_private_path was set to "files/private".                        [success]

Successfully started peakhrconsulting.com
Your project can be reached at http://peakhrconsulting.com.ddev.local, https://peakhrconsulting.com.ddev.local
```

## Manual Testing Instructions:

Run `ddev start` with and without router_http_port and router_https_port set in config.yaml.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

There was currently no testing for router_http_port that I could find, so I didn't add this to it. I'm sad that got in without a test.

## Related Issue Link(s):

#760 details the discovery of this bug.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

