### PR TITLE
ConfigFileOverrideAction() should only override if no config exists yet, fixes #900

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -188,9 +188,9 @@ func (app *DdevApp) PostImportDBAction() error {
 }
 
 // ConfigFileOverrideAction gives a chance for an apptype to override any element
-// of config.yaml that it needs to.
+// of config.yaml that it needs to (on initial creation, but not after that)
 func (app *DdevApp) ConfigFileOverrideAction() error {
-	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.configOverrideAction != nil {
+	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.configOverrideAction != nil && !app.ConfigExists() {
 		return appFuncs.configOverrideAction(app)
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -245,7 +245,7 @@ func (app *DdevApp) PromptForConfig() error {
 		output.UserOut.Printf("%v", err)
 	}
 
-	err := app.appTypePrompt()
+	err := app.AppTypePrompt()
 	if err != nil {
 		return err
 	}
@@ -523,8 +523,8 @@ func (app *DdevApp) ConfigExists() bool {
 	return true
 }
 
-// appTypePrompt handles the Type workflow.
-func (app *DdevApp) appTypePrompt() error {
+// AppTypePrompt handles the Type workflow.
+func (app *DdevApp) AppTypePrompt() error {
 	provider, err := app.GetProvider()
 	if err != nil {
 		return err


### PR DESCRIPTION
## The Problem/Issue/Bug:

#900 - ddev config incorrectly updates php version in some situations.

## How this PR Solves The Problem:

ConfigOverrideAction() really should only override on a new config, and had only been used for D7 and D6. Both places it didn't work correctly.

It now only does its job if the config doesn't already exist.

## Manual Testing Instructions:

Described in OP #900 

## Automated Testing Overview:

TestPostConfigAction() tests the expected behavior of ConfigFileOverrideAction().

## Related Issue Link(s):

OP #900 

