### PR TITLE
Override docker-compose.yaml on ddev start, fixes #762

### DIFF
--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -77,7 +77,7 @@ We've seen cases where this is caused by old databases that are not compatible w
 Note: Your project database will be destroyed by this procedure.
 
 1. `ddev remove --remove-data`
-2. rm -r .ddev (removes the config.yaml and docker-compose.yml, do this only if you haven't modified those)
+2. rm -r .ddev (removes the config.yaml and docker-compose.yml and any custom nginx/php/mariadb config you may have added. It makes sense to make a backup of these before proceeding.)
 3. `ddev start` 
 4. `ddev import-db` if you have a db to import
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -617,9 +617,7 @@ func (app *DdevApp) Start() error {
 	// Warn the user if there is any custom configuration in use.
 	app.CheckCustomConfig()
 
-	// WriteConfig docker-compose.yaml (if it doesn't exist).
-	// If the user went through the `ddev config` process it will be written already, but
-	// we also do it here in the case of a manually created `.ddev/config.yaml` file.
+	// WriteConfig docker-compose.yaml
 	err = app.WriteDockerComposeConfig()
 	if err != nil {
 		return err

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -3,7 +3,7 @@ package ddevapp
 // DDevComposeTemplate is used to create the main docker-compose.yaml
 // file for a ddev site.
 const DDevComposeTemplate = `version: '3'
-
+{{ .ddevgenerated }}
 services:
   db:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-db


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #762: We keep having to tell people to delete docker-compose.yaml on ddev upgrades. We made the decision to take control of docker-compose.yaml

This PR addresses the changes for docker-compose.yaml, another PR will address the changes to config.yaml handling.

## How this PR Solves The Problem:

* Looks for docker-compose.yaml `#ddev-generated` in docker-compose. If not found, renames the file to docker-compose.yaml.bak and warns the user.
* Creates the docker-compose.yaml on every start
* Overrides can be done in docker-compose.*.yaml

## Manual Testing Instructions:

* Run `ddev start` with this version
* Existing docker-compose.yaml should be renamed to .bak, and new one created.
* Run it again, with or without changes. A new one should be created. No warning should be given.

## Automated Testing Overview:

Nothing at this point.

## Related Issue Link(s):

OP #762

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

