### PR TITLE
Create typo3conf/ if it doesn't exist, fixes #741

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -62,7 +62,7 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	dir := filepath.Dir(filePath)
 	var perms os.FileMode = 0755
 	if err := os.Chmod(dir, perms); err != nil {
-		if os.IsExist(err) {
+		if !os.IsNotExist(err) {
 			// The directory exists, but chmod failed.
 			return err
 		}

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"os"
+	"path/filepath"
+
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
-	"os"
-	"path/filepath"
 )
 
 const typo3AdditionalConfigTemplate = `<?php
@@ -55,10 +56,18 @@ func createTypo3SettingsFile(app *DdevApp) (string, error) {
 func writeTypo3SettingsFile(app *DdevApp) error {
 
 	filePath := app.SiteLocalSettingsPath
+	var perms os.FileMode = 0755
+
+	// Ensure target directory exists.
+	dir := filepath.Dir(filePath)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.Mkdir(dir, perms); err != nil {
+			return err
+		}
+	}
 
 	// Ensure target directory is writable.
-	dir := filepath.Dir(filePath)
-	err := os.Chmod(dir, 0755)
+	err := os.Chmod(dir, perms)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -51,8 +51,9 @@ func createTypo3SettingsFile(app *DdevApp) (string, error) {
 }
 
 // writeTypo3SettingsFile produces AdditionalConfiguration.php file
-// It's assumed that the LocalConfiguration.php must already exist, and we're
-// overriding the db config values in it.
+// It's assumed that the LocalConfiguration.php already exists, and we're
+// overriding the db config values in it. The typo3conf/ directory will
+// be created if it does not yet exist.
 func writeTypo3SettingsFile(app *DdevApp) error {
 
 	filePath := app.SiteLocalSettingsPath

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -57,20 +57,20 @@ func createTypo3SettingsFile(app *DdevApp) (string, error) {
 func writeTypo3SettingsFile(app *DdevApp) error {
 
 	filePath := app.SiteLocalSettingsPath
-	var perms os.FileMode = 0755
 
-	// Ensure target directory exists.
+	// Ensure target directory is writable.
 	dir := filepath.Dir(filePath)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
+	var perms os.FileMode = 0755
+	if err := os.Chmod(dir, perms); err != nil {
+		if os.IsExist(err) {
+			// The directory exists, but chmod failed.
+			return err
+		}
+
+		// The directory doesn't exist, create it with the appropriate permissions.
 		if err := os.Mkdir(dir, perms); err != nil {
 			return err
 		}
-	}
-
-	// Ensure target directory is writable.
-	err := os.Chmod(dir, perms)
-	if err != nil {
-		return err
 	}
 
 	file, err := os.Create(filePath)


### PR DESCRIPTION
## The Problem/Issue/Bug:
Previously, `ddev config` would fail to write `AdditionalConfig.php` if TYPO3 was not set up (specifically, the `typo3conf` directory did not exist).

## How this PR Solves The Problem:
This change will allow `ddev config` to create the `typo3conf` directory in order to write `typo3conf/AdditionalConfiguration.php`, even if TYPO3 has not been set up yet.

## Manual Testing Instructions:
Recreate the issue by executing `ddev config` with `ddev version` v0.19.0:
- `cd` to a new TYPO3 project
- Ensure no `typo3conf/` directory exists in the project root
- `ddev config`
- Note the error message: 
`Unable to create settings file: Failed to write TYPO3 AdditionalConfiguration.php file: chmod /Users/afrench/Code/typo3.cms/typo3conf: no such file or directory`

To test the fix, build this version of `ddev` and execute `ddev config`:
- `cd` to a new TYPO3 project
-  Ensure no `typo3conf/` directory exists in the project root
- `ddev config`
- No `Unable to create settings file` error message was printed
- Ensure `typo3conf/AdditionalConfiguration.php` has been created
- Continue the TYPO3 setup process and ensure `typo3conf/LocalConfiguration.php` is created 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#741 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

