### PR TITLE
Fix nightly_build.mak after container name change

### DIFF
--- a/nightly_build.mak
+++ b/nightly_build.mak
@@ -11,7 +11,7 @@ RouterTag = $(VERSION)
 DBATag = $(VERSION)
 
 # List of containers to be built in containers/ directory
-CONTAINER_DIRS = ddev-router nginx-php-fpm-local mariadb-local phpmyadmin
+CONTAINER_DIRS = $(shell pushd containers >/dev/null && \ls && popd >/dev/null )
 
 BASEDIR=./containers/
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

I should have pre-run the nightly build before pulling https://github.com/drud/ddev/pull/991

nightly_build.mak had a remaining reference to nginx-php-fpm-local in it.

## How this PR Solves The Problem:

Actually look in the containers directory and build what's found there.

I hope this approach is less fragile!

## Manual Testing Instructions:

`make -f nightly_build.mak`
Make sure it passes the nightly build on circleci  (https://circleci.com/gh/rfay/ddev/546)

