### PR TITLE
php.ini should add switch "-t" for the sendmail-call

### DIFF
--- a/containers/nginx-php-fpm-local/files/etc/php/5.6/cli/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/5.6/cli/php.ini
@@ -82,7 +82,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025 -t"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/nginx-php-fpm-local/files/etc/php/5.6/fpm/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/5.6/fpm/php.ini
@@ -81,7 +81,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025 -t"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/nginx-php-fpm-local/files/etc/php/7.0/cli/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.0/cli/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025 -t"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/nginx-php-fpm-local/files/etc/php/7.0/fpm/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.0/fpm/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025 -t"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/nginx-php-fpm-local/files/etc/php/7.1/cli/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025 -t"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/nginx-php-fpm-local/files/etc/php/7.1/fpm/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025 -t"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/nginx-php-fpm-local/files/etc/php/7.2/cli/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025 -t"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/nginx-php-fpm-local/files/etc/php/7.2/fpm/php.ini
+++ b/containers/nginx-php-fpm-local/files/etc/php/7.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025 -t"
 
 [SQL]
 sql.safe_mode = Off


### PR DESCRIPTION
The famous SwiftMailer-component (used for example by
TYPO3) expects either -bs or -t in the sendmail-call.
Provide -t by default, as it is usually done when
calling the real sendmail-binary.

Resolves: #971

## The Problem/Issue/Bug:
With ddev and a typo3-project the default of sending a mail from TYPO3 to MailHog is using the sendmail-functionality of php. TYPO3 uses the famous SwiftMailer-component to send mail.

Trying to send a testmail SwiftMailer then fails with an error because it expects either "-bs" or "-t" in the sendmail-commandline. MailHog doesn't seem to care if -t is provided or not.

## How this PR Solves The Problem:
Let's add "-t" to the sendmail-call in php.ini-files.

## Manual Testing Instructions:
Installing a TYPO3-project with ddev, using the test-mail-functionality from the install-tool.

## Automated Testing Overview:
Calling the sendmail-binary with or without -t doesn't make a difference for MailHog.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/971