### PR TITLE
Improve buildkite test_containers.sh by not erroring if docker rm/rmi --fail

### DIFF
--- a/.buildkite/test_containers.sh
+++ b/.buildkite/test_containers.sh
@@ -38,7 +38,7 @@ set -x
 for dir in containers/*
     do pushd $dir
     echo "--- Build container $dir"
-    time make container
+    time make container DOCKER_ARGS=--no-cache
     echo "--- Test container $dir"
     time make test
     popd

--- a/.buildkite/test_containers.sh
+++ b/.buildkite/test_containers.sh
@@ -5,13 +5,13 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -x
 
 function cleanup {
+    set +x
     echo "--- Cleanup docker"
     echo "Warning: deleting all docker containers and deleting images that match this build."
     if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
-        docker rm -f $(docker ps -aq)
+        docker rm -f $(docker ps -aq) >/dev/null || true
     fi
 
     # Make sure we don't have any existing containers on the testbot that might
@@ -19,7 +19,7 @@ function cleanup {
     VERSION=$(make version | sed 's/^VERSION://')
     IMAGES=$(docker images | awk "/$VERSION/ { print \$3 }")
     if [ ! -z "${IMAGES:-}" ] ; then
-      docker rmi --force $IMAGES
+      docker rmi --force $IMAGES 2>&1 >/dev/null || true
     fi
 }
 
@@ -33,6 +33,7 @@ cleanup
 # Our testbot should now be sane, run the testbot checker to make sure.
 ./.buildkite/sanetestbot.sh
 
+set -x
 
 for dir in containers/*
     do pushd $dir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - run:
           command: |
             make -f nightly_build.mak clean  # Remove any existing binaries
-            make -f nightly_build.mak -s --print-directory
+            make -f nightly_build.mak -s --print-directory DOCKER_ARGS=--no-cache
           no_output_timeout: "40m"
           name: Full nightly build and test with containers
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* There seem to be times on the buildkite testbots where docker rm or docker rmi can fail... but we're only doing it in the context of cleaning up anyway, so it shouldn't cause the tests to fail.
* Docker images should be built in testing with --no-cache. Turns out build-tools has a DOCKER_ARGS makefile variable for this exact purpose.

## How this PR Solves The Problem:

* Ignore failure on docker rm.
* Add --no-cache to container build in circle and buildkite tests.

