### PR TITLE
fixes nginx conf for access to d8 update.php

### DIFF
--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal8.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal8.conf
@@ -43,8 +43,7 @@ server {
     }
 
     # pass the PHP scripts to FastCGI server listening on socket
-    location ~ \.php$ {
-        try_files $uri =404;
+    location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php-fpm.sock;
         fastcgi_buffers 16 16k;


### PR DESCRIPTION
## The Problem/Issue/Bug:

@tannerjfco 's PR from https://github.com/drud/docker.nginx-php-fpm-local/pull/72, referenced in https://github.com/drud/ddev/issues/830 and https://github.com/drud/ddev/issues/851

Pushed in drud/nginx-php-fpm-local:20180514_fix_d8_updatephp

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

