### PR TITLE
Check testbot sanity before continuing with tests

### DIFF
--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -24,4 +24,4 @@ if [ $(go env GOOS) = "windows"  -a $(git config core.autocrlf) != "false" ] ; t
  exit 3
 fi
 
-echo "testbot seems to be set up OK"
+echo "=== testbot $HOSTNAME seems to be set up OK ==="

--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -19,7 +19,7 @@ for command in mysql git go make; do
     command -v $command >/dev/null || ( echo "Did not find command installed '$command'" && exit 2 )
 done
 
-if [ $(go env GOOS) = "windows"  -a $(git config core.autocrlf) != "false" ] ; then
+if [ "$(go env GOOS)" = "windows"  -a "$(git config core.autocrlf)" != "false" ] ; then
  echo "git config core.autocrlf is not set to false on windows"
  exit 3
 fi

--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check a testbot or test environment to make sure it's likely to be sane.
+# We should add to this script whenever a testbot fails and we can figure out why.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+#set -x
+
+# Test to make sure docker is installed and working
+docker ps >/dev/null
+# Test that docker can allocate 80 and 443, get get busybox
+docker pull busybox:latest >/dev/null
+docker run -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 --rm busybox:latest ls >/dev/null
+
+# Check that required commands are available.
+for command in mysql git go make; do
+    command -v $command >/dev/null || ( echo "Did not find command installed '$command'" && exit 2 )
+done
+
+if [ $(go env GOOS) = "windows"  -a $(git config core.autocrlf) != "false" ] ; then
+ echo "git config core.autocrlf is not set to false on windows"
+ exit 3
+fi
+
+echo "testbot seems to be set up OK"

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -19,12 +19,18 @@ echo "Warning: deleting all docker containers and deleting ~/.ddev/Test*"
 if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
 	docker rm -f $(docker ps -aq)
 fi
-echo "Docker ps -a:"
-docker ps -a
 
-# Update all images that may have changed
-docker images |grep -v REPOSITORY | awk '{print $1":"$2 }' | xargs -L1 docker pull
+# Update all images that couyld have changed
+docker images | awk '/drud/ {print $1":"$2 }' | xargs -L1 docker pull
 rm -rf ~/.ddev/Test*
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -x
+
+# Our testbot should now be sane, run the testbot checker to make sure.
+./.buildkite/sanetestbot.sh
 
 echo "Running tests..."
 time make test

--- a/.buildkite/test_containers.sh
+++ b/.buildkite/test_containers.sh
@@ -21,6 +21,9 @@ if [ ! -z "$IMAGES" ] ; then
   docker rmi --force $IMAGES
 fi
 
+# Our testbot should now be sane, run the testbot checker to make sure.
+./.buildkite/sanetestbot.sh
+
 for dir in containers/*
     do pushd $dir
     echo "--- Build container $dir"

--- a/docs/developers/buildkite-testmachine-setup.md
+++ b/docs/developers/buildkite-testmachine-setup.md
@@ -19,8 +19,8 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 12. On Docker Toolbox systems, make sure that nested virtualization is enabled however you need to enable it.
 13. Edit /c/ProgramData/git/config to `autocrlf: false` and verify that `git config --list` shows only autocrlf: false. 
 14. Run `winpty docker run -it -p 80 busybox ls` to trigger the Windows Defender warning, and "allow access".
-`
-15. Reboot the machine and do a test run.
+15. Try running .buildkite/sanetestbot.sh to check your work.
+16. Reboot the machine and do a test run.
 
 ### macOS Test Agent Setup
 
@@ -33,4 +33,5 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 7. Enable nosleep using its shortcut in the Mac status bar.
 8. In nosleep Preferences, enable "Never sleep on AC Adapter", "Never sleep on Battery", and "Start nosleep utility on system startup".
 9. Set up Mac to [automatically log in on boot](https://support.apple.com/en-us/HT201476).
-10. Reboot the machine and do a test run.
+10. Try running .buildkite/sanetestbot.sh to check your work.
+11. Reboot the machine and do a test run.


### PR DESCRIPTION
## The Problem/Issue/Bug:

We sometimes have a broken buildkite testbot in any of a number of ways, and never find out about it until it's run forever and ever. This additional script does an initial test to see if the testbot is sane before continuing the test.

