### PR TITLE
Allow environment variables to propagate into php-fpm

### DIFF
--- a/containers/nginx-php-fpm-local/Dockerfile.in
+++ b/containers/nginx-php-fpm-local/Dockerfile.in
@@ -100,7 +100,7 @@ RUN mkdir -p /etc/nginx/sites-enabled && \
 
 RUN chmod -R 777 /var/log
 
-RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules
+RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php
 # All users will have their home directory in /home, make it fully writeable
 RUN mkdir -p /home/.composer /home/.drush/commands && chmod 777 /home && chmod -R ugo+w /home/.composer /home/.drush
 

--- a/containers/nginx-php-fpm-local/files/etc/php/5.6/fpm/pool.d/www.conf
+++ b/containers/nginx-php-fpm-local/files/etc/php/5.6/fpm/pool.d/www.conf
@@ -368,7 +368,7 @@ catch_workers_output = yes
 ; Setting to "no" will make all environment variables available to PHP code
 ; via getenv(), $_ENV and $_SERVER.
 ; Default Value: yes
-;clear_env = no
+clear_env = no
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit

--- a/containers/nginx-php-fpm-local/files/etc/php/7.0/fpm/pool.d/www.conf
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.0/fpm/pool.d/www.conf
@@ -368,7 +368,7 @@ catch_workers_output = yes
 ; Setting to "no" will make all environment variables available to PHP code
 ; via getenv(), $_ENV and $_SERVER.
 ; Default Value: yes
-;clear_env = no
+clear_env = no
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit

--- a/containers/nginx-php-fpm-local/files/etc/php/7.1/fpm/pool.d/www.conf
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.1/fpm/pool.d/www.conf
@@ -368,7 +368,7 @@ catch_workers_output = yes
 ; Setting to "no" will make all environment variables available to PHP code
 ; via getenv(), $_ENV and $_SERVER.
 ; Default Value: yes
-;clear_env = no
+clear_env = no
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit

--- a/containers/nginx-php-fpm-local/files/etc/php/7.2/fpm/pool.d/www.conf
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.2/fpm/pool.d/www.conf
@@ -368,7 +368,7 @@ catch_workers_output = yes
 ; Setting to "no" will make all environment variables available to PHP code
 ; via getenv(), $_ENV and $_SERVER.
 ; Default Value: yes
-;clear_env = no
+clear_env = no
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20180515_fix_backup_migrate" // Note that this can be overridden by make
+var WebTag = "20180522_fpm_env_vars" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"


### PR DESCRIPTION
## The Problem/Issue/Bug:

TYPO3 users perpetually need to set environment variables in php-fpm, especially TYPO3_CONTEXT=Development.  We have a [Stack Overflow article](https://stackoverflow.com/questions/50109020/how-can-i-set-environment-variables-inside-ddevs-containers) on this, but it's not strictly correct, as fpm currently ignores environment variables that are set.

## How this PR Solves The Problem:

* Let fpm see the environment variables (clear_env = no in fpm config)
* Make fpm config writeable by ordinary user to make these options more available in general to non-root user.

## Manual Testing Instructions:

* Set an environment variable in the web container as in https://stackoverflow.com/questions/50109020/how-can-i-set-environment-variables-inside-ddevs-containers
* Verify the existence of the variable with `ddev ssh` and `echo $myvar`
* Verify the existence of the environment variable in an fpm session. 
    * Use a test.php file like this:
```
<?php
$env=getenv("TESTVAR");
echo "TESTVAR=$env";
```
     * Use a docker-compose.env.yaml like this:
```
version: "3"
services:
  web:
    environment:
      - TESTVAR="some test environment variable"
```

Hit /test.php and verify that the variable is shown.

## Automated Testing Overview:

Not adding anything for this at this time.

## Related Issue Link(s):

## Release/Deployment notes:

- [ ] The docker tag will have to be bumped at release time.
- [ ] Update Stack Overflow articles at release time.
