### PR TITLE
Install php-redis module in the web container

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get -qq update && \
         unzip \
         rsync \
         libpcre3 && \
-    for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
+    for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \


### PR DESCRIPTION


## The Problem/Issue/Bug:
This PR adds php-redis module to the web container.



## Manual Testing Instructions:

check in phpInfo if the redis module is installed, or check through php code `extension_loaded('redis');`

## Related Issue Link(s):

Resolves: #267

## Release/Deployment notes:

nothing to be done.

