### PR TITLE
Allow `ddev start` to accept project name arguments

### DIFF
--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"strings"
 
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -20,12 +19,6 @@ var StartCmd = &cobra.Command{
 	Long: `Start initializes and configures the web server and database containers to
 provide a local development environment.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if len(args) > 0 {
-			err := cmd.Usage()
-			util.CheckErr(err)
-			os.Exit(0)
-		}
-
 		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -28,4 +28,23 @@ func TestDdevStart(t *testing.T) {
 	for _, app := range apps {
 		assert.True(app.SiteStatus() == ddevapp.SiteRunning, "All sites should be running, but %s status: %s", app.GetName(), app.SiteStatus())
 	}
+
+	// Stop all sites.
+	_, err = exec.RunCommand(DdevBin, []string{"stop", "--all"})
+	assert.NoError(err)
+
+	// Build start command startMultipleArgs
+	startMultipleArgs := []string{"start"}
+	for _, app := range apps {
+		startMultipleArgs = append(startMultipleArgs, app.GetName())
+	}
+
+	// Start multiple projects in one command
+	out, err = exec.RunCommand(DdevBin, startMultipleArgs)
+	assert.NoError(err, "ddev start with multiple project names should have succeeded, but failed, err: %v, output %s", err, out)
+
+	// Confirm all sites are running
+	for _, app := range apps {
+		assert.True(app.SiteStatus() == ddevapp.SiteRunning, "All sites should be running, but %s status: %s", app.GetName(), app.SiteStatus())
+	}
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
An args slice length check was preventing any project names from being provided to `ddev start`.

## How this PR Solves The Problem:
This PR removes the block of code preventing `ddev start` from accepting arguments, as that is now an accepted use case.

## Manual Testing Instructions:
- Create at two projects, `p1` and `p2`
- Stop both projects with `ddev stop p1 p2`
- Start both projects with `ddev start p1 p2`
- Ensure both start as expected

## Automated Testing Overview:
`ddev start` with multiple project names as arguments has been added as a test case.
