### PR TITLE
Private files must take precedence before static files in nginx config, fixes #847

### DIFF
--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-backdrop.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-backdrop.conf
@@ -65,13 +65,6 @@ server {
         expires 1h;
     }
 
-    # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
-    }
-
     # Prevent clients from accessing hidden files (starting with a dot)
     # This is particularly important if you store .htpasswd files in the site hierarchy
     # Access to `/.well-known/` is allowed.
@@ -95,6 +88,13 @@ server {
         access_log off;
         expires 30d;
         try_files $uri @rewrite;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
     }
 
     ## provide a health check endpoint

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal6.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal6.conf
@@ -78,10 +78,10 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
     }
 
     # Prevent clients from accessing hidden files (starting with a dot)

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal7.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal7.conf
@@ -70,10 +70,10 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
     }
 
     # Prevent clients from accessing hidden files (starting with a dot)
@@ -99,6 +99,13 @@ server {
         access_log off;
         expires 30d;
         try_files $uri @rewrite;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
     }
 
     ## provide a health check endpoint

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal8.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal8.conf
@@ -65,13 +65,6 @@ server {
         expires 1h;
     }
 
-    # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
-    }
-
     # Prevent clients from accessing hidden files (starting with a dot)
     # This is particularly important if you store .htpasswd files in the site hierarchy
     # Access to `/.well-known/` is allowed.
@@ -95,6 +88,13 @@ server {
         access_log off;
         expires 30d;
         try_files $uri @rewrite;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
     }
 
     ## provide a health check endpoint

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.18.0-11-gd6cb228c" // Note that this can be overridden by make
+var WebTag = "v0.18.0-5-g78f25609" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.18.0-5-g78f25609" // Note that this can be overridden by make
+var WebTag = "20180515_fix_backup_migrate" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #847 mentions that it's impossible to download a .mysql.gz file from backup_migrate on d8. 

It turns out looking at https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/ that this seems to be a failure of putting static files in our configuration first, when the private files handling needs to come first.

## How this PR Solves The Problem:

Update d7/d8/backdrop config based on https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/  

## Manual Testing Instructions:

* Try to download a backup_migrate .mysql.gz archive
* Make sure all other static file situations remain correct, including private files attached to a node

## Related Issue Link(s):

OP #847

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


