### PR TITLE
Improve handling of missing settings files, fixes #958

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -467,9 +467,8 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 	makeWritable := []string{path.Dir(app.SiteSettingsPath), app.SiteSettingsPath}
 	for _, o := range makeWritable {
 		stat, err := os.Stat(o)
-		if err != nil {
-			// Warn the user, but continue.
-			util.Warning("Unable to set permissions: %v", err)
+		// If the file doesn't exist, don't try to set the permissions.
+		if os.IsNotExist(err) {
 			continue
 		}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
#958 

## How this PR Solves The Problem:
Specifically check for os.IsNotExist(), remove warning output that implied a permissions change was attempted.

## Manual Testing Instructions:
Remove a Drupal project's sites/default/settings.php, execute `ddev start`. No warning message is emitted.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

