### PR TITLE
Set COLUMNS and LINES in container shell, fixes #799

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+	"golang.org/x/crypto/ssh/terminal"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -23,7 +24,7 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/lextoumbourou/goodhosts"
-	shellwords "github.com/mattn/go-shellwords"
+	"github.com/mattn/go-shellwords"
 )
 
 const containerWaitTimeout = 61
@@ -736,6 +737,15 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_ROUTER_HTTP_PORT":         app.RouterHTTPPort,
 		"DDEV_ROUTER_HTTPS_PORT":        app.RouterHTTPSPort,
 	}
+
+	// Find out terminal dimensions
+	columns, lines, err := terminal.GetSize(0)
+	if err != nil {
+		columns = 80
+		lines = 24
+	}
+	envVars["COLUMNS"] = strconv.Itoa(columns)
+	envVars["LINES"] = strconv.Itoa(lines)
 
 	if len(app.AdditionalHostnames) > 0 {
 		// TODO: Warn people about additional names in use.

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -23,6 +23,10 @@ services:
       com.ddev.app-type: {{ .appType }}
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
+    environment:
+      - COLUMNS=$COLUMNS
+      - LINES=$LINES
+
   web:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
@@ -49,6 +53,8 @@ services:
       - DDEV_ROUTER_HTTPS_PORT=$DDEV_ROUTER_HTTPS_PORT
       - DEPLOY_NAME=local
       - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - COLUMNS=$COLUMNS
+      - LINES=$LINES
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
       - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,{{ .mailhogport }}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -242,6 +242,8 @@ func ClearDockerEnv() {
 		"DDEV_PROJECT_TYPE",
 		"DDEV_ROUTER_HTTP_PORT",
 		"DDEV_ROUTER_HTTPS_PORT",
+		"COLUMNS",
+		"LINES",
 	}
 	for _, env := range envVars {
 		err := os.Unsetenv(env)


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #799 explains our trouble with $COLUMNS and $LINES inside `ddev ssh`.

## How this PR Solves The Problem:

Set those values when we use docker-compose.

## Manual Testing Instructions:

`ddev ssh` with and without and observe the behavior on a long line.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

