### PR TITLE
Remove com.ddev.container-type from documentation

### DIFF
--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -24,8 +24,6 @@ When defining additional services for your project, we recommended you follow th
 
   - `com.ddev.app-url: $DDEV_URL`
 
-  - `com.ddev.container-type: [servicename]`
-
 - Exposing ports for service: you can expose the port for a service to be accessible as `projectname.ddev.local:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
 
   - Define only the internal port in the `ports` section for docker-compose. The `hostPort:containerPort` convention normally used to expose ports in docker should not be used here, since we are leveraging the ddev router to expose the ports.


### PR DESCRIPTION
PR https://github.com/drud/ddev/pull/215 has changed the `com.ddev.container-type` label to 
`com.docker.compose.service`.

Documentation  https://ddev.readthedocs.io/en/latest/users/extend/custom-compose-files/
and solr example needs to be updated.


