### PR TITLE
Fix ddev exec message offered to wp users on import

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -189,7 +189,7 @@ func getBackdropUploadDir(app *DdevApp) string {
 func getBackdropHooks() []byte {
 	backdropHooks := `
 #  post-import-db:
-#    - exec: "drush cc all"`
+#    - exec: drush cc all`
 	return []byte(backdropHooks)
 }
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -394,7 +394,7 @@ func TestWriteConfig(t *testing.T) {
 
 	out, err = ioutil.ReadFile(filepath.Join(testDir, "config.yaml"))
 	assert.NoError(err)
-	assert.Contains(string(out), `exec: "wp search-replace`)
+	assert.Contains(string(out), `- exec: wp search-replace`)
 
 	err = os.RemoveAll(testDir)
 	assert.NoError(err)

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -491,7 +491,7 @@ const Drupal8Hooks = `
 // Drupal7Hooks adds a d7-specific hooks example for post-import-db
 const Drupal7Hooks = `
 #  post-import-db:
-#    - exec: "drush cc all"`
+#    - exec: drush cc all`
 
 // getDrupal7Hooks for appending as byte array
 func getDrupal7Hooks() []byte {

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -107,7 +107,7 @@ func getTypo3UploadDir(app *DdevApp) string {
 // Typo3Hooks adds a TYPO3-specific hooks example for post-import-db
 const Typo3Hooks = `
 #  post-start:
-#    - exec: "composer install -d /var/www/html"`
+#    - exec: composer install -d /var/www/html`
 
 // getTypo3Hooks for appending as byte array
 func getTypo3Hooks() []byte {

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -200,6 +200,6 @@ func isWordpressApp(app *DdevApp) bool {
 // wordpressPostImportDBAction just emits a warning about updating URLs as is
 // required with wordpress when running on a different URL.
 func wordpressPostImportDBAction(app *DdevApp) error {
-	util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec 'wp search-replace [http://www.myproductionsite.example] %s'\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", app.GetHTTPURL())
+	util.Warning("Wordpress sites require a search/replace of the database when the URL is changed. You can run \"ddev exec wp search-replace [http://www.myproductionsite.example] %s\" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/", app.GetHTTPURL())
 	return nil
 }

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -57,8 +57,8 @@ func NewWordpressConfig() *WordpressConfig {
 const wordPressHooks = `
 # Un-comment and enter the production url and local url
 # to replace in your database after import.
-#post-import-db:
-#  - exec: "wp search-replace <production-url> <local-url>"`
+#  post-import-db:
+#    - exec: wp search-replace <production-url> <local-url>`
 
 // getWordpressHooks for appending as byte array
 func getWordpressHooks() []byte {


### PR DESCRIPTION
## The Problem/Issue/Bug:

A user in slack pointed out that our prompted suggestion of wp search-replace results in an error because we quote it.

The prompt says

> Wordpress sites require a search/replace of the database when the URL is changed. You can run "ddev exec 'wp search-replace [http://www.myproductionsite.example] http://wpsite.ddev.local'" to update the URLs across your database. For more information, see http://wp-cli.org/commands/search-replace/

The result if you do that is:

`ddev exec 'Failed to execute command [wp search-replace [http://www.myproductionsite.exampleto update the URLs across your da] http://wpsite.ddev.local]: Failed to run docker-compose [-f /Users/brentr
obbins/wpsite/.ddev/docker-compose.yaml exec -T web wp search-repl
ace [http://www.myproductionsite.example] http://wpsite.ddev.local], err='exit status 126', stdout='OCI runtime exec failed: exec failed: container_linux.go
:348: starting container process caused "exec: \"wp search-replace [http://www.my
productionsite.example] http://wpsite.ddev.local\": stat wp search-replace
[http://www.myproductionsite.example] http://wpsite.ddev.local: no such file or directory": unknown
', stderr=''`

Because ddev exec is trying to run an executable called "wp search-replace ..." instead of just running wp. 

## How this PR Solves The Problem:

Remove the quotes around the command.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

