### PR TITLE
Fix Slack channel formatting and add link to ddev releases page, fixes #899

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you're having trouble using ddev, please use these resources to get help:
 2. Review [Stack Overflow DDEV-Local questions and answers](https://stackoverflow.com/tags/ddev) (or ask a question there! We get notified when you ask.)
 3. The [ddev issue queue](https://github.com/drud/ddev/issues) may have an issue related to your problem.
 4. For suspected bugs or feature requests, [file an issue](https://github.com/drud/ddev/issues/new).
-5. #ddev channel in [Drupal Slack](https://drupal.slack.com/messages/C5TQRQZRR) and [TYPO3 Slack](https://typo3.slack.com/messages/C8TRNQ601) for interactive, immediate community support
+5. The `#ddev` channel in [Drupal Slack](https://drupal.slack.com/messages/C5TQRQZRR) and [TYPO3 Slack](https://typo3.slack.com/messages/C8TRNQ601) for interactive, immediate community support
 
 
 ## Contributing

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Note that third party packaging is encouraged, but only supported on a best-effo
 
 ### Installation or Upgrade - Windows
 
-- A windows installer is provided in the release (`ddev_windows_installer.<version>.exe`). Run that and it will do the full installation for you. If you get a Windows Defender Smartscreen warning "Windows protected your PC", click "More info" and then "Run anyway". Open a new terminal or cmd window and start using ddev.
+- A windows installer is provided in each [ddev release](https://github.com/drud/ddev/releases) (`ddev_windows_installer.<version>.exe`). Run that and it will do the full installation for you. If you get a Windows Defender Smartscreen warning "Windows protected your PC", click "More info" and then "Run anyway". Open a new terminal or cmd window and start using ddev.
 
 ### Versioning
 
@@ -72,4 +72,4 @@ The DDEV project is committed to supporting [Semantic Version 2.0.0](https://sem
 - [ddev Documentation](https://ddev.readthedocs.io)
 - [ddev StackOverflow](https://stackoverflow.com/questions/tagged/ddev) for support and frequently asked questions
 - [ddev issue queue](https://github.com/drud/ddev/issues) for bugs and feature requests
-- #ddev channel in [Drupal Slack](https://drupal.slack.com/messages/C5TQRQZRR) and [TYPO3 Slack](https://typo3.slack.com/messages/C8TRNQ601) for interactive, immediate community support
+- The `#ddev` channel in [Drupal Slack](https://drupal.slack.com/messages/C5TQRQZRR) and [TYPO3 Slack](https://typo3.slack.com/messages/C8TRNQ601) for interactive, immediate community support


### PR DESCRIPTION
## The Problem/Issue/Bug:
The `#` in the Markdown sections discussing `#ddev` community Slack channels caused broken formatting and the Installation page had no link to where a user could find the Windows installer .exe.

## How this PR Solves The Problem:
This PR correctly handles the `#` character in Slack channel names and adds a link to the Github releases page, where a Windows installer can be downloaded.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#899 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

