### PR TITLE
Bump container versions to planned v0.19.0 for release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,25 +20,25 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20180522_fpm_env_vars" // Note that this can be overridden by make
+var WebTag = "v0.19.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "20180530_remove_max_allowed_packet" // Note that this may be overridden by make
+var DBTag = "v0.19.0" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "v0.2.0" // Note that this can be overridden by make
+var DBATag = "v0.19.0" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.18.0-11-gd6cb228c" // Note that this can be overridden by make
+var RouterTag = "v0.19.0" // Note that this can be overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our container code is now part of the main code tree, so during development we used temporary pushed container.

Now, though, we're about to do a release with the code in our containers. But we want to be able to test and reference the new containers (all tagged v0.19.0 on dockerhub) at the time of the tag.

To do that we have to temporarily push v0.19.0 containers, so I've just done that with the current code.

## Manual Testing Instructions:

Use it, look at the tests.

## Release/Deployment notes:

The 4 containers should be re-pushed at tag time.
