### PR TITLE
Improve reliability with a more unique tmpdir and outdir

### DIFF
--- a/containers/mariadb-local/test/testserver.sh
+++ b/containers/mariadb-local/test/testserver.sh
@@ -6,7 +6,7 @@ IMAGE="$1"  # Full image name with tag
 MYSQL_VERSION="$2"
 CONTAINER_NAME="testserver"
 HOSTPORT=33000
-MYTMPDIR=~/tmp/testserver-sh_$$
+MYTMPDIR=~"/tmp/testserver-sh_${SECONDS}_$$"
 
 # Always clean up the container on exit.
 function cleanup {
@@ -106,7 +106,7 @@ cleanup
 
 # Test that the create_base_db.sh script can create a starter tarball.
 # This one runs as root, and ruins the underlying host mount on linux (makes it owned by root)
-outdir=~/tmp/mariadb_testserver/output_$$
+outdir="~/tmp/mariadb_testserver/output_${SECONDS}_$$"
 mkdir -p $outdir
 docker run -t -v "/$outdir://mysqlbase" --rm --entrypoint=//create_base_db.sh $IMAGE
 if [ ! -f "$outdir/mariadb_10.1_base_db.tgz" ] ; then

--- a/containers/mariadb-local/test/testserver.sh
+++ b/containers/mariadb-local/test/testserver.sh
@@ -39,7 +39,7 @@ mkdir -p "$MYTMPDIR"
 rm -rf $MYTMPDIR/*
 
 echo "Starting image with database image $IMAGE"
-if ! docker run -u "$(id -u):$(id -g)" -v "/${MYTMPDIR}:/var/lib/mysql" --name="$CONTAINER_NAME" -p "$HOSTPORT:3306" -d $IMAGE; then
+if ! docker run -u "$(id -u):$(id -g)" -v /$MYTMPDIR:/var/lib/mysql --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
 	echo "MySQL server start failed with error code $?"
 	exit 2
 fi
@@ -86,7 +86,7 @@ mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$H
 cleanup
 
 # Run with alternate configuration my.cnf mounted
-if ! docker run -u "$(id -u):$(id -g)" -v "/${MYTMPDIR}:/var/lib/mysql" -v "/${PWD}/test/testdata:/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
+if ! docker run -u "$(id -u):$(id -g)" -v /$MYTMPDIR:/var/lib/mysql -v /$PWD/test/testdata:/mnt/ddev_config --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
 	echo "MySQL server start failed with error code $?"
 	exit 3
 fi
@@ -113,7 +113,7 @@ if [ ! -f "$outdir/mariadb_10.1_base_db.tgz" ] ; then
   echo "Failed to build test starter tarball for mariadb."
   exit 4
 fi
-rm -rf $outdir ${MYTMPDIR}
+rm -rf $outdir $MYTMPDIR
 
 echo "Tests passed"
 exit 0

--- a/containers/mariadb-local/test/testserver.sh
+++ b/containers/mariadb-local/test/testserver.sh
@@ -108,7 +108,7 @@ cleanup
 # This one runs as root, and ruins the underlying host mount on linux (makes it owned by root)
 outdir="${HOME}/tmp/mariadb_testserver/output_${RANDOM}_$$"
 mkdir -p $outdir
-docker run -t -v "$outdir://mysqlbase" --rm --entrypoint=//create_base_db.sh $IMAGE
+docker run -t -v "/$outdir://mysqlbase" --rm --entrypoint=//create_base_db.sh $IMAGE
 if [ ! -f "$outdir/mariadb_10.1_base_db.tgz" ] ; then
   echo "Failed to build test starter tarball for mariadb."
   exit 4


### PR DESCRIPTION
## The Problem/Issue/Bug:

Working on reliability issues with the container build I noted possible collisions of the directory we're using, so added $SECONDS to the tmp directory name maker. We'd be better to use TMPDIR, but that provides an unusable directory on macOS.

## How this PR Solves The Problem:

Improve tmp directory name; should not do any harm.

