### PR TITLE
Improve predictable builds on Windows containers by removing quotes from mount

### DIFF
--- a/containers/ddev-router/Makefile
+++ b/containers/ddev-router/Makefile
@@ -41,7 +41,7 @@ include ../../build-tools/makefile_components/base_test_python.mak
 test: container
 	@docker stop ddev-router-test 2>/dev/null || true
 	@docker rm ddev-router-test 2>/dev/null || true
-	docker run -p 1082:80 -v "//var/run/docker.sock:/tmp/docker.sock:ro" --name ddev-router-test -d $(DOCKER_REPO):$(VERSION)
+	docker run -p 1082:80 -v //var/run/docker.sock:/tmp/docker.sock:ro --name ddev-router-test -d $(DOCKER_REPO):$(VERSION)
 	CONTAINER_NAME=ddev-router-test test/containercheck.sh
 	curl -s -I localhost:1082 | grep 503  # Make sure we get a 503 from nginx by default
 	@docker stop ddev-router-test


### PR DESCRIPTION
## The Problem/Issue/Bug:

Docker and Windows are horrendously finicky about what is a legitimate mount on what platform.

We use "//" on the front of a mount to tell *docker* not to rewrite it to a windows path. But if you put that in quotes you can get broken behavior on macos. 

## How this PR Solves The Problem:

This is an experiment to see if we can get a clean windows container build for ddev-router.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

