### PR TITLE
Add debugging in build.sh for running sites problem

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,10 @@ echo "Warning: deleting all docker containers and deleting ~/.ddev/Test*"
 if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
 	docker rm -f $(docker ps -aq)
 fi
+ddev list
+echo "Docker ps -a:"
+docker ps -a
+
 # Update all images that may have changed
 docker images |grep -v REPOSITORY | awk '{print $1":"$2 }' | xargs -L1 docker pull
 rm -rf ~/.ddev/Test*


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our windows build especially often fails on running tests (pkg tests require no projects running at all, which is a problem in its own right - #421, which is the whole problem with this.)

Example: https://gist.github.com/drud-test-machine-account/943c09556790ade2a7edbfc07bb6434b

## How this PR Solves The Problem:

Does a ddev list and docker ps to help us understand the failures we see.

Note that this PR affects *only* the macOS and Windows testbots, and nothing else, so it's pretty harmless. Just some debugging info.