### PR TITLE
Allow arbitrary additional_fqdns, fixes #868

### DIFF
--- a/docs/users/extend/additional-hostnames.md
+++ b/docs/users/extend/additional-hostnames.md
@@ -13,3 +13,18 @@ additional_hostnames:
 ```
 
 This configuration would result in working hostnames of mysite.ddev.local, extraname.ddev.local, fr.mysite.ddev.local, es.mysite.ddev.local, and it.mysite.ddev.local (with full http and https URLs for each).
+
+You can also provide additional_fqdn entries, which don't use the ".ddev.local" top-level domain. 
+
+```
+name: somename
+
+additional_fqdns:
+- mysite.com
+- somesite.yoursite.com
+- anothersite.yoursite.com
+```
+
+This configuration would result in working hostnames of somename.ddev.local, mysite.com, somesite.yoursite.com http://anothersite.yoursite.com, and anothersite.yoursite.com.
+
+Please be warned that this may not work predictably on all systems. There are operating systems and machines where /etc/hosts may not be the first or only resolution technique, especially if the additional_fqdn you use is also in DNS.

--- a/docs/users/extend/additional-hostnames.md
+++ b/docs/users/extend/additional-hostnames.md
@@ -27,6 +27,8 @@ additional_fqdns:
 
 This configuration would result in working FQDNs of somename.ddev.local, example.com, somesite.example.com, and anothersite.example.com.
 
+**Note**: If you see ddev-router status become unhealthy in `ddev list`, it's most often a result of trying to use conflicting FQDNs in more than one project. "example.com" can only be assigned to one project, or it will break ddev-router.
+
 **Warning**: this may not work predictably on all systems. There are operating systems and machines where /etc/hosts may not be the first or only resolution technique, especially if the additional_fqdn you use is also in DNS.
 
 **Warning**: if you use an additional_fqdn that exists on the internet (like "www.google.com"), your hosts file will override access to the original (internet) site, and you'll be sad and confused that you can't get to it.

--- a/docs/users/extend/additional-hostnames.md
+++ b/docs/users/extend/additional-hostnames.md
@@ -14,18 +14,18 @@ additional_hostnames:
 
 This configuration would result in working hostnames of mysite.ddev.local, extraname.ddev.local, fr.mysite.ddev.local, es.mysite.ddev.local, and it.mysite.ddev.local (with full http and https URLs for each).
 
-You can also provide additional_fqdn entries, which don't use the ".ddev.local" top-level domain. 
+**Although we recommend extreme care with this feature**, you can also provide additional_fqdn entries, which don't use the ".ddev.local" top-level domain.  **This feature populates your hosts file with entries which may hide the real DNS entries on the internet, causing way too much head-scratching.**
 
 ```
 name: somename
 
 additional_fqdns:
-- mysite.com
-- somesite.yoursite.com
-- anothersite.yoursite.com
+- example.com
+- somesite.example.com
+- anothersite.example.com
 ```
 
-This configuration would result in working FQDNs of somename.ddev.local, mysite.com, somesite.yoursite.com http://anothersite.yoursite.com, and anothersite.yoursite.com.
+This configuration would result in working FQDNs of somename.ddev.local, example.com, somesite.example.com, and anothersite.example.com.
 
 **Warning**: this may not work predictably on all systems. There are operating systems and machines where /etc/hosts may not be the first or only resolution technique, especially if the additional_fqdn you use is also in DNS.
 

--- a/docs/users/extend/additional-hostnames.md
+++ b/docs/users/extend/additional-hostnames.md
@@ -25,6 +25,8 @@ additional_fqdns:
 - anothersite.yoursite.com
 ```
 
-This configuration would result in working hostnames of somename.ddev.local, mysite.com, somesite.yoursite.com http://anothersite.yoursite.com, and anothersite.yoursite.com.
+This configuration would result in working FQDNs of somename.ddev.local, mysite.com, somesite.yoursite.com http://anothersite.yoursite.com, and anothersite.yoursite.com.
 
-Please be warned that this may not work predictably on all systems. There are operating systems and machines where /etc/hosts may not be the first or only resolution technique, especially if the additional_fqdn you use is also in DNS.
+**Warning**: this may not work predictably on all systems. There are operating systems and machines where /etc/hosts may not be the first or only resolution technique, especially if the additional_fqdn you use is also in DNS.
+
+**Warning**: if you use an additional_fqdn that exists on the internet (like "www.google.com"), your hosts file will override access to the original (internet) site, and you'll be sad and confused that you can't get to it.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -307,6 +307,10 @@ func (app *DdevApp) GetHostnames() []string {
 		nameListMap[name+"."+version.DDevTLD] = 1
 	}
 
+	for _, name := range app.AdditionalFQDNs {
+		nameListMap[name] = 1
+	}
+
 	// Now walk the map and extract the keys into an array.
 	nameListArray := make([]string, 0, len(nameListMap))
 	for k := range nameListMap {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -66,6 +66,7 @@ type DdevApp struct {
 	RouterHTTPSPort       string               `yaml:"router_https_port"`
 	XdebugEnabled         bool                 `yaml:"xdebug_enabled"`
 	AdditionalHostnames   []string             `yaml:"additional_hostnames"`
+	AdditionalFQDNs       []string             `yaml:"additional_fqdns"`
 	ConfigPath            string               `yaml:"-"`
 	AppRoot               string               `yaml:"-"`
 	Platform              string               `yaml:"-"`
@@ -794,7 +795,7 @@ func (app *DdevApp) DockerEnv() {
 	envVars["COLUMNS"] = strconv.Itoa(columns)
 	envVars["LINES"] = strconv.Itoa(lines)
 
-	if len(app.AdditionalHostnames) > 0 {
+	if len(app.AdditionalHostnames) > 0 || len(app.AdditionalFQDNs) > 0 {
 		// TODO: Warn people about additional names in use.
 		envVars["DDEV_HOSTNAME"] = strings.Join(app.GetHostnames(), ",")
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -796,7 +796,6 @@ func (app *DdevApp) DockerEnv() {
 	envVars["LINES"] = strconv.Itoa(lines)
 
 	if len(app.AdditionalHostnames) > 0 || len(app.AdditionalFQDNs) > 0 {
-		// TODO: Warn people about additional names in use.
 		envVars["DDEV_HOSTNAME"] = strings.Join(app.GetHostnames(), ",")
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -695,12 +695,6 @@ func TestDdevLogs(t *testing.T) {
 		assert.Contains(out, "Server started")
 
 		stdout = testcommon.CaptureUserOut()
-		err = app.Logs("db", false, false, "1000")
-		assert.NoError(err)
-		out = stdout()
-		assert.Contains(out, "Database initialized")
-
-		stdout = testcommon.CaptureUserOut()
 		err = app.Logs("db", false, false, "")
 		assert.NoError(err)
 		out = stdout()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -291,7 +291,15 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 			assert.NoError(err)
 		}
 
+		// Multiple projects can't run at the same time with the fqdns, so we need to clean
+		// up these for tests that run later.
+		app.AdditionalFQDNs = []string{}
+		app.AdditionalHostnames = []string{}
+		app.WriteConfig()
+
 		err = app.Stop()
+		assert.NoError(err)
+		err = app.Down(false)
 		assert.NoError(err)
 
 		runTime()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/version"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/lunixbochs/vtclean"
 	log "github.com/sirupsen/logrus"
@@ -255,6 +256,10 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		// "a" is repeated for the same reason; a user error of this type should not cause a failure; GetHostNames()
 		// should uniqueify them.
 		app.AdditionalHostnames = []string{"sub1." + site.Name, "sub2." + site.Name, "subname.sub3." + site.Name, site.Name, site.Name, site.Name}
+
+		// sub1.<sitename>.ddev.local and sitename.ddev.local are deliberately included to prove they don't
+		// cause ddev-router failures"
+		app.AdditionalFQDNs = []string{"one.example.com", "two.example.com", "a.one.example.com", site.Name + "." + version.DDevTLD, "sub1." + site.Name + version.DDevTLD}
 
 		err = app.WriteConfig()
 		assert.NoError(err)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -129,6 +129,12 @@ const ConfigInstructions = `
 # would provide http and https URLs for "somename.ddev.local"
 # and "someothername.ddev.local".
 
+#additional_fqdns:
+# - example.com
+# - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
 # provider: default # Currently either "default" or "pantheon"
 #
 # Many ddev commands can be extended to run tasks after the ddev command is


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #868: People want to use URLs that do not container ddev.local. 

## How this PR Solves The Problem:

* Add additional_fqdns[] array to the config.yaml. People can then have as many URLs pointing to their project as they could ever want.
* Add docs explain it, but mentioning why to avoid this feature.

## Manual Testing Instructions:

Set up config.yaml with additional_fqdns as in the docs added here. 

## Automated Testing Overview:

Added additional_fqdns testing into TestDdevStartMultipleHostnames()

## Related Issue Link(s):

OP #868 
[Make ddev-router more transparent about failures #774](https://github.com/drud/ddev/issues/774) - It's a known issue that two live sites can't share the same fqdn or additional_hostname, and it causes an annoying and hard-to-understand ddev-router failure to start.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

