### PR TITLE
Use colors on windows instead of funny characters, fixes #363

### DIFF
--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -3,6 +3,7 @@ package output
 import (
 	"os"
 
+	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -17,9 +18,9 @@ var (
 
 // LogSetUp sets up UserOut and log loggers as needed by ddev
 func LogSetUp() {
-	// Use stdout instead of stderr for all user output
-	log.SetOutput(os.Stdout)
-	UserOut.Out = os.Stdout
+	// Use color.Output instead of stderr for all user output
+	log.SetOutput(color.Output)
+	UserOut.Out = color.Output
 
 	if !JSONOutput {
 		UserOut.Formatter = UserOutFormatter


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've been emitting really ugly escape characters instead of colors on Windows for a long time, OP #363 

## How this PR Solves The Problem:

Finally outputs nicer stuff.

![windows_cmd_colors](https://user-images.githubusercontent.com/112444/38902659-a79a8936-425e-11e8-9b9c-612acb7355b8.png)


## Manual Testing Instructions:

Run basic commands on Windows (in both cmd and git-bash), on Linux, and macOS and verify basic behavior.

The colors in cmd are not exactly the same, but IMO they're good enough.

## Automated Testing Overview:

I don't know how to test this in our current testing environment.

## Related Issue Link(s):

OP #363

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

