### PR TITLE
Safely get global ddev directory, fixes #806

### DIFF
--- a/cmd/ddev/cmd/auth_pantheon.go
+++ b/cmd/ddev/cmd/auth_pantheon.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/go-pantheon/pkg/pantheon"
-	gohomedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
@@ -22,12 +21,12 @@ var PantheonAuthCommand = &cobra.Command{
 		if len(args) != 1 {
 			util.Failed("Too many arguments detected. Please provide only your Pantheon Machine token., e.g. 'ddev auth-pantheon [token]'. See https://pantheon.io/docs/machine-tokens/ for instructions on creating a token.")
 		}
-		userDir, err := gohomedir.Dir()
-		util.CheckErr(err)
-		sessionLocation := filepath.Join(userDir, ".ddev", "pantheonconfig.json")
+
+		ddevDir := util.GetGlobalDdevDir()
+		sessionLocation := filepath.Join(ddevDir, "pantheonconfig.json")
 
 		session := pantheon.NewAuthSession(args[0])
-		err = session.Auth()
+		err := session.Auth()
 		if err != nil {
 			util.Failed("Could not authenticate with pantheon: %v", err)
 		}

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -9,8 +9,6 @@ import (
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
-	gohomedir "github.com/mitchellh/go-homedir"
-
 	"fmt"
 
 	"github.com/drud/go-pantheon/pkg/pantheon"
@@ -133,9 +131,9 @@ func (p *PantheonProvider) prepDownloadDir() {
 }
 
 func (p *PantheonProvider) getDownloadDir() string {
-	userDir, err := gohomedir.Dir()
-	util.CheckErr(err)
-	destDir := filepath.Join(userDir, ".ddev", "pantheon", p.app.Name)
+	ddevDir := util.GetGlobalDdevDir()
+	destDir := filepath.Join(ddevDir, "pantheon", p.app.Name)
+
 	return destDir
 }
 
@@ -304,15 +302,14 @@ func findPantheonSite(name string) (pantheon.Site, error) {
 
 // getPantheonSession loads the pantheon API config from disk and returns a pantheon session struct.
 func getPantheonSession() *pantheon.AuthSession {
-	userDir, err := gohomedir.Dir()
-	util.CheckErr(err)
-	sessionLocation := filepath.Join(userDir, ".ddev", "pantheonconfig.json")
+	ddevDir := util.GetGlobalDdevDir()
+	sessionLocation := filepath.Join(ddevDir, "pantheonconfig.json")
 
 	// Generate a session object based on the DDEV_PANTHEON_API_TOKEN environment var.
 	session := &pantheon.AuthSession{}
 
 	// Read a previously saved session.
-	err = session.Read(sessionLocation)
+	err := session.Read(sessionLocation)
 
 	if err != nil {
 		// If we can't read a previous session fall back to using the API token.

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"fmt"
+
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
-	"fmt"
 
 	"github.com/drud/go-pantheon/pkg/pantheon"
 	"gopkg.in/yaml.v2"


### PR DESCRIPTION
## The Problem/Issue/Bug:
In some situations, `ddev` would assume that the global ddev directory (`~/.ddev`) already existed, causing problems if this wasn't true -- for example, by running `ddev auth-pantheon` before `ddev config` as in #806.

## How this PR Solves The Problem:
These changes replace ad-hoc global ddev directory path building with the `GetGlobalDdevDir()` command, which will ensure that the global ddev directory exists before operating on/in it.

## Manual Testing Instructions:
- Ensure the test system does not have a `~/.ddev` directory (`mv ~/.ddev ~/.ddev.bak`)
- Execute `ddev auth-pantheon $TOKEN` where $TOKEN is a Pantheon Machine Token
- The command will execute successfully
- Command execution will have created the missing `~/.ddev` directory

## Related Issue Link(s):
#806 
