### PR TITLE
Add linux deriving host.docker.internal, fixes #843

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -396,8 +396,8 @@ func (app *DdevApp) CheckCustomConfig() {
 func (app *DdevApp) RenderComposeYAML() (string, error) {
 	var doc bytes.Buffer
 	var err error
-	var docker0Addr string = "127.0.0.1"
-	var docker0Hostname string = "unneeded"
+	var docker0Addr = "127.0.0.1"
+	var docker0Hostname = "unneeded"
 	templ := template.New("compose template")
 	templ, err = templ.Parse(DDevComposeTemplate)
 	if err != nil {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -12,12 +12,14 @@ import (
 	"regexp"
 
 	"github.com/drud/ddev/pkg/appports"
+	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
+	"runtime"
 )
 
 // DefaultProviderName contains the name of the default provider which will be used if one is not otherwise specified.
@@ -394,10 +396,28 @@ func (app *DdevApp) CheckCustomConfig() {
 func (app *DdevApp) RenderComposeYAML() (string, error) {
 	var doc bytes.Buffer
 	var err error
+	var docker0Addr string = "127.0.0.1"
+	var docker0Hostname string = "unneeded"
 	templ := template.New("compose template")
 	templ, err = templ.Parse(DDevComposeTemplate)
 	if err != nil {
 		return "", err
+	}
+	// Docker 18.03 on linux doesn't define host.docker.internal
+	// so we need to go get the ip address of docker0
+	// We would hope to be able to remove this when
+	// https://github.com/docker/for-linux/issues/264 gets resolved.
+	if runtime.GOOS == "linux" {
+		out, err := exec.RunCommandPipe("ip", []string{"address", "show", "dev", "docker0"})
+		// Do not process if ip command fails, we'll just ignore and not act.
+		if err == nil {
+			addr := regexp.MustCompile(`inet *[0-9\.]+`).FindString(out)
+			components := strings.Split(addr, " ")
+			if len(components) == 2 {
+				docker0Addr = components[1]
+				docker0Hostname = "host.docker.internal"
+			}
+		}
 	}
 	templateVars := map[string]string{
 		"name":          app.Name,
@@ -407,6 +427,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		"dbaport":       appports.GetPort("dba"),
 		"dbport":        appports.GetPort("db"),
 		"ddevgenerated": DdevFileSignature,
+		"extra_host":    docker0Hostname + `:` + docker0Addr,
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -68,6 +68,7 @@ services:
       com.ddev.app-type: {{ .appType }}
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
+    extra_hosts: ["{{ .extra_host }}"]
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE


### PR DESCRIPTION
## The Problem/Issue/Bug:

Although the hostname "host.docker.internal" is defined and supported for Docker for Windows and Docker for Mac, it's not provided in the container on linux docker at this time. That breaks our approach to xdebug in v0.18.0, which worked great on the other situations.

## How this PR Solves The Problem:

On linux, use `ip address show dev docker0` to get the IP address, then add the address to `extra hosts`.

Note that this is a bit awkward, and a throwaway address is used on non-linux. This is because golang templating by default escapes the required quotes, breaking yaml :(  There are workarounds for it, but it's a bit of work (You have to treat things as HTML attributes instead of as strings in the golang templating.)

## Manual Testing Instructions:

xdebug instructions should work for Linux, Mac, and Windows as shown in [our docs](https://ddev.readthedocs.io/en/latest/users/step-debugging/)

## Automated Testing Overview:

I haven't added a test for this.

## Related Issue Link(s):

The problem was introduced in https://github.com/drud/ddev/pull/785

## Release/Deployment notes:

- [ ] Update Stack Overflow article with Linux fix on release.
- [ ] When Docker for Linux is fixed, remove this code.
