### PR TITLE
Allow ddev stop/rm to act on multiple/all sites, fixes #952

### DIFF
--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -26,7 +26,7 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 			util.Failed("Illegal option combination: --all and --remove-data")
 		}
 
-		apps, err := determineAppList(args, removeAll)
+		apps, err := getRequestedApps(args, removeAll)
 		if err != nil {
 			util.Failed("Unable to remove project(s): %v", err)
 		}

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -28,17 +28,17 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 
 		apps, err := getRequestedApps(args, removeAll)
 		if err != nil {
-			util.Failed("Unable to remove project(s): %v", err)
+			util.Failed("Unable to get project(s): %v", err)
 		}
 
 		// Iterate through the list of apps built above, removing each one.
 		for _, app := range apps {
 			if app.SiteStatus() == ddevapp.SiteNotFound {
-				util.Warning("Project is not currently running. Try 'ddev start'.")
+				util.Warning("Project %s is not currently running. Try 'ddev start'.", app.GetName())
 			}
 
 			if err := app.Down(removeData); err != nil {
-				util.Warning("Failed to remove %s: %s", app.GetName(), err)
+				util.Failed("Failed to remove %s: %v", app.GetName(), err)
 			}
 
 			util.Success("Project %s has been removed.", app.GetName())
@@ -48,6 +48,6 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 
 func init() {
 	DdevRemoveCmd.Flags().BoolVarP(&removeData, "remove-data", "R", false, "Remove stored project data (MySQL, logs, etc.)")
-	DdevRemoveCmd.Flags().BoolVarP(&removeAll, "all", "a", false, "Remove all active sites")
+	DdevRemoveCmd.Flags().BoolVarP(&removeAll, "all", "a", false, "Remove all running and stopped sites")
 	RootCmd.AddCommand(DdevRemoveCmd)
 }

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -19,7 +20,13 @@ func TestDevRemove(t *testing.T) {
 
 		out, err := exec.RunCommand(DdevBin, []string{"remove"})
 		assert.NoError(err, "ddev remove should succeed but failed, err: %v, output: %s", err, out)
-		assert.Contains(out, "Successfully removed")
+		assert.Contains(out, "has been removed")
+
+		// Ensure the site that was just stopped does not appear in the list of sites
+		apps := ddevapp.GetApps()
+		for _, app := range apps {
+			assert.True(app.GetName() != site.Name)
+		}
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -33,11 +33,21 @@ func TestDevRemove(t *testing.T) {
 
 	// Re-create running sites.
 	addSites()
-	out, err := exec.RunCommand(DdevBin, []string{"remove", "--all"})
+
+	// Ensure a user can't accidentally wipe out everything.
+	appsBefore := len(ddevapp.GetApps())
+	out, err := exec.RunCommand(DdevBin, []string{"remove", "--remove-data", "--all"})
+	assert.Error(err, "ddev remove --all --remove-data should error, but succeeded")
+	assert.Contains(out, "Illegal option")
+	assert.EqualValues(appsBefore, len(ddevapp.GetApps()), "No apps should be removed or added after ddev remove --all --remove-data")
+
+	// Ensure the --all option can remove all active apps
+	out, err = exec.RunCommand(DdevBin, []string{"remove", "--all"})
 	assert.NoError(err, "ddev remove --all should succeed but failed, err: %v, output: %s", err, out)
 	out, err = exec.RunCommand(DdevBin, []string{"list"})
 	assert.NoError(err)
 	assert.Contains(out, "no running ddev projects")
+	assert.Equal(0, len(ddevapp.GetApps()), "Not all apps were removed after ddev remove --all")
 
 	// Now put the sites back together so other tests can use them.
 	addSites()

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -23,6 +23,15 @@ func TestDevRemove(t *testing.T) {
 
 		cleanup()
 	}
+
+	// Re-create running sites.
+	addSites()
+	out, err := exec.RunCommand(DdevBin, []string{"remove", "--all"})
+	assert.NoError(err, "ddev remove --all should succeed but failed, err: %v, output: %s", err, out)
+	out, err = exec.RunCommand(DdevBin, []string{"list"})
+	assert.NoError(err)
+	assert.Contains(out, "no running ddev projects")
+
 	// Now put the sites back together so other tests can use them.
 	addSites()
 }

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -35,6 +35,10 @@ provide a local development environment.`,
 			util.Failed("Unable to start project(s): %v", err)
 		}
 
+		if len(apps) == 0 {
+			output.UserOut.Printf("There are no stopped projects to start.")
+		}
+
 		for _, app := range apps {
 			if app.SiteStatus() == ddevapp.SiteRunning {
 				continue

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
@@ -32,19 +31,15 @@ provide a local development environment.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		apps, err := getRequestedApps(args, startAll)
 		if err != nil {
-			util.Failed("Unable to start project(s): %v", err)
+			util.Failed("Unable to get project(s): %v", err)
 		}
 
 		if len(apps) == 0 {
-			output.UserOut.Printf("There are no stopped projects to start.")
+			output.UserOut.Printf("There are no projects to start.")
 		}
 
 		for _, app := range apps {
-			if app.SiteStatus() == ddevapp.SiteRunning {
-				continue
-			}
-
-			output.UserOut.Printf("Starting environment for %s...", app.GetName())
+			output.UserOut.Printf("Starting %s...", app.GetName())
 
 			if err := app.Start(); err != nil {
 				util.Warning("Failed to start %s: %v", app.GetName(), err)
@@ -52,7 +47,7 @@ provide a local development environment.`,
 			}
 
 			util.Success("Successfully started %s", app.GetName())
-			util.Success("Your project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
+			util.Success("Project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
 		}
 	},
 }

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/exec"
+	asrt "github.com/stretchr/testify/assert"
+)
+
+// TestDdevStart runs `ddev start` on the test apps
+func TestDdevStart(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Make sure we have running sites.
+	addSites()
+
+	// Stop all sites.
+	_, err := exec.RunCommand(DdevBin, []string{"stop", "--all"})
+	assert.NoError(err)
+
+	// Ensure all sites are started after ddev start --all.
+	out, err := exec.RunCommand(DdevBin, []string{"start", "--all"})
+	assert.NoError(err, "ddev start --all should succeed but failed, err: %v, output: %s", err, out)
+
+	// Confirm all sites are running.
+	apps := ddevapp.GetApps()
+	for _, app := range apps {
+		assert.True(app.SiteStatus() == ddevapp.SiteRunning, "All sites should be running, but %s status: %s", app.GetName(), app.SiteStatus())
+	}
+}

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -31,11 +31,6 @@ to stop by running 'ddev stop <projectname>.`,
 				continue
 			}
 
-			if app.SiteStatus() != ddevapp.SiteStopped {
-				util.Warning("Failed to stop %s", app.GetName())
-				continue
-			}
-
 			util.Success("Project %s has been stopped.", app.GetName())
 		}
 	},

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -18,17 +17,12 @@ to stop by running 'ddev stop <projectname>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		apps, err := getRequestedApps(args, stopAll)
 		if err != nil {
-			util.Failed("Unable to stop project(s): %v", err)
+			util.Failed("Unable to get project(s): %v", err)
 		}
 
 		for _, app := range apps {
-			if app.SiteStatus() == ddevapp.SiteStopped {
-				continue
-			}
-
 			if err := app.Stop(); err != nil {
-				util.Warning("Failed to stop %s: %v", app.GetName(), err)
-				continue
+				util.Failed("Failed to stop %s: %v", app.GetName(), err)
 			}
 
 			util.Success("Project %s has been stopped.", app.GetName())

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -16,7 +16,7 @@ var DdevStopCmd = &cobra.Command{
 from a project directory to stop that project, or you can specify a running project
 to stop by running 'ddev stop <projectname>.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		apps, err := determineAppList(args, stopAll)
+		apps, err := getRequestedApps(args, stopAll)
 		if err != nil {
 			util.Failed("Unable to stop project(s): %v", err)
 		}

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -8,7 +8,7 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDevRemove runs `ddev rm` on the test apps
+// TestDdevStop runs `ddev stop` on the test apps
 func TestDdevStop(t *testing.T) {
 	assert := asrt.New(t)
 
@@ -37,7 +37,7 @@ func TestDdevStop(t *testing.T) {
 	// Re-create running sites.
 	addSites()
 	out, err := exec.RunCommand(DdevBin, []string{"stop", "--all"})
-	assert.NoError(err, "ddev remove --all should succeed but failed, err: %v, output: %s", err, out)
+	assert.NoError(err, "ddev stop --all should succeed but failed, err: %v, output: %s", err, out)
 
 	// Confirm all sites are stopped.
 	apps := ddevapp.GetApps()

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/exec"
+	asrt "github.com/stretchr/testify/assert"
+)
+
+// TestDevRemove runs `ddev rm` on the test apps
+func TestDdevStop(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Make sure we have running sites.
+	addSites()
+
+	for _, site := range DevTestSites {
+		cleanup := site.Chdir()
+
+		out, err := exec.RunCommand(DdevBin, []string{"stop"})
+		assert.NoError(err, "ddev stop should succeed but failed, err: %v, output: %s", err, out)
+		assert.Contains(out, "has been stopped")
+
+		apps := ddevapp.GetApps()
+		for _, app := range apps {
+			if app.GetName() != site.Name {
+				continue
+			}
+
+			assert.True(app.SiteStatus() == ddevapp.SiteStopped)
+		}
+
+		cleanup()
+	}
+
+	// Re-create running sites.
+	addSites()
+	out, err := exec.RunCommand(DdevBin, []string{"stop", "--all"})
+	assert.NoError(err, "ddev remove --all should succeed but failed, err: %v, output: %s", err, out)
+
+	// Confirm all sites are stopped.
+	apps := ddevapp.GetApps()
+	for _, app := range apps {
+		assert.True(app.SiteStatus() == ddevapp.SiteStopped, "All sites should be stopped, but %s status: %s", app.GetName(), app.SiteStatus())
+	}
+
+	// Now put the sites back together so other tests can use them.
+	addSites()
+}

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/drud/ddev/pkg/util"
 )
 
-func determineAppList(args []string, allFlag bool) ([]*ddevapp.DdevApp, error) {
+func getRequestedApps(args []string, allFlag bool) ([]*ddevapp.DdevApp, error) {
 	// If allFlag is true, all active apps will be returned.
 	if allFlag {
 		if len(args) > 0 {

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/util"
+)
+
+func determineAppList(args []string, allFlag bool) ([]*ddevapp.DdevApp, error) {
+	// If allFlag is true, all active apps will be returned.
+	if allFlag {
+		if len(args) > 0 {
+			return []*ddevapp.DdevApp{}, fmt.Errorf("too many arguments provided with the --all flag")
+		}
+
+		return ddevapp.GetApps(), nil
+	}
+
+	// If multiple apps are requested by their site name, collect and return them.
+	if len(args) > 0 {
+		var apps []*ddevapp.DdevApp
+
+		for _, siteName := range args {
+			app, err := ddevapp.GetActiveApp(siteName)
+			if err != nil {
+				util.Warning("Failed to get %s: %v", siteName, err)
+			} else {
+				apps = append(apps, app)
+			}
+		}
+
+		return apps, nil
+	}
+
+	// If the allFlag is false and no specific apps are requested, return the current app.
+	app, err := ddevapp.GetActiveApp("")
+	if err != nil {
+		return []*ddevapp.DdevApp{}, err
+	}
+
+	return []*ddevapp.DdevApp{app}, nil
+}

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -4,16 +4,12 @@ import (
 	"fmt"
 
 	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/util"
 )
 
-func getRequestedApps(args []string, allFlag bool) ([]*ddevapp.DdevApp, error) {
-	// If allFlag is true, all active apps will be returned.
-	if allFlag {
-		if len(args) > 0 {
-			return []*ddevapp.DdevApp{}, fmt.Errorf("too many arguments provided with the --all flag")
-		}
-
+// getRequestedApps will collect and return the requested apps from command line arguments and flags.
+func getRequestedApps(args []string, all bool) ([]*ddevapp.DdevApp, error) {
+	// If all is true, all active apps will be returned.
+	if all {
 		return ddevapp.GetApps(), nil
 	}
 
@@ -24,16 +20,16 @@ func getRequestedApps(args []string, allFlag bool) ([]*ddevapp.DdevApp, error) {
 		for _, siteName := range args {
 			app, err := ddevapp.GetActiveApp(siteName)
 			if err != nil {
-				util.Warning("Failed to get %s: %v", siteName, err)
-			} else {
-				apps = append(apps, app)
+				return []*ddevapp.DdevApp{}, fmt.Errorf("failed to get %s: %v", siteName, err)
 			}
+
+			apps = append(apps, app)
 		}
 
 		return apps, nil
 	}
 
-	// If the allFlag is false and no specific apps are requested, return the current app.
+	// If all is false and no specific apps are requested, return the current app.
 	app, err := ddevapp.GetActiveApp("")
 	if err != nil {
 		return []*ddevapp.DdevApp{}, err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -798,14 +798,11 @@ func (app *DdevApp) DockerEnv() {
 		// TODO: Warn people about additional names in use.
 		envVars["DDEV_HOSTNAME"] = strings.Join(app.GetHostnames(), ",")
 	}
+
 	// Only set values if they don't already exist in env.
 	for k, v := range envVars {
-		if os.Getenv(k) == "" {
-
-			err := os.Setenv(k, v)
-			if err != nil {
-				util.Error("Failed to set the environment variable %s=%s: %v", k, v, err)
-			}
+		if err := os.Setenv(k, v); err != nil {
+			util.Error("Failed to set the environment variable %s=%s: %v", k, v, err)
 		}
 	}
 }
@@ -826,9 +823,8 @@ func (app *DdevApp) Stop() error {
 	if err != nil {
 		return err
 	}
-	_, _, err = dockerutil.ComposeCmd(files, "stop")
 
-	if err != nil {
+	if _, _, err := dockerutil.ComposeCmd(files, "stop"); err != nil {
 		return err
 	}
 
@@ -886,7 +882,7 @@ func (app *DdevApp) Down(removeData bool) error {
 	// Remove all the containers and volumes for app.
 	err = Cleanup(app)
 	if err != nil {
-		return fmt.Errorf("Failed to remove %s: %s", app.GetName(), err)
+		return fmt.Errorf("failed to remove %s: %v", app.GetName(), err)
 	}
 
 	// Remove data/database if we need to.


### PR DESCRIPTION
## The Problem/Issue/Bug:
#952: a user was unable to act on all active sites.

## How this PR Solves The Problem:
Add the ability to pass a list of sites into `ddev stop` and `ddev remove`, e.g. `ddev remove site1 site2 site3`.  Additionally add the `--all`/`-a` option, acting on all running or active sites.

## Manual Testing Instructions:
- Start several sites, stop them all by passing their names into one `ddev stop` command
- Start several sites, stop all at once with `ddev stop --all`
- Start several again by passing their names into one `ddev start` command
- Start all sites again with `ddev start --all`
- Start several sites, remove them all by passing their names into one `ddev remove` command
- Start several sites, remove all at once with `ddev remove --all`

Note that I've added a failsafe to prevent a user from removing all site data through `ddev remove --all --remove-data`.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#952
#44 was an earlier request, may not be fully satisfied by this (Do we want "start", for example?)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

