### PR TITLE
Fix conflicting hostname problem by making list unique, fixes #789

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -299,13 +299,23 @@ func (app *DdevApp) GetHostname() string {
 // GetHostnames returns an array of all the configured hostnames.
 func (app *DdevApp) GetHostnames() []string {
 
-	var nameList []string
-	nameList = append(nameList, app.GetHostname())
+	// Use a map to make sure that we have unique hostnames
+	// The value is useless, so just use the int 1 for assignment.
+	nameListMap := make(map[string]int)
+
+	nameListMap[app.GetHostname()] = 1
 
 	for _, name := range app.AdditionalHostnames {
-		nameList = append(nameList, name+"."+version.DDevTLD)
+		nameListMap[name+"."+version.DDevTLD] = 1
 	}
-	return nameList
+
+	// Now walk the map and extract the keys into an array.
+	nameListArray := make([]string, 0, len(nameListMap))
+	for k := range nameListMap {
+		nameListArray = append(nameListArray, k)
+	}
+
+	return nameListArray
 }
 
 // WriteDockerComposeConfig writes a docker-compose.yaml to the app configuration directory.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -244,7 +244,10 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		err := app.Init(site.Dir)
 		assert.NoError(err)
 
-		app.AdditionalHostnames = []string{"sub1." + site.Name, "sub2." + site.Name, "subname.sub3." + site.Name}
+		// site.Name is explicitly added because if not removed in GetHostNames() it will cause ddev-router failure
+		// "a" is repeated for the same reason; a user error of this type should not cause a failure; GetHostNames()
+		// should uniqueify them.
+		app.AdditionalHostnames = []string{"sub1." + site.Name, "sub2." + site.Name, "subname.sub3." + site.Name, site.Name, site.Name, site.Name}
 
 		err = app.WriteConfig()
 		assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #789: Since we introduced the additional_hostnames feature, there have been a few reports of people accidentally introducing conflicting hostnames. The most common is probably where the project name is "myname", adding "myname" again in the additional_hostnames. This causes the ddev-router to freak out and fail to preprocess its nginx configs.

## How this PR Solves The Problem:

Make sure that the list of hostnames provided to docker-compose.yaml (and thus to ddev-router) is unique.

This PR does *not* solve the problem of multiple projects competing for one hostname.

## Manual Testing Instructions:

For a project named "junk", add "junk" in additional_hostnames config. When you `ddev start` things should work. This should go down in flames in earlier versions of ddev.

## Automated Testing Overview:

This adds the broken case to TestDdevStartMultipleHostnames(), so a regression should be caught there.

## Related Issue Link(s):

OP #789 

Related: Make ddev-router more transparent about failures: #774 


