### PR TITLE
Allow a user to issue root commands from ddev, fixes #918

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -11,12 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var root bool
+
 // DdevExecCmd allows users to execute arbitrary bash commands within a container.
 var DdevExecCmd = &cobra.Command{
 	Use:     "exec <command>",
 	Aliases: []string{"."},
 	Short:   "Execute a shell command in the container for a service. Uses the web service by default.",
-	Long:    `Execute a shell command in the container for a service. Uses the web service by default. To run your command in the container for another service, run "ddev exec --service <service> <cmd>"`,
+	Long:    `Execute a shell command in the container for a service. Uses the web service by default. To run your command in the container for another service, run "ddev exec --service <service> <cmd>". To run your command as root, run "ddev exec --root <cmd>".`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			err := cmd.Usage()
@@ -39,16 +41,27 @@ var DdevExecCmd = &cobra.Command{
 
 		app.DockerEnv()
 
-		out, _, err := app.Exec(serviceType, args...)
-		if err != nil {
-			util.Failed("Failed to execute command %s: %v", args, err)
+		var out string
+		if root {
+			out, _, err = app.ExecRoot(serviceType, args...)
+			if err != nil {
+				util.Failed("Failed to execute root command %s: %v", args, err)
+			}
+		} else {
+			out, _, err = app.Exec(serviceType, args...)
+			if err != nil {
+				util.Failed("Failed to execute command %s: %v", args, err)
+			}
 		}
+
 		output.UserOut.Print(out)
 	},
 }
 
 func init() {
 	DdevExecCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to connect to. [e.g. web, db]")
+	DdevExecCmd.Flags().BoolVarP(&root, "root", "R", false, "Indicates that the command should be run as root in the target container")
+
 	// This requires flags for exec to be specified prior to any arguments, allowing for
 	// flags to be ignored by cobra for commands that are to be executed in a container.
 	DdevExecCmd.Flags().SetInterspersed(false)

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -44,12 +44,12 @@ func TestDevExec(t *testing.T) {
 		args = []string{"exec", "--root", "whoami"}
 		out, err = exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
-		assert.EqualValues(string(out), "root")
+		assert.Contains(string(out), "root")
 
 		args = []string{"exec", "-R", "whoami"}
 		out, err = exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
-		assert.EqualValues(string(out), "root")
+		assert.Contains(string(out), "root")
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -17,6 +17,11 @@ func TestDevExecBadArgs(t *testing.T) {
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.Error(err)
 	assert.Contains(string(out), "Usage:")
+
+	args = []string{"exec", "--root"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.Error(err)
+	assert.Contains(string(out), "Usage:")
 }
 
 // TestDevExec run `ddev exec pwd` with proper args
@@ -32,6 +37,16 @@ func TestDevExec(t *testing.T) {
 		assert.Contains(string(out), "/var/www/html")
 
 		args = []string{"-s", "db", "exec", "pwd"}
+		out, err = exec.RunCommand(DdevBin, args)
+		assert.NoError(err)
+		assert.Contains(string(out), "/")
+
+		args = []string{"exec", "--root", "pwd"}
+		out, err = exec.RunCommand(DdevBin, args)
+		assert.NoError(err)
+		assert.Contains(string(out), "/")
+		d
+		args = []string{"exec", "-R", "pwd"}
 		out, err = exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
 		assert.Contains(string(out), "/")

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -41,15 +41,15 @@ func TestDevExec(t *testing.T) {
 		assert.NoError(err)
 		assert.Contains(string(out), "/")
 
-		args = []string{"exec", "--root", "pwd"}
+		args = []string{"exec", "--root", "whoami"}
 		out, err = exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
-		assert.Contains(string(out), "/")
-		d
-		args = []string{"exec", "-R", "pwd"}
+		assert.EqualValues(string(out), "root")
+
+		args = []string{"exec", "-R", "whoami"}
 		out, err = exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
-		assert.Contains(string(out), "/")
+		assert.EqualValues(string(out), "root")
 
 		cleanup()
 	}

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -382,7 +382,9 @@ ddev provides several commands to facilitate interacting with your project in th
 ### Executing Commands in Containers
 The `ddev exec` command allows you to run shell commands in the container for a ddev service. By default, commands are executed on the web service container, in the docroot path of your project. This allows you to use [the developer tools included in the web container](developer-tools.md). For example, to run the Drush CLI in the web container, you would run `ddev exec drush status`.
 
-To run a shell command in the container for a different service, use the `--service` flag at the beginning of your exec command to specify the service the command should be run against. For example, to run the mysql client in the database, container, you would run `ddev exec --service db mysql`.
+To run a shell command in the container for a different service, use the `--service` flag at the beginning of your exec command to specify the service the command should be run against. For example, to run the mysql client in the database container, you would run `ddev exec --service db mysql`.
+
+To run a shell command as root in the container, use the `--root` flag at the beginning of your exec command. For example, to run the apt-get update command, which requires root privileges, you would run `ddev exec --root apt-get update`.
 
 Commands can also be executed using the shorter `ddev . <cmd>` alias.
 

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -13,6 +13,7 @@ hooks:
   post-start:
     - exec: "simple command expression"
     - exec-host: "simple command expression"
+    - rexec: "simple command expression"
   post-import-db:
     - exec-host: "drush uli"
 ```
@@ -52,6 +53,22 @@ hooks:
   post-import-db:
     - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
 ```
+
+### `rexec`: Execute a shell command in the web service container as root.
+
+Value: string providing the command to run as root. Commands requiring user interaction are not supported.
+
+Example:
+
+_Use apt to install the php-sqlite3 package_
+
+```
+hooks:
+  post-start:
+    - rexec: "apt-get update"
+    - rexec: "apt-get install -y php-sqlite3"
+```
+
 
 ### `exec-host`: Execute a shell command on the host system.
 

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -12,8 +12,8 @@ Example:
 hooks:
   post-start:
     - exec: "simple command expression"
-    - exec-host: "simple command expression"
     - rexec: "simple command expression"
+    - exec-host: "simple command expression"
   post-import-db:
     - exec-host: "drush uli"
 ```

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -12,7 +12,7 @@ Example:
 hooks:
   post-start:
     - exec: "simple command expression"
-    - rexec: "simple command expression"
+    - exec-root: "simple command expression"
     - exec-host: "simple command expression"
   post-import-db:
     - exec-host: "drush uli"
@@ -54,7 +54,7 @@ hooks:
     - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
 ```
 
-### `rexec`: Execute a shell command in the web service container as root.
+### `exec-root`: Execute a shell command in the web service container as root.
 
 Value: string providing the command to run as root. Commands requiring user interaction are not supported.
 
@@ -65,8 +65,8 @@ _Use apt to install the php-sqlite3 package_
 ```
 hooks:
   post-start:
-    - rexec: "apt-get update"
-    - rexec: "apt-get install -y php-sqlite3"
+    - exec-root: "apt-get update"
+    - exec-root: "apt-get install -y php-sqlite3"
 ```
 
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -41,8 +41,8 @@ var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-z
 // Command defines commands to be run as pre/post hooks
 type Command struct {
 	Exec     string `yaml:"exec,omitempty"`
-	ExecHost string `yaml:"exec-host,omitempty"`
 	RExec    string `yaml:"rexec"`
+	ExecHost string `yaml:"exec-host,omitempty"`
 }
 
 // Provider is the interface which all provider plugins must implement.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -11,6 +11,8 @@ import (
 
 	"regexp"
 
+	"runtime"
+
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
@@ -19,7 +21,6 @@ import (
 	"github.com/drud/ddev/pkg/version"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
-	"runtime"
 )
 
 // DefaultProviderName contains the name of the default provider which will be used if one is not otherwise specified.
@@ -41,6 +42,7 @@ var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-z
 type Command struct {
 	Exec     string `yaml:"exec,omitempty"`
 	ExecHost string `yaml:"exec-host,omitempty"`
+	RExec    string `yaml:"rexec"`
 }
 
 // Provider is the interface which all provider plugins must implement.
@@ -589,6 +591,7 @@ func validateCommandYaml(source []byte) error {
 	validTasks := []string{
 		"exec",
 		"exec-host",
+		"rexec",
 	}
 
 	type Validate struct {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -41,7 +41,7 @@ var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-z
 // Command defines commands to be run as pre/post hooks
 type Command struct {
 	Exec     string `yaml:"exec,omitempty"`
-	RExec    string `yaml:"rexec"`
+	ExecRoot string `yaml:"exec-root"`
 	ExecHost string `yaml:"exec-host,omitempty"`
 }
 
@@ -590,8 +590,8 @@ func validateCommandYaml(source []byte) error {
 
 	validTasks := []string{
 		"exec",
+		"exec-root",
 		"exec-host",
-		"rexec",
 	}
 
 	type Validate struct {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -604,20 +604,20 @@ func (app *DdevApp) ProcessHooks(hookName string) error {
 			util.Success("--- %s host command succeeded ---\n", hookName)
 		}
 
-		if c.RExec != "" {
-			output.UserOut.Printf("--- Running rexec command: %s ---", c.RExec)
+		if c.ExecRoot != "" {
+			output.UserOut.Printf("--- Running exec-root command: %s ---", c.ExecRoot)
 
-			args, err := shellwords.Parse(c.RExec)
+			args, err := shellwords.Parse(c.ExecRoot)
 			if err != nil {
-				return fmt.Errorf("%s exec failed: %v", hookName, err)
+				return fmt.Errorf("%s exec-root failed: %v", hookName, err)
 			}
 
 			stdout, stderr, err := app.ExecRoot("web", args...)
 			if err != nil {
-				return fmt.Errorf("%s rexec failed: %v, stderr='%s'", hookName, err, stderr)
+				return fmt.Errorf("%s exec-root failed: %v, stderr='%s'", hookName, err, stderr)
 			}
 
-			util.Success("--- %s rexec command succeeded, output below ---", hookName)
+			util.Success("--- %s exec-root command succeeded, output below ---", hookName)
 			output.UserOut.Println(stdout + "\n" + stderr)
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:
Users are currently unable to issue commands within a container as root from ddev. 

## How this PR Solves The Problem:
This PR adds the `--root/-R` flag to `ddev exec`, which executes the commands as the root user. A new hook command, `exec-root`, allows a user to define a hook command to be run as root, allowing for automated modifications of the standard container. Documentation on hooks and commands has been updated.

## Manual Testing Instructions:
With a running ddev project, execute a command that requires root privileges with `ddev exec`. For example, `ddev exec apt-get update` should fail due to lack of permissions.  Execute the same command with root flags: `ddev exec --root apt-get update`.  The command will complete successfully.

## Automated Testing Overview:
Simple test cases that confirm the `--root` flag provides a root user have been added.

## Related Issue Link(s):
#918 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

