### PR TITLE
Improve ddev start/stop/remove help text

### DIFF
--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -11,13 +11,14 @@ var removeAll bool
 
 // DdevRemoveCmd represents the remove command
 var DdevRemoveCmd = &cobra.Command{
-	Use:     "remove [projectname]",
+	Use:     "remove [projectname ...]",
 	Aliases: []string{"rm"},
 	Short:   "Remove the development environment for a project.",
 	Long: `Remove the development environment for a project. You can run 'ddev remove'
-from a project directory to remove that project, or you can specify a project to remove
-by running 'ddev remove <projectname>'. By default, remove is a non-destructive operation and will
-leave database contents intact. Remove never touches your code or files directories.
+from a project directory to remove that project, or you can specify projects
+to remove by running 'ddev remove [projectname ...]'. By default, remove is
+a non-destructive operation and will leave database contents intact. Remove
+never touches your code or files directories.
 
 To remove database contents, you may use the --remove-data flag with remove.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -15,10 +15,11 @@ var DdevRemoveCmd = &cobra.Command{
 	Aliases: []string{"rm"},
 	Short:   "Remove the development environment for a project.",
 	Long: `Remove the development environment for a project. You can run 'ddev remove'
-from a project directory to remove that project, or you can specify projects
-to remove by running 'ddev remove [projectname ...]'. By default, remove is
-a non-destructive operation and will leave database contents intact. Remove
-never touches your code or files directories.
+from a project directory to remove that project, or you can remove projects in
+any directory by running 'ddev remove projectname [projectname ...]'.
+
+By default, remove is a non-destructive operation and will leave database
+contents intact. Remove never touches your code or files directories.
 
 To remove database contents, you may use the --remove-data flag with remove.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -48,6 +48,6 @@ To remove database contents, you may use the --remove-data flag with remove.`,
 
 func init() {
 	DdevRemoveCmd.Flags().BoolVarP(&removeData, "remove-data", "R", false, "Remove stored project data (MySQL, logs, etc.)")
-	DdevRemoveCmd.Flags().BoolVarP(&removeAll, "all", "a", false, "Remove all running and stopped sites")
+	DdevRemoveCmd.Flags().BoolVarP(&removeAll, "all", "a", false, "Remove all running and stopped projects")
 	RootCmd.AddCommand(DdevRemoveCmd)
 }

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -53,6 +53,6 @@ provide a local development environment.`,
 }
 
 func init() {
-	StartCmd.Flags().BoolVarP(&startAll, "all", "a", false, "Start all stopped sites")
+	StartCmd.Flags().BoolVarP(&startAll, "all", "a", false, "Start all stopped projects")
 	RootCmd.AddCommand(StartCmd)
 }

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -19,7 +19,7 @@ var StartCmd = &cobra.Command{
 	Short:   "Start a ddev project.",
 	Long: `Start initializes and configures the web server and database containers
 to provide a local development environment. You can run 'ddev start' from a
-project directory to stop that project, or you can start stopped projects by
+project directory to start that project, or you can start stopped projects by
 running 'ddev start [projectname ...]'`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -19,8 +19,8 @@ var StartCmd = &cobra.Command{
 	Short:   "Start a ddev project.",
 	Long: `Start initializes and configures the web server and database containers
 to provide a local development environment. You can run 'ddev start' from a
-project directory to start that project, or you can start stopped projects by
-running 'ddev start [projectname ...]'`,
+project directory to start that project, or you can start stopped projects in
+any directory by running 'ddev start projectname [projectname ...]'`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -14,11 +14,13 @@ var startAll bool
 
 // StartCmd represents the add command
 var StartCmd = &cobra.Command{
-	Use:     "start",
+	Use:     "start [projectname ...]",
 	Aliases: []string{"add"},
 	Short:   "Start a ddev project.",
-	Long: `Start initializes and configures the web server and database containers to
-provide a local development environment.`,
+	Long: `Start initializes and configures the web server and database containers
+to provide a local development environment. You can run 'ddev start' from a
+project directory to stop that project, or you can start stopped projects by
+running 'ddev start [projectname ...]'`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -9,11 +9,11 @@ var stopAll bool
 
 // DdevStopCmd represents the stop command
 var DdevStopCmd = &cobra.Command{
-	Use:   "stop [projectname]",
+	Use:   "stop [projectname ...]",
 	Short: "Stop the development environment for a project.",
 	Long: `Stop the development environment for a project. You can run 'ddev stop'
-from a project directory to stop that project, or you can specify a running project
-to stop by running 'ddev stop <projectname>.`,
+from a project directory to stop that project, or you can stop running
+projects by running 'ddev stop [projectname ...]'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		apps, err := getRequestedApps(args, stopAll)
 		if err != nil {

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -12,8 +12,8 @@ var DdevStopCmd = &cobra.Command{
 	Use:   "stop [projectname ...]",
 	Short: "Stop the development environment for a project.",
 	Long: `Stop the development environment for a project. You can run 'ddev stop'
-from a project directory to stop that project, or you can stop running
-projects by running 'ddev stop [projectname ...]'`,
+from a project directory to stop that project, or you can stop running projects
+in any directory by running 'ddev stop projectname [projectname ...]'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		apps, err := getRequestedApps(args, stopAll)
 		if err != nil {

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -31,6 +31,6 @@ to stop by running 'ddev stop <projectname>.`,
 }
 
 func init() {
-	DdevStopCmd.Flags().BoolVarP(&stopAll, "all", "a", false, "Stop all running sites")
+	DdevStopCmd.Flags().BoolVarP(&stopAll, "all", "a", false, "Stop all running projects")
 	RootCmd.AddCommand(DdevStopCmd)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
DDEV start/stop/remove referred to "sites", not "projects", and the CLI help text didn't relate the ability to pass multiple project names as arguments.

## How this PR Solves The Problem:
Updates the CLI help text.

## Manual Testing Instructions:
Execute `ddev start -h`, `ddev stop -h`, `ddev remove -h`.