### PR TITLE
Windows installer, fixes #786, fixes #780, fixes #798, fixes #701

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -6,7 +6,7 @@ set -x
 # Basic tools
 
 sudo apt-get update -qq
-sudo apt-get install -qq mysql-client realpath zip
+sudo apt-get install -qq mysql-client realpath zip nsis
 
 # golang of the version we want
 sudo apt-get remove -qq golang && sudo rm -rf /usr/local/go &&

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,9 @@ jobs:
 
       # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
       - run:
-          command: make -s clean linux darwin windows
+          command: |
+            make -s clean linux darwin windows
+            makensis -DVERSION=$(git describe --tags --always --dirty) winpkg/ddev.nsi
           name: Build the ddev executables
 
       # Run the built-in ddev tests with the executables just built.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ jobs:
           command: |
             make -s clean linux darwin windows
             makensis -DVERSION=$(git describe --tags --always --dirty) winpkg/ddev.nsi
+            curl -o /tmp/sudo.zip -O -L https://github.com/mattn/sudo/releases/download/v0.0.1/sudo-x86_64.zip
+            unzip -d bin/windows/windows_amd64 /tmp/sudo.zip
           name: Build the ddev executables
 
       # Run the built-in ddev tests with the executables just built.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,7 @@ jobs:
       # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
       - run:
           command: |
-            make -s clean linux darwin windows
-            makensis -DVERSION=$(git describe --tags --always --dirty) winpkg/ddev.nsi
-            curl -o /tmp/sudo.zip -O -L https://github.com/mattn/sudo/releases/download/v0.0.1/sudo-x86_64.zip
-            unzip -d bin/windows/windows_amd64 /tmp/sudo.zip
+            make -s clean linux darwin windows_install
           name: Build the ddev executables
 
       # Run the built-in ddev tests with the executables just built.

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -36,6 +36,7 @@ zip $ARTIFACTS/ddev_linux.$VERSION.zip ddev ddev_bash_completion.sh
 cd $BASE_DIR/bin/windows/windows_amd64
 tar -czf $ARTIFACTS/ddev_windows.$VERSION.tar.gz ddev.exe ddev_bash_completion.sh
 zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
+cp ddev_windows_installer*.exe $ARTIFACTS
 
 # Create the sha256 files
 cd $ARTIFACTS

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,10 @@ setup:
 # Required static analysis targets used in circleci - these cause fail if they don't work
 staticrequired: gometalinter
 
-windows_install: windows bin/windows/windows_amd64/sudo.exe
+windows_install: windows bin/windows/windows_amd64/sudo.exe bin/windows/windows_amd64/sudo_license.txt
 	makensis -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows
 
-bin/windows/windows_amd64/sudo.exe:
+bin/windows/windows_amd64/sudo.exe bin/windows/windows_amd64/sudo_license.txt:
 	curl -sSL -o /tmp/sudo.zip -O  https://github.com/mattn/sudo/releases/download/$(WINDOWS_SUDO_VERSION)/sudo-x86_64.zip
 	unzip -o -d $(PWD)/bin/windows/windows_amd64 /tmp/sudo.zip
+	curl -sSL -o $(PWD)/bin/windows/windows_amd64/sudo_license.txt https://raw.githubusercontent.com/mattn/sudo/master/LICENSE

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 GOMETALINTER_ARGS := --vendored-linters --disable-all --enable=gofmt --enable=vet --enable vetshadow --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode --deadline=2m
 
+WINDOWS_SUDO_VERSION=v0.0.1
+
 ##### These variables need to be adjusted in most repositories #####
 
 # This repo's root import path (under GOPATH).
@@ -57,7 +59,7 @@ include build-tools/makefile_components/base_build_go.mak
 #include build-tools/makefile_components/base_test_go.mak
 #include build-tools/makefile_components/base_test_python.mak
 
-.PHONY: test testcmd testpkg build setup staticrequired
+.PHONY: test testcmd testpkg build setup staticrequired windows_install
 
 TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
@@ -91,3 +93,10 @@ setup:
 
 # Required static analysis targets used in circleci - these cause fail if they don't work
 staticrequired: gometalinter
+
+windows_install: windows bin/windows/windows_amd64/sudo.exe
+	makensis -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows
+
+bin/windows/windows_amd64/sudo.exe:
+	curl -sSL -o /tmp/sudo.zip -O  https://github.com/mattn/sudo/releases/download/$(WINDOWS_SUDO_VERSION)/sudo-x86_64.zip
+	unzip -o -d $(PWD)/bin/windows/windows_amd64 /tmp/sudo.zip

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ You can also easily perform the installation or upgrade manually if preferred. d
 
 ### Installation or Upgrade - Windows
 
-- A windows installer is provided in the release (`ddev_windows_installer.<version>.exe`). Run that and it will do the full installation for you. Open a new terminal or cmd window so ddev will be in your path.
+- A windows installer is provided in the release (`ddev_windows_installer.<version>.exe`). Run that and it will do the full installation for you. If you get a Windows Defender Smartscreen warning "Windows protected your PC", click "More info" and then "Run anyway". Open a new terminal or cmd window and start using ddev.
 
 ### Versioning
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,11 +50,9 @@ You can also easily perform the installation or upgrade manually if preferred. d
 - Move ddev to /usr/local/bin: `mv ddev /usr/local/bin/` (may require sudo), or another directory in your `$PATH` as preferred.
 - Run `ddev` to test your installation. You should see ddev's command usage output.
 
-### Manual Installation or Upgrade - Windows
+### Installation or Upgrade - Windows
 
-- Download and extract the latest [ddev release](https://github.com/drud/ddev/releases) for Windows.
-- Copy `ddev.exe` into `%HOMEPATH%\AppData\Local\Microsoft\WindowsApps`, or otherwise add `ddev.exe` to a folder defined in your `PATH`
-- Run `ddev` from a Command Prompt or PowerShell to test your installation. You should see ddev's command usage output.
+- A windows installer is provided in the release (`ddev_windows_installer.<version>.exe`). Run that and it will do the full installation for you. Open a new terminal or cmd window so ddev will be in your path.
 
 ### Versioning
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -965,7 +965,7 @@ func (app *DdevApp) AddHostsEntries() error {
 			continue
 		}
 
-		_, err = osexec.Command("sudo", "-h").Output()
+		_, err = osexec.LookPath("sudo")
 		if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
 			util.Warning("You must manually add the following entry to your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname %s %s'", dockerIP, name, name, dockerIP)
 			return nil
@@ -981,7 +981,9 @@ func (app *DdevApp) AddHostsEntries() error {
 		util.Warning(fmt.Sprintf("    sudo %s", command))
 		output.UserOut.Println("Please enter your password if prompted.")
 		_, err = exec.RunCommandPipe("sudo", hostnameArgs)
-		util.CheckErr(err)
+		if err != nil {
+			util.Warning("Failed to execute sudo command, you will need to manually execute '%s' with administrative privileges", command)
+		}
 	}
 	return nil
 }

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -13,7 +13,7 @@
 Name "ddev"
 
 ; The file to write
-OutFile "ddev_installer.exe"
+OutFile "..\bin\windows\windows_amd64\ddev_installer.$DDEV_VERSION.exe"
 
 ; The default installation directory
 InstallDir $PROGRAMFILES64\ddev

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -39,7 +39,7 @@ RequestExecutionLevel admin
 !define MUI_HEADERIMAGE
 
 !define MUI_WELCOMEPAGE_TITLE "DDEV-Local, a local PHP development environment system"
-!define MUI_WELCOMEPAGE_TEXT "From DRUD Tech, https://ddev.drud.com$\r$\nWe welcome your input and contributions. $\r$\nDocs: ddev.readthedocs.io"
+!define MUI_WELCOMEPAGE_TEXT "From DRUD Tech, https://ddev.com$\r$\nWe welcome your input and contributions. $\r$\nDocs: ddev.readthedocs.io"
 
 !insertmacro MUI_PAGE_WELCOME
 

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -42,18 +42,16 @@ RequestExecutionLevel admin
 
 ;--------------------------------
 
-; The stuff to install
-Section "ddev (required)"
+Section "ddev and sudo"
 
   SectionIn RO
   
   ; Set output path to the installation directory.
   SetOutPath $INSTDIR
   
-  ; Put file there
   File "../bin/windows/windows_amd64/ddev.exe"
   FIle "../bin/windows/windows_amd64/sudo.exe"
-  
+
   ; Write the installation path into the registry
   WriteRegStr HKLM SOFTWARE\NSIS_ddev "Install_Dir" "$INSTDIR"
   
@@ -63,10 +61,9 @@ Section "ddev (required)"
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "NoModify" 1
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "NoRepair" 1
   WriteUninstaller "ddev_uninstall.exe"
-
 SectionEnd
 
-Section "Add to PATH (Recommended)"
+Section "Add to PATH"
   Push $INSTDIR
   Call AddToPath
 SectionEnd

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -51,7 +51,8 @@ Section "ddev (required)"
   SetOutPath $INSTDIR
   
   ; Put file there
-  File "..\bin\windows\windows_amd64\ddev.exe"
+  File "../bin/windows/windows_amd64/ddev.exe"
+  FIle "../bin/windows/windows_amd64/sudo.exe"
   
   ; Write the installation path into the registry
   WriteRegStr HKLM SOFTWARE\NSIS_ddev "Install_Dir" "$INSTDIR"
@@ -87,6 +88,7 @@ Section "Uninstall"
 
   ; Remove files and uninstaller
   Delete $INSTDIR\ddev.exe
+  Delete $INSTDIR\sudo.exe
   Delete $INSTDIR\ddev_uninstall.exe
 
   ; Remove shortcuts, if any

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -42,15 +42,11 @@ RequestExecutionLevel admin
 
 ;--------------------------------
 
-Section "ddev and sudo"
-
+Section "ddev"
   SectionIn RO
-  
-  ; Set output path to the installation directory.
   SetOutPath $INSTDIR
   
   File "../bin/windows/windows_amd64/ddev.exe"
-  FIle "../bin/windows/windows_amd64/sudo.exe"
 
   ; Write the installation path into the registry
   WriteRegStr HKLM SOFTWARE\NSIS_ddev "Install_Dir" "$INSTDIR"
@@ -63,7 +59,14 @@ Section "ddev and sudo"
   WriteUninstaller "ddev_uninstall.exe"
 SectionEnd
 
+Section "sudo"
+  SectionIn 1
+  SetOutPath $INSTDIR
+  FIle "../bin/windows/windows_amd64/sudo.exe"
+SectionEnd
+
 Section "Add to PATH"
+  SectionIn 2
   Push $INSTDIR
   Call AddToPath
 SectionEnd

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -7,6 +7,10 @@
 
 ;--------------------------------
 
+!define MUI_PRODUCT "DDEV-Local"
+!define MUI_VERSION "${VERSION}"
+CRCCheck On
+
 !include MUI2.nsh
 
 ; The name of the installer
@@ -31,18 +35,41 @@ RequestExecutionLevel admin
 
 ;--------------------------------
 ;Pages
+!define MUI_PAGE_HEADER_TEXT "Monkey Town Presents:"
+!define MUI_PAGE_HEADER_SUBTEXT "Monkey Chooser (c) 2013"
 
-  !insertmacro MUI_PAGE_LICENSE "..\LICENSE"
-  !insertmacro MUI_PAGE_COMPONENTS
-  !insertmacro MUI_PAGE_DIRECTORY
-  !insertmacro MUI_PAGE_INSTFILES
+!define MUI_WELCOMEPAGE_TITLE "DDEV-Local"
+!define MUI_WELCOMEPAGE_TEXT "From DRUD Tech, https://ddev.drud.com"
+!insertmacro MUI_PAGE_WELCOME
 
-  !insertmacro MUI_UNPAGE_CONFIRM
-  !insertmacro MUI_UNPAGE_INSTFILES
+!define MUI_LICENSEPAGE_TEXT_TOP "Apache 2.0 License for DDEV-Live (ddev)"
+!define MUI_LICENSEPAGE_BUTTON "I agree"
+
+!insertmacro MUI_PAGE_LICENSE "..\LICENSE"
+
+!define MUI_LICENSEPAGE_TEXT_TOP "MIT License for github.com/mattn/sudo"
+!define MUI_LICENSEPAGE_BUTTON "I agree"
+
+!insertmacro MUI_PAGE_LICENSE "..\bin\windows\windows_amd64\sudo_license.txt"
+
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!define MUI_FINISHPAGE_TITLE_3LINES "Welcome to DDEV-Local"
+!define MUI_FINISHPAGE_TEXT "Please review the release notes"
+!define MUI_FINISHPAGE_SHOWREADME https://github.com/drud/ddev/releases/tag/${VERSION}
+!define MUI_FINISHPAGE_SHOWREADME_TEXT "Continue to review the release notes."
+!define MUI_FINISHPAGE_LINK "github.com/drud/ddev"
+!define MUI_FINISHPAGE_LINK_LOCATION "https://github.com/drud/ddev"
+!insertmacro MUI_PAGE_FINISH
 
 ;--------------------------------
 
-Section "ddev"
+Section "ddev (github.com/drud/ddev)"
   SectionIn RO
   SetOutPath $INSTDIR
   
@@ -59,7 +86,7 @@ Section "ddev"
   WriteUninstaller "ddev_uninstall.exe"
 SectionEnd
 
-Section "sudo"
+Section "sudo (github.com/mattn/sudo)"
   SectionIn 1
   SetOutPath $INSTDIR
   FIle "../bin/windows/windows_amd64/sudo.exe"

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -1,0 +1,377 @@
+; ddev.nsi
+;
+; This script is based on example2.nsi. It remembers the directory,
+; uninstall support and (optionally) installs start menu shortcuts.
+;
+; It will install ddev.nsi into a directory that the user selects,
+
+;--------------------------------
+
+; The name of the installer
+Name "ddev"
+
+; The file to write
+OutFile "ddev_installer.exe"
+
+; The default installation directory
+InstallDir $PROGRAMFILES64\ddev
+
+; Registry key to check for directory (so if you install again, it will 
+; overwrite the old one automatically)
+InstallDirRegKey HKLM "Software\NSIS_ddev" "Install_Dir"
+
+; Request application privileges for Windows Vista
+RequestExecutionLevel admin
+
+;--------------------------------
+
+; Pages
+
+Page components
+Page directory
+Page instfiles
+
+UninstPage uninstConfirm
+UninstPage instfiles
+
+;--------------------------------
+
+; The stuff to install
+Section "ddev (required)"
+
+  SectionIn RO
+  
+  ; Set output path to the installation directory.
+  SetOutPath $INSTDIR
+  
+  ; Put file there
+  File "..\bin\windows\windows_amd64\ddev.exe"
+  
+  ; Write the installation path into the registry
+  WriteRegStr HKLM SOFTWARE\NSIS_ddev "Install_Dir" "$INSTDIR"
+  
+  ; Write the uninstall keys for Windows
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "DisplayName" "NSIS ddev"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "UninstallString" '"$INSTDIR\uninstall.exe"'
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "NoModify" 1
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "NoRepair" 1
+  WriteUninstaller "uninstall.exe"
+
+SectionEnd
+
+Section "Add to PATH"
+  Push $INSTDIR
+  Call AddToPath
+
+SectionEnd
+
+; Optional section (can be disabled by the user)
+Section "Start Menu Shortcuts"
+
+  CreateDirectory "$SMPROGRAMS\ddev"
+  CreateShortcut "$SMPROGRAMS\ddev\Uninstall.lnk" "$INSTDIR\uninstall.exe" "" "$INSTDIR\uninstall.exe" 0
+  CreateShortcut "$SMPROGRAMS\ddev\ddev (MakeNSISW).lnk" "$INSTDIR\ddev.nsi" "" "$INSTDIR\ddev.nsi" 0
+  
+SectionEnd
+
+;--------------------------------
+
+; Uninstaller
+
+Section "Uninstall"
+  
+  ; Remove registry keys
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev"
+  DeleteRegKey HKLM SOFTWARE\NSIS_ddev
+
+  ; Remove files and uninstaller
+  Delete $INSTDIR\ddev.nsi
+  Delete $INSTDIR\uninstall.exe
+
+  ; Remove shortcuts, if any
+  Delete "$SMPROGRAMS\ddev\*.*"
+
+  ; Remove directories used
+  RMDir "$SMPROGRAMS\ddev"
+  RMDir "$INSTDIR"
+
+  Push $INSTDIR
+  Call un.RemoveFromPath
+
+SectionEnd
+
+!ifndef _AddToPath_nsh
+!define _AddToPath_nsh
+
+!verbose 3
+!include "WinMessages.NSH"
+!verbose 4
+
+!ifndef WriteEnvStr_RegKey
+  !ifdef ALL_USERS
+    !define WriteEnvStr_RegKey \
+       'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
+  !else
+    !define WriteEnvStr_RegKey 'HKCU "Environment"'
+  !endif
+!endif
+
+; AddToPath - Adds the given dir to the search path.
+;        Input - head of the stack
+;        Note - Win9x systems requires reboot
+
+Function AddToPath
+  Exch $0
+  Push $1
+  Push $2
+  Push $3
+
+  # don't add if the path doesn't exist
+  IfFileExists "$0\*.*" "" AddToPath_done
+
+  ReadEnvStr $1 PATH
+  Push "$1;"
+  Push "$0;"
+  Call StrStr
+  Pop $2
+  StrCmp $2 "" "" AddToPath_done
+  Push "$1;"
+  Push "$0\;"
+  Call StrStr
+  Pop $2
+  StrCmp $2 "" "" AddToPath_done
+  GetFullPathName /SHORT $3 $0
+  Push "$1;"
+  Push "$3;"
+  Call StrStr
+  Pop $2
+  StrCmp $2 "" "" AddToPath_done
+  Push "$1;"
+  Push "$3\;"
+  Call StrStr
+  Pop $2
+  StrCmp $2 "" "" AddToPath_done
+
+  Call IsNT
+  Pop $1
+  StrCmp $1 1 AddToPath_NT
+    ; Not on NT
+    StrCpy $1 $WINDIR 2
+    FileOpen $1 "$1\autoexec.bat" a
+    FileSeek $1 -1 END
+    FileReadByte $1 $2
+    IntCmp $2 26 0 +2 +2 # DOS EOF
+      FileSeek $1 -1 END # write over EOF
+    FileWrite $1 "$\r$\nSET PATH=%PATH%;$3$\r$\n"
+    FileClose $1
+    SetRebootFlag true
+    Goto AddToPath_done
+
+  AddToPath_NT:
+    ReadRegStr $1 ${WriteEnvStr_RegKey} "PATH"
+    StrCmp $1 "" AddToPath_NTdoIt
+      Push $1
+      Call Trim
+      Pop $1
+      StrCpy $0 "$1;$0"
+    AddToPath_NTdoIt:
+      WriteRegExpandStr ${WriteEnvStr_RegKey} "PATH" $0
+      SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+  AddToPath_done:
+    Pop $3
+    Pop $2
+    Pop $1
+    Pop $0
+FunctionEnd
+
+; RemoveFromPath - Remove a given dir from the path
+;     Input: head of the stack
+
+Function un.RemoveFromPath
+  Exch $0
+  Push $1
+  Push $2
+  Push $3
+  Push $4
+  Push $5
+  Push $6
+
+  IntFmt $6 "%c" 26 # DOS EOF
+
+  Call un.IsNT
+  Pop $1
+  StrCmp $1 1 unRemoveFromPath_NT
+    ; Not on NT
+    StrCpy $1 $WINDIR 2
+    FileOpen $1 "$1\autoexec.bat" r
+    GetTempFileName $4
+    FileOpen $2 $4 w
+    GetFullPathName /SHORT $0 $0
+    StrCpy $0 "SET PATH=%PATH%;$0"
+    Goto unRemoveFromPath_dosLoop
+
+    unRemoveFromPath_dosLoop:
+      FileRead $1 $3
+      StrCpy $5 $3 1 -1 # read last char
+      StrCmp $5 $6 0 +2 # if DOS EOF
+        StrCpy $3 $3 -1 # remove DOS EOF so we can compare
+      StrCmp $3 "$0$\r$\n" unRemoveFromPath_dosLoopRemoveLine
+      StrCmp $3 "$0$\n" unRemoveFromPath_dosLoopRemoveLine
+      StrCmp $3 "$0" unRemoveFromPath_dosLoopRemoveLine
+      StrCmp $3 "" unRemoveFromPath_dosLoopEnd
+      FileWrite $2 $3
+      Goto unRemoveFromPath_dosLoop
+      unRemoveFromPath_dosLoopRemoveLine:
+        SetRebootFlag true
+        Goto unRemoveFromPath_dosLoop
+
+    unRemoveFromPath_dosLoopEnd:
+      FileClose $2
+      FileClose $1
+      StrCpy $1 $WINDIR 2
+      Delete "$1\autoexec.bat"
+      CopyFiles /SILENT $4 "$1\autoexec.bat"
+      Delete $4
+      Goto unRemoveFromPath_done
+
+  unRemoveFromPath_NT:
+    ReadRegStr $1 ${WriteEnvStr_RegKey} "PATH"
+    StrCpy $5 $1 1 -1 # copy last char
+    StrCmp $5 ";" +2 # if last char != ;
+      StrCpy $1 "$1;" # append ;
+    Push $1
+    Push "$0;"
+    Call un.StrStr ; Find `$0;` in $1
+    Pop $2 ; pos of our dir
+    StrCmp $2 "" unRemoveFromPath_done
+      ; else, it is in path
+      # $0 - path to add
+      # $1 - path var
+      StrLen $3 "$0;"
+      StrLen $4 $2
+      StrCpy $5 $1 -$4 # $5 is now the part before the path to remove
+      StrCpy $6 $2 "" $3 # $6 is now the part after the path to remove
+      StrCpy $3 $5$6
+
+      StrCpy $5 $3 1 -1 # copy last char
+      StrCmp $5 ";" 0 +2 # if last char == ;
+        StrCpy $3 $3 -1 # remove last char
+
+      WriteRegExpandStr ${WriteEnvStr_RegKey} "PATH" $3
+      SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+  unRemoveFromPath_done:
+    Pop $6
+    Pop $5
+    Pop $4
+    Pop $3
+    Pop $2
+    Pop $1
+    Pop $0
+FunctionEnd
+
+
+
+!ifndef IsNT_KiCHiK
+!define IsNT_KiCHiK
+
+###########################################
+#            Utility Functions            #
+###########################################
+
+; IsNT
+; no input
+; output, top of the stack = 1 if NT or 0 if not
+;
+; Usage:
+;   Call IsNT
+;   Pop $R0
+;  ($R0 at this point is 1 or 0)
+
+!macro IsNT un
+Function ${un}IsNT
+  Push $0
+  ReadRegStr $0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" CurrentVersion
+  StrCmp $0 "" 0 IsNT_yes
+  ; we are not NT.
+  Pop $0
+  Push 0
+  Return
+
+  IsNT_yes:
+    ; NT!!!
+    Pop $0
+    Push 1
+FunctionEnd
+!macroend
+!insertmacro IsNT ""
+!insertmacro IsNT "un."
+
+!endif ; IsNT_KiCHiK
+
+; StrStr
+; input, top of stack = string to search for
+;        top of stack-1 = string to search in
+; output, top of stack (replaces with the portion of the string remaining)
+; modifies no other variables.
+;
+; Usage:
+;   Push "this is a long ass string"
+;   Push "ass"
+;   Call StrStr
+;   Pop $R0
+;  ($R0 at this point is "ass string")
+
+!macro StrStr un
+Function ${un}StrStr
+Exch $R1 ; st=haystack,old$R1, $R1=needle
+  Exch    ; st=old$R1,haystack
+  Exch $R2 ; st=old$R1,old$R2, $R2=haystack
+  Push $R3
+  Push $R4
+  Push $R5
+  StrLen $R3 $R1
+  StrCpy $R4 0
+  ; $R1=needle
+  ; $R2=haystack
+  ; $R3=len(needle)
+  ; $R4=cnt
+  ; $R5=tmp
+  loop:
+    StrCpy $R5 $R2 $R3 $R4
+    StrCmp $R5 $R1 done
+    StrCmp $R5 "" done
+    IntOp $R4 $R4 + 1
+    Goto loop
+done:
+  StrCpy $R1 $R2 "" $R4
+  Pop $R5
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Exch $R1
+FunctionEnd
+!macroend
+!insertmacro StrStr ""
+!insertmacro StrStr "un."
+
+Function Trim ; Added by Pelaca
+	Exch $R1
+	Push $R2
+Loop:
+	StrCpy $R2 "$R1" 1 -1
+	StrCmp "$R2" " " RTrim
+	StrCmp "$R2" "$\n" RTrim
+	StrCmp "$R2" "$\r" RTrim
+	StrCmp "$R2" ";" RTrim
+	GoTo Done
+RTrim:
+	StrCpy $R1 "$R1" -1
+	Goto Loop
+Done:
+	Pop $R2
+	Exch $R1
+FunctionEnd
+
+!endif ; _AddToPath_nsh

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -12,9 +12,10 @@
 CRCCheck On
 
 !include MUI2.nsh
+!include LogicLib.nsh
 
 ; The name of the installer
-Name "ddev"
+Name "ddev ${VERSION}"
 
 OutFile "../bin/windows/windows_amd64/ddev_windows_installer.${VERSION}.exe"
 
@@ -35,8 +36,7 @@ RequestExecutionLevel admin
 
 ;--------------------------------
 ;Pages
-!define MUI_PAGE_HEADER_TEXT "Monkey Town Presents:"
-!define MUI_PAGE_HEADER_SUBTEXT "Monkey Chooser (c) 2013"
+!define MUI_SPECIALBITMAP "ddev-logo-light-bg.bmp"
 
 !define MUI_WELCOMEPAGE_TITLE "DDEV-Local"
 !define MUI_WELCOMEPAGE_TEXT "From DRUD Tech, https://ddev.drud.com"
@@ -44,12 +44,10 @@ RequestExecutionLevel admin
 
 !define MUI_LICENSEPAGE_TEXT_TOP "Apache 2.0 License for DDEV-Live (ddev)"
 !define MUI_LICENSEPAGE_BUTTON "I agree"
-
 !insertmacro MUI_PAGE_LICENSE "..\LICENSE"
 
 !define MUI_LICENSEPAGE_TEXT_TOP "MIT License for github.com/mattn/sudo"
 !define MUI_LICENSEPAGE_BUTTON "I agree"
-
 !insertmacro MUI_PAGE_LICENSE "..\bin\windows\windows_amd64\sudo_license.txt"
 
 !insertmacro MUI_PAGE_COMPONENTS
@@ -129,6 +127,17 @@ Section "Uninstall"
   Call un.RemoveFromPath
 
 SectionEnd
+
+; Check on startup for docker-compose. If it doesn't exist, warn the user.
+Function .onInit
+    nsExec::ExecToStack "docker-compose -v"
+    Pop $0 # return value/error/timeout
+    Pop $1
+    ${If} $0 != "0"
+      MessageBox MB_OK "Docker and docker-compose do not seem to be installed (or are not available in %PATH%), but they are required for ddev to function. Please install them after you complete ddev installation."
+    ${EndIf}
+FunctionEnd
+
 
 !ifndef _AddToPath_nsh
 !define _AddToPath_nsh

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -36,10 +36,11 @@ RequestExecutionLevel admin
 
 ;--------------------------------
 ;Pages
-!define MUI_SPECIALBITMAP "ddev-logo-light-bg.bmp"
+!define MUI_HEADERIMAGE
 
-!define MUI_WELCOMEPAGE_TITLE "DDEV-Local"
-!define MUI_WELCOMEPAGE_TEXT "From DRUD Tech, https://ddev.drud.com"
+!define MUI_WELCOMEPAGE_TITLE "DDEV-Local, a local PHP development environment system"
+!define MUI_WELCOMEPAGE_TEXT "From DRUD Tech, https://ddev.drud.com$\r$\nWe welcome your input and contributions. $\r$\nDocs: ddev.readthedocs.io"
+
 !insertmacro MUI_PAGE_WELCOME
 
 !define MUI_LICENSEPAGE_TEXT_TOP "Apache 2.0 License for DDEV-Live (ddev)"
@@ -57,13 +58,16 @@ RequestExecutionLevel admin
 !insertmacro MUI_UNPAGE_CONFIRM
 !insertmacro MUI_UNPAGE_INSTFILES
 
+
 !define MUI_FINISHPAGE_TITLE_3LINES "Welcome to DDEV-Local"
-!define MUI_FINISHPAGE_TEXT "Please review the release notes"
-!define MUI_FINISHPAGE_SHOWREADME https://github.com/drud/ddev/releases/tag/${VERSION}
+!define MUI_FINISHPAGE_TEXT "Please review the release notes."
+!define MUI_FINISHPAGE_SHOWREADME https://github.com/drud/ddev/releases
 !define MUI_FINISHPAGE_SHOWREADME_TEXT "Continue to review the release notes."
 !define MUI_FINISHPAGE_LINK "github.com/drud/ddev"
 !define MUI_FINISHPAGE_LINK_LOCATION "https://github.com/drud/ddev"
 !insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English"
 
 ;--------------------------------
 

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -19,9 +19,9 @@ InstallDir $PROGRAMFILES64\ddev
 
 ; Registry key to check for directory (so if you install again, it will 
 ; overwrite the old one automatically)
-InstallDirRegKey HKLM "Software\NSIS_ddev" "Install_Dir"
+InstallDirRegKey HKLM "Software\ddev" ""
 
-; Request application privileges for Windows Vista
+; Request admin privileges
 RequestExecutionLevel admin
 
 ;--------------------------------
@@ -57,7 +57,7 @@ Section "ddev (required)"
   WriteRegStr HKLM SOFTWARE\NSIS_ddev "Install_Dir" "$INSTDIR"
   
   ; Write the uninstall keys for Windows
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "DisplayName" "NSIS ddev"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "DisplayName" "ddev"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "UninstallString" '"$INSTDIR\ddev_uninstall.exe"'
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "NoModify" 1
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "NoRepair" 1
@@ -70,13 +70,9 @@ Section "Add to PATH (Recommended)"
   Call AddToPath
 SectionEnd
 
-; Optional section (can be disabled by the user)
 Section "Start Menu Shortcuts"
-
   CreateDirectory "$SMPROGRAMS\ddev"
   CreateShortcut "$SMPROGRAMS\ddev\Uninstall.lnk" "$INSTDIR\ddev_uninstall.exe" "" "$INSTDIR\ddev_uninstall.exe" 0
-  CreateShortcut "$SMPROGRAMS\ddev\ddev (MakeNSISW).lnk" "$INSTDIR\ddev.nsi" "" "$INSTDIR\ddev.nsi" 0
-  
 SectionEnd
 
 ;--------------------------------
@@ -90,7 +86,7 @@ Section "Uninstall"
   DeleteRegKey HKLM SOFTWARE\NSIS_ddev
 
   ; Remove files and uninstaller
-  Delete $INSTDIR\ddev.nsi
+  Delete $INSTDIR\ddev.exe
   Delete $INSTDIR\ddev_uninstall.exe
 
   ; Remove shortcuts, if any

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -3,7 +3,7 @@
 ; This script is based on example2.nsi. It remembers the directory,
 ; uninstall support and (optionally) installs start menu shortcuts.
 ;
-; It will install ddev.exe into $PROGRAMFILES64\ddev,
+; It will install ddev.exe into $PROGRAMFILES64/ddev,
 
 ;--------------------------------
 
@@ -12,8 +12,7 @@
 ; The name of the installer
 Name "ddev"
 
-; The file to write
-OutFile "..\bin\windows\windows_amd64\ddev_installer.$DDEV_VERSION.exe"
+OutFile "../bin/windows/windows_amd64/ddev_windows_installer.${VERSION}.exe"
 
 ; The default installation directory
 InstallDir $PROGRAMFILES64\ddev

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -3,9 +3,11 @@
 ; This script is based on example2.nsi. It remembers the directory,
 ; uninstall support and (optionally) installs start menu shortcuts.
 ;
-; It will install ddev.nsi into a directory that the user selects,
+; It will install ddev.exe into $PROGRAMFILES64\ddev,
 
 ;--------------------------------
+
+!include MUI2.nsh
 
 ; The name of the installer
 Name "ddev"
@@ -24,15 +26,20 @@ InstallDirRegKey HKLM "Software\NSIS_ddev" "Install_Dir"
 RequestExecutionLevel admin
 
 ;--------------------------------
+;Interface Settings
 
-; Pages
+  !define MUI_ABORTWARNING
 
-Page components
-Page directory
-Page instfiles
+;--------------------------------
+;Pages
 
-UninstPage uninstConfirm
-UninstPage instfiles
+  !insertmacro MUI_PAGE_LICENSE "..\LICENSE"
+  !insertmacro MUI_PAGE_COMPONENTS
+  !insertmacro MUI_PAGE_DIRECTORY
+  !insertmacro MUI_PAGE_INSTFILES
+
+  !insertmacro MUI_UNPAGE_CONFIRM
+  !insertmacro MUI_UNPAGE_INSTFILES
 
 ;--------------------------------
 
@@ -52,24 +59,23 @@ Section "ddev (required)"
   
   ; Write the uninstall keys for Windows
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "DisplayName" "NSIS ddev"
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "UninstallString" '"$INSTDIR\uninstall.exe"'
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "UninstallString" '"$INSTDIR\ddev_uninstall.exe"'
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "NoModify" 1
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ddev" "NoRepair" 1
-  WriteUninstaller "uninstall.exe"
+  WriteUninstaller "ddev_uninstall.exe"
 
 SectionEnd
 
-Section "Add to PATH"
+Section "Add to PATH (Recommended)"
   Push $INSTDIR
   Call AddToPath
-
 SectionEnd
 
 ; Optional section (can be disabled by the user)
 Section "Start Menu Shortcuts"
 
   CreateDirectory "$SMPROGRAMS\ddev"
-  CreateShortcut "$SMPROGRAMS\ddev\Uninstall.lnk" "$INSTDIR\uninstall.exe" "" "$INSTDIR\uninstall.exe" 0
+  CreateShortcut "$SMPROGRAMS\ddev\Uninstall.lnk" "$INSTDIR\ddev_uninstall.exe" "" "$INSTDIR\ddev_uninstall.exe" 0
   CreateShortcut "$SMPROGRAMS\ddev\ddev (MakeNSISW).lnk" "$INSTDIR\ddev.nsi" "" "$INSTDIR\ddev.nsi" 0
   
 SectionEnd
@@ -86,7 +92,7 @@ Section "Uninstall"
 
   ; Remove files and uninstaller
   Delete $INSTDIR\ddev.nsi
-  Delete $INSTDIR\uninstall.exe
+  Delete $INSTDIR\ddev_uninstall.exe
 
   ; Remove shortcuts, if any
   Delete "$SMPROGRAMS\ddev\*.*"


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've not had a windows installer, we need one.

This uses the excellent NSIS to build an installer (and uninstaller).  The installer is built in the regular Circleci build and is available in the artifacts on the Circleci build. For example, on https://circleci.com/gh/drud/ddev/2785#artifacts/containers/0

## How this PR Solves The Problem:

* Adds a windows installer (`make windows_install`) which packages ddev and sudo (#786)
* Adds sudo so we no longer make Windows users go manually edit hosts file.  (#798)
* Fixes a bug discovered at Drupalcon where a failed sudo attempt results in a stack trace, (#780)

## Manual Testing Instructions:

* Remove any existing ddev instances from your %PATH%
* Install using the downloaded installer (Perhaps https://circleci.com/gh/drud/ddev/2726#artifacts/containers/0 )
* Open a new cmd or git-bash window (to get the new %PATH%
* Test basic usage
* Uninstall and verify that the binary, the directory it was installed in, and the %PATH% component are properly updated.
* Take pleasure in not having to manually add hostnames on Windows.

## Related Issues

#786: Implement Windows Installer
#780: Poor handling of `sudo ddev hostname` - We now warn instead of stack trace.
#798: Admin-priv handling for windows users (add sudo command in our install)