### PR TITLE
Make ddev logs work against stopped project/container, fixes #719

### DIFF
--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -29,10 +29,6 @@ var DdevLogsCmd = &cobra.Command{
 			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 
-		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
-			util.Failed("Project is stopped. Run 'ddev start' to start the environment.")
-		}
-
 		err = app.Logs(serviceType, follow, timestamp, tail)
 		if err != nil {
 			util.Failed("Failed to retrieve logs for %s: %v", app.GetName(), err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -574,6 +574,25 @@ func TestDdevLogs(t *testing.T) {
 		out = stdout()
 		assert.Contains(out, "MySQL init process done. Ready for start up.")
 
+		// Test that we can get logs when project is stopped also
+		err = app.Stop()
+		assert.NoError(err)
+
+		stdout = testcommon.CaptureUserOut()
+		err = app.Logs("web", false, false, "")
+		assert.NoError(err)
+		out = stdout()
+		assert.Contains(out, "Server started")
+
+		stdout = testcommon.CaptureUserOut()
+		err = app.Logs("db", false, false, "")
+		assert.NoError(err)
+		out = stdout()
+		assert.Contains(out, "MySQL init process done. Ready for start up.")
+
+		err = app.Start()
+		assert.NoError(err)
+
 		runTime()
 		switchDir()
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #719: Currently `ddev logs` only works against running containers, so is useless when trying to debug a stopped container (perhaps stopped for a healthcheck failure). This commonly happens when people add custom config that is broken. But then `ddev logs` doesn't help them and we have to coach them on using the more arcane docker logs options.

## How this PR Solves The Problem:

There was an explicit stanza that forbade getting logs on stopped containers. Remove it.

## Manual Testing Instructions:

* Start a project
* Stop the project
* Run `ddev logs` and `ddev logs -s db` to see the logs from the project.

## Automated Testing Overview:

I didn't add anything.

## Related Issue Link(s):

OP #719 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

