### PR TITLE
Upgrade docker-compose and golang on circleci build

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -10,7 +10,7 @@ sudo apt-get install -qq mysql-client realpath zip nsis
 
 # golang of the version we want
 sudo apt-get remove -qq golang && sudo rm -rf /usr/local/go &&
-wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.linux-amd64.tar.gz &&
+wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.2.linux-amd64.tar.gz &&
 sudo tar -C /usr/local -xzf /tmp/golang.tgz
 
 
@@ -30,5 +30,5 @@ sudo apt-get update -qq
 sudo apt-get install -qq docker-ce
 
 # docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.20.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -s -L "https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
## The Problem/Issue/Bug:

Time to upgrade docker-compose and golang (1.10.2). 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

