### PR TITLE
Improve Drupal 6/7/8 file permissions, fixes #715

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -654,6 +654,11 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
+	err = app.PostStartAction()
+	if err != nil {
+		return err
+	}
+
 	err = app.ProcessHooks("post-start")
 	if err != nil {
 		return err

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -93,7 +93,7 @@ $settings['file_scan_ignore_directories'] = [
 // This will prevent Drupal from setting read-only permissions on sites/default.
 $settings['skip_permissions_hardening'] = TRUE;
 
-// This is super ugly but it determines whether or not drush should include a custom settings file which allows
+// This determines whether or not drush should include a custom settings file which allows
 // it to work both within a docker container and natively on the host system.
 if (!empty($_SERVER["argv"]) && strpos($_SERVER["argv"][0], "drush") && empty($_ENV['DEPLOY_NAME'])) {
   include __DIR__ . '../../../drush.settings.php';

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -126,7 +126,7 @@ ini_set('session.cookie_lifetime', 2000000);
 
 $drupal_hash_salt = '{{ $config.HashSalt }}';
 
-// This is super ugly but it determines whether or not drush should include a custom settings file which allows
+// This determines whether or not drush should include a custom settings file which allows
 // it to work both within a docker container and natively on the host system.
 if (!empty($_SERVER["argv"]) && strpos($_SERVER["argv"][0], "drush") && empty($_ENV['DEPLOY_NAME'])) {
   include __DIR__ . '../../../drush.settings.php';

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -466,14 +466,16 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 
 	makeWritable := []string{path.Dir(app.SiteSettingsPath), app.SiteSettingsPath}
 	for _, o := range makeWritable {
-		if stat, err := os.Stat(o); err != nil {
-			// Warn the user, but don't fail.
+		stat, err := os.Stat(o)
+		if err != nil {
+			// Warn the user, but continue.
 			util.Warning("Unable to set permissions: %v", err)
-		} else {
-			if err := os.Chmod(o, stat.Mode()|writePerms); err != nil {
-				// Warn the user, but don't fail.
-				util.Warning("Unable to set permissions: %v", err)
-			}
+			continue
+		}
+
+		if err := os.Chmod(o, stat.Mode()|writePerms); err != nil {
+			// Warn the user, but continue.
+			util.Warning("Unable to set permissions: %v", err)
 		}
 	}
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -89,6 +89,8 @@ $settings['file_scan_ignore_directories'] = [
   'bower_components',
 ];
 
+// This will prevent Drupal from setting read-only permissions on sites/default.
+$settings['skip_permissions_hardening'] = TRUE;
 
 // This is super ugly but it determines whether or not drush should include a custom settings file which allows
 // it to work both within a docker container and natively on the host system.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.19.0-12-ge51bdbef" // Note that this can be overridden by make
+var WebTag = "v0.19.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.19.0" // Note that this can be overridden by make
+var WebTag = "v0.19.0-12-ge51bdbef" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"


### PR DESCRIPTION
## The Problem/Issue/Bug:
Drupal will remove write permissions from `sites/default` and `sites/default/settings.php` unless `$settings['skip_permissions_hardening'] = TRUE;` is included in generated Drupal8 settings as explained in #715.

## How this PR Solves The Problem:
This PR adds the `$settings['skip_permissions_hardening'] = TRUE;` line to the generated Drupal8 settings and ensures that the `sites/default` directory and the `sites/default/settings.php` file are writable upon `ddev start`.   

## Manual Testing Instructions:
Using a Drupal 6/7/8 project, 
- Ensure the project is stopped with `ddev stop`
- Remove write permissions from `sites/default` and `sites/default/settings.php`
- Execute `ddev start`
- Inspect the permissions of `sites/default` and `sites/default/settings.php` via `ddev exec ls -lah sites/default`
- Confirm that `sites/default` (`.` in `exec` output) and `sites/default/settings.php` include user write permissions

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#715 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

