### PR TITLE
Attempt to remove running projects before testing

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -111,7 +111,7 @@ func TestMain(m *testing.M) {
 
 	// Attempt to remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
-	//
+	// If a system doesn't have `ddev` in its $PATH, this will emit a warning but will not fail the test.
 	if _, err := exec.RunCommand("ddev", []string{"remove", "--all"}); err != nil {
 		log.Warnf("Failed to remove all running projects: %v", err)
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -109,9 +109,16 @@ func TestMain(m *testing.M) {
 	// This is normally done by Testsite.Prepare()
 	_ = os.Setenv("DRUD_NONINTERACTIVE", "true")
 
+	// Attempt to remove all running containers before starting a test.
+	// If no projects are running, this will exit silently and without error.
+	//
+	if _, err := exec.RunCommand("ddev", []string{"remove", "--all"}); err != nil {
+		log.Warnf("Failed to remove all running projects: %v", err)
+	}
+
 	count := len(ddevapp.GetApps())
 	if count > 0 {
-		log.Fatalf("ddevapp tests require no sites running. You have %v site(s) running.", count)
+		log.Fatalf("ddevapp tests require no projects running. You have %v project(s) running.", count)
 	}
 
 	// If GOTEST_SHORT is an integer, then use it as index for a single usage


### PR DESCRIPTION
## The Problem/Issue/Bug:
Local tests fail all the time because projects are already running.

## How this PR Solves The Problem:
Non-destructively remove running projects before beginning tests by attempting to call `ddev remove --all`.

If a system doesn't have `ddev` in its $PATH (CircleCI), the command will fail and emit a warning message, but it will not fail the test. 

## Manual Testing Instructions:
- Manually start a few projects
- `make test`
- TestMain will remove running projects before testing and not fail immediately
