### PR TITLE
Bring in drud/mariadb-local#63 to solve Windows 10 Home problem, fixes #636, fixes #854

### DIFF
--- a/containers/mariadb-local/files/etc/my.cnf
+++ b/containers/mariadb-local/files/etc/my.cnf
@@ -24,9 +24,13 @@ socket                         = /var/tmp/mysql.sock
 socket                         = /var/tmp/mysql.sock
 skip-host-cache
 skip-name-resolve
-skip-log-bin
 datadir=/var/lib/mysql
 secure-file-priv=/var/lib/mysql-files
+# Windows 10 home fix: must not use native_aio, since there is none.
+# log-bin=on fixes a bug with Virtualbox (used by docker toolbox)
+# see https://dba.stackexchange.com/a/185006/149238
+innodb_use_native_aio=0
+log-bin=on
 
 character-set-server = utf8mb4
 collation-server = utf8mb4_bin

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var WebTag = "20180522_fpm_env_vars" // Note that this can be overridden by make
 var DBImg = "drud/mariadb-local"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "20180529_fix_maria_root" // Note that this may be overridden by make
+var DBTag = "20180514_win_10_home" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem:

Docker Toolbox/Windows 10 Home uses a completely different virtualization environment that can break Mariadb. 

This is migrated from drud/mariadb-local#63, and the comments related to it are in #854

## The Fix:

* Turn off innodb_use_native_aio since it just doesn't work with NTFS/Windows
* log-bin=on - Fixes [a weird problem](https://dba.stackexchange.com/a/185006/149238) with Virtualbox and mariadb. 

## The Test:

* Use ddev with this on Windows 10 Home (dbimage: drud/mariadb-local:20180416_win_10_home)
* Use it everywhere else.
* Check for performance everywhere

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP drud/ddev#636

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

