### PR TITLE
Include direct web container access in GetAllURLs(), resolves #796

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -950,7 +950,7 @@ func (app *DdevApp) GetAllURLs() []string {
 	} else {
 		for _, p := range webContainer.Ports {
 			if p.PrivatePort == 80 {
-				URLs = append(URLs, fmt.Sprintf("http://%s:%d", "127.0.0.1", p.PublicPort))
+				URLs = append(URLs, fmt.Sprintf("http://%s:%d", p.IP, p.PublicPort))
 				break
 			}
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -946,13 +946,9 @@ func (app *DdevApp) GetAllURLs() []string {
 
 	webContainer, err := app.FindContainerByType("web")
 	if err != nil {
-		util.Error("Unable to find web container for app %s: %s", app.Name, err)
+		util.Error("Unable to find web container for app: %s, err %s", app.Name, err)
 	} else {
 		for _, p := range webContainer.Ports {
-			// TODO: Remove
-			fmt.Printf("%s %s %d %d\n", p.Type, p.IP, p.PublicPort, p.PrivatePort)
-
-			// TODO: Always private port 80?
 			if p.PrivatePort == 80 {
 				URLs = append(URLs, fmt.Sprintf("http://%s:%d", p.IP, p.PublicPort))
 			}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -950,7 +950,7 @@ func (app *DdevApp) GetAllURLs() []string {
 	} else {
 		for _, p := range webContainer.Ports {
 			if p.PrivatePort == 80 {
-				URLs = append(URLs, fmt.Sprintf("http://%s:%d", p.IP, p.PublicPort))
+				URLs = append(URLs, fmt.Sprintf("http://%s:%d", "127.0.0.1", p.PublicPort))
 				break
 			}
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -975,7 +975,7 @@ func (app *DdevApp) HostName() string {
 func (app *DdevApp) AddHostsEntries() error {
 	dockerIP, err := dockerutil.GetDockerIP()
 	if err != nil {
-		return fmt.Errorf("could not get Docker IP: %s", err)
+		return fmt.Errorf("could not get Docker IP: %v", err)
 	}
 
 	hosts, err := goodhosts.NewHosts()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -944,15 +944,21 @@ func (app *DdevApp) GetAllURLs() []string {
 	}
 
 	dockerIP, err := dockerutil.GetDockerIP()
+	if err != nil {
+		util.Error("Unable to get Docker IP: %s", err)
+		return URLs
+	}
+
 	webContainer, err := app.FindContainerByType("web")
 	if err != nil {
 		util.Error("Unable to find web container for app: %s, err %s", app.Name, err)
-	} else {
-		for _, p := range webContainer.Ports {
-			if p.PrivatePort == 80 {
-				URLs = append(URLs, fmt.Sprintf("http://%s:%d", dockerIP, p.PublicPort))
-				break
-			}
+		return URLs
+	}
+
+	for _, p := range webContainer.Ports {
+		if p.PrivatePort == 80 {
+			URLs = append(URLs, fmt.Sprintf("http://%s:%d", dockerIP, p.PublicPort))
+			break
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -943,15 +943,16 @@ func (app *DdevApp) GetAllURLs() []string {
 		URLs = append(URLs, "http://"+name+httpPort, "https://"+name+httpsPort)
 	}
 
+	// Get direct address of web container
 	dockerIP, err := dockerutil.GetDockerIP()
 	if err != nil {
-		util.Error("Unable to get Docker IP: %s", err)
+		util.Error("Unable to get Docker IP: %v", err)
 		return URLs
 	}
 
 	webContainer, err := app.FindContainerByType("web")
 	if err != nil {
-		util.Error("Unable to find web container for app: %s, err %s", app.Name, err)
+		util.Error("Unable to find web container for app: %s, err %v", app.Name, err)
 		return URLs
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -951,6 +951,7 @@ func (app *DdevApp) GetAllURLs() []string {
 		for _, p := range webContainer.Ports {
 			if p.PrivatePort == 80 {
 				URLs = append(URLs, fmt.Sprintf("http://%s:%d", p.IP, p.PublicPort))
+				break
 			}
 		}
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -393,7 +393,7 @@ func GetDockerIP() (string, error) {
 	if dockerHostRawURL != "" {
 		dockerHostURL, err := url.Parse(dockerHostRawURL)
 		if err != nil {
-			return dockerIP, fmt.Errorf("failed to parse $DOCKER_HOST: %v, err: %v", dockerHostRawURL, err)
+			return "", fmt.Errorf("failed to parse $DOCKER_HOST: %v, err: %v", dockerHostRawURL, err)
 		}
 
 		dockerIP = dockerHostURL.Hostname()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"net/url"
+
 	"github.com/Masterminds/semver"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
@@ -381,4 +383,21 @@ func CheckForHTTPS(container docker.APIContainers) bool {
 		return true
 	}
 	return false
+}
+
+// GetDockerIP returns either the default Docker IP address (127.0.0.1)
+// or the value as configured by $DOCKER_HOST,
+func GetDockerIP() (string, error) {
+	dockerIP := "127.0.0.1"
+	dockerHostRawURL := os.Getenv("DOCKER_HOST")
+	if dockerHostRawURL != "" {
+		dockerHostURL, err := url.Parse(dockerHostRawURL)
+		if err != nil {
+			return dockerIP, fmt.Errorf("failed to parse $DOCKER_HOST: %v, err: %v", dockerHostRawURL, err)
+		}
+
+		dockerIP = dockerHostURL.Hostname()
+	}
+
+	return dockerIP, nil
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -386,7 +386,7 @@ func CheckForHTTPS(container docker.APIContainers) bool {
 }
 
 // GetDockerIP returns either the default Docker IP address (127.0.0.1)
-// or the value as configured by $DOCKER_HOST,
+// or the value as configured by $DOCKER_HOST.
 func GetDockerIP() (string, error) {
 	dockerIP := "127.0.0.1"
 	dockerHostRawURL := os.Getenv("DOCKER_HOST")


### PR DESCRIPTION
## The Problem/Issue/Bug:
In order to access a project's web container directly, a user would need to know how to obtain the container's ephemeral port via a command like `docker ps`.

## How this PR Solves The Problem:
This PR adds code that queries the project's web container for its public ephemeral port and local IP, returning this direct address at the end of the URLs list presented in `ddev describe`. A user can find this address without any Docker knowledge and access this address to interact directly with the web container, bypassing the ddev router.

## Manual Testing Instructions:
- `ddev start` a project 
- Execute `ddev describe` within the project
- The last address in the URLs list under Project Information should be in the format `http://<ip>:<port>`
- Visit this direct address and interact with the site, bypassing the ddev router

## Automated Testing Overview:
A basic test (`TestGetAllURLs()`) was added to ensure the direct web container address is returned.

## Related Issue Link(s):
#796 