### PR TITLE
Add configuration for typo3 mail and errors, default to php 7.2, fixes #924

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -69,7 +69,7 @@ func init() {
 			createWordpressSettingsFile, getWordpressUploadDir, getWordpressHooks, setWordpressSiteSettingsPaths, isWordpressApp, wordpressPostImportDBAction, nil, nil, nil,
 		},
 		"typo3": {
-			createTypo3SettingsFile, getTypo3UploadDir, getTypo3Hooks, setTypo3SiteSettingsPaths, isTypo3App, nil, nil, nil, nil,
+			createTypo3SettingsFile, getTypo3UploadDir, getTypo3Hooks, setTypo3SiteSettingsPaths, isTypo3App, nil, typo3ConfigOverrideAction, nil, nil,
 		},
 		"backdrop": {
 			createBackdropSettingsFile, getBackdropUploadDir, getBackdropHooks, setBackdropSiteSettingsPaths, isBackdropApp, backdropPostImportDBAction, nil, nil, nil,

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -25,7 +25,17 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($GLOBA
                     'password' => 'db',
                     'port' => '3306',
                     'user' => 'db',
-]);`
+]);
+
+// This mail configuration sends all emails to mailhog
+$GLOBALS['TYPO3_CONF_VARS']['MAIL'] = [
+    'transport' => 'smtp',
+    'transport_smtp_server' => 'localhost:1025',
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'] = '*';
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = 1;
+`
 
 // createTypo3SettingsFile creates the app's LocalConfiguration.php and
 // AdditionalConfiguration.php, adding things like database host, name, and
@@ -122,4 +132,10 @@ func isTypo3App(app *DdevApp) bool {
 		return true
 	}
 	return false
+}
+
+// typo3ConfigOverrideAction sets a safe php_version for TYPO3
+func typo3ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = "7.2"
+	return nil
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

* TYPO3 wasn't sending mail to mailhog correctly, per #924 
* TYPO3 config needed to display errors, something we'd always want in a dev environment
* TYPO3 default php version was 7.1, and 7.2 is required for TYPO3 v9 (and best elsewhere really)

## How this PR Solves The Problem:

* Adds config to the AdditionalConfiguration.php
* Sets default php to 7.2

## Manual Testing Instructions:

* Create a TYPO3 site with composer
* `ddev config` and step through
* Check that .ddev/config.yaml has php 7.2
* `ddev start`
* Visit and install the site
* In the ENVIRONMENT section of the backend "Admin Tools", use "Test Mail Setup" to send an email. The email should be delivered to mailhog (See `ddev describe` for accessing mailhog)

## Automated Testing Overview:

No testing was added.

## Related Issue Link(s):

#924 is fixed by this
@spoonerweb's excellent #925 PR provided the start for this, but it went in a different direction in the end. 

It would be lovely to get a review of this from the TYPO3 community.