### PR TITLE
Revert "Install php-redis module in the web container (#1008), for #267"

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get -qq update && \
         unzip \
         rsync \
         libpcre3 && \
-    for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
+    for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \


### PR DESCRIPTION
Although #1008 did in fact pass all tests and was able to build
containers, I'm completely unable to get a successful container build
whether using the code here or just adding an apt-get install -y php-redis

I suspect something may have changed in the upstream PHP repo.

The failure breaks nightly builds and all container builds.

This reverts commit f6784fe02d9ba02d2a96fc0ab96939e2b538a924.

