### PR TITLE
Add rsync to nginx-php-fpm-local, fixes #867

### DIFF
--- a/containers/nginx-php-fpm-local/Dockerfile.in
+++ b/containers/nginx-php-fpm-local/Dockerfile.in
@@ -23,7 +23,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV NGINX_SITE_VARS '$NGINX_DOCROOT'
 
 RUN apt-get -qq update && \
-	apt-get -qq install --no-install-recommends --no-install-suggests -y \
+    apt-get -qq install --no-install-recommends --no-install-suggests -y \
         procps \
         curl \
         ca-certificates \
@@ -40,8 +40,8 @@ RUN apt-get -qq update && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list && \
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-	apt-get -qq update && \
-	apt-get -qq install --no-install-recommends --no-install-suggests -y \
+    apt-get -qq update && \
+    apt-get -qq install --no-install-recommends --no-install-suggests -y \
         less \
         git \
         mysql-client \
@@ -56,19 +56,20 @@ RUN apt-get -qq update && \
         telnet \
         netcat6 \
         iproute2 \
-		vim \
-		nano \
-		gettext \
-		ncurses-bin \
-		yarn \
-		zip \
-		unzip \
-		libpcre3 && \
-	for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring  $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
-	for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
+        vim \
+        nano \
+        gettext \
+        ncurses-bin \
+        yarn \
+        zip \
+        unzip \
+        rsync \
+        libpcre3 && \
+    for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring  $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
+    for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
-	rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 # Arbitrary user needs to be able to bind to privileged ports (for nginx)
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/nginx


### PR DESCRIPTION
## The Problem/Issue/Bug:

#867 requests rsync be added to the web container, and it's an easy fix. 

This was also done in PR #909, but the contributor didn't sign the CLA, and I didn't want it to go stale, so adding here and closing that one.

I also reformatted this to use spaces for indents, as it was a mix of spaces and tabs before. The only logic change is one line, adding rsync to the list of packages.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

