### PR TITLE
Fix reference to php-fpm.log, docs only

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -391,9 +391,9 @@ The `ddev ssh` command will open an interactive bash shell session to the contai
 
 ### Log Access
 
-The `ddev logs` command allows you to easily retrieve error logs from the web server. To follow the web server error log (watch the lines in real time), run `ddev logs -f`. When you are done, press CTRL+C to exit from the log trail.
+The `ddev logs` command allows you to easily retrieve error logs from the web container (both nginx and php-fpm logs are concatenated). To follow the log (watch the lines in real time), run `ddev logs -f`. When you are done, press CTRL+C to exit from the log trail.
 
-To manually review additional log files use the `ddev ssh` command. The web server stores access logs at `/var/log/nginx/access.log`, and PHP-FPM logs at `/var/log/php7.0-fpm.log`.
+To manually review additional log files use the `ddev ssh` command and review logs in /var/log and /var/log/nginx. The web server stores access logs at `/var/log/nginx/access.log`, and PHP-FPM logs at `/var/log/php-fpm.log`.
 
 ## Removing a project
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

@nerdstein pointed out an error in our docs with the name of the php-fpm log. This fixes that. Docs only.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

