### PR TITLE
Add Memcached service configuration file and documentation.

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -8,14 +8,24 @@ If you need a service not provided here, see [Defining an additional service wit
 This recipe adds an Apache Solr 5.4 container to a project. It will setup a solr core with the solr configuration you define.
 
 **Installation:**
-
 - Copy [docker-compose.solr.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/services/docker-compose.solr.yaml) to the .ddev folder for your project.
 - Create the folder path .ddev/solr/conf.
 - Copy the solr configuration files for your project to .ddev/solr/conf. _e.g., using Drupal Search API Solr, you would copy the solr-conf/5.x/ contents from the module code base into .ddev/solr/conf._
 - Ensure the configuration files must be present before running `ddev start`.
 
 **Interacting with Apache Solr**
-
 - The Solr admin interface will be accessible at `http://<projectname>.ddev.local:8983/solr/`
 - To access the Solr container from the web container use `http://solr:8983/solr/`
 - The Solr core will be "dev"
+
+## Memcached
+This recipe adds a Memcached 1.5 container to a project. The default configuration allocates 128 MB of RAM for the Memcached instance; to change that or other command line arguments, edit the `command` array within the docker-compose file.
+
+**Installation:**
+- Copy [docker-compose.memcached.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/services/docker-compose.memcached.yaml) to the .ddev folder for your project.
+- Run `ddev start`.
+
+**Interacting with Memcached**
+- The Memcached instance will listen on TCP port 11211 (the Memcached default).
+- Configure your application to access Memcached on the host:port `memcached:11211`.
+- To reach the Memcached admin interface, run `ddev ssh` to connect to the web container, then use `nc` or `telnet` to connect to the Memcached container on port 11211, i.e. `nc memcached 11211`. You can then run commands such as `stats` to see usage information.

--- a/pkg/servicetest/testdata/services/README.md
+++ b/pkg/servicetest/testdata/services/README.md
@@ -1,3 +1,3 @@
 # Additional Service Configurations for ddev
 
-This directory contains additional service configurations that can be added to the .ddev directory for a project to enable additional services for the project. Setup instructions for these service files can be found in the [Additional Services Documentation]().
+This directory contains additional service configurations that can be added to the .ddev directory for a project to enable additional services for the project. Setup instructions for these service files can be found in the [Additional Services Documentation](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/).

--- a/pkg/servicetest/testdata/services/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.memcached.yaml
@@ -16,15 +16,5 @@ services:
     labels:
     # These labels ensure this service is discoverable by ddev
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
-      com.ddev.app-url: $DDEV_URL
-    environment:
-      - VIRTUAL_HOST=$DDEV_HOSTNAME # This defines the host name the service should be accessible from. This will be sitename.ddev.local
-      - HTTP_EXPOSE=11211
 
     command: ["-m", "128"]
-
-# This links the memcached service to the web service defined in the main docker-compose.yml, allowing applications running in the web service to access the memcached service at memcached:11211
-  web:
-    links:
-      - memcached:$DDEV_HOSTNAME

--- a/pkg/servicetest/testdata/services/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.memcached.yaml
@@ -1,0 +1,30 @@
+# ddev memcached recipe file
+#
+# To use this in your own project: Copy this file to your project's .ddev folder.
+# Edit the 'command' settings to change CLI flags sent to memcached.
+# Defaults to '-m 128' to allocate 128 MB of memcached storage.
+
+version: '3'
+
+services:
+  memcached: # This is the service name used when running ddev commands accepting the --service flag
+    container_name: ddev-${DDEV_SITENAME}-memcached # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
+    image: memcached:1.5
+    restart: always
+    ports:
+      - 11211 # memcached is available at this port inside the container
+    labels:
+    # These labels ensure this service is discoverable by ddev
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.app-url: $DDEV_URL
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME # This defines the host name the service should be accessible from. This will be sitename.ddev.local
+      - HTTP_EXPOSE=11211
+
+    command: ["-m", "128"]
+
+# This links the memcached service to the web service defined in the main docker-compose.yml, allowing applications running in the web service to access the memcached service at memcached:11211
+  web:
+    links:
+      - memcached:$DDEV_HOSTNAME

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -133,7 +133,7 @@ func EnsureHTTPStatus(o *HTTPOptions) error {
 		}).Info("HTTP Status could not be matched, expected %d, received %d", o.ExpectedStatus, resp.StatusCode)
 
 	}
-	return fmt.Errorf("Failed to match status code %d", o.ExpectedStatus)
+	return fmt.Errorf("failed to match status code: %d, got: %d", o.ExpectedStatus, resp.StatusCode)
 }
 
 // IsPortActive checks to see if the given port on docker IP is answering.


### PR DESCRIPTION
## The Problem/Issue/Bug:
Currently ddev does not provide a Memcached container. Memcached is used as a caching layer by many applications.

## How this PR Solves The Problem:
Adds an example docker-compose file and documentation to setup a Memcached container within a ddev environment.

## Manual Testing Instructions:
Follow instructions in documentation included in PR to create a Memcached container.

## Automated Testing Overview:
This should get picked up automatically by the already-existing servicetest test script.

## Related Issue Link(s):
#269