### PR TITLE
Only build xz images on tag build, fixes #801

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,12 @@ jobs:
           command: bin/linux/ddev version
           name: ddev version information
 
+      # We only build the xz version of the docker images on tag build.
       - run:
-          command: ./.circleci/generate_artifacts.sh $ARTIFACTS
-          name: tar/zip up artifacts and make hashes
+          command: |
+            ./.circleci/generate_artifacts.sh $ARTIFACTS
+            xz $ARTIFACTS/ddev_docker_images.$VERSION.tar
+          name: tar/zip/xz up artifacts and make hashes
           no_output_timeout: "20m"
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - run:
           command: |
             ./.circleci/generate_artifacts.sh $ARTIFACTS
-            xz $ARTIFACTS/ddev_docker_images.$VERSION.tar
+            xz $ARTIFACTS/ddev_docker_images.*.tar
           name: tar/zip/xz up artifacts and make hashes
           no_output_timeout: "20m"
 

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -39,6 +39,6 @@ zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
 
 # Create the sha256 files
 cd $ARTIFACTS
-for item in *.tar.gz *.zip *.xz; do
+for item in *.*; do
   sha256sum $item > $item.sha256.txt
 done

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -39,6 +39,6 @@ zip $ARTIFACTS/ddev_windows.$VERSION.zip ddev.exe ddev_bash_completion.sh
 
 # Create the sha256 files
 cd $ARTIFACTS
-for item in *.tar.gz *.zip ddev_docker_images.$VERSION.tar.gz ddev_docker_images.$VERSION.tar.xz; do
+for item in *.tar.gz *.zip *.xz; do
   sha256sum $item > $item.sha256.txt
 done

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -15,7 +15,6 @@ for item in $(cat /tmp/images.txt); do
 done
 docker save -o $ARTIFACTS/ddev_docker_images.$VERSION.tar $(cat /tmp/images.txt)
 gzip --keep $ARTIFACTS/ddev_docker_images.$VERSION.tar
-xz $ARTIFACTS/ddev_docker_images.$VERSION.tar
 
 # Generate and place extra items like autocomplete
 bin/linux/ddev_gen_autocomplete


### PR DESCRIPTION
## The Problem/Issue/Bug:

The xz compression of our docker images takes *forever*. It was added for quicksprint, and is only needed on releases. So remove it from normal builds.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

