### PR TITLE
Make ComposeCmd() interactive again, fixes #859

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1,6 +1,7 @@
 package dockerutil
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"log"
@@ -214,8 +215,8 @@ func ComposeNoCapture(composeFiles []string, action ...string) error {
 // returns stdout, stderr, error/nil
 func ComposeCmd(composeFiles []string, action ...string) (string, string, error) {
 	var arg []string
-	var stdoutBuf bytes.Buffer
-	var stderrBuf bytes.Buffer
+	var stdout bytes.Buffer
+	var stderr string
 
 	for _, file := range composeFiles {
 		arg = append(arg, "-f")
@@ -225,26 +226,34 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 	arg = append(arg, action...)
 
 	proc := exec.Command("docker-compose", arg...)
-	proc.Stdout = &stdoutBuf
+	proc.Stdout = &stdout
 	proc.Stdin = os.Stdin
-	proc.Stderr = &stderrBuf
 
-	var err error
+	stderrPipe, err := proc.StderrPipe()
+	util.CheckErr(err)
+
 	if err = proc.Start(); err != nil {
 		return "", "", fmt.Errorf("Failed to exec docker-compose: %v", err)
 	}
 
-	err = proc.Wait()
-	if err != nil {
-		return stdoutBuf.String(), stderrBuf.String(), fmt.Errorf("Failed to run docker-compose %v, err='%v', stdoutBuf='%s', stderrBuf='%s'", arg, err, stdoutBuf.String(), stderrBuf.String())
-	}
+	// read command's stdout line by line
+	in := bufio.NewScanner(stderrPipe)
 
-	outStrings := strings.Split(stderrBuf.String(), "\n")
-	for _, item := range outStrings {
-		line := strings.Trim(item, "\n\r")
+	for in.Scan() {
+		line := in.Text()
+		if len(stderr) > 0 {
+			stderr = stderr + "\n"
+		}
+		stderr = stderr + line
+		line = strings.Trim(line, "\n\r")
 		output.UserOut.Println(line)
 	}
-	return stdoutBuf.String(), stderrBuf.String(), nil
+
+	err = proc.Wait()
+	if err != nil {
+		return stdout.String(), stderr, fmt.Errorf("Failed to run docker-compose %v, err='%v', stdout='%s', stderr='%s'", arg, err, stdout.String(), stderr)
+	}
+	return stdout.String(), stderr, nil
 }
 
 // GetAppContainers retrieves docker containers for a given sitename.


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #859: Output from docker-compose command was no longer interactive, so it was impossible to tell what was happening as it pulled images, and it looked like it was hung.


## How this PR Solves The Problem:

This PR makes ComposeCmd() exactly what it was before #845 messed it up.


## Manual Testing Instructions:

Use `docker rmi` to remove the nginx-php-fpm-local image. Then `ddev start`. You should see it pulling the image as it does it.


## Related Issue Link(s):

OP #859, Regression introduced in #845 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

