### PR TITLE
Fix bash completion filename in CLI docs, fixes #881

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -405,4 +405,4 @@ To remove the imported database for a project, use the flag `--remove-data`, as 
 
 ## ddev Command Auto-Completion
 
-Bash auto-completion is available for ddev. Bash auto-completion is included in the homebrew install on macOS. For other platforms, download the [latest ddev release](https://github.com/drud/ddev/releases) tarball and locate the ddev_bash_completions.sh inside it. This can be installed wherever your bash_completions.d is. For example, `cp ddev_bash_completions.sh /etc/bash_completion.d/ddev`.
+Bash auto-completion is available for ddev. Bash auto-completion is included in the homebrew install on macOS. For other platforms, download the [latest ddev release](https://github.com/drud/ddev/releases) tarball and locate `ddev_bash_completion.sh` inside it. This can be installed wherever your bash_completions.d is. For example, `cp ddev_bash_completion.sh /etc/bash_completion.d/ddev`.


### PR DESCRIPTION
## The Problem/Issue/Bug:
The docs reference `ddev_bash_completions.sh`, but the actual filename has no 's', it's `ddev_bash_completion.sh`

## How this PR Solves The Problem:
Removes the 's'.

## Manual Testing Instructions:
Build docs, read bash completion section.

## Automated Testing Overview:
N/A - Docs update only.

## Related Issue Link(s):
Fixes #881 

## Release/Deployment notes:
N/A - Docs update only.

