### PR TITLE
Update docs about composer on Windows

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -84,6 +84,7 @@ cd my-drupal8-site
 ```
 
 **Composer Setup Example**
+*Do not use this technique with Windows, as composer on an NTFS filesystem can result in major problems with NTFS symlinks that can't be read in the Linux web container. Instead, use the [community-provided hints on Stack Overflow](https://stackoverflow.com/questions/49660082/how-can-i-run-composer-with-ddev)*
 
 ```
 composer create-project drupal-composer/drupal-project:8.x-dev my-drupal8-site --stability dev --no-interaction
@@ -127,6 +128,7 @@ cd example-typo3-site
 If necessary, run build steps that you may require, like `composer install` in the correct directory.
 
 **Composer Setup Example**
+*Do not use this technique with Windows, as composer on an NTFS filesystem can result in major problems with NTFS symlinks that can't be read in the Linux web container. Instead, use the [community-provided hints on Stack Overflow](https://stackoverflow.com/questions/49660082/how-can-i-run-composer-with-ddev)*
 
 ```
 composer create-project typo3/cms-base-distribution my-typo3-site ^8

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -84,6 +84,7 @@ cd my-drupal8-site
 ```
 
 **Composer Setup Example**
+
 *Do not use this technique with Windows, as composer on an NTFS filesystem can result in major problems with NTFS symlinks that can't be read in the Linux web container. Instead, use the [community-provided hints on Stack Overflow](https://stackoverflow.com/questions/49660082/how-can-i-run-composer-with-ddev)*
 
 ```
@@ -128,6 +129,7 @@ cd example-typo3-site
 If necessary, run build steps that you may require, like `composer install` in the correct directory.
 
 **Composer Setup Example**
+
 *Do not use this technique with Windows, as composer on an NTFS filesystem can result in major problems with NTFS symlinks that can't be read in the Linux web container. Instead, use the [community-provided hints on Stack Overflow](https://stackoverflow.com/questions/49660082/how-can-i-run-composer-with-ddev)*
 
 ```


### PR DESCRIPTION
## The Problem/Issue/Bug:

We advocated using composer on the host in our quickstart, because that's fairly easy to do on macOS and Linux.

However, users on Windows will never be able to succeed with that, and have to be much more sophisticated.

## How this PR Solves The Problem:

Point them to the Stack Overflow article about ddev with composer.


