### PR TITLE
Make web container .my.cnf read-only so mysql will use it, fixes #944

### DIFF
--- a/containers/nginx-php-fpm-local/Dockerfile.in
+++ b/containers/nginx-php-fpm-local/Dockerfile.in
@@ -103,7 +103,9 @@ RUN chmod -R 777 /var/log
 
 RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php
 # All users will have their home directory in /home, make it fully writeable
-RUN mkdir -p /home/.composer/cache /home/.drush/commands /home/.drush/aliases && chmod -R ugo+rw /home 
+RUN mkdir -p /home/.composer/cache /home/.drush/commands /home/.drush/aliases && chmod -R ugo+rw /home
+# Except that .my.cnf can't be writeable or mysql won't use it.
+RUN chmod 444 /home/.my.cnf
 
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
   chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -336,6 +336,41 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 }
 
+// TestDdevMysqlWorks tests that mysql client can be run in both containers.
+func TestDdevMysqlWorks(t *testing.T) {
+	assert := asrt.New(t)
+	app := &ddevapp.DdevApp{}
+
+	site := TestSites[0]
+	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevMysqlWorks", site.Name))
+
+	err := app.Init(site.Dir)
+	assert.NoError(err)
+
+	testcommon.ClearDockerEnv()
+	//err = app.WriteConfig()
+	//assert.NoError(err)
+	err = app.Start()
+	assert.NoError(err)
+
+	// Test that mysql + .my.cnf works on web container
+	_, _, err = app.Exec("web", "bash", "-c", "mysql -e 'SELECT USER();' | grep 'db@'")
+	assert.NoError(err)
+	_, _, err = app.Exec("web", "bash", "-c", "mysql -e 'SELECT DATABASE();' | grep 'db'")
+	assert.NoError(err)
+
+	// Test that mysql + .my.cnf works on db container
+	_, _, err = app.Exec("db", "bash", "-c", "mysql -e 'SELECT USER();' | grep 'root@localhost'")
+	assert.NoError(err)
+	_, _, err = app.Exec("db", "bash", "-c", "mysql -e 'SELECT DATABASE();' | grep 'db'")
+	assert.NoError(err)
+
+	err = app.Stop()
+	assert.NoError(err)
+
+	runTime()
+
+}
 // TestStartWithoutDdev makes sure we don't have a regression where lack of .ddev
 // causes a panic.
 func TestStartWithoutDdevConfig(t *testing.T) {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -348,8 +348,6 @@ func TestDdevMysqlWorks(t *testing.T) {
 	assert.NoError(err)
 
 	testcommon.ClearDockerEnv()
-	//err = app.WriteConfig()
-	//assert.NoError(err)
 	err = app.Start()
 	assert.NoError(err)
 
@@ -371,6 +369,7 @@ func TestDdevMysqlWorks(t *testing.T) {
 	runTime()
 
 }
+
 // TestStartWithoutDdev makes sure we don't have a regression where lack of .ddev
 // causes a panic.
 func TestStartWithoutDdevConfig(t *testing.T) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.10.0-alpha1"
 var WebImg = "drud/nginx-php-fpm-local"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v0.20.0" // Note that this can be overridden by make
+var WebTag = "20180628_fix_writeable_my_conf" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/mariadb-local"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The web container's .my.cnf didn't work right, see #944 

## How this PR Solves The Problem:

Make /home/.my.cnf unwriteable in container

## Manual Testing Instructions:

```
ddev ssh
mysql
```
You should be able to do anything you want at the mysql prompt; previously this would not run because the connection was not defined.

## Automated Testing Overview:

* Added TestDdevMysqlWorks to verify that the mysql command works as expected in both the web and db containers.

## Related Issue Link(s):

OP #944 

