### PR TITLE
Remove duplicate config path resolving in ddevapp/config.go

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -58,7 +58,6 @@ type Provider interface {
 func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	// Set defaults.
 	app := &DdevApp{}
-	app.ConfigPath = filepath.Join(AppRoot, ".ddev", "config.yaml")
 
 	app.AppRoot = AppRoot
 	app.ConfigPath = app.GetConfigPath("config.yaml")


### PR DESCRIPTION
## The Problem/Issue/Bug:
The path to the config file (`config.yml`) is set multiple times (see https://github.com/drud/ddev/blob/master/pkg/ddevapp/config.go#L61 and https://github.com/drud/ddev/blob/master/pkg/ddevapp/config.go#L64) in config class when creating a new application.
