### PR TITLE
Improved management of settings files, introduce settings.ddev.php

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -5,7 +5,7 @@ Type `ddev` or `ddev -h`in a terminal windows to see the available ddev commands
 
 ## Quickstart Guides
 
-These are quickstart instructions for WordPress, Drupal 7, Drupal 8, TYPO3, and Backdrop.
+These are quickstart instructions for WordPress, Drupal 6, Drupal 7, Drupal 8, TYPO3, and Backdrop.
 
 **Prerequisites:** Before you start, follow the [installation instructions](../index.md#installation). Make sure to [check the system requirements](../index.md#system-requirements), you will need *docker* and *docker-compose* to use ddev.
 
@@ -213,7 +213,7 @@ For in-depth application monitoring, use the command `ddev describe` to see deta
 
 ## Getting Started
 
-Check out the git repository for the project you want to work on. `cd` into the directory and run `ddev config` and follow the prompts.
+Check out the git repository for the project you want to work on. `cd` into the directory, run `ddev config`, and follow the prompts.
 
 ```
 $ cd ~/Projects
@@ -232,22 +232,7 @@ Docroot Location: web
 Found a drupal8 codebase at /Users/username/Projects/drupal8/web
 ```
 
-Configuration files have now been created for your project. (Take a look at the file on the project's .ddev/ddev.yaml file). Additionally, the `ddev config` steps attempts to create a CMS specific database settings with the DDEV specific credentials pre-populated. Here's a Drupal specific example that is mirrored in the other CMSes.
-
-* If settings.php does not exist, create it.
-* If a settings.php file exists that DDEV manages, recreate it.
-* If a settings.php file exists that DDEV does not manage, create settings.local.php.
-* If a settings.local.php file exists that DDEV manages, recreate it.
-* If a settings.local.php file exists that DDEV does not manage, warn the user and proceed.
-
-How do you know if DDEV manages a database settings file? You will see the following comment. Remove the comment and DDEV will not attempt to overwrite it!
-
-```
-/**
- #ddev-generated: Automatically generated Drupal settings.php file.
- ddev manages this file and may delete or overwrite the file unless this comment is removed.
- */
-```
+Configuration files have now been created for your project. Take a look at the project's .ddev/config.yaml file.
 
 Now that the configuration files have been created, you can start your project with `ddev start` (still from within the project working directory):
 
@@ -264,7 +249,29 @@ Your project can be reached at: http://drupal8.ddev.local
 
 And you can now visit your working project. Enjoy!
 
+### Configuration files
 _Please note that if you're providing the settings.php or wp-config.php and ddev is creating the settings.local.php (or wordpress wp-config-local.php), the main settings file must explicitly include the appropriate "settings.local.php" or equivalent._
+
+The `ddev config` command attempts to create a CMS-specific settings file with DDEV credentials pre-populated.
+
+For **Drupal** and **Backdrop**, DDEV settings are written to a DDEV-managed file, settings.ddev.php. The `ddev config` command will ensure that these settings are included in your settings.php through the following steps:
+
+* Write DDEV settings to settings.ddev.php
+* If no settings.php file exists, create one that includes settings.ddev.php
+* If a settings.php file already exists, ensure that it includes settings.ddev.php, modifying settings.php to write the include if necessary
+
+For **TYPO3**, DDEV settings are written to AdditionalConfiguration.php.  If AdditionalConfiguration.php exists and is not managed by DDEV, it will not be modified.
+
+For **Wordpress**, DDEV settings are written to wp-config.php.
+
+How do you know if DDEV manages a settings file? You will see the following comment. Remove the comment and DDEV will not attempt to overwrite it!
+
+```
+/**
+ #ddev-generated: Automatically generated Drupal settings.php file.
+ ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ */
+```
 
 ## Listing project information
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -250,7 +250,7 @@ Your project can be reached at: http://drupal8.ddev.local
 And you can now visit your working project. Enjoy!
 
 ### Configuration files
-_Please note that if you're providing the settings.php or wp-config.php and ddev is creating the settings.local.php (or wordpress wp-config-local.php), the main settings file must explicitly include the appropriate "settings.local.php" or equivalent._
+_**Note:** If you're providing the settings.php or wp-config.php and DDEV is creating the settings.ddev.php (or wp-config-local.php, AdditionalConfig.php, or similar), the main settings file must explicitly include the appropriate DDEV-generated settings file._
 
 The `ddev config` command attempts to create a CMS-specific settings file with DDEV credentials pre-populated.
 

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -119,7 +119,7 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteLocalSettingsPath), settings.SiteSettingsLocal); err != nil {
-		output.UserOut.Warnf("Failed to write .gitignore: %v", err)
+		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", app.SiteLocalSettingsPath, err)
 	}
 
 	return app.SiteLocalSettingsPath, nil

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -143,7 +143,7 @@ func writeBackdropMainSettingsFile(settings *BackdropSettings, filePath string) 
 
 	// Ensure target directory is writable.
 	dir := filepath.Dir(filePath)
-	if err := os.Chmod(dir, 0755); err != nil {
+	if err = os.Chmod(dir, 0755); err != nil {
 		return err
 	}
 
@@ -170,7 +170,7 @@ func writeBackdropDdevSettingsFile(settings *BackdropSettings, filePath string) 
 
 	// Ensure target directory is writable
 	dir := filepath.Dir(filePath)
-	if err := os.Chmod(dir, 0755); err != nil {
+	if err = os.Chmod(dir, 0755); err != nil {
 		return err
 	}
 
@@ -242,7 +242,7 @@ func addIncludeToBackdropSettingsFile(settings *BackdropSettings, siteSettingsPa
 
 	// If settings.php is empty, write the complete settings template
 	if len(currentSiteSettings) == 0 {
-		if err := writeBackdropMainSettingsFile(settings, siteSettingsPath); err != nil {
+		if err = writeBackdropMainSettingsFile(settings, siteSettingsPath); err != nil {
 			return err
 		}
 	}

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -51,8 +51,8 @@ func NewBackdropSettings() *BackdropSettings {
 const backdropMainSettingsTemplate = `<?php
 {{ $config := . }}
 // {{ $config.Signature }}: Automatically generated Backdrop settings file.
-if (file_exists('{{ $config.SiteSettingsLocal }}')) {
-  include '{{ $config.SiteSettingsLocal }}';
+if (file_exists(__DIR__ . '/{{ $config.SiteSettingsLocal }}')) {
+  include __DIR__ . '/{{ $config.SiteSettingsLocal }}';
 }
 `
 
@@ -60,8 +60,8 @@ if (file_exists('{{ $config.SiteSettingsLocal }}')) {
 // settings.php in the event that one exists.
 const backdropSettingsAppendTemplate = `{{ $config := . }}
 // Automatically generated include for settings managed by ddev.
-if (file_exists('{{ $config.SiteSettingsLocal }}')) {
-  include '{{ $config.SiteSettingsLocal }}';
+if (file_exists(__DIR__ . '/{{ $config.SiteSettingsLocal }}')) {
+  include __DIR__ . '/{{ $config.SiteSettingsLocal }}';
 }
 `
 

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -119,7 +119,7 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteLocalSettingsPath), settings.SiteSettingsLocal); err != nil {
-		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", app.SiteLocalSettingsPath, err)
+		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteLocalSettingsPath), err)
 	}
 
 	return app.SiteLocalSettingsPath, nil

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -54,7 +54,7 @@ const backdropMainSettingsTemplate = `<?php
 /**
  This was automatically generated to include settings managed by ddev.
  */
-include {{ '$config.SiteSettingsLocal }}';
+include '{{ $config.SiteSettingsLocal }}';
 `
 
 const backdropSettingsAppendTemplate = `{{ $config := . }}
@@ -94,7 +94,7 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 
 	if !fileutil.FileExists(app.SiteSettingsPath) {
 		output.UserOut.Printf("No %s file exists, creating one", settings.SiteSettings)
-		if err := writeBackdropMainSettingsFile(settings, app.SiteLocalSettingsPath); err != nil {
+		if err := writeBackdropMainSettingsFile(settings, app.SiteSettingsPath); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -116,14 +116,8 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 		}
 	}
 
-	// Create settings.ddev.php if one doesn't already exist
-	if fileutil.FileExists(app.SiteLocalSettingsPath) {
-		output.UserOut.Printf("ddev settings file %s already exists", settings.SiteSettingsLocal)
-	} else {
-		output.UserOut.Printf("No %s exists, creating one", settings.SiteSettingsLocal)
-		if err := writeBackdropDdevSettingsFile(settings, app.SiteLocalSettingsPath); err != nil {
-			return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
-		}
+	if err := writeBackdropDdevSettingsFile(settings, app.SiteLocalSettingsPath); err != nil {
+		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteLocalSettingsPath), settings.SiteSettingsLocal); err != nil {

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -59,7 +59,7 @@ if (file_exists('{{ $config.SiteSettingsLocal }}')) {
 // backdropSettingsAppendTemplate defines the template that will be appended to
 // settings.php in the event that one exists.
 const backdropSettingsAppendTemplate = `{{ $config := . }}
-// {{ $config.Signature }}: Automatically generated include for settings managed by ddev.
+// Automatically generated include for settings managed by ddev.
 if (file_exists('{{ $config.SiteSettingsLocal }}')) {
   include '{{ $config.SiteSettingsLocal }}';
 }

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -52,26 +52,26 @@ func NewBackdropSettings() *BackdropSettings {
 // the event that one does not already exist.
 const backdropMainSettingsTemplate = `<?php
 {{ $config := . }}
-/**
- This was automatically generated to include settings managed by ddev.
- */
-include '{{ $config.SiteSettingsLocal }}';
+// {{ $config.Signature }}: Automatically generated Backdrop settings file.
+if (file_exists( {{ $config.SiteSettingsLocal }} )) {
+  include '{{ $config.SiteSettingsLocal }}';
+}
 `
 
 // backdropSettingsAppendTemplate defines the template that will be appended to
 // settings.php in the event that one exists.
 const backdropSettingsAppendTemplate = `{{ $config := . }}
-/**
- This was automatically generated to include settings managed by ddev.
- */
-include '{{ $config.SiteSettingsLocal }}';
+// {{ $config.Signature }}: Automatically generated include for settings managed by ddev.
+if (file_exists( {{ $config.SiteSettingsLocal }} )) {
+  include '{{ $config.SiteSettingsLocal }}';
+}
 `
 
 // backdropLocalSettingsTemplate defines the template that will become settings.ddev.php.
 const backdropLocalSettingsTemplate = `<?php
 {{ $config := . }}
 /**
- {{ $config.Signature }}: Automatically generated Backdrop settings.php file.
+ {{ $config.Signature }}: Automatically generated Backdrop settings file.
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
 

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -48,7 +48,6 @@ func NewBackdropSettings() *BackdropSettings {
 	}
 }
 
-// TODO: Share basic settings templates
 const backdropMainSettingsTemplate = `<?php
 {{ $config := . }}
 /**
@@ -252,7 +251,7 @@ func addIncludeToBackdropSettingsFile(settings *BackdropSettings, siteSettingsPa
 		return err
 	}
 
-	// If settings.php is empty, just write the entire settings file to it
+	// If settings.php is empty, write the complete settings template
 	if len(currentSiteSettings) == 0 {
 		if err := writeBackdropMainSettingsFile(settings, siteSettingsPath); err != nil {
 			return err

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -6,43 +6,67 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/Masterminds/sprig"
+	"io/ioutil"
+
+	"bytes"
+
 	"github.com/drud/ddev/pkg/appports"
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 )
 
 // BackdropSettings holds database connection details for Backdrop.
 type BackdropSettings struct {
-	DatabaseName     string
-	DatabaseUsername string
-	DatabasePassword string
-	DatabaseHost     string
-	DatabaseDriver   string
-	DatabasePort     string
-	DatabasePrefix   string
-	HashSalt         string
-	Signature        string
+	DatabaseName      string
+	DatabaseUsername  string
+	DatabasePassword  string
+	DatabaseHost      string
+	DatabaseDriver    string
+	DatabasePort      string
+	DatabasePrefix    string
+	HashSalt          string
+	Signature         string
+	SiteSettings      string
+	SiteSettingsLocal string
 }
 
 // NewBackdropSettings produces a BackdropSettings object with default values.
 func NewBackdropSettings() *BackdropSettings {
 	return &BackdropSettings{
-		DatabaseName:     "db",
-		DatabaseUsername: "db",
-		DatabasePassword: "db",
-		DatabaseHost:     "db",
-		DatabaseDriver:   "mysql",
-		DatabasePort:     appports.GetPort("db"),
-		DatabasePrefix:   "",
-		HashSalt:         util.RandString(64),
-		Signature:        DdevFileSignature,
+		DatabaseName:      "db",
+		DatabaseUsername:  "db",
+		DatabasePassword:  "db",
+		DatabaseHost:      "db",
+		DatabaseDriver:    "mysql",
+		DatabasePort:      appports.GetPort("db"),
+		DatabasePrefix:    "",
+		HashSalt:          util.RandString(64),
+		Signature:         DdevFileSignature,
+		SiteSettings:      "settings.php",
+		SiteSettingsLocal: "settings.ddev.php",
 	}
 }
 
+// TODO: Share basic settings templates
+const backdropMainSettingsTemplate = `<?php
+{{ $config := . }}
+/**
+ This was automatically generated to include settings managed by ddev.
+ */
+include {{ '$config.SiteSettingsLocal }}';
+`
+
+const backdropSettingsAppendTemplate = `{{ $config := . }}
+/**
+ This was automatically generated to include settings managed by ddev.
+ */
+include '{{ $config.SiteSettingsLocal }}';
+`
+
 // Note that this template will almost always be used for settings.local.php
 // because Backdrop ships with it's own default settings.php.
-const backdropTemplate = `<?php
+const backdropLocalSettingsTemplate = `<?php
 {{ $config := . }}
 /**
  {{ $config.Signature }}: Automatically generated Backdrop settings.php file.
@@ -66,34 +90,73 @@ ini_set('session.cookie_lifetime', 2000000);
 // adding things like database host, name, and password.
 // Returns the full path to the settings file and err.
 func createBackdropSettingsFile(app *DdevApp) (string, error) {
-	settingsFilePath, err := app.DetermineSettingsPathLocation()
-	if err != nil {
-		return "", fmt.Errorf("Failed to get Backdrop settings file path: %v", err.Error())
-	}
-	output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
+	settings := NewBackdropSettings()
 
-	backdropConfig := NewBackdropSettings()
-
-	err = writeBackdropSettingsFile(backdropConfig, settingsFilePath)
-	if err != nil {
-		return settingsFilePath, fmt.Errorf("Failed to write Backdrop settings file: %v", err.Error())
+	if !fileutil.FileExists(app.SiteSettingsPath) {
+		output.UserOut.Printf("No %s file exists, creating one", settings.SiteSettings)
+		if err := writeBackdropMainSettingsFile(settings, app.SiteLocalSettingsPath); err != nil {
+			return "", err
+		}
 	}
 
-	return settingsFilePath, nil
+	included, err := fileutil.FgrepStringInFile(app.SiteSettingsPath, settings.SiteSettingsLocal)
+	if err != nil {
+		return "", err
+	}
+
+	if included {
+		output.UserOut.Printf("Existing %s includes %s", settings.SiteSettings, settings.SiteSettingsLocal)
+	} else {
+		output.UserOut.Printf("Existing %s file does not include %s, modifying to include ddev settings", settings.SiteSettings, settings.SiteSettingsLocal)
+
+		if err := addIncludeToBackdropSettingsFile(settings, app.SiteSettingsPath); err != nil {
+			return "", fmt.Errorf("failed to include %s in %s: %v", settings.SiteSettingsLocal, settings.SiteSettings, err)
+		}
+	}
+
+	// Create settings.ddev.php if one doesn't already exist
+	if fileutil.FileExists(app.SiteLocalSettingsPath) {
+		output.UserOut.Printf("ddev settings file %s already exists", settings.SiteSettingsLocal)
+	} else {
+		output.UserOut.Printf("No %s exists, creating one", settings.SiteSettingsLocal)
+		if err := writeBackdropDdevSettingsFile(settings, app.SiteLocalSettingsPath); err != nil {
+			return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
+		}
+	}
+
+	if err := createGitIgnore(filepath.Dir(app.SiteLocalSettingsPath), settings.SiteSettingsLocal); err != nil {
+		output.UserOut.Warnf("Failed to write .gitignore: %v", err)
+	}
+
+	return app.SiteLocalSettingsPath, nil
+
+	//settingsFilePath, err := app.DetermineSettingsPathLocation()
+	//if err != nil {
+	//	return "", fmt.Errorf("Failed to get Backdrop settings file path: %v", err.Error())
+	//}
+	//output.UserOut.Printf("Generating %s file for database connection.", filepath.Base(settingsFilePath))
+	//
+	//settings := NewBackdropSettings()
+	//
+	//err = writeBackdropMainSettingsFile(settings, settingsFilePath)
+	//if err != nil {
+	//	return settingsFilePath, fmt.Errorf("Failed to write Backdrop settings file: %v", err.Error())
+	//}
+	//
+	//return settingsFilePath, nil
 }
 
-// writeBackdropSettingsFile dynamically produces a valid settings.php file by
+// writeBackdropMainSettingsFile dynamically produces a valid settings.php file by
 // combining a configuration object with a data-driven template.
-func writeBackdropSettingsFile(settings *BackdropSettings, filePath string) error {
-	tmpl, err := template.New("settings").Funcs(sprig.TxtFuncMap()).Parse(backdropTemplate)
+func writeBackdropMainSettingsFile(settings *BackdropSettings, filePath string) error {
+	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(backdropMainSettingsTemplate)
 	if err != nil {
 		return err
 	}
 
 	// Ensure target directory is writable.
 	dir := filepath.Dir(filePath)
-	err = os.Chmod(dir, 0755)
-	if err != nil {
+	if err := os.Chmod(dir, 0755); err != nil {
 		return err
 	}
 
@@ -101,11 +164,39 @@ func writeBackdropSettingsFile(settings *BackdropSettings, filePath string) erro
 	if err != nil {
 		return err
 	}
-	err = tmpl.Execute(file, settings)
+	defer util.CheckClose(file)
+
+	if err := tmpl.Execute(file, settings); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeBackdropDdevSettingsFile dynamically produces a valid settings.ddev.php file
+// by combining a configuration object with a data-driven template.
+func writeBackdropDdevSettingsFile(settings *BackdropSettings, filePath string) error {
+	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(backdropLocalSettingsTemplate)
 	if err != nil {
 		return err
 	}
-	util.CheckClose(file)
+
+	// Ensure target directory is writable
+	dir := filepath.Dir(filePath)
+	if err := os.Chmod(dir, 0755); err != nil {
+		return err
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer util.CheckClose(file)
+
+	if err := tmpl.Execute(file, settings); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -125,8 +216,10 @@ func getBackdropHooks() []byte {
 
 // setBackdropSiteSettingsPaths sets the paths to settings.php for templating.
 func setBackdropSiteSettingsPaths(app *DdevApp) {
+	settings := NewBackdropSettings()
 	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
-	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, "settings.local.php")
+	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, settings.SiteSettings)
+	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, settings.SiteSettingsLocal)
 }
 
 // isBackdropApp returns true if the app is of type "backdrop".
@@ -141,5 +234,45 @@ func isBackdropApp(app *DdevApp) bool {
 // appropriately in order for Backdrop to function properly.
 func backdropPostImportDBAction(app *DdevApp) error {
 	util.Warning("Backdrop sites require your config JSON files to be located in your site's \"active\" configuration directory. Please refer to the Backdrop documentation (https://backdropcms.org/user-guide/moving-backdrop-site) for more information about this process.")
+	return nil
+}
+
+//
+func addIncludeToBackdropSettingsFile(settings *BackdropSettings, siteSettingsPath string) error {
+	// Open file for appending to preserve current contents
+	file, err := os.OpenFile(siteSettingsPath, os.O_RDWR|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	defer util.CheckClose(file)
+
+	// Get current contents of settings.php
+	currentSiteSettings, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
+	// If settings.php is empty, just write the entire settings file to it
+	if len(currentSiteSettings) == 0 {
+		if err := writeBackdropMainSettingsFile(settings, siteSettingsPath); err != nil {
+			return err
+		}
+	}
+
+	// The file is not empty, append the include
+	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(backdropSettingsAppendTemplate)
+	if err != nil {
+		return err
+	}
+
+	b := bytes.NewBuffer([]byte{})
+	if err := tmpl.Execute(b, settings); err != nil {
+		return err
+	}
+
+	if _, err := file.Write(b.Bytes()); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -460,11 +460,11 @@ func TestDdevImportDB(t *testing.T) {
 			// Test that a settings file has correct hash_salt format
 			switch app.Type {
 			case "drupal7":
-				drupalHashSalt, err := fileutil.FgrepStringInFile(app.SiteSettingsPath, "$drupal_hash_salt")
+				drupalHashSalt, err := fileutil.FgrepStringInFile(app.SiteLocalSettingsPath, "$drupal_hash_salt")
 				assert.NoError(err)
 				assert.True(drupalHashSalt)
 			case "drupal8":
-				settingsHashSalt, err := fileutil.FgrepStringInFile(app.SiteSettingsPath, "settings['hash_salt']")
+				settingsHashSalt, err := fileutil.FgrepStringInFile(app.SiteLocalSettingsPath, "settings['hash_salt']")
 				assert.NoError(err)
 				assert.True(settingsHashSalt)
 			case "wordpress":

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -3,7 +3,6 @@ package ddevapp
 import (
 	"fmt"
 
-	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
@@ -615,15 +614,4 @@ func addIncludeToSettingsFile(siteSettingsPath string, drupalConfig *DrupalSetti
 
 	util.CheckClose(file)
 	return nil
-}
-
-//
-func getTemplateFuncMap() map[string]interface{} {
-	// Use sprig's template function map as a base
-	m := sprig.FuncMap()
-
-	// Add helpful utilities on top of it
-	m["joinPath"] = filepath.Join
-
-	return m
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -210,7 +210,7 @@ $databases['default']['default'] = array(
 // manageDrupalCommonSettingsFile will direct inspecting and writing the main settings file (settings.php).
 func manageDrupalCommonSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) error {
 	if !fileutil.FileExists(app.SiteSettingsPath) {
-		output.UserOut.Printf("No %s file exists", drupalConfig.SiteSettings)
+		output.UserOut.Printf("No %s file exists, creating one", drupalConfig.SiteSettings)
 
 		if err := writeDrupalCommonSettingsFile(drupalConfig, app.SiteSettingsPath); err != nil {
 			return fmt.Errorf("failed to write %s: %v", app.SiteSettingsPath, err)
@@ -223,7 +223,7 @@ func manageDrupalCommonSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) 
 	}
 
 	if !included {
-		output.UserOut.Printf("Existing %s file does not include %s", drupalConfig.SiteSettings, drupalConfig.SiteSettingsLocal)
+		output.UserOut.Printf("Existing %s file does not include %s, modifying to include ddev settings", drupalConfig.SiteSettings, drupalConfig.SiteSettingsLocal)
 
 		if err := addIncludeToSettingsFile(drupalConfig, app.SiteSettingsPath); err != nil {
 			return fmt.Errorf("failed to include %s in %s: %v", drupalConfig.SiteSettingsLocal, drupalConfig.SiteSettings, err)
@@ -236,8 +236,6 @@ func manageDrupalCommonSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) 
 // writeDrupalCommonSettingsFile creates the app's settings.php or equivalent,
 // which does nothing more than imports the ddev-managed settings.ddev.php.
 func writeDrupalCommonSettingsFile(drupalConfig *DrupalSettings, settingsFilePath string) error {
-	output.UserOut.Printf("Generating %s file to include %s.", drupalConfig.SiteSettings, drupalConfig.SiteSettingsLocal)
-
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(drupalCommonSettingsTemplate)
 	if err != nil {
 		return err
@@ -592,17 +590,11 @@ func settingsHasInclude(drupalConfig *DrupalSettings, siteSettingsPath string) (
 		return false, err
 	}
 
-	if !included {
-		output.UserOut.Printf("Settings file at %s does not include %s", siteSettingsPath, drupalConfig.SiteSettingsLocal)
-	}
-
 	return included, nil
 }
 
 // addIncludeToSettingsFile will include settings.ddev.php in settings.php.
 func addIncludeToSettingsFile(drupalConfig *DrupalSettings, siteSettingsPath string) error {
-	output.UserOut.Printf("Modifying %s to include %s", drupalConfig.SiteSettings, siteSettingsPath)
-
 	// Open file for appending to preserve current contents
 	file, err := os.OpenFile(siteSettingsPath, os.O_RDWR|os.O_APPEND, 0644)
 	if err != nil {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -237,7 +237,7 @@ func manageDrupalCommonSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) 
 }
 
 // writeDrupalCommonSettingsFile creates the app's settings.php or equivalent,
-// which does nothing more than imports the ddev-managed settings.ddev.php.
+// which does nothing more than import the ddev-managed settings.ddev.php.
 func writeDrupalCommonSettingsFile(drupalConfig *DrupalSettings, filePath string) error {
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(drupalCommonSettingsTemplate)
 	if err != nil {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -72,6 +72,8 @@ func NewDrushConfig() *DrushConfig {
 	}
 }
 
+// drupalCommonSettingsTemplate defines the template that will become settings.php
+// in the even that one does not already exist.
 const drupalCommonSettingsTemplate = `<?php
 {{ $config := . }}
 /**
@@ -80,6 +82,8 @@ const drupalCommonSettingsTemplate = `<?php
 include '{{ joinPath $config.SitePath $config.SiteSettingsLocal }}';
 `
 
+// drupalCommonSettingsAppendTemplate defines the template that will be appended to
+// settings.php in the event that one exists.
 const drupalCommonSettingsAppendTemplate = `{{ $config := . }}
 /**
  This was automatically generated to include settings managed by ddev.
@@ -206,7 +210,7 @@ $databases['default']['default'] = array(
 );
 `
 
-// manageDrupalCommonSettingsFile will direct inspecting and writing the main settings file (settings.php).
+// manageDrupalCommonSettingsFile will direct inspecting and writing of settings.php.
 func manageDrupalCommonSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) error {
 	if !fileutil.FileExists(app.SiteSettingsPath) {
 		output.UserOut.Printf("No %s file exists, creating one", drupalConfig.SiteSettings)
@@ -262,9 +266,9 @@ func writeDrupalCommonSettingsFile(drupalConfig *DrupalSettings, filePath string
 	return nil
 }
 
-// createDrupal7SettingsFile creates the app's settings.php or equivalent,
-// adding things like database host, name, and password
-// Returns the fullpath to settings file and err
+// createDrupal7SettingsFile manages creation and modification of settings.php and settings.ddev.php.
+// If a settings.php file already exists, it will be modified to ensure that it includes
+// settings.ddev.php, which contains ddev-specific configuration.
 func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 	// Currently there isn't any customization done for the drupal config, but
 	// we may want to do some kind of customization in the future.
@@ -291,9 +295,9 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 	return app.SiteLocalSettingsPath, nil
 }
 
-// createDrupal8SettingsFile creates the app's settings.php or equivalent,
-// adding things like database host, name, and password
-// Returns the fullpath to settings file and err
+// createDrupal8SettingsFile manages creation and modification of settings.php and settings.ddev.php.
+// If a settings.php file already exists, it will be modified to ensure that it includes
+// settings.ddev.php, which contains ddev-specific configuration.
 func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 	// Currently there isn't any customization done for the drupal config, but
 	// we may want to do some kind of customization in the future.
@@ -320,9 +324,9 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 	return app.SiteLocalSettingsPath, nil
 }
 
-// createDrupal6SettingsFile creates the app's settings.php or equivalent,
-// adding things like database host, name, and password
-// Returns the fullpath to settings file and err
+// createDrupal6SettingsFile manages creation and modification of settings.php and settings.ddev.php.
+// If a settings.php file already exists, it will be modified to ensure that it includes
+// settings.ddev.php, which contains ddev-specific configuration.
 func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 	// Currently there isn't any customization done for the drupal config, but
 	// we may want to do some kind of customization in the future.
@@ -349,7 +353,7 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 	return app.SiteLocalSettingsPath, nil
 }
 
-// writeDrupal8SettingsFile dynamically produces valid settings.php file by combining a configuration
+// writeDrupal8SettingsFile dynamically produces valid settings.ddev.php file by combining a configuration
 // object with a data-driven template.
 func writeDrupal8SettingsFile(settings *DrupalSettings, filePath string) error {
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(drupal8Template)
@@ -376,7 +380,7 @@ func writeDrupal8SettingsFile(settings *DrupalSettings, filePath string) error {
 	return nil
 }
 
-// writeDrupal7SettingsFile dynamically produces valid settings.php file by combining a configuration
+// writeDrupal7SettingsFile dynamically produces valid settings.ddev.php file by combining a configuration
 // object with a data-driven template.
 func writeDrupal7SettingsFile(settings *DrupalSettings, filePath string) error {
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(drupal7Template)
@@ -403,7 +407,7 @@ func writeDrupal7SettingsFile(settings *DrupalSettings, filePath string) error {
 	return nil
 }
 
-// writeDrupal6SettingsFile dynamically produces valid settings.php file by combining a configuration
+// writeDrupal6SettingsFile dynamically produces valid settings.ddev.php file by combining a configuration
 // object with a data-driven template.
 func writeDrupal6SettingsFile(settings *DrupalSettings, filePath string) error {
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(drupal6Template)
@@ -630,7 +634,8 @@ func settingsHasInclude(drupalConfig *DrupalSettings, siteSettingsPath string) (
 	return included, nil
 }
 
-// addIncludeToDrupalSettingsFile will include settings.ddev.php in settings.php.
+// addIncludeToDrupalSettingsFile modifies the settings.php file to include the settings.ddev.php
+// file, which contains ddev-specific configuration.
 func addIncludeToDrupalSettingsFile(drupalConfig *DrupalSettings, siteSettingsPath string) error {
 	// Open file for appending to preserve current contents
 	file, err := os.OpenFile(siteSettingsPath, os.O_RDWR|os.O_APPEND, 0644)

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -76,19 +76,19 @@ func NewDrushConfig() *DrushConfig {
 // in the even that one does not already exist.
 const drupalCommonSettingsTemplate = `<?php
 {{ $config := . }}
-/**
- This was automatically generated to include settings managed by ddev.
- */
-include '{{ joinPath $config.SitePath $config.SiteSettingsLocal }}';
+// {{ $config.Signature }}: Automatically generated Drupal settings file.
+if (file_exists('{{ joinPath $config.SitePath $config.SiteSettingsLocal }}')) {
+  include '{{ joinPath $config.SitePath $config.SiteSettingsLocal }}';
+}
 `
 
 // drupalCommonSettingsAppendTemplate defines the template that will be appended to
 // settings.php in the event that one exists.
 const drupalCommonSettingsAppendTemplate = `{{ $config := . }}
-/**
- This was automatically generated to include settings managed by ddev.
- */
-include '{{ joinPath $config.SitePath $config.SiteSettingsLocal }}';
+// {{ $config.Signature }}: Automatically generated include for settings managed by ddev.
+if (file_exists('{{ joinPath $config.SitePath $config.SiteSettingsLocal }}')) {
+  include '{{ joinPath $config.SitePath $config.SiteSettingsLocal }}';
+}
 `
 
 const (

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -302,7 +302,7 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := writeDrupal8SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-		return "", fmt.Errorf("failed to write Drupal settings file: %v", err.Error())
+		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
@@ -325,7 +325,7 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := writeDrupal6SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-		return "", fmt.Errorf("failed to write Drupal settings file: %v", err)
+		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -267,8 +267,14 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	if err := writeDrupal7SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
+	// Create settings.ddev.php if one doesn't already exist
+	if fileutil.FileExists(app.SiteLocalSettingsPath) {
+		output.UserOut.Printf("ddev settings file %s already exists", drupalConfig.SiteSettingsLocal)
+	} else {
+		output.UserOut.Printf("No %s exists, creating one", drupalConfig.SiteSettingsLocal)
+		if err := writeDrupal7SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
+			return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
+		}
 	}
 
 	return app.SiteLocalSettingsPath, nil
@@ -286,8 +292,14 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	if err := writeDrupal8SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-		return app.SiteLocalSettingsPath, fmt.Errorf("failed to write Drupal settings file: %v", err.Error())
+	// Create settings.ddev.php if one doesn't already exist
+	if fileutil.FileExists(app.SiteLocalSettingsPath) {
+		output.UserOut.Printf("ddev settings file %s already exists", drupalConfig.SiteSettingsLocal)
+	} else {
+		output.UserOut.Printf("No %s exists, creating one", drupalConfig.SiteSettingsLocal)
+		if err := writeDrupal8SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
+			return "", fmt.Errorf("failed to write Drupal settings file: %v", err.Error())
+		}
 	}
 
 	return app.SiteLocalSettingsPath, nil
@@ -305,8 +317,14 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	if err := writeDrupal6SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-		return "", fmt.Errorf("failed to write Drupal settings file: %v", err)
+	// Create settings.ddev.php if one doesn't already exist
+	if fileutil.FileExists(app.SiteLocalSettingsPath) {
+		output.UserOut.Printf("ddev settings file %s already exists", drupalConfig.SiteSettingsLocal)
+	} else {
+		output.UserOut.Printf("No %s exists, creating one", drupalConfig.SiteSettingsLocal)
+		if err := writeDrupal6SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
+			return "", fmt.Errorf("failed to write Drupal settings file: %v", err)
+		}
 	}
 
 	return app.SiteLocalSettingsPath, nil

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -645,7 +645,7 @@ func addIncludeToDrupalSettingsFile(drupalConfig *DrupalSettings, siteSettingsPa
 		return err
 	}
 
-	// If settings.php is empty, just write the entire settings file to it
+	// If settings.php is empty, write the complete settings template
 	if len(currentSiteSettings) == 0 {
 		if err := writeDrupalCommonSettingsFile(drupalConfig, siteSettingsPath); err != nil {
 			return err

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -47,10 +47,10 @@ func NewDrupalSettings() *DrupalSettings {
 		DatabasePrefix:    "",
 		HashSalt:          util.RandString(64),
 		Signature:         DdevFileSignature,
-		SitePath:          filepath.Join("sites", "default"),
+		SitePath:          path.Join("sites", "default"),
 		SiteSettings:      "settings.php",
 		SiteSettingsLocal: "settings.ddev.php",
-		SyncDir:           filepath.Join("files", "sync"),
+		SyncDir:           path.Join("files", "sync"),
 	}
 }
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -281,7 +281,7 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteLocalSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
-		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", app.SiteLocalSettingsPath, err)
+		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteLocalSettingsPath), err)
 	}
 
 	return app.SiteLocalSettingsPath, nil
@@ -304,7 +304,7 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
-		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", app.SiteLocalSettingsPath, err)
+		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteLocalSettingsPath), err)
 	}
 
 	return app.SiteLocalSettingsPath, nil
@@ -327,7 +327,7 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
-		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", app.SiteLocalSettingsPath, err)
+		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteLocalSettingsPath), err)
 	}
 
 	return app.SiteLocalSettingsPath, nil

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -207,9 +207,6 @@ $databases['default']['default'] = array(
 );
 `
 
-const gitignoreTemplate = `{{ .SiteSettingsLocal }}
-`
-
 // manageDrupalCommonSettingsFile will direct inspecting and writing the main settings file (settings.php).
 func manageDrupalCommonSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) error {
 	if !fileutil.FileExists(app.SiteSettingsPath) {
@@ -280,7 +277,7 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 		}
 	}
 
-	if err := createGitignore(app, drupalConfig); err != nil {
+	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
 		output.UserOut.Warnf("Failed to write .gitignore: %v", err)
 	}
 
@@ -309,7 +306,7 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 		}
 	}
 
-	if err := createGitignore(app, drupalConfig); err != nil {
+	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
 		output.UserOut.Warnf("Failed to write .gitignore: %v", err)
 	}
 
@@ -338,7 +335,7 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 		}
 	}
 
-	if err := createGitignore(app, drupalConfig); err != nil {
+	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
 		output.UserOut.Warnf("Failed to write .gitignore: %v", err)
 	}
 
@@ -660,32 +657,6 @@ func addIncludeToSettingsFile(drupalConfig *DrupalSettings, siteSettingsPath str
 	}
 
 	if _, err := file.Write(b.Bytes()); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// createGitIgnore will prevent the settings.ddev.php file from being committed to version control.
-func createGitignore(app *DdevApp, drupalConfig *DrupalSettings) error {
-	// TODO: should this existence check be handled before this is called?
-	gitignorePath := filepath.Join(path.Dir(app.SiteLocalSettingsPath), ".gitignore")
-	if fileutil.FileExists(gitignorePath) {
-		return nil
-	}
-
-	tmpl, err := template.New("gitignore").Funcs(getTemplateFuncMap()).Parse(gitignoreTemplate)
-	if err != nil {
-		return err
-	}
-
-	file, err := os.OpenFile(gitignorePath, os.O_RDWR|os.O_CREATE, 0644)
-	if err != nil {
-		return err
-	}
-	defer util.CheckClose(file)
-
-	if err := tmpl.Execute(file, drupalConfig); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -75,8 +75,8 @@ func NewDrushConfig() *DrushConfig {
 const drupalCommonSettingsTemplate = `<?php
 {{ $config := . }}
 // {{ $config.Signature }}: Automatically generated Drupal settings file.
-if (file_exists('{{ joinPath $config.SitePath $config.SiteSettingsLocal }}')) {
-  include '{{ joinPath $config.SitePath $config.SiteSettingsLocal }}';
+if (file_exists($app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}')) {
+  include $app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}';
 }
 `
 
@@ -84,8 +84,8 @@ if (file_exists('{{ joinPath $config.SitePath $config.SiteSettingsLocal }}')) {
 // settings.php in the event that one exists.
 const drupalCommonSettingsAppendTemplate = `{{ $config := . }}
 // Automatically generated include for settings managed by ddev.
-if (file_exists('{{ joinPath $config.SitePath $config.SiteSettingsLocal }}')) {
-  include '{{ joinPath $config.SitePath $config.SiteSettingsLocal }}';
+if (file_exists($app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}')) {
+  include $app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}';
 }
 `
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -652,7 +652,7 @@ func addIncludeToDrupalSettingsFile(drupalConfig *DrupalSettings, siteSettingsPa
 
 	// If settings.php is empty, write the complete settings template
 	if len(currentSiteSettings) == 0 {
-		if err := writeDrupalCommonSettingsFile(drupalConfig, siteSettingsPath); err != nil {
+		if err = writeDrupalCommonSettingsFile(drupalConfig, siteSettingsPath); err != nil {
 			return err
 		}
 	}

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -281,7 +281,7 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteLocalSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
-		output.UserOut.Warnf("Failed to write .gitignore: %v", err)
+		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", app.SiteLocalSettingsPath, err)
 	}
 
 	return app.SiteLocalSettingsPath, nil
@@ -304,7 +304,7 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
-		output.UserOut.Warnf("Failed to write .gitignore: %v", err)
+		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", app.SiteLocalSettingsPath, err)
 	}
 
 	return app.SiteLocalSettingsPath, nil
@@ -327,7 +327,7 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
-		output.UserOut.Warnf("Failed to write .gitignore: %v", err)
+		output.UserOut.Warnf("Failed to write .gitignore in %s: %v", app.SiteLocalSettingsPath, err)
 	}
 
 	return app.SiteLocalSettingsPath, nil

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -239,6 +239,11 @@ $databases['default']['default'] = array(
 
 // manageDrupalSettingsFile will direct inspecting and writing of settings.php.
 func manageDrupalSettingsFile(app *DdevApp, drupalConfig *DrupalSettings, settingsTemplate, appendTemplate string) error {
+	// We'll be writing/appending to the settings files and parent directory, make sure we have permissions to do so
+	if err := drupalEnsureWritePerms(app); err != nil {
+		return err
+	}
+
 	if !fileutil.FileExists(app.SiteSettingsPath) {
 		output.UserOut.Printf("No %s file exists, creating one", drupalConfig.SiteSettings)
 
@@ -587,7 +592,7 @@ func drupal6PostStartAction(app *DdevApp) error {
 // drupalEnsureWritePerms will ensure sites/default and sites/default/settings.php will
 // have the appropriate permissions for development.
 func drupalEnsureWritePerms(app *DdevApp) error {
-	output.UserOut.Printf("Ensuring write permissions for %s...", app.GetName())
+	output.UserOut.Printf("Ensuring write permissions for %s", app.GetName())
 	var writePerms os.FileMode = 0200
 
 	settingsDir := path.Dir(app.SiteSettingsPath)

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -278,14 +278,8 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	// Create settings.ddev.php if one doesn't already exist
-	if fileutil.FileExists(app.SiteLocalSettingsPath) {
-		output.UserOut.Printf("ddev settings file %s already exists", drupalConfig.SiteSettingsLocal)
-	} else {
-		output.UserOut.Printf("No %s exists, creating one", drupalConfig.SiteSettingsLocal)
-		if err := writeDrupal7SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-			return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
-		}
+	if err := writeDrupal7SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
+		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteLocalSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
@@ -307,14 +301,8 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	// Create settings.ddev.php if one doesn't already exist
-	if fileutil.FileExists(app.SiteLocalSettingsPath) {
-		output.UserOut.Printf("ddev settings file %s already exists", drupalConfig.SiteSettingsLocal)
-	} else {
-		output.UserOut.Printf("No %s exists, creating one", drupalConfig.SiteSettingsLocal)
-		if err := writeDrupal8SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-			return "", fmt.Errorf("failed to write Drupal settings file: %v", err.Error())
-		}
+	if err := writeDrupal8SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
+		return "", fmt.Errorf("failed to write Drupal settings file: %v", err.Error())
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {
@@ -336,14 +324,8 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	// Create settings.ddev.php if one doesn't already exist
-	if fileutil.FileExists(app.SiteLocalSettingsPath) {
-		output.UserOut.Printf("ddev settings file %s already exists", drupalConfig.SiteSettingsLocal)
-	} else {
-		output.UserOut.Printf("No %s exists, creating one", drupalConfig.SiteSettingsLocal)
-		if err := writeDrupal6SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-			return "", fmt.Errorf("failed to write Drupal settings file: %v", err)
-		}
+	if err := writeDrupal6SettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
+		return "", fmt.Errorf("failed to write Drupal settings file: %v", err)
 	}
 
 	if err := createGitIgnore(filepath.Dir(app.SiteSettingsPath), drupalConfig.SiteSettingsLocal); err != nil {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -83,7 +83,7 @@ if (file_exists('{{ joinPath $config.SitePath $config.SiteSettingsLocal }}')) {
 // drupalCommonSettingsAppendTemplate defines the template that will be appended to
 // settings.php in the event that one exists.
 const drupalCommonSettingsAppendTemplate = `{{ $config := . }}
-// {{ $config.Signature }}: Automatically generated include for settings managed by ddev.
+// Automatically generated include for settings managed by ddev.
 if (file_exists('{{ joinPath $config.SitePath $config.SiteSettingsLocal }}')) {
   include '{{ joinPath $config.SitePath $config.SiteSettingsLocal }}';
 }

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -19,8 +19,9 @@ import (
 // settings.php/settings.local.php
 func TestWriteSettings(t *testing.T) {
 	expectations := map[string]string{
-		"drupal7":   "sites/default/settings.php",
-		"drupal8":   "sites/default/settings.php",
+		"drupal6":   "sites/default/settings.ddev.php",
+		"drupal7":   "sites/default/settings.ddev.php",
+		"drupal8":   "sites/default/settings.ddev.php",
 		"wordpress": "wp-config.php",
 		"typo3":     "typo3conf/AdditionalConfiguration.php",
 	}

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -185,78 +185,8 @@ func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 		assert.True(t, existingSettingsIncludesSettingsDdev)
 
 		// Ensure that settings.php includes original contents
-		modifiedSettingsInlcudesOriginalContents, err := fileutil.FgrepStringInFile(expectedSettingsLocation, originalContents)
+		modifiedSettingsIncludesOriginalContents, err := fileutil.FgrepStringInFile(expectedSettingsLocation, originalContents)
 		assert.NoError(t, err)
-		assert.True(t, modifiedSettingsInlcudesOriginalContents)
-	}
-}
-
-func TestIncludeAndWriteSettingsDdev(t *testing.T) {
-	dir := testcommon.CreateTmpDir("")
-	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
-	assert.NoError(t, err)
-
-	app, err := NewApp(dir, DefaultProviderName)
-	assert.NoError(t, err)
-
-	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
-		app.Type = appType
-
-		relativeSettingsLocation := relativeSettingsLocations[0]
-		relativeSettingsDdevLocation := relativeSettingsLocations[1]
-		expectedSettingsLocation := filepath.Join(dir, relativeSettingsLocation)
-		expectedSettingsDdevLocation := filepath.Join(dir, relativeSettingsDdevLocation)
-
-		// Ensure that no settings.php exists
-		os.Remove(expectedSettingsLocation)
-
-		// Ensure that no settings.ddev.php file exists
-		os.Remove(expectedSettingsDdevLocation)
-
-		// Invoke the settings file creation process
-		_, err := app.CreateSettingsFile()
-		assert.NoError(t, err)
-
-		// Ensure that a settings.php was created
-		assert.True(t, fileutil.FileExists(expectedSettingsLocation))
-
-		// Ensure that settings.php references settings.ddev.php
-		newSettingsIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedSettingsLocation, relativeSettingsDdevLocation)
-		assert.NoError(t, err)
-		assert.True(t, newSettingsIncludesSettingsDdev)
-
-		// Ensure that settings.ddev.php exists
-		assert.True(t, fileutil.FileExists(expectedSettingsDdevLocation))
-
-		// Remove settings.php and settings.ddev.php
-		assert.NoError(t, os.Remove(expectedSettingsLocation))
-		assert.NoError(t, os.Remove(expectedSettingsDdevLocation))
-
-		// Create a settings.php that does not include settings.ddev.php
-		originalContents := "not empty"
-		settingsFile, err := os.Create(expectedSettingsLocation)
-		assert.NoError(t, err)
-		_, err = settingsFile.Write([]byte(originalContents))
-		assert.NoError(t, err)
-
-		// Invoke the settings file creation process
-		_, err = app.CreateSettingsFile()
-		assert.NoError(t, err)
-
-		// Ensure that settings.php exists
-		assert.True(t, fileutil.FileExists(expectedSettingsLocation))
-
-		// Ensure that settings.ddev.php exists
-		assert.True(t, fileutil.FileExists(expectedSettingsDdevLocation))
-
-		// Ensure that settings.php references settings.ddev.php
-		existingSettingsIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedSettingsLocation, relativeSettingsDdevLocation)
-		assert.NoError(t, err)
-		assert.True(t, existingSettingsIncludesSettingsDdev)
-
-		// Ensure that settings.php includes original contents
-		modifiedSettingsInlcudesOriginalContents, err := fileutil.FgrepStringInFile(expectedSettingsLocation, originalContents)
-		assert.NoError(t, err)
-		assert.True(t, modifiedSettingsInlcudesOriginalContents)
+		assert.True(t, modifiedSettingsIncludesOriginalContents)
 	}
 }

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -230,8 +230,6 @@ func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 		// Ensure that a .gitignore exists
 		assert.True(t, fileutil.FileExists(expectedGitIgnoreLocation))
 
-		c, _ := ioutil.ReadFile(expectedGitIgnoreLocation)
-
 		// Ensure that the new .gitignore includes settings.ddev.php
 		settingsDdev := filepath.Base(relativeSettingsDdevLocation)
 		newGitIgnoreIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedGitIgnoreLocation, settingsDdev)

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -231,7 +231,6 @@ func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 		assert.True(t, fileutil.FileExists(expectedGitIgnoreLocation))
 
 		c, _ := ioutil.ReadFile(expectedGitIgnoreLocation)
-		fmt.Printf("gitignore contents: %s", c)
 
 		// Ensure that the new .gitignore includes settings.ddev.php
 		settingsDdev := filepath.Base(relativeSettingsDdevLocation)

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -40,7 +40,7 @@ func TestWriteSettings(t *testing.T) {
 		"wordpress": "wp-config.php",
 		"typo3":     "typo3conf/AdditionalConfiguration.php",
 	}
-	dir := testcommon.CreateTmpDir("example")
+	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
 	err = os.MkdirAll(filepath.Join(dir, "typo3conf"), 0777)
@@ -81,7 +81,7 @@ func TestWriteSettings(t *testing.T) {
 // is noted properly. Do we need it? Are we using it?
 func TestWriteDrushConfig(t *testing.T) {
 
-	dir := testcommon.CreateTmpDir("example")
+	dir := testcommon.CreateTmpDir(t.Name())
 
 	file, err := ioutil.TempFile(dir, "file")
 	assert.NoError(t, err)
@@ -104,7 +104,7 @@ func TestWriteDrushConfig(t *testing.T) {
 // TestIncludeSettingsDdevInNewSettingsFile verifies that when no settings.php file exists,
 // a settings.php file is created that includes settings.ddev.php.
 func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
-	dir := testcommon.CreateTmpDir("")
+	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
 
@@ -145,7 +145,7 @@ func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 // TestIncludeSettingsDdevInExistingSettingsFile verifies that when a settings.php file already exists,
 // it is modified to include settings.ddev.php
 func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
-	dir := testcommon.CreateTmpDir("")
+	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
 
@@ -198,7 +198,7 @@ func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 // TestCreateGitIgnoreIfNoneExists verifies that if no .gitignore file exists in the directory
 // containing settings.php and settings.ddev.php, a .gitignore is created that includes settings.ddev.php.
 func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
-	dir := testcommon.CreateTmpDir("")
+	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
 
@@ -236,7 +236,7 @@ func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
 // TestGitIgnoreAlreadyExists verifies that if a .gitignore already exists in the directory
 // containing settings.php and settings.ddev.php, it is not modified.
 func TestGitIgnoreAlreadyExists(t *testing.T) {
-	dir := testcommon.CreateTmpDir("")
+	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
 

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -70,7 +70,7 @@ func TestWriteSettings(t *testing.T) {
 		// nolint: vetshadow
 		signatureFound, err := fileutil.FgrepStringInFile(expectedSettingsFile, DdevFileSignature)
 		assert.NoError(t, err)
-		assert.True(t, signatureFound)
+		assert.True(t, signatureFound, "Failed to find %s in %s", DdevFileSignature, expectedSettingsFile)
 		err = os.Remove(expectedSettingsFile)
 		assert.NoError(t, err)
 	}
@@ -138,7 +138,7 @@ func TestDrupalBackdropIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 		// Ensure that settings.php references settings.ddev.php
 		newSettingsIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedSettingsLocation, relativeSettingsDdevLocation)
 		assert.NoError(t, err)
-		assert.True(t, newSettingsIncludesSettingsDdev)
+		assert.True(t, newSettingsIncludesSettingsDdev, "Failed to find %s in %s", relativeSettingsDdevLocation, expectedSettingsLocation)
 
 		// Ensure that settings.ddev.php exists
 		assert.True(t, fileutil.FileExists(expectedSettingsDdevLocation))
@@ -190,12 +190,12 @@ func TestDrupalBackdropIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 		// Ensure that settings.php references settings.ddev.php
 		existingSettingsIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedSettingsLocation, relativeSettingsDdevLocation)
 		assert.NoError(t, err)
-		assert.True(t, existingSettingsIncludesSettingsDdev)
+		assert.True(t, existingSettingsIncludesSettingsDdev, "Failed to find %s in %s", relativeSettingsDdevLocation, expectedSettingsLocation)
 
 		// Ensure that settings.php includes original contents
 		modifiedSettingsIncludesOriginalContents, err := fileutil.FgrepStringInFile(expectedSettingsLocation, originalContents)
 		assert.NoError(t, err)
-		assert.True(t, modifiedSettingsIncludesOriginalContents)
+		assert.True(t, modifiedSettingsIncludesOriginalContents, "Failed to find %s in %s", originalContents, expectedSettingsLocation)
 	}
 }
 
@@ -234,7 +234,7 @@ func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 		// Ensure that the new .gitignore includes settings.ddev.php
 		newGitIgnoreIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedGitIgnoreLocation, filepath.Base(relativeSettingsDdevLocation))
 		assert.NoError(t, err)
-		assert.True(t, newGitIgnoreIncludesSettingsDdev)
+		assert.True(t, newGitIgnoreIncludesSettingsDdev, "Failed to find %s in %s", filepath.Base(relativeSettingsDdevLocation), expectedGitIgnoreLocation)
 	}
 }
 
@@ -274,7 +274,7 @@ func TestDrupalBackdropGitIgnoreAlreadyExists(t *testing.T) {
 		// Ensure that the new .gitignore has not been modified to include settings.ddev.php
 		existingGitIgnoreIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedGitIgnoreLocation, filepath.Base(relativeSettingsDdevLocation))
 		assert.NoError(t, err)
-		assert.False(t, existingGitIgnoreIncludesSettingsDdev)
+		assert.False(t, existingGitIgnoreIncludesSettingsDdev, "Found unexpected %s in %s", filepath.Base(relativeSettingsDdevLocation), expectedGitIgnoreLocation)
 	}
 }
 
@@ -312,6 +312,6 @@ func TestDrupalBackdropOverwriteDdevSettings(t *testing.T) {
 		// Ensure settings.ddev.php was overwritten with new contents
 		containsOriginalString, err := fileutil.FgrepStringInFile(expectedSettingsDdevLocation, originalContents)
 		assert.NoError(t, err)
-		assert.False(t, containsOriginalString)
+		assert.False(t, containsOriginalString, "Found unexpected %s in %s", originalContents, expectedSettingsDdevLocation)
 	}
 }

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -120,10 +120,10 @@ func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 		expectedSettingsDdevLocation := filepath.Join(dir, relativeSettingsDdevLocation)
 
 		// Ensure that no settings.php exists
-		os.Remove(expectedSettingsLocation)
+		_ = os.Remove(expectedSettingsLocation)
 
 		// Ensure that no settings.ddev.php file exists
-		os.Remove(expectedSettingsDdevLocation)
+		_ = os.Remove(expectedSettingsDdevLocation)
 
 		// Invoke the settings file creation process
 		_, err := app.CreateSettingsFile()
@@ -161,10 +161,10 @@ func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 		expectedSettingsDdevLocation := filepath.Join(dir, relativeSettingsDdevLocation)
 
 		// Ensure that no settings.php exists
-		os.Remove(expectedSettingsLocation)
+		_ = os.Remove(expectedSettingsLocation)
 
 		// Ensure that no settings.ddev.php file exists
-		os.Remove(expectedSettingsDdevLocation)
+		_ = os.Remove(expectedSettingsDdevLocation)
 
 		// Create a settings.php that does not include settings.ddev.php
 		originalContents := "not empty"
@@ -214,7 +214,7 @@ func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
 		fmt.Println(expectedGitIgnoreLocation)
 
 		// Ensure that no .gitignore exists
-		os.Remove(expectedGitIgnoreLocation)
+		_ = os.Remove(expectedGitIgnoreLocation)
 
 		// Invoke the settings file creation process
 		_, err = app.CreateSettingsFile()

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -17,11 +17,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var appTypeSettingsLocations = map[string][]string{
-	"drupal6":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-	"drupal7":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-	"drupal8":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-	"backdrop": {"settings.php", "settings.ddev.php"},
+type settingsLocations struct {
+	main  string
+	local string
+}
+
+var appTypeSettingsLocations = map[string]settingsLocations{
+	"drupal6":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
+	"drupal7":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
+	"drupal8":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
+	"backdrop": {main: "settings.php", local: "settings.ddev.php"},
 }
 
 // TestWriteSettings tests writing app settings (like Drupal
@@ -109,8 +114,8 @@ func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
 		app.Type = appType
 
-		relativeSettingsLocation := relativeSettingsLocations[0]
-		relativeSettingsDdevLocation := relativeSettingsLocations[1]
+		relativeSettingsLocation := relativeSettingsLocations.main
+		relativeSettingsDdevLocation := relativeSettingsLocations.local
 		expectedSettingsLocation := filepath.Join(dir, relativeSettingsLocation)
 		expectedSettingsDdevLocation := filepath.Join(dir, relativeSettingsDdevLocation)
 
@@ -150,8 +155,8 @@ func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
 		app.Type = appType
 
-		relativeSettingsLocation := relativeSettingsLocations[0]
-		relativeSettingsDdevLocation := relativeSettingsLocations[1]
+		relativeSettingsLocation := relativeSettingsLocations.main
+		relativeSettingsDdevLocation := relativeSettingsLocations.local
 		expectedSettingsLocation := filepath.Join(dir, relativeSettingsLocation)
 		expectedSettingsDdevLocation := filepath.Join(dir, relativeSettingsDdevLocation)
 
@@ -203,7 +208,7 @@ func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
 	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
 		app.Type = appType
 
-		relativeSettingsDdevLocation := relativeSettingsLocations[1]
+		relativeSettingsDdevLocation := relativeSettingsLocations.local
 		expectedSettingsDdevLocation := filepath.Join(dir, relativeSettingsDdevLocation)
 		expectedGitIgnoreLocation := filepath.Join(filepath.Dir(expectedSettingsDdevLocation), ".gitignore")
 		fmt.Println(expectedGitIgnoreLocation)
@@ -241,7 +246,7 @@ func TestGitIgnoreAlreadyExists(t *testing.T) {
 	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
 		app.Type = appType
 
-		relativeSettingsDdevLocation := relativeSettingsLocations[1]
+		relativeSettingsDdevLocation := relativeSettingsLocations.local
 		expectedSettingsDdevLocation := filepath.Join(dir, relativeSettingsDdevLocation)
 		expectedGitIgnoreLocation := filepath.Join(filepath.Dir(expectedSettingsDdevLocation), ".gitignore")
 		fmt.Println(expectedGitIgnoreLocation)
@@ -280,7 +285,7 @@ func TestOverwriteDdevSettings(t *testing.T) {
 	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
 		app.Type = appType
 
-		relativeSettingsDdevLocation := relativeSettingsLocations[1]
+		relativeSettingsDdevLocation := relativeSettingsLocations.local
 		expectedSettingsDdevLocation := filepath.Join(dir, relativeSettingsDdevLocation)
 
 		// Ensure that a settings.ddev.php file exists

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -41,16 +41,18 @@ func TestWriteSettings(t *testing.T) {
 		"typo3":     "typo3conf/AdditionalConfiguration.php",
 	}
 	dir := testcommon.CreateTmpDir(t.Name())
-	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
+
+	app, err := NewApp(dir, DefaultProviderName)
 	assert.NoError(t, err)
-	err = os.MkdirAll(filepath.Join(dir, "typo3conf"), 0777)
+
+	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "typo3conf"), 0777)
 	assert.NoError(t, err)
 
 	// TYPO3 wants LocalConfiguration.php to exist in the repo ahead of time.
-	err = ioutil.WriteFile(filepath.Join(dir, "typo3conf", "LocalConfiguration.php"), []byte("<?php\n"), 0644)
-	assert.NoError(t, err)
-
-	app, err := NewApp(dir, DefaultProviderName)
+	err = ioutil.WriteFile(filepath.Join(dir, app.Docroot, "typo3conf", "LocalConfiguration.php"), []byte("<?php\n"), 0644)
 	assert.NoError(t, err)
 
 	for apptype, settingsRelativePath := range expectations {
@@ -105,10 +107,11 @@ func TestWriteDrushConfig(t *testing.T) {
 // a settings.php file is created that includes settings.ddev.php.
 func TestDrupalBackdropIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
-	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
-	assert.NoError(t, err)
 
 	app, err := NewApp(dir, DefaultProviderName)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
 	assert.NoError(t, err)
 
 	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
@@ -146,10 +149,11 @@ func TestDrupalBackdropIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 // it is modified to include settings.ddev.php
 func TestDrupalBackdropIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
-	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
-	assert.NoError(t, err)
 
 	app, err := NewApp(dir, DefaultProviderName)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
 	assert.NoError(t, err)
 
 	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
@@ -199,10 +203,11 @@ func TestDrupalBackdropIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 // containing settings.php and settings.ddev.php, a .gitignore is created that includes settings.ddev.php.
 func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
-	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
-	assert.NoError(t, err)
 
 	app, err := NewApp(dir, DefaultProviderName)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
 	assert.NoError(t, err)
 
 	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
@@ -237,10 +242,11 @@ func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 // containing settings.php and settings.ddev.php, it is not modified.
 func TestDrupalBackdropGitIgnoreAlreadyExists(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
-	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
-	assert.NoError(t, err)
 
 	app, err := NewApp(dir, DefaultProviderName)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
 	assert.NoError(t, err)
 
 	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
@@ -276,10 +282,11 @@ func TestDrupalBackdropGitIgnoreAlreadyExists(t *testing.T) {
 // settings creation process.
 func TestDrupalBackdropOverwriteDdevSettings(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
-	err := os.MkdirAll(filepath.Join(dir, "sites", "default"), 0777)
-	assert.NoError(t, err)
 
 	app, err := NewApp(dir, DefaultProviderName)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
 	assert.NoError(t, err)
 
 	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -136,9 +136,10 @@ func TestDrupalBackdropIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 		assert.True(t, fileutil.FileExists(expectedSettingsLocation))
 
 		// Ensure that settings.php references settings.ddev.php
-		newSettingsIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedSettingsLocation, relativeSettingsDdevLocation)
+		settingsDdev := filepath.Base(relativeSettingsDdevLocation)
+		newSettingsIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedSettingsLocation, settingsDdev)
 		assert.NoError(t, err)
-		assert.True(t, newSettingsIncludesSettingsDdev, "Failed to find %s in %s", relativeSettingsDdevLocation, expectedSettingsLocation)
+		assert.True(t, newSettingsIncludesSettingsDdev, "Failed to find %s in %s", settingsDdev, expectedSettingsLocation)
 
 		// Ensure that settings.ddev.php exists
 		assert.True(t, fileutil.FileExists(expectedSettingsDdevLocation))
@@ -188,9 +189,10 @@ func TestDrupalBackdropIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 		assert.True(t, fileutil.FileExists(expectedSettingsDdevLocation))
 
 		// Ensure that settings.php references settings.ddev.php
-		existingSettingsIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedSettingsLocation, relativeSettingsDdevLocation)
+		settingsDdev := filepath.Base(relativeSettingsDdevLocation)
+		existingSettingsIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedSettingsLocation, settingsDdev)
 		assert.NoError(t, err)
-		assert.True(t, existingSettingsIncludesSettingsDdev, "Failed to find %s in %s", relativeSettingsDdevLocation, expectedSettingsLocation)
+		assert.True(t, existingSettingsIncludesSettingsDdev, "Failed to find %s in %s", settingsDdev, expectedSettingsLocation)
 
 		// Ensure that settings.php includes original contents
 		modifiedSettingsIncludesOriginalContents, err := fileutil.FgrepStringInFile(expectedSettingsLocation, originalContents)
@@ -232,9 +234,10 @@ func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 		fmt.Printf("gitignore contents: %s", c)
 
 		// Ensure that the new .gitignore includes settings.ddev.php
-		newGitIgnoreIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedGitIgnoreLocation, filepath.Base(relativeSettingsDdevLocation))
+		settingsDdev := filepath.Base(relativeSettingsDdevLocation)
+		newGitIgnoreIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedGitIgnoreLocation, settingsDdev)
 		assert.NoError(t, err)
-		assert.True(t, newGitIgnoreIncludesSettingsDdev, "Failed to find %s in %s", filepath.Base(relativeSettingsDdevLocation), expectedGitIgnoreLocation)
+		assert.True(t, newGitIgnoreIncludesSettingsDdev, "Failed to find %s in %s", settingsDdev, expectedGitIgnoreLocation)
 	}
 }
 
@@ -272,9 +275,10 @@ func TestDrupalBackdropGitIgnoreAlreadyExists(t *testing.T) {
 		assert.True(t, fileutil.FileExists(expectedGitIgnoreLocation))
 
 		// Ensure that the new .gitignore has not been modified to include settings.ddev.php
-		existingGitIgnoreIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedGitIgnoreLocation, filepath.Base(relativeSettingsDdevLocation))
+		settingsDdev := relativeSettingsDdevLocation
+		existingGitIgnoreIncludesSettingsDdev, err := fileutil.FgrepStringInFile(expectedGitIgnoreLocation, settingsDdev)
 		assert.NoError(t, err)
-		assert.False(t, existingGitIgnoreIncludesSettingsDdev, "Found unexpected %s in %s", filepath.Base(relativeSettingsDdevLocation), expectedGitIgnoreLocation)
+		assert.False(t, existingGitIgnoreIncludesSettingsDdev, "Found unexpected %s in %s", settingsDdev, expectedGitIgnoreLocation)
 	}
 }
 

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var appTypeSettingsLocations = map[string][]string{
+	"drupal6":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
+	"drupal7":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
+	"drupal8":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
+	"backdrop": {"settings.php", "settings.ddev.php"},
+}
+
 // TestWriteSettings tests writing app settings (like Drupal
 // settings.php/settings.local.php
 func TestWriteSettings(t *testing.T) {
@@ -134,13 +141,6 @@ func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 }
 
 func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
-	appTypeSettingsLocations := map[string][]string{
-		"drupal6":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-		"drupal7":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-		"drupal8":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-		"backdrop": {"settings.php", "settings.ddev.php"},
-	}
-
 	dir := testcommon.CreateTmpDir("")
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
@@ -192,13 +192,6 @@ func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 }
 
 func TestIncludeAndWriteSettingsDdev(t *testing.T) {
-	appTypeSettingsLocations := map[string][]string{
-		"drupal6":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-		"drupal7":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-		"drupal8":  {"sites/default/settings.php", "sites/default/settings.ddev.php"},
-		"backdrop": {"settings.php", "settings.ddev.php"},
-	}
-
 	dir := testcommon.CreateTmpDir("")
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -96,7 +96,8 @@ func TestWriteDrushConfig(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// Test
+// TestIncludeSettingsDdevInNewSettingsFile verifies that when no settings.php file exists,
+// a settings.php file is created that includes settings.ddev.php.
 func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 	dir := testcommon.CreateTmpDir("")
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
@@ -136,7 +137,8 @@ func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 	}
 }
 
-// Test
+// TestIncludeSettingsDdevInExistingSettingsFile verifies that when a settings.php file already exists,
+// it is modified to include settings.ddev.php
 func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 	dir := testcommon.CreateTmpDir("")
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
@@ -188,7 +190,8 @@ func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 	}
 }
 
-// Test
+// TestCreateGitIgnoreIfNoneExists verifies that if no .gitignore file exists in the directory
+// containing settings.php and settings.ddev.php, a .gitignore is created that includes settings.ddev.php.
 func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
 	dir := testcommon.CreateTmpDir("")
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
@@ -225,7 +228,8 @@ func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
 	}
 }
 
-// Test
+// TestGitIgnoreAlreadyExists verifies that if a .gitignore already exists in the directory
+// containing settings.php and settings.ddev.php, it is not modified.
 func TestGitIgnoreAlreadyExists(t *testing.T) {
 	dir := testcommon.CreateTmpDir("")
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -19,6 +19,7 @@ import (
 // settings.php/settings.local.php
 func TestWriteSettings(t *testing.T) {
 	expectations := map[string]string{
+		"backdrop":  "settings.ddev.php",
 		"drupal6":   "sites/default/settings.ddev.php",
 		"drupal7":   "sites/default/settings.ddev.php",
 		"drupal8":   "sites/default/settings.ddev.php",

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -22,7 +22,7 @@ type settingsLocations struct {
 	local string
 }
 
-var appTypeSettingsLocations = map[string]settingsLocations{
+var drupalBackdropSettingsLocations = map[string]settingsLocations{
 	"drupal6":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
 	"drupal7":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
 	"drupal8":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
@@ -101,9 +101,9 @@ func TestWriteDrushConfig(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestIncludeSettingsDdevInNewSettingsFile verifies that when no settings.php file exists,
+// TestDrupalBackdropIncludeSettingsDdevInNewSettingsFile verifies that when no settings.php file exists,
 // a settings.php file is created that includes settings.ddev.php.
-func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
+func TestDrupalBackdropIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
@@ -111,7 +111,7 @@ func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 	app, err := NewApp(dir, DefaultProviderName)
 	assert.NoError(t, err)
 
-	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
+	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
 		app.Type = appType
 
 		relativeSettingsLocation := relativeSettingsLocations.main
@@ -142,9 +142,9 @@ func TestIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 	}
 }
 
-// TestIncludeSettingsDdevInExistingSettingsFile verifies that when a settings.php file already exists,
+// TestDrupalBackdropIncludeSettingsDdevInExistingSettingsFile verifies that when a settings.php file already exists,
 // it is modified to include settings.ddev.php
-func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
+func TestDrupalBackdropIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
@@ -152,7 +152,7 @@ func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 	app, err := NewApp(dir, DefaultProviderName)
 	assert.NoError(t, err)
 
-	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
+	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
 		app.Type = appType
 
 		relativeSettingsLocation := relativeSettingsLocations.main
@@ -195,9 +195,9 @@ func TestIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 	}
 }
 
-// TestCreateGitIgnoreIfNoneExists verifies that if no .gitignore file exists in the directory
+// TestDrupalBackdropCreateGitIgnoreIfNoneExists verifies that if no .gitignore file exists in the directory
 // containing settings.php and settings.ddev.php, a .gitignore is created that includes settings.ddev.php.
-func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
+func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
@@ -205,7 +205,7 @@ func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
 	app, err := NewApp(dir, DefaultProviderName)
 	assert.NoError(t, err)
 
-	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
+	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
 		app.Type = appType
 
 		relativeSettingsDdevLocation := relativeSettingsLocations.local
@@ -233,9 +233,9 @@ func TestCreateGitIgnoreIfNoneExists(t *testing.T) {
 	}
 }
 
-// TestGitIgnoreAlreadyExists verifies that if a .gitignore already exists in the directory
+// TestDrupalBackdropGitIgnoreAlreadyExists verifies that if a .gitignore already exists in the directory
 // containing settings.php and settings.ddev.php, it is not modified.
-func TestGitIgnoreAlreadyExists(t *testing.T) {
+func TestDrupalBackdropGitIgnoreAlreadyExists(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites/default"), 0777)
 	assert.NoError(t, err)
@@ -243,7 +243,7 @@ func TestGitIgnoreAlreadyExists(t *testing.T) {
 	app, err := NewApp(dir, DefaultProviderName)
 	assert.NoError(t, err)
 
-	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
+	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
 		app.Type = appType
 
 		relativeSettingsDdevLocation := relativeSettingsLocations.local
@@ -272,9 +272,9 @@ func TestGitIgnoreAlreadyExists(t *testing.T) {
 	}
 }
 
-// TestOverwriteDdevSettings ensures that if a settings.ddev.php file already exists, it is overwritten by the
+// TestDrupalBackdropOverwriteDdevSettings ensures that if a settings.ddev.php file already exists, it is overwritten by the
 // settings creation process.
-func TestOverwriteDdevSettings(t *testing.T) {
+func TestDrupalBackdropOverwriteDdevSettings(t *testing.T) {
 	dir := testcommon.CreateTmpDir(t.Name())
 	err := os.MkdirAll(filepath.Join(dir, "sites", "default"), 0777)
 	assert.NoError(t, err)
@@ -282,7 +282,7 @@ func TestOverwriteDdevSettings(t *testing.T) {
 	app, err := NewApp(dir, DefaultProviderName)
 	assert.NoError(t, err)
 
-	for appType, relativeSettingsLocations := range appTypeSettingsLocations {
+	for appType, relativeSettingsLocations := range drupalBackdropSettingsLocations {
 		app.Type = appType
 
 		relativeSettingsDdevLocation := relativeSettingsLocations.local

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"errors"
 
+	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
@@ -163,4 +164,15 @@ func ddevContainersRunning() (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// getTemplateFuncMap will return a map of useful template functions.
+func getTemplateFuncMap() map[string]interface{} {
+	// Use sprig's template function map as a base
+	m := sprig.FuncMap()
+
+	// Add helpful utilities on top of it
+	m["joinPath"] = filepath.Join
+
+	return m
 }

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -177,7 +178,7 @@ func getTemplateFuncMap() map[string]interface{} {
 	m := sprig.FuncMap()
 
 	// Add helpful utilities on top of it
-	m["joinPath"] = filepath.Join
+	m["joinPath"] = path.Join
 
 	return m
 }

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -180,8 +180,11 @@ func getTemplateFuncMap() map[string]interface{} {
 	return m
 }
 
+// gitIgnoreTemplate will write a .gitignore file.
+// This template expects string slice to be provided, with each string corresponding to
+// a line in the resulting .gitignore.
 const gitIgnoreTemplate = `{{ range $i, $f := . -}}
-{{ $f }}
+/{{ $f }}
 {{- end }}
 `
 

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"text/template"
 
+	"io/ioutil"
+
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
@@ -193,7 +195,15 @@ const gitIgnoreTemplate = `{{ range $i, $f := . -}}
 func createGitIgnore(targetDir string, ignores ...string) error {
 	gitIgnoreFilePath := filepath.Join(targetDir, ".gitignore")
 	if fileutil.FileExists(gitIgnoreFilePath) {
-		return nil
+		gitIgnoreContents, err := ioutil.ReadFile(gitIgnoreFilePath)
+		if err != nil {
+			return err
+		}
+
+		// The .gitignore exists and is not empty
+		if len(gitIgnoreContents) > 0 {
+			return nil
+		}
 	}
 
 	tmpl, err := template.New("gitignore").Funcs(getTemplateFuncMap()).Parse(gitIgnoreTemplate)


### PR DESCRIPTION
## The Problem/Issue/Bug:
#468, improved management of settings files.

## How this PR Solves The Problem:
This PR creates settings.ddev.php, placing ddev-specific configurations in this file to preserve user settings.  The settings.php file is only modified to include settings.ddev.php.

## Manual Testing Instructions:
[Randy's comment here](https://github.com/drud/ddev/issues/468#issuecomment-395548090) describes the desired behavior and was used as the template for the changes in this PR. 

For Drupal 6/7/8 and Backdrop, begin with the situation in which no settings files exist.
- Begin with no settings.php file and no settings.ddev.php file, and no .gitignore in the directory containing the settings files,
- `ddev config`
- Ensure a settings.php has been created that does nothing but include settings.ddev.php
- Ensure a settings.ddev.php has been created that contains ddev-generated configurations
- Ensure a .gitignore has been created that ignores settings.ddev.php

Now, test the situation in which a settings.php file already exists but does not include settings.ddev.php
- Begin with no settings.ddev.php and a settings.php file that has contents, but does not include settings.ddev.php
- `ddev config`
- Ensure settings.php has been modified to include settings.ddev.php
- Ensure settings.ddev.php has been created
- Ensure a .gitignore has been created that ignores settings.ddev.php

Finally, test the situation in which settings.pho and .gitignore already exist and won't be modified, and a settings.ddev.php will be overwritten.
- Begin with a settings.php that includes settings.ddev.php, an existing settings.ddev.php filled with "junk" data, and an existing user-managed .gitignore in the settings directory
- `ddev config`
- Ensure settings.php has not been modified to include settings.ddev.php
- Ensure settings.ddev.php has been overwritten and contains the settings as generated by ddev
- Ensure .gitginore has not been overwritten

## Automated Testing Overview:
Several tests have been added to ensure the desired creation/modification behavior of settings.php, settings.ddev.php, and .gitignore in settings_test.go.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

