### PR TITLE
Document adding extra env variables, fixes #757, also #758 (docs only)

### DIFF
--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -2,13 +2,17 @@
 
 ## Prerequisite knowledge
 
-The majority of ddev's customization ability and extensibility comes from leveraging features and functionality provided by [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/overview/). Some working knowledge of these tools is required in order to customize or extend the environment ddev provides.
+Much of ddev's customization ability and extensibility comes from leveraging features and functionality provided by [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/overview/). Some working knowledge of these tools is required in order to customize or extend the environment ddev provides.
 
 ## Background
 
-Under the hood, ddev uses docker-compose to define and run the multiple containers that make up the local environment for a web application. Docker Compose supports defining multiple compose files to facilitate [sharing Compose configurations between files and projects](https://docs.docker.com/compose/extends/), and ddev is designed to leverage this ability.
+Under the hood, ddev uses docker-compose to define and run the multiple containers that make up the local environment for a project. docker-compose supports defining multiple compose files to facilitate [sharing Compose configurations between files and projects](https://docs.docker.com/compose/extends/), and ddev is designed to leverage this ability.
 
-To add services to your project, create docker-compose files in the `.ddev` directory for your project. ddev will process any files using the `docker-compose.[servicename].yml` naming convention and include them in executing docker-compose functionality. In addition, create a `docker-compose.override.yml` to override any configurations from the main docker-compose file or any service compose files added to your project.
+To add custom configuration or additional services to your project, create docker-compose files in the `.ddev` directory for your project. ddev will process any files using the `docker-compose.[servicename].yaml` naming convention and include them in executing docker-compose functionality. Optionally you can also create a `docker-compose.override.yaml` to override any configurations from the main docker-compose.yaml or any additional compose files added to your project.
+
+## Restrictions on the docker-compose.yaml file
+
+The main docker-compose.yaml file is exclusively reserved for ddev's use, and will be overwritten on ddev upgrades and when a project is started, so it should not be edited, or edits will be lost. If you need to override configuration provided by docker-compose.yaml, use an additional file to do so.
 
 ## Conventions for defining additional services
 

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -13,6 +13,24 @@ A collection of vetted service configurations is available in the [Additional Se
 
 If you need to create a service configuration for your project, see [Defining an additional service with Docker Compose](custom-compose-files.md)
 
+## Providing custom environment variables to a container
+
+Each project can have an unlimited number of .ddev/docker-compose.*.yaml files, so it's easy to maintain custom environment variables in a .ddev/docker-compose.environment.yaml file (the exact name doesn't matter, if it just matches docker-compose*.y*ml).
+
+For example, 
+
+```
+version: '3'
+
+services:
+  web:
+    environment:
+      - TYPO3_CONTEXT=Development
+  db:
+    environment:
+      - SOMETHING=something special
+```
+
 ## Providing custom nginx configuration
 The default web container for ddev uses NGINX as the web server. A default configuration is provided in the web container that should work for most Drupal 7+ and WordPress projects. Some projects may require custom configuration, for example to support a module or plugin requiring special rules. To accommodate these needs, ddev provides a way to replace the default configuration with a custom version.
 

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -15,9 +15,9 @@ If you need to create a service configuration for your project, see [Defining an
 
 ## Providing custom environment variables to a container
 
-Each project can have an unlimited number of .ddev/docker-compose.*.yaml files, so it's easy to maintain custom environment variables in a .ddev/docker-compose.environment.yaml file (the exact name doesn't matter, if it just matches docker-compose*.y*ml).
+Each project can have an unlimited number of .ddev/docker-compose.*.yaml files as described in [Custom Compose Files](./custom-compose-files.md), so it's easy to maintain custom environment variables in a .ddev/docker-compose.environment.yaml file (the exact name doesn't matter, if it just matches docker-compose.*.yaml).
 
-For example, 
+For example, a `.ddev/docker-compose.environment.yaml` with these contents would add a $TYPO3_CONTEXT environment variable to the web container, and a $SOMETHING environment variable to the db container: 
 
 ```
 version: '3'


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #757 points out that especially TYPO3 users need to set environment variables in the container. It's actually quite easy to do (without editing the main docker-compose.yaml). This just tells how to do it.

Thanks @kaystrobach - Hope you can review this.

## How this PR Solves The Problem:

Adds docs with simple technique.

