### PR TITLE
Fix case of Sequel Pro.app, fixes #969

### DIFF
--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -21,7 +21,7 @@ import (
 
 // SequelproLoc is where we expect to find the sequel pro.app
 // It's global so it can be mocked in testing.
-var SequelproLoc = "/Applications/sequel pro.app"
+var SequelproLoc = "/Applications/Sequel Pro.app"
 
 // DdevSequelproCmd represents the sequelpro command
 var DdevSequelproCmd = &cobra.Command{


### PR DESCRIPTION
## The Problem/Issue/Bug:

The app location for looking for Sequel Pro uses wrong capitalization, breaking the command for macOS systems with case-sensitive file systems.

## How this PR Solves The Problem:

Change the capitalization.

## Manual Testing Instructions:

Unfortunately I wasn't able to figure out an easy way to test this, so will have to ask the issue originator to test.

## Automated Testing Overview:

This is too hard and too obscure to do tests.

## Related Issue Link(s):

OP #969 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

