### PR TITLE
[BUGFIX] Trusted hosts pattern for TYPO3, for #680

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -15,6 +15,8 @@ const typo3AdditionalConfigTemplate = `<?php
 /** ` + DdevFileSignature + `: Automatically generated TYPO3 AdditionalConfiguration.php file.
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
+ 
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
 
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'], [
                     'dbname' => 'db',


### PR DESCRIPTION
Problem:
`The current host header value does not match the configured trusted hosts pattern! Check the pattern defined in $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] and adapt it, if you want to allow the current host header 'website.ddev.local:8080' for your installation.`

[edited by rfay]
This fixes half of #680 - support trusted hosts patterns for both TYPO3 and Drupal8