### PR TITLE
Add arg to build xz archive of ddev images, fixes #839

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,10 +124,8 @@ jobs:
 
       # We only build the xz version of the docker images on tag build.
       - run:
-          command: |
-            ./.circleci/generate_artifacts.sh $ARTIFACTS
-            xz $ARTIFACTS/ddev_docker_images.*.tar
-          name: tar/zip/xz up artifacts and make hashes
+          command: ./.circleci/generate_artifacts.sh $ARTIFACTS TRUE
+          name: tar/zip up artifacts and make hashes
           no_output_timeout: "40m"
 
       - store_artifacts:

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
+# This script builds ddev artifacts and their sha256 hashes.
+# First arg is the artifact directory
+# Optional second arg is whether to build xz version of ddev_docker_images.tar
 
 set -o errexit
 
 ARTIFACTS=$1
+# We only build the xz artifacts if $2 ($BUILD_XZ) is not empty.
+BUILD_XZ=$2
 BASE_DIR=$PWD
 
 sudo mkdir $ARTIFACTS && sudo chmod 777 $ARTIFACTS
@@ -15,6 +20,9 @@ for item in $(cat /tmp/images.txt); do
 done
 docker save -o $ARTIFACTS/ddev_docker_images.$VERSION.tar $(cat /tmp/images.txt)
 gzip --keep $ARTIFACTS/ddev_docker_images.$VERSION.tar
+if [ ! -z "$BUILD_XZ" ] ; then
+    xz $ARTIFACTS/ddev_docker_images.$VERSION.tar
+fi
 
 # Generate and place extra items like autocomplete
 bin/linux/ddev_gen_autocomplete


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #839 - the tag build didn't build ddev_docker_images.version.xz.sha256.txt

## How this PR Solves The Problem:

This moves the logic for doing that into the generate_artifacts script where it should have remained. And builds it.

## Manual Testing Instructions:

* Look at a tag build and see if the tar.xz and tar.xz.sha256.txt gets created. Hint: See [this tag build](https://circleci.com/gh/rfay/ddev/406#artifacts/containers/0)
* Look at a regular build and see that neither gets created. (For example, https://circleci.com/gh/rfay/ddev/409#artifacts/containers/0)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

