### PR TITLE
Fix broken containers resulting from CRs in scripts

### DIFF
--- a/.buildkite/test_containers.sh
+++ b/.buildkite/test_containers.sh
@@ -7,6 +7,14 @@ set -o pipefail
 set -o nounset
 set -x
 
+# Make sure we don't have any existing containers on the testbot that might
+# result in this container not being built from scratch.
+VERSION=$(make version | sed 's/^VERSION://')
+IMAGES=$(docker images | awk "/$VERSION/ { print \$3 }")
+if [ ! -z "$IMAGES" ] ; then
+  docker rmi --force $IMAGES
+fi
+
 for dir in containers/*
     do pushd $dir
     time make test

--- a/containers/.gitattributes
+++ b/containers/.gitattributes
@@ -1,2 +1,0 @@
-# Shell scripts must be checked out binary for use in containers
-*.sh -diff


### PR DESCRIPTION
## The Problem/Issue/Bug:

In https://github.com/drud/ddev/pull/902 I deliberately let slide test failures on Windows of the containers. This is to fix that. Hopefully getting buildkite to check out as-on-server, with linefeeds and no CRs will solve that problem.  

## How this PR Solves The Problem:

I *think* the largest part of the problem was that Windows agents have to check out at least the container stuff with core.autocrlf=false, so we have shell scripts that don't have CRs in them. This meant a change in the Windows *agent* testbots:

`git-clone-flags="-v --config core.autocrlf=false"`

And that was the most important change.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

