### PR TITLE
If a ddev-local specific config file exists, include it.

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -60,6 +60,11 @@ ini_set('session.gc_probability', 1);
 ini_set('session.gc_divisor', 100);
 ini_set('session.gc_maxlifetime', 200000);
 ini_set('session.cookie_lifetime', 2000000);
+
+// Include local settings if it exists.
+if (file_exists(__DIR__ . '/settings.ddev-local.php')) {
+	require_once __DIR__ . '/settings.ddev-local.php';
+}
 `
 
 // createBackdropSettingsFile creates the app's settings.php or equivalent,

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -95,6 +95,11 @@ $settings['file_scan_ignore_directories'] = [
 if (!empty($_SERVER["argv"]) && strpos($_SERVER["argv"][0], "drush") && empty($_ENV['DEPLOY_NAME'])) {
   include __DIR__ . '../../../drush.settings.php';
 }
+
+// Include local settings if it exists.
+if (file_exists(__DIR__ . '/settings.ddev-local.php')) {
+	require_once __DIR__ . '/settings.ddev-local.php';
+}
 `
 )
 
@@ -128,6 +133,11 @@ $drupal_hash_salt = '{{ $config.HashSalt }}';
 if (!empty($_SERVER["argv"]) && strpos($_SERVER["argv"][0], "drush") && empty($_ENV['DEPLOY_NAME'])) {
   include __DIR__ . '../../../drush.settings.php';
 }
+
+// Include local settings if it exists.
+if (file_exists(__DIR__ . '/settings.ddev-local.php')) {
+	require_once __DIR__ . '/settings.ddev-local.php';
+}
 `
 )
 
@@ -150,6 +160,11 @@ ini_set('session.cookie_lifetime', 2000000);
 // it to work both within a docker container and natively on the host system.
 if (!empty($_SERVER["argv"]) && strpos($_SERVER["argv"][0], "drush") && empty($_ENV['DEPLOY_NAME'])) {
   include __DIR__ . '../../../drush.settings.php';
+}
+
+// Include local settings if it exists.
+if (file_exists(__DIR__ . '/settings.ddev-local.php')) {
+	require_once __DIR__ . '/settings.ddev-local.php';
 }
 `
 )

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -24,7 +24,13 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($GLOBA
                     'password' => 'db',
                     'port' => '3306',
                     'user' => 'db',
-]);`
+]);
+
+// Include local settings if it exists.
+if (file_exists(__DIR__ . '/LocalConfigurationDdev.php')) {
+	require_once __DIR__ . '/LocalConfigurationDdev.php';
+}
+`
 
 // createTypo3SettingsFile creates the app's LocalConfiguration.php and
 // AdditionalConfiguration.php, adding things like database host, name, and

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -134,6 +134,11 @@ included again if this file is written to wp-config-local.php.
 if (basename(__FILE__) == "wp-config.php") {
 	require_once(ABSPATH . '/wp-settings.php');
 }
+
+// Include local settings if it exists.
+if (file_exists(__DIR__ . '/wp-config-ddev-local.php')) {
+	require_once __DIR__ . '/wp-config-ddev-local.php';
+}
 `
 )
 

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -78,24 +78,35 @@ const (
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
 
+// Include local settings if it exists.
+if (file_exists(__DIR__ . '/wp-config-ddev-local.php')) {
+	require_once __DIR__ . '/wp-config-ddev-local.php';
+}
+
 // ** MySQL settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */
-define('DB_NAME', '{{ $config.DatabaseName }}');
+if ( !defined('DB_NAME') )
+	define('DB_NAME', '{{ $config.DatabaseName }}');
 
 /** MySQL database username */
-define('DB_USER', '{{ $config.DatabaseUsername }}');
+if ( !defined('DB_USER') )
+	define('DB_USER', '{{ $config.DatabaseUsername }}');
 
 /** MySQL database password */
-define('DB_PASSWORD', '{{ $config.DatabasePassword }}');
+if ( !defined('DB_PASSWORD') )
+	define('DB_PASSWORD', '{{ $config.DatabasePassword }}');
 
 /** MySQL hostname */
-define('DB_HOST', '{{ $config.DatabaseHost }}');
+if ( !defined('DB_HOST') )
+	define('DB_HOST', '{{ $config.DatabaseHost }}');
 
 /** Database Charset to use in creating database tables. */
-define('DB_CHARSET', 'utf8mb4');
+if ( !defined('DB_CHARSET') )
+	define('DB_CHARSET', 'utf8mb4');
 
 /** The Database Collate type. Don't change this if in doubt. */
-define('DB_COLLATE', '');
+if ( !defined('DB_COLLATE') )
+	define('DB_COLLATE', '');
 
 /**
  * WordPress Database Table prefix.
@@ -105,7 +116,8 @@ $table_prefix  = '{{ $config.TablePrefix }}';
 /**
  * For developers: WordPress debugging mode.
  */
-define('WP_DEBUG', false);
+if ( !defined('WP_DEBUG') )
+	define('WP_DEBUG', false);
 
 /**#@+
  * Authentication Unique Keys and Salts.
@@ -133,11 +145,6 @@ included again if this file is written to wp-config-local.php.
 */
 if (basename(__FILE__) == "wp-config.php") {
 	require_once(ABSPATH . '/wp-settings.php');
-}
-
-// Include local settings if it exists.
-if (file_exists(__DIR__ . '/wp-config-ddev-local.php')) {
-	require_once __DIR__ . '/wp-config-ddev-local.php';
 }
 `
 )


### PR DESCRIPTION
## The Problem/Issue/Bug:

We need a place where users can reliably put ddev-local related configuration for their applications.

## How this PR Solves The Problem:

If settings.ddev-local.php, wp-config-ddev-local.php, or LocalConfigurationDdev.php exist (for Backdrop/Drupal, Wordpress, and Typo3 respectively), we'll require it.

## Manual Testing Instructions:

Spin up a vanilla site, create one of the files mentioned above and put something simple in it (for instance, just `<?php die('file was included');` should verify that the file is included properly), and then hit any page on the site.

This should only happen if ddev generated the config file.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

