### PR TITLE
[regression fix] Make project uniqueness constraint work again, fixes #136

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -102,7 +102,7 @@ func (app *DdevApp) Init(basePath string) error {
 	if err == nil {
 		containerApproot := web.Labels["com.ddev.approot"]
 		if containerApproot != app.AppRoot {
-			return fmt.Errorf("a web container in %s state already exists for %s that was created at %s", web.State, app.Name, containerApproot)
+			return fmt.Errorf("a project (web container) in %s state already exists for %s that was created at %s", web.State, app.Name, containerApproot)
 		}
 		return nil
 	} else if strings.Contains(err.Error(), "could not find containers") {
@@ -1071,7 +1071,7 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 	// We already were successful with *finding* the app, and if we get an
 	// incomplete one we have to add to it.
 	err = app.Init(activeAppRoot)
-	if err != nil && (strings.Contains(err.Error(), "is not a valid hostname") || strings.Contains(err.Error(), "is not a valid apptype") || strings.Contains(err.Error(), "config.yaml exists but cannot be read.") || strings.Contains(err.Error(), "web container in running state already exists")) {
+	if err != nil && (strings.Contains(err.Error(), "is not a valid hostname") || strings.Contains(err.Error(), "is not a valid apptype") || strings.Contains(err.Error(), "config.yaml exists but cannot be read.") || strings.Contains(err.Error(), "a project (web container) in ")) {
 		return app, err
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1071,7 +1071,7 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 	// We already were successful with *finding* the app, and if we get an
 	// incomplete one we have to add to it.
 	err = app.Init(activeAppRoot)
-	if err != nil && (strings.Contains(err.Error(), "is not a valid hostname") || strings.Contains(err.Error(), "is not a valid apptype") || strings.Contains(err.Error(), "config.yaml exists but cannot be read.")) {
+	if err != nil && (strings.Contains(err.Error(), "is not a valid hostname") || strings.Contains(err.Error(), "is not a valid apptype") || strings.Contains(err.Error(), "config.yaml exists but cannot be read.") || strings.Contains(err.Error(), "web container in running state already exists")) {
 		return app, err
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -228,8 +228,15 @@ func TestDdevStart(t *testing.T) {
 
 	err = app.Init(another.Dir)
 	assert.Error(err)
-	assert.Contains(err.Error(), fmt.Sprintf("container in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
+	assert.Contains(err.Error(), fmt.Sprintf("a project (web container) in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
+
+	// Make sure that GetActiveApp() also fails when trying to start app of duplicate name in current directory.
+	switchDir := another.Chdir()
+	app, err = ddevapp.GetActiveApp("")
+	assert.Error(err)
+	assert.Contains(err.Error(), fmt.Sprintf("a project (web container) in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
 	testcommon.CleanupDir(another.Dir)
+	switchDir()
 }
 
 // TestDdevStartMultipleHostnames tests start with multiple hostnames

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -232,7 +232,7 @@ func TestDdevStart(t *testing.T) {
 
 	// Make sure that GetActiveApp() also fails when trying to start app of duplicate name in current directory.
 	switchDir := another.Chdir()
-	app, err = ddevapp.GetActiveApp("")
+	_, err = ddevapp.GetActiveApp("")
 	assert.Error(err)
 	assert.Contains(err.Error(), fmt.Sprintf("a project (web container) in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
 	testcommon.CleanupDir(another.Dir)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -159,12 +159,14 @@ func Chdir(path string) func() {
 	curDir, _ := os.Getwd()
 	err := os.Chdir(path)
 	if err != nil {
+		// TODO: This should never Fatalf, as it terminates the process without test running finishing cleanup.
 		log.Fatalf("Could not change to directory %s: %v\n", path, err)
 	}
 
 	return func() {
 		err := os.Chdir(curDir)
 		if err != nil {
+			// TODO: This should never Fatalf, as it terminates the process without test running finishing cleanup.
 			log.Fatalf("Failed to change directory to original dir=%s, err=%v", curDir, err)
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#136: We had made running projects have to have unique names, but that got lost somewhere. This restores it.

This does not solve:
* Duplicate project name when one is not running
* One project taking over another project's database inappropriately (databases are uniquely named as well)
* Duplicated hostnames (across projects) breaking ddev-router. (Adding an additional_hostname to one project that is already taken by another)

## How this PR Solves The Problem:

Take seriously when the error says there's a duplicate site.

## Manual Testing Instructions:

Start a site.
In another directory, start a site with the same name. You should get a failure.

## Automated Testing Overview:

* The test for uniqueness was updated to catch this case. 

## Related Issue Link(s):

OP #136 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

