### PR TITLE
Include direct web container access in GetAllURLs(), resolves #796

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"net/url"
+
 	"github.com/Masterminds/semver"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
@@ -381,4 +383,21 @@ func CheckForHTTPS(container docker.APIContainers) bool {
 		return true
 	}
 	return false
+}
+
+// GetDockerIP returns either the default Docker IP address (127.0.0.1)
+// or the value as configured by $DOCKER_HOST.
+func GetDockerIP() (string, error) {
+	dockerIP := "127.0.0.1"
+	dockerHostRawURL := os.Getenv("DOCKER_HOST")
+	if dockerHostRawURL != "" {
+		dockerHostURL, err := url.Parse(dockerHostRawURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse $DOCKER_HOST: %v, err: %v", dockerHostRawURL, err)
+		}
+
+		dockerIP = dockerHostURL.Hostname()
+	}
+
+	return dockerIP, nil
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
In order to access a project's web container directly, a user would need to know how to obtain the container's ephemeral port via a command like `docker ps`.

## How this PR Solves The Problem:
This PR adds code that queries the project's web container for its public ephemeral port and local IP, returning this direct address at the end of the URLs list presented in `ddev describe`. A user can find this address without any Docker knowledge and access this address to interact directly with the web container, bypassing the ddev router.

## Manual Testing Instructions:
- `ddev start` a project 
- Execute `ddev describe` within the project
- The last address in the URLs list under Project Information should be in the format `http://<ip>:<port>`
- Visit this direct address and interact with the site, bypassing the ddev router

## Automated Testing Overview:
A basic `TestGetAllURLs()` was added to `ddevapp_test.go`, which ensures `GetAllURLs()` returns the expected number of URLs, including the direct address of the web container.

## Related Issue Link(s):
#796 