### PR TITLE
test_containers.sh needs to clean up containers it creates, not leave temp builds on testbot

### DIFF
--- a/.buildkite/test_containers.sh
+++ b/.buildkite/test_containers.sh
@@ -7,22 +7,32 @@ set -o pipefail
 set -o nounset
 set -x
 
-echo "--- Cleanup docker"
-echo "Warning: deleting all docker containers and deleting images that match this build."
-if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
-	docker rm -f $(docker ps -aq)
-fi
+function cleanup {
+    echo "--- Cleanup docker"
+    echo "Warning: deleting all docker containers and deleting images that match this build."
+    if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
+        docker rm -f $(docker ps -aq)
+    fi
 
-# Make sure we don't have any existing containers on the testbot that might
-# result in this container not being built from scratch.
-VERSION=$(make version | sed 's/^VERSION://')
-IMAGES=$(docker images | awk "/$VERSION/ { print \$3 }")
-if [ ! -z "$IMAGES" ] ; then
-  docker rmi --force $IMAGES
-fi
+    # Make sure we don't have any existing containers on the testbot that might
+    # result in this container not being built from scratch.
+    VERSION=$(make version | sed 's/^VERSION://')
+    IMAGES=$(docker images | awk "/$VERSION/ { print \$3 }")
+    if [ ! -z "${IMAGES:-}" ] ; then
+      docker rmi --force $IMAGES
+    fi
+}
+
+# Now that we've got a container running, we need to make sure to clean up
+# at the end of the test run, even if something fails.
+trap cleanup EXIT
+
+# Do initial cleanup of images that might not be needed; they'll be cleaned at exit as well.
+cleanup
 
 # Our testbot should now be sane, run the testbot checker to make sure.
 ./.buildkite/sanetestbot.sh
+
 
 for dir in containers/*
     do pushd $dir


### PR DESCRIPTION
## The Problem/Issue/Bug:

test_containers.sh was leaving its temporary built containers on the testbot, where test.sh could stumble on them later. They should get cleaned up.

## How this PR Solves The Problem:

Reorganize test_containers.sh to always clean up on exit. 

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

