### PR TITLE
Ensure write permissions of settings.local.php and services.yml, fixes #983

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -473,7 +473,6 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 	}
 
 	for _, o := range makeWritable {
-		fmt.Printf("Making %s writable\n", o)
 		stat, err := os.Stat(o)
 		// If the file doesn't exist, don't try to set the permissions.
 		if os.IsNotExist(err) {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -464,8 +464,16 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 	output.UserOut.Printf("Ensuring write permissions for %s...", app.GetName())
 	var writePerms os.FileMode = 0200
 
-	makeWritable := []string{path.Dir(app.SiteSettingsPath), app.SiteSettingsPath}
+	settingsDir := path.Dir(app.SiteSettingsPath)
+	makeWritable := []string{
+		settingsDir,
+		app.SiteSettingsPath,
+		app.SiteLocalSettingsPath,
+		path.Join(settingsDir, "services.yml"),
+	}
+
 	for _, o := range makeWritable {
+		fmt.Printf("Making %s writable\n", o)
 		stat, err := os.Stat(o)
 		// If the file doesn't exist, don't try to set the permissions.
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## The Problem/Issue/Bug:
#983: Drupal sets read-only permissions on settings.local.php and services.yml.

## How this PR Solves The Problem:
Adds these two files to makeWritable, which will check for their existence and ensure they're writable.

## Manual Testing Instructions:
- Create sites/default/settings.local.php
- Create sites/default/services.yml
- chmod both files to 400
- ddev start
- Both files have user write permissions

