### PR TITLE
Add mention of phpMyAdmin and the Sequel Pro command

### DIFF
--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -1,7 +1,7 @@
 <h1>Using Developer Tools with ddev</h1>
 
 ## Developer Tools Included in the Container
-We have included several useful developer tools in our containers.
+We have included several useful developer tools in our containers. Run `ddev describe` to see the project information and services available for your project and how to access them.   
 
 ### Command-line Tools
 - MySQL Client (mysql) - Command-line interface for interacting with MySQL.
@@ -33,7 +33,7 @@ After your project is started, access the phpMyAdmin web interface at its defaul
 http://mysite.ddev.local:8036
 ```
 
-If you use [Sequel Pro](https://www.sequelpro.com/) for macOS, run `ddev sequelpro` within a project folder, and Sequel Pro will launch and load the database for that project. Sequel Pro is a free open source database browser for macOS. 
+If you use the free [Sequel Pro](https://www.sequelpro.com/) database browser for macOS, run `ddev sequelpro` within a project folder, and Sequel Pro will launch and access the database for that project. 
 
 ## Using Development Tools on the Host Machine
 

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -23,6 +23,18 @@ http://mysite.ddev.local:8025
 
 Please note this will not intercept emails if your application is configured to use SMTP or a 3rd-party ESP integration. If you are using SMTP for outgoing mail handling ([Swiftmailer](https://www.drupal.org/project/swiftmailer) or [SMTP](https://www.drupal.org/project/smtp) modules for example), update your application configuration to use `localhost` on port `1025` as the SMTP server locally in order to use MailHog.
 
+### Database Management
+
+[phpMyAdmin](https://www.phpmyadmin.net/) is a free software tool to manage MySQL and MariaDB databases from a browser. phpMyAdmin comes installed with ddev. 
+
+After your project is started, access the phpMyAdmin web interface at its default port:
+
+```
+http://mysite.ddev.local:8036
+```
+
+If you use [Sequel Pro](https://www.sequelpro.com/) for macOS, run `ddev sequelpro` within a project folder, and Sequel Pro will launch and load the database for that project. Sequel Pro is a free open source database browser for macOS. 
+
 ## Using Development Tools on the Host Machine
 
 It is possible in many cases to use development tools installed on your host machine on a project provisioned by ddev. Tools that interact with files and require no database connection, such as Git or Composer, can be run from the host machine against the code base for a ddev project with no additional configuration necessary.


### PR DESCRIPTION
## The Problem/Issue/Bug:

Tell users about database management options with ddev

See #769 

## How this PR Solves The Problem:

Add information about the phpMyAdmin service included in ddev. 
Add explanation of `sequelpro` command

## Manual Testing Instructions:

Visit
https://ddev.readthedocs.io/en/latest/users/developer-tools/.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
https://github.com/drud/ddev/issues/769

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

