### PR TITLE
Install php-memcached extension on web container

### DIFF
--- a/containers/nginx-php-fpm-local/Dockerfile.in
+++ b/containers/nginx-php-fpm-local/Dockerfile.in
@@ -65,7 +65,7 @@ RUN apt-get -qq update && \
         unzip \
         rsync \
         libpcre3 && \
-    for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring  $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
+    for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \


### PR DESCRIPTION
## The Problem/Issue/Bug:
Adds ability to connect to memcached with PHP. Fixes #269 

## How this PR Solves The Problem:
This installs and enables the php-memcached extension on the web container.

## Manual Testing Instructions:
Check that docker image builds cleanly, and memcached shows up in PHP `mods-available`.

## Automated Testing Overview:
I don't see any tests for specific PHP extensions outside of xdebug.

## Related Issue Link(s):

## Release/Deployment notes:
This adds PHP memcached support. To actually test out memcached in localdev, it will require adding a memcached container -- see the docker compose example in #269.
