### PR TITLE
 Simplify ContainerWait(), ComposerCmd, EnsureHTTPStatus, fix build, fixes #837

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           command: make -s test
           name: ddev tests
-          no_output_timeout: "20m"
+          no_output_timeout: "40m"
 
       - run: make -s gometalinter
 
@@ -42,7 +42,7 @@ jobs:
       - run:
           command: ./.circleci/generate_artifacts.sh $ARTIFACTS
           name: tar/zip up artifacts and make hashes
-          no_output_timeout: "20m"
+          no_output_timeout: "40m"
 
       - store_artifacts:
           path: /artifacts
@@ -81,7 +81,7 @@ jobs:
       - run:
           command: ./.circleci/generate_artifacts.sh $ARTIFACTS
           name: tar/zip up artifacts and make hashes
-          no_output_timeout: "20m"
+          no_output_timeout: "40m"
 
       - store_artifacts:
           path: /artifacts
@@ -120,7 +120,7 @@ jobs:
             ./.circleci/generate_artifacts.sh $ARTIFACTS
             xz $ARTIFACTS/ddev_docker_images.*.tar
           name: tar/zip/xz up artifacts and make hashes
-          no_output_timeout: "20m"
+          no_output_timeout: "40m"
 
       - store_artifacts:
           path: /artifacts

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ include build-tools/makefile_components/base_build_go.mak
 
 TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
-TEST_TIMEOUT=20m
+TEST_TIMEOUT=40m
 BUILD_ARCH = $(shell go env GOARCH)
 ifeq ($(BUILD_OS),linux)
     DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/ddev
@@ -71,7 +71,7 @@ endif
 
 ifeq ($(BUILD_OS),windows)
     DDEV_BINARY_FULLPATH=$(PWD)/bin/$(BUILD_OS)/$(BUILD_OS)_$(BUILD_ARCH)/ddev.exe
-    TEST_TIMEOUT=40m
+    TEST_TIMEOUT=80m
 endif
 
 ifeq ($(BUILD_OS),darwin)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"bufio"
-
 	"github.com/Masterminds/semver"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
@@ -227,8 +225,8 @@ func ComposeNoCapture(composeFiles []string, action ...string) error {
 // returns stdout, stderr, error/nil
 func ComposeCmd(composeFiles []string, action ...string) (string, string, error) {
 	var arg []string
-	var stdout bytes.Buffer
-	var stderr string
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
 
 	for _, file := range composeFiles {
 		arg = append(arg, "-f")
@@ -238,34 +236,26 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 	arg = append(arg, action...)
 
 	proc := exec.Command("docker-compose", arg...)
-	proc.Stdout = &stdout
+	proc.Stdout = &stdoutBuf
 	proc.Stdin = os.Stdin
+	proc.Stderr = &stderrBuf
 
-	stderrPipe, err := proc.StderrPipe()
-	util.CheckErr(err)
-
+	var err error
 	if err = proc.Start(); err != nil {
 		return "", "", fmt.Errorf("Failed to exec docker-compose: %v", err)
 	}
 
-	// read command's stdout line by line
-	in := bufio.NewScanner(stderrPipe)
-
-	for in.Scan() {
-		line := in.Text()
-		if len(stderr) > 0 {
-			stderr = stderr + "\n"
-		}
-		stderr = stderr + line
-		line = strings.Trim(line, "\n\r")
-		output.UserOut.Println(line)
-	}
-
 	err = proc.Wait()
 	if err != nil {
-		return stdout.String(), stderr, fmt.Errorf("Failed to run docker-compose %v, err='%v', stdout='%s', stderr='%s'", arg, err, stdout.String(), stderr)
+		return stdoutBuf.String(), stderrBuf.String(), fmt.Errorf("Failed to run docker-compose %v, err='%v', stdoutBuf='%s', stderrBuf='%s'", arg, err, stdoutBuf.String(), stderrBuf.String())
 	}
-	return stdout.String(), stderr, nil
+
+	outStrings := strings.Split(stderrBuf.String(), "\n")
+	for _, item := range outStrings {
+		line := strings.Trim(item, "\n\r")
+		output.UserOut.Println(line)
+	}
+	return stdoutBuf.String(), stderrBuf.String(), nil
 }
 
 // GetAppContainers retrieves docker containers for a given sitename.

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -139,12 +139,12 @@ func ContainerWait(waittime time.Duration, labels map[string]string) error {
 	for {
 		select {
 		case <-timeoutChan:
-			return fmt.Errorf("Container %v timed out without becoming healthy, status=%v", container, status)
+			return fmt.Errorf("health check timed out: labels %v timed out without becoming healthy, status=%v", labels, status)
 
 		case <-tickChan:
 			container, err := FindContainerByLabels(labels)
 			if err != nil {
-				return fmt.Errorf("failed to query container %v", container)
+				return fmt.Errorf("failed to query container labels %v", labels)
 			}
 			status = GetContainerHealth(container)
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -147,9 +147,7 @@ func ContainerWait(timeout time.Duration, labels map[string]string) error {
 				doneChan <- true
 			}
 			status := GetContainerHealth(container)
-			if status == "restarting" {
-				containerErr = fmt.Errorf("container %s: detected container restart; invalid configuration or container. consider using `docker logs %s` to debug", ContainerName(container), container.ID)
-			}
+
 			if status == "healthy" {
 				containerErr = nil
 				doneChan <- true

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -101,11 +101,11 @@ func TestContainerWait(t *testing.T) {
 
 	err := ContainerWait(0, labels)
 	assert.Error(err)
-	assert.Equal("health check timed out", err.Error())
+	assert.Contains(err.Error(), "health check timed out")
 
 	err = ContainerWait(5, labels)
 	assert.Error(err)
-	assert.Equal("failed to query container", err.Error())
+	assert.Contains(err.Error(), "failed to query container")
 }
 
 // TestComposeCmd tests execution of docker-compose commands.


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #837 - we're having regular failures in test that seem to be centered around ContainerWait(), which is complex with goroutines and such. This is a simpler implementation.

## How this PR Solves The Problem:

* Simplify ComposeCmd()
* Simplify ContainerWait()
* Simplify EnsureHTTPStatus()
* Make more generous timeouts for golang tests. It may be that much of what I was seeing was golang killing off the test and spewing lots of goroutine info. However, I'm pretty sure that means we were leaking tickers too; I like this simplified version better.

## Manual Testing Instructions:

It's hard to test this. Restart a CircleCI test.

## Automated Testing Overview:

* Modest changes were made to one TestContainerWait()

## Related Issue Link(s):

OP #837 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

