### PR TITLE
Add windows_install to nightly and tag builds, fix nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
 
       - run:
           command: |
-            make -s linux darwin windows
+            make -s linux darwin windows_install
           name: Build the ddev executables normally, with normal image tags
 
       # Run the built-in ddev tests with the clean binaries just built.
@@ -107,7 +107,7 @@ jobs:
 
       # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
       - run:
-          command: make -s clean linux darwin windows
+          command: make -s clean linux darwin windows_install
           name: Build the ddev executables
 
       - run:

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -38,8 +38,8 @@ var (
 		},
 		{
 			Name:                          "TestPkgDrupal8",
-			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-8.4.0/",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.5.3.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-8.5.3/",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/drupal8_files.tar.gz",
 			FilesZipballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/drupal8_files.zip",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/drupal8_db.tar.gz",


### PR DESCRIPTION
## The Problem/Issue/Bug:

https://github.com/drud/ddev/pull/787 went in last week, adding a windows installer, but the nightly and tag builds didn't include it, so the artifact script failed. Fix that.


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

