### PR TITLE
Bump container verisons to v0.20.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,25 +20,25 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "2018-06-20_exec-sudo" // Note that this can be overridden by make
+var WebTag = "v0.20.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "v0.19.0" // Note that this may be overridden by make
+var DBTag = "v0.20.0" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "v0.19.0" // Note that this can be overridden by make
+var DBATag = "v0.20.0" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v0.19.0" // Note that this can be overridden by make
+var RouterTag = "v0.20.0" // Note that this can be overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
Temporarily pushing provisional v0.20.0 containers for building and testing.

## Release/Deployment notes:
The 4 containers should be re-pushed at tag time.

