### PR TITLE
Don't use apk cache to reduce image size

### DIFF
--- a/containers/mariadb-local/Dockerfile.in
+++ b/containers/mariadb-local/Dockerfile.in
@@ -8,7 +8,7 @@ ENV MYSQL_ROOT_PASSWORD root
 RUN mkdir /docker-entrypoint-initdb.data
 
 # Install mariadb and other packages
-RUN apk update && apk add mariadb mariadb-client bash tzdata shadow
+RUN apk add --no-cache mariadb mariadb-client bash tzdata shadow
 # Remove the installed version as we need to set up our own from scratch
 
 RUN rm -rf /var/lib/mysql/* /etc/mysql

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var WebTag = "v0.20.0" // Note that this can be overridden by make
 var DBImg = "drud/mariadb-local"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "v0.20.0" // Note that this may be overridden by make
+var DBTag = "20180627_mariadb_no_apk_cache" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:
Apk cache remains in image and makes it larger as it must be
## How this PR Solves The Problem:
Use apk --no-cache parameter

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

