### PR TITLE
Improve mariadb-local test to work on linux without making un-deletable files

### DIFF
--- a/.buildkite/macos_container.yml
+++ b/.buildkite/macos_container.yml
@@ -4,4 +4,5 @@
       - "dockertype=dockerformac"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
+      BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
     parallelism: 1

--- a/.buildkite/macosdockerformac.yml
+++ b/.buildkite/macosdockerformac.yml
@@ -4,4 +4,5 @@
       - "dockertype=dockerformac"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
+      BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
     parallelism: 1

--- a/containers/mariadb-local/test/testserver.sh
+++ b/containers/mariadb-local/test/testserver.sh
@@ -7,11 +7,21 @@ MYSQL_VERSION="$2"
 CONTAINER_NAME="testserver"
 HOSTPORT=33000
 MYTMPDIR="${HOME}/tmp/testserver-sh_${RANDOM}_$$"
+outdir="${HOME}/tmp/mariadb_testserver/output_${RANDOM}_$$"
+
+export MOUNTUID=$UID
+export MOUNTGID=$(id -g)
+if [[ "$MOUNTUID" -gt "60000" || "$MOUNTGID" -gt "60000" ]] ; then
+	MOUNTUID=1
+	MOUNTGID=1
+fi
+
 
 # Always clean up the container on exit.
 function cleanup {
 	echo "Removing ${CONTAINER_NAME}"
 	docker rm -f $CONTAINER_NAME 2>/dev/null || true
+	rm -rf $outdir $MYTMPDIR
 }
 
 # Wait for container to be ready.
@@ -39,7 +49,7 @@ mkdir -p "$MYTMPDIR"
 rm -rf $MYTMPDIR/*
 
 echo "Starting image with database image $IMAGE"
-if ! docker run -u "$(id -u):$(id -g)" -v /$MYTMPDIR:/var/lib/mysql --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
+if ! docker run -u "$MOUNTUID:$MOUNTGID" -v /$MYTMPDIR:/var/lib/mysql --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
 	echo "MySQL server start failed with error code $?"
 	exit 2
 fi
@@ -86,7 +96,7 @@ mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$H
 cleanup
 
 # Run with alternate configuration my.cnf mounted
-if ! docker run -u "$(id -u):$(id -g)" -v /$MYTMPDIR:/var/lib/mysql -v /$PWD/test/testdata:/mnt/ddev_config --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
+if ! docker run -u "$MOUNTUID:$MOUNTGID" -v /$MYTMPDIR:/var/lib/mysql -v /$PWD/test/testdata:/mnt/ddev_config --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
 	echo "MySQL server start failed with error code $?"
 	exit 3
 fi
@@ -105,15 +115,12 @@ mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$H
 cleanup
 
 # Test that the create_base_db.sh script can create a starter tarball.
-# This one runs as root, and ruins the underlying host mount on linux (makes it owned by root)
-outdir="${HOME}/tmp/mariadb_testserver/output_${RANDOM}_$$"
 mkdir -p $outdir
-docker run -t -v "/$outdir://mysqlbase" --rm --entrypoint=//create_base_db.sh $IMAGE
+docker run -u "$MOUNTUID:$MOUNTGID" -t -v "/$outdir://mysqlbase" --rm --entrypoint=//create_base_db.sh $IMAGE
 if [ ! -f "$outdir/ibdata1" ] ; then
   echo "Failed to build test starter database for mariadb."
   exit 4
 fi
-rm -rf $outdir $MYTMPDIR
 
 echo "Tests passed"
 exit 0

--- a/containers/mariadb-local/test/testserver.sh
+++ b/containers/mariadb-local/test/testserver.sh
@@ -21,7 +21,10 @@ fi
 function cleanup {
 	echo "Removing ${CONTAINER_NAME}"
 	docker rm -f $CONTAINER_NAME 2>/dev/null || true
-	rm -rf $outdir $MYTMPDIR
+	# We use MYTMPDIR for a bogus temp dir since mktemp -d creates a dir
+    # outside a docker-mountable directory on macOS
+    mkdir -p "$MYTMPDIR" "$outdir"
+    rm -rf $MYTMPDIR/* $outdir/*
 }
 
 # Wait for container to be ready.
@@ -42,11 +45,6 @@ function containercheck {
 
 # Just to make sure we're starting with a clean environment.
 cleanup
-
-# We use MYTMPDIR for a bogus temp dir since mktemp -d creates a dir
-# outside a docker-mountable directory on macOS
-mkdir -p "$MYTMPDIR"
-rm -rf $MYTMPDIR/*
 
 echo "Starting image with database image $IMAGE"
 if ! docker run -u "$MOUNTUID:$MOUNTGID" -v /$MYTMPDIR:/var/lib/mysql --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then

--- a/containers/mariadb-local/test/testserver.sh
+++ b/containers/mariadb-local/test/testserver.sh
@@ -29,7 +29,7 @@ function cleanup {
 
 # Wait for container to be ready.
 function containercheck {
-	for i in {60..0};
+	for i in {15..0};
 	do
 		# status contains uptime and health in parenthesis, sed to return health
 		status="$(docker ps --format "{{.Status}}" --filter "name=$CONTAINER_NAME" | sed  's/.*(\(.*\)).*/\1/')"

--- a/containers/mariadb-local/test/testserver.sh
+++ b/containers/mariadb-local/test/testserver.sh
@@ -116,7 +116,7 @@ cleanup
 
 # Test that the create_base_db.sh script can create a starter tarball.
 mkdir -p $outdir
-docker run -u "$MOUNTUID:$MOUNTGID" -t -v "/$outdir://mysqlbase" --rm --entrypoint=//create_base_db.sh $IMAGE
+docker run -u "$MOUNTUID:$MOUNTGID" -t -v /$outdir://mysqlbase --rm --entrypoint=//create_base_db.sh $IMAGE
 if [ ! -f "$outdir/ibdata1" ] ; then
   echo "Failed to build test starter database for mariadb."
   exit 4


### PR DESCRIPTION

## The Problem/Issue/Bug:

Nightly build is breaking due to changes in how we test/generate the mysql starter db. See https://circleci.com/gh/drud/ddev/3052?utm_campaign=build-failed&utm_medium=email&utm_source=notification


## How this PR Solves The Problem:

Try to make the output not violate fs permissions.

## Manual Testing Instructions:

Run the nightly build against this PR.

