### PR TITLE
Add nodejs and npm to web container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION_VARIABLES = DdevVersion WebImg WebTag DBImg DBTag RouterImage RouterTag 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
 WebImg ?= drud/nginx-php-fpm-local
-WebTag ?= v1.2.2
+WebTag ?= 20180416_add_node
 DBImg ?= drud/mariadb-local
 DBTag ?=  v0.9.0
 RouterImage ?= drud/ddev-router

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local" // Note that this is overridden by make
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.2.2" // Note that this is overridden by make
+var WebTag = "20180416_add_node" // Note that this is overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local" // Note that this is overridden by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

People want node and npm for their web container.

## How this PR Solves The Problem:

Add it, from https://github.com/drud/docker.nginx-php-fpm-local/pull/68

## Manual Testing Instructions:

Use this (or just set your config.yaml to use `webimage: drud/nginx-php-fpm-local: 20180416_add_node`

`ddev ssh` in there and do something useful.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

