### PR TITLE
Bump ddev-router image tag to solve problem with header too big

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ WebTag ?= v1.3.0
 DBImg ?= drud/mariadb-local
 DBTag ?=  v0.9.0
 RouterImage ?= drud/ddev-router
-RouterTag ?= v0.5.0
+RouterTag ?= v0.5.1
 DBAImg ?= drud/phpmyadmin
 DBATag ?= v0.2.0
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -38,7 +38,7 @@ var DBATag = "v0.2.0"
 var RouterImage = "drud/ddev-router" // Note that this is overridden by make
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.5.0" // Note that this is overridden by make
+var RouterTag = "v0.5.1" // Note that this is overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The bug is described in https://github.com/drud/docker.ddev-router/pull/17 - This PR just bumps the version to pull that in.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

