### PR TITLE
 Increase proxy_read_timeout for ddev-router, fixes #844, fixes #672

### DIFF
--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -270,6 +270,7 @@ server {
                 proxy_buffer_size   128k;
                 proxy_buffers   4 256k;
                 proxy_busy_buffers_size   256k;
+                proxy_read_timeout 10m;
                 proxy_pass {{ trim $proto }}://{{ trim $upstream_name }}-{{ trim $upstream_port }};
                 {{ end }}
                 error_page 502 @brokenupstream;
@@ -367,6 +368,7 @@ server {
                 proxy_buffer_size   128k;
                 proxy_buffers   4 256k;
                 proxy_busy_buffers_size   256k;
+                proxy_read_timeout 10m;
                 proxy_pass {{ trim $proto }}://{{ trim $upstream_name }}-{{ trim $upstream_port }};
                 {{ end }}
                 error_page 502 @brokenupstream;

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-backdrop.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-backdrop.conf
@@ -54,7 +54,7 @@ server {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         # fastcgi_read_timeout should match max_execution_time in php.ini
-        fastcgi_read_timeout 360;
+        fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-default.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-default.conf
@@ -55,7 +55,7 @@ server {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         # fastcgi_read_timeout should match max_execution_time in php.ini
-        fastcgi_read_timeout 360;
+        fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal6.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal6.conf
@@ -66,7 +66,7 @@ server {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         # fastcgi_read_timeout should match max_execution_time in php.ini
-        fastcgi_read_timeout 360;
+        fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal7.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal7.conf
@@ -58,7 +58,7 @@ server {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         # fastcgi_read_timeout should match max_execution_time in php.ini
-        fastcgi_read_timeout 360;
+        fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal8.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-drupal8.conf
@@ -54,7 +54,7 @@ server {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         # fastcgi_read_timeout should match max_execution_time in php.ini
-        fastcgi_read_timeout 360;
+        fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-typo3.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-typo3.conf
@@ -44,7 +44,7 @@ server {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         # fastcgi_read_timeout should match max_execution_time in php.ini
-        fastcgi_read_timeout 360;
+        fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }

--- a/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-wordpress.conf
+++ b/containers/nginx-php-fpm-local/files/etc/nginx/nginx-site-wordpress.conf
@@ -78,7 +78,7 @@ server {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         # fastcgi_read_timeout should match max_execution_time in php.ini
-        fastcgi_read_timeout 360;
+        fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }

--- a/containers/nginx-php-fpm-local/files/etc/php/5.6/fpm/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/5.6/fpm/php.ini
@@ -16,9 +16,9 @@ disable_classes =
 zend.enable_gc = On
 expose_php = Off
 ; Resource Limits ;
-max_execution_time = 360
-request_terminate_timeout = 360
-max_input_time = 120
+max_execution_time = 600
+request_terminate_timeout = 0
+max_input_time = -1
 ;max_input_nesting_level = 64
 max_input_vars = 1500
 memory_limit = 512M

--- a/containers/nginx-php-fpm-local/files/etc/php/7.0/fpm/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.0/fpm/php.ini
@@ -16,9 +16,9 @@ disable_classes =
 zend.enable_gc = On
 expose_php = Off
 ; Resource Limits ;
-max_execution_time = 360
-request_terminate_timeout = 360
-max_input_time = 120
+max_execution_time = 600
+request_terminate_timeout = 0
+max_input_time = -1
 ;max_input_nesting_level = 64
 max_input_vars = 1500
 memory_limit = 512M

--- a/containers/nginx-php-fpm-local/files/etc/php/7.1/fpm/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.1/fpm/php.ini
@@ -16,9 +16,9 @@ disable_classes =
 zend.enable_gc = On
 expose_php = Off
 ; Resource Limits ;
-max_execution_time = 360
-request_terminate_timeout = 360
-max_input_time = 120
+max_execution_time = 600
+request_terminate_timeout = 0
+max_input_time = -1
 ;max_input_nesting_level = 64
 max_input_vars = 1500
 memory_limit = 512M

--- a/containers/nginx-php-fpm-local/files/etc/php/7.2/fpm/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.2/fpm/php.ini
@@ -16,9 +16,9 @@ disable_classes =
 zend.enable_gc = On
 expose_php = Off
 ; Resource Limits ;
-max_execution_time = 360
-request_terminate_timeout = 360
-max_input_time = 120
+max_execution_time = 600
+request_terminate_timeout = 0
+max_input_time = -1
 ;max_input_nesting_level = 64
 max_input_vars = 1500
 memory_limit = 512M

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.18.0-9-g767d60c8" // Note that this can be overridden by make
+var WebTag = "v0.18.0-11-gd6cb228c" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"
@@ -32,13 +32,13 @@ var DBTag = "v0.9.0" // Note that this may be overridden by make
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "v0.2.0"
+var DBATag = "v0.2.0" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
-var RouterImage = "drud/ddev-router" // Note that this is overridden by make
+var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.18.0-9-g767d60c8" // Note that this is overridden by make
+var RouterTag = "v0.18.0-11-gd6cb228c" // Note that this can be overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.18.0-5-g78f25609" // Note that this can be overridden by make
+var WebTag = "v0.18.0-9-g767d60c8" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"
@@ -38,7 +38,7 @@ var DBATag = "v0.2.0"
 var RouterImage = "drud/ddev-router" // Note that this is overridden by make
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.5.1" // Note that this is overridden by make
+var RouterTag = "v0.18.0-9-g767d60c8" // Note that this is overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

People debugging with xdebug (or running a long-running process) could encounter timeouts from nginx even though the web container had them set quite high. We discovered that the timeout on the ddev-router was the issue with this. 

## How this PR Solves The Problem:

Increase timeouts everywhere to 10m.

## Manual Testing Instructions:

Debug into a project. Wait a couple of minutes. Let the debugger continue. The page should load in the browser without a timeout.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #844 
Related issue #672 (varbase install): I tested this with a varbase install and made it through to the end, taking the defaults. Admittedly it's with a faster machine than I tested with then, but I think this solves the problem.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

