### PR TITLE
Clean up hostnames when removing project data, closes #831

### DIFF
--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -162,8 +162,8 @@ func removeInactiveHostnames(hosts goodhosts.Hosts) {
 	var detail string
 	rawResult := make(map[string]interface{})
 
-	// Get the list active hosts names to preserve, always including localhost
-	activeHostNames := map[string]bool{"localhost": true}
+	// Get the list active hosts names to preserve
+	activeHostNames := make(map[string]bool)
 	for _, app := range ddevapp.GetApps() {
 		for _, h := range app.GetHostnames() {
 			activeHostNames[h] = true
@@ -196,7 +196,7 @@ func removeInactiveHostnames(hosts goodhosts.Hosts) {
 					continue
 				}
 
-				// Silently ignore those that may not be ddev-managed to not spam the user's terminal
+				// Silently ignore those that may not be ddev-managed
 				if !strings.HasSuffix(h, version.DDevTLD) {
 					continue
 				}
@@ -223,11 +223,6 @@ func removeInactiveHostnames(hosts goodhosts.Hosts) {
 		rawResult["full_error"] = detail
 		output.UserOut.WithField("raw", rawResult).Fatal(detail)
 	}
-
-	detail = "Cleaned up inactive host names"
-	rawResult["error"] = "SUCCESS"
-	rawResult["detail"] = detail
-	output.UserOut.WithField("raw", rawResult).Info(detail)
 
 	return
 }

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -25,10 +25,11 @@ var HostNameCmd = &cobra.Command{
 
 		hosts, err := goodhosts.NewHosts()
 		if err != nil {
+			detail := fmt.Sprintf("Could not open hosts file for reading: %v", err)
 			rawResult := make(map[string]interface{})
 			rawResult["error"] = "READERROR"
-			rawResult["full_error"] = fmt.Sprintf("%v", err)
-			output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("could not open hosts file for read: %v", err))
+			rawResult["full_error"] = detail
+			output.UserOut.WithField("raw", rawResult).Fatal(detail)
 
 			return
 		}
@@ -43,38 +44,42 @@ var HostNameCmd = &cobra.Command{
 	},
 }
 
+// addHost encapsulates the
 func addHost(hosts goodhosts.Hosts, ip, hostname string) {
+	var detail string
 	rawResult := make(map[string]interface{})
 
 	if hosts.Has(ip, hostname) {
-		if output.JSONOutput {
-			rawResult["error"] = "SUCCESS"
-			rawResult["detail"] = "hostname already exists in hosts file"
-			output.UserOut.WithField("raw", rawResult).Info("")
-		}
+		detail = "Hostname already exists in hosts file"
+		rawResult["error"] = "SUCCESS"
+		rawResult["detail"] = detail
+		output.UserOut.WithField("raw", rawResult).Info(detail)
 
 		return
 	}
 
 	if err := hosts.Add(ip, hostname); err != nil {
+		detail = fmt.Sprintf("Could notk add hostname %s at %s: %v", hostname, ip, err)
 		rawResult["error"] = "ADDERROR"
-		rawResult["full_error"] = fmt.Sprintf("%v", err)
-		output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("could not add hostname %s at %s: %v", hostname, ip, err))
+		rawResult["full_error"] = detail
+		output.UserOut.WithField("raw", rawResult).Fatal(detail)
 
 		return
 	}
 
 	if err := hosts.Flush(); err != nil {
+		detail = fmt.Sprintf("Could not write hosts file: %v", err)
 		rawResult["error"] = "WRITEERROR"
-		rawResult["full_error"] = fmt.Sprintf("%v", err)
-		output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("Could not write hosts file: %v", err))
+		rawResult["full_error"] = detail
+		output.UserOut.WithField("raw", rawResult).Fatal(detail)
 
 		return
 	}
 
+	detail = "Hostname added to hosts file"
 	rawResult["error"] = "SUCCESS"
-	rawResult["detail"] = "hostname added to hosts file"
-	output.UserOut.WithField("raw", rawResult).Info("")
+	rawResult["detail"] = detail
+	output.UserOut.WithField("raw", rawResult).Info(detail)
 
 	return
 }
@@ -83,32 +88,36 @@ func removeHost(hosts goodhosts.Hosts, ip, hostname string) {
 	rawResult := make(map[string]interface{})
 
 	if !hosts.Has(ip, hostname) {
+		detail := "Hostname does not exist in hosts file"
 		rawResult["error"] = "SUCCESS"
-		rawResult["detail"] = "hostname does not exist in hosts file"
-		output.UserOut.WithField("raw", rawResult).Info("")
+		rawResult["detail"] = detail
+		output.UserOut.WithField("raw", rawResult).Info(detail)
 
 		return
 	}
 
 	if err := hosts.Remove(ip, hostname); err != nil {
+		detail := fmt.Sprintf("Could not remove hostname %s at %s: %v", hostname, ip, err)
 		rawResult["error"] = "REMOVEERROR"
-		rawResult["full_error"] = fmt.Sprintf("%v", err)
-		output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("could not remove hostname %s at %s: %v", hostname, ip, err))
+		rawResult["full_error"] = detail
+		output.UserOut.WithField("raw", rawResult).Fatal(detail)
 
 		return
 	}
 
 	if err := hosts.Flush(); err != nil {
-		rawResult["error"] = "WRITERROR"
-		rawResult["full_error"] = fmt.Sprintf("%v", err)
-		output.UserOut.WithField("raw", rawResult).Info("")
+		detail := fmt.Sprintf("Could not write hosts file: %v", err)
+		rawResult["error"] = "WRITEERROR"
+		rawResult["full_error"] = detail
+		output.UserOut.WithField("raw", rawResult).Info(detail)
 
 		return
 	}
 
+	detail := "Hostname removed from hosts file"
 	rawResult["error"] = "SUCCESS"
-	rawResult["detail"] = "hostname removed from hosts file"
-	output.UserOut.WithField("raw", rawResult).Info("")
+	rawResult["detail"] = detail
+	output.UserOut.WithField("raw", rawResult).Info(detail)
 
 	return
 }

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var removeHostName bool
+
 // HostNameCmd represents the hostname command
 var HostNameCmd = &cobra.Command{
 	Use:   "hostname [hostname] [ip]",
@@ -19,44 +21,99 @@ var HostNameCmd = &cobra.Command{
 			output.UserOut.Fatal("Invalid arguments supplied. Please use 'ddev hostname [hostname] [ip]'")
 		}
 
-		rawResult := make(map[string]interface{})
-
 		hostname, ip := args[0], args[1]
+
 		hosts, err := goodhosts.NewHosts()
 		if err != nil {
+			rawResult := make(map[string]interface{})
 			rawResult["error"] = "READERROR"
 			rawResult["full_error"] = fmt.Sprintf("%v", err)
 			output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("could not open hosts file for read: %v", err))
-			return
-		}
-		if hosts.Has(ip, hostname) {
-			if output.JSONOutput {
-				rawResult["error"] = "SUCCESS"
-				rawResult["detail"] = "hostname already exists in hosts file"
-				output.UserOut.WithField("raw", rawResult).Info("")
-			}
+
 			return
 		}
 
-		err = hosts.Add(ip, hostname)
-		if err != nil {
-			rawResult["error"] = "ADDERROR"
-			rawResult["full_error"] = fmt.Sprintf("%v", err)
-			output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("could not add hostname %s at %s: %v", hostname, ip, err))
+		if removeHostName {
+			removeHost(hosts, ip, hostname)
+
+			return
 		}
 
-		if err := hosts.Flush(); err != nil {
-			rawResult["error"] = "WRITEERROR"
-			rawResult["full_error"] = fmt.Sprintf("%v", err)
-			output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("Could not write hosts file: %v", err))
-		} else {
-			rawResult["error"] = "SUCCESS"
-			rawResult["detail"] = "hostname added to hosts file"
-			output.UserOut.WithField("raw", rawResult).Info("")
-		}
+		addHost(hosts, ip, hostname)
 	},
 }
 
+func addHost(hosts goodhosts.Hosts, ip, hostname string) {
+	rawResult := make(map[string]interface{})
+
+	if hosts.Has(ip, hostname) {
+		if output.JSONOutput {
+			rawResult["error"] = "SUCCESS"
+			rawResult["detail"] = "hostname already exists in hosts file"
+			output.UserOut.WithField("raw", rawResult).Info("")
+		}
+
+		return
+	}
+
+	if err := hosts.Add(ip, hostname); err != nil {
+		rawResult["error"] = "ADDERROR"
+		rawResult["full_error"] = fmt.Sprintf("%v", err)
+		output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("could not add hostname %s at %s: %v", hostname, ip, err))
+
+		return
+	}
+
+	if err := hosts.Flush(); err != nil {
+		rawResult["error"] = "WRITEERROR"
+		rawResult["full_error"] = fmt.Sprintf("%v", err)
+		output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("Could not write hosts file: %v", err))
+
+		return
+	}
+
+	rawResult["error"] = "SUCCESS"
+	rawResult["detail"] = "hostname added to hosts file"
+	output.UserOut.WithField("raw", rawResult).Info("")
+
+	return
+}
+
+func removeHost(hosts goodhosts.Hosts, ip, hostname string) {
+	rawResult := make(map[string]interface{})
+
+	if !hosts.Has(ip, hostname) {
+		rawResult["error"] = "SUCCESS"
+		rawResult["detail"] = "hostname does not exist in hosts file"
+		output.UserOut.WithField("raw", rawResult).Info("")
+
+		return
+	}
+
+	if err := hosts.Remove(ip, hostname); err != nil {
+		rawResult["error"] = "REMOVEERROR"
+		rawResult["full_error"] = fmt.Sprintf("%v", err)
+		output.UserOut.WithField("raw", rawResult).Fatal(fmt.Sprintf("could not remove hostname %s at %s: %v", hostname, ip, err))
+
+		return
+	}
+
+	if err := hosts.Flush(); err != nil {
+		rawResult["error"] = "WRITERROR"
+		rawResult["full_error"] = fmt.Sprintf("%v", err)
+		output.UserOut.WithField("raw", rawResult).Info("")
+
+		return
+	}
+
+	rawResult["error"] = "SUCCESS"
+	rawResult["detail"] = "hostname removed from hosts file"
+	output.UserOut.WithField("raw", rawResult).Info("")
+
+	return
+}
+
 func init() {
+	HostNameCmd.Flags().BoolVarP(&removeHostName, "remove", "R", false, "Remove the provided host name - ip correlation")
 	RootCmd.AddCommand(HostNameCmd)
 }

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -235,5 +235,6 @@ func removeInactiveHostnames(hosts goodhosts.Hosts) {
 func init() {
 	HostNameCmd.Flags().BoolVarP(&removeHostName, "remove", "r", false, "Remove the provided host name - ip correlation")
 	HostNameCmd.Flags().BoolVarP(&removeInactive, "remove-inactive", "R", false, "Remove host names of inactive projects")
+	HostNameCmd.Flags().BoolVar(&removeInactive, "fire-bazooka", false, "Alias of --remove-inactive")
 	RootCmd.AddCommand(HostNameCmd)
 }

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -5,8 +5,11 @@ import (
 
 	"github.com/drud/ddev/pkg/output"
 
+	"strings"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/version"
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/spf13/cobra"
 )
@@ -182,6 +185,12 @@ func removeInactiveHostnames(hosts goodhosts.Hosts) {
 					continue
 				}
 
+				// Silently ignore those that may not be ddev-managed to not spam the user's terminal
+				if !strings.HasSuffix(h, version.DDevTLD) {
+					continue
+				}
+
+				// Remaining host names are fair game to be removed
 				if err := hosts.Remove(line.IP, h); err != nil {
 					detail = fmt.Sprintf("Could not remove hostname %s at %s: %v", h, line.IP, err)
 					internalResult["error"] = "REMOVEERROR"

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -35,17 +35,17 @@ var HostNameCmd = &cobra.Command{
 		}
 
 		if removeHostName {
-			removeHost(hosts, ip, hostname)
+			removeHostname(hosts, ip, hostname)
 
 			return
 		}
 
-		addHost(hosts, ip, hostname)
+		addHostname(hosts, ip, hostname)
 	},
 }
 
-// addHost encapsulates the
-func addHost(hosts goodhosts.Hosts, ip, hostname string) {
+// addHostname encapsulates the logic of adding a hostname to the system's hosts file.
+func addHostname(hosts goodhosts.Hosts, ip, hostname string) {
 	var detail string
 	rawResult := make(map[string]interface{})
 
@@ -84,7 +84,8 @@ func addHost(hosts goodhosts.Hosts, ip, hostname string) {
 	return
 }
 
-func removeHost(hosts goodhosts.Hosts, ip, hostname string) {
+// removeHostname encapsulates the logic of removing a hostname from the system's hosts file.
+func removeHostname(hosts goodhosts.Hosts, ip, hostname string) {
 	rawResult := make(map[string]interface{})
 
 	if !hosts.Has(ip, hostname) {

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -27,9 +27,20 @@ to allow ddev to modify your hosts file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		hosts, err := goodhosts.NewHosts()
 		if err != nil {
-			detail := fmt.Sprintf("Could not open hosts file for reading: %v", err)
 			rawResult := make(map[string]interface{})
+			detail := fmt.Sprintf("Could not open hosts file for reading: %v", err)
 			rawResult["error"] = "READERROR"
+			rawResult["full_error"] = detail
+			output.UserOut.WithField("raw", rawResult).Fatal(detail)
+
+			return
+		}
+
+		// Attempt to write the hosts file first to catch any permissions issues early
+		if err := hosts.Flush(); err != nil {
+			rawResult := make(map[string]interface{})
+			detail := fmt.Sprintf("Could not write hosts file: %v", err)
+			rawResult["error"] = "WRITEERROR"
 			rawResult["full_error"] = detail
 			output.UserOut.WithField("raw", rawResult).Fatal(detail)
 

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -231,5 +231,7 @@ func init() {
 	HostNameCmd.Flags().BoolVarP(&removeHostName, "remove", "r", false, "Remove the provided host name - ip correlation")
 	HostNameCmd.Flags().BoolVarP(&removeInactive, "remove-inactive", "R", false, "Remove host names of inactive projects")
 	HostNameCmd.Flags().BoolVar(&removeInactive, "fire-bazooka", false, "Alias of --remove-inactive")
+	HostNameCmd.Flags().MarkHidden("fire-bazooka")
+
 	RootCmd.AddCommand(HostNameCmd)
 }

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -231,7 +231,7 @@ func init() {
 	HostNameCmd.Flags().BoolVarP(&removeHostName, "remove", "r", false, "Remove the provided host name - ip correlation")
 	HostNameCmd.Flags().BoolVarP(&removeInactive, "remove-inactive", "R", false, "Remove host names of inactive projects")
 	HostNameCmd.Flags().BoolVar(&removeInactive, "fire-bazooka", false, "Alias of --remove-inactive")
-	HostNameCmd.Flags().MarkHidden("fire-bazooka")
+	_ = HostNameCmd.Flags().MarkHidden("fire-bazooka")
 
 	RootCmd.AddCommand(HostNameCmd)
 }

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -5,24 +5,23 @@ import (
 
 	"github.com/drud/ddev/pkg/output"
 
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/spf13/cobra"
 )
 
 var removeHostName bool
+var removeInactive bool
 
 // HostNameCmd represents the hostname command
 var HostNameCmd = &cobra.Command{
 	Use:   "hostname [hostname] [ip]",
 	Short: "Manage your hostfile entries.",
-	Long:  `Manage your hostfile entries.`,
+	Long: `Manage your hostfile entries. Managing host names has security and usability
+implications and requires elevated privileges. You may be asked for a password
+to allow ddev to modify your hosts file.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 2 {
-			output.UserOut.Fatal("Invalid arguments supplied. Please use 'ddev hostname [hostname] [ip]'")
-		}
-
-		hostname, ip := args[0], args[1]
-
 		hosts, err := goodhosts.NewHosts()
 		if err != nil {
 			detail := fmt.Sprintf("Could not open hosts file for reading: %v", err)
@@ -34,12 +33,32 @@ var HostNameCmd = &cobra.Command{
 			return
 		}
 
+		// If requested, remove all inactive host names and exit
+		if removeInactive {
+			if len(args) > 0 {
+				output.UserOut.Fatal("Invalid arguments supplied. 'ddev hostname --remove-all' accepts no arguments.")
+			}
+
+			removeInactiveHostnames(hosts)
+
+			return
+		}
+
+		// If operating on one host name, two arguments are required
+		if len(args) != 2 {
+			output.UserOut.Fatal("Invalid arguments supplied. Please use 'ddev hostname [hostname] [ip]'")
+		}
+
+		hostname, ip := args[0], args[1]
+
+		// If requested, remove the provided host name and exit
 		if removeHostName {
 			removeHostname(hosts, ip, hostname)
 
 			return
 		}
 
+		// By default, add a host name
 		addHostname(hosts, ip, hostname)
 	},
 }
@@ -59,7 +78,7 @@ func addHostname(hosts goodhosts.Hosts, ip, hostname string) {
 	}
 
 	if err := hosts.Add(ip, hostname); err != nil {
-		detail = fmt.Sprintf("Could notk add hostname %s at %s: %v", hostname, ip, err)
+		detail = fmt.Sprintf("Could not add hostname %s at %s: %v", hostname, ip, err)
 		rawResult["error"] = "ADDERROR"
 		rawResult["full_error"] = detail
 		output.UserOut.WithField("raw", rawResult).Fatal(detail)
@@ -86,10 +105,11 @@ func addHostname(hosts goodhosts.Hosts, ip, hostname string) {
 
 // removeHostname encapsulates the logic of removing a hostname from the system's hosts file.
 func removeHostname(hosts goodhosts.Hosts, ip, hostname string) {
+	var detail string
 	rawResult := make(map[string]interface{})
 
 	if !hosts.Has(ip, hostname) {
-		detail := "Hostname does not exist in hosts file"
+		detail = "Hostname does not exist in hosts file"
 		rawResult["error"] = "SUCCESS"
 		rawResult["detail"] = detail
 		output.UserOut.WithField("raw", rawResult).Info(detail)
@@ -98,7 +118,7 @@ func removeHostname(hosts goodhosts.Hosts, ip, hostname string) {
 	}
 
 	if err := hosts.Remove(ip, hostname); err != nil {
-		detail := fmt.Sprintf("Could not remove hostname %s at %s: %v", hostname, ip, err)
+		detail = fmt.Sprintf("Could not remove hostname %s at %s: %v", hostname, ip, err)
 		rawResult["error"] = "REMOVEERROR"
 		rawResult["full_error"] = detail
 		output.UserOut.WithField("raw", rawResult).Fatal(detail)
@@ -107,15 +127,84 @@ func removeHostname(hosts goodhosts.Hosts, ip, hostname string) {
 	}
 
 	if err := hosts.Flush(); err != nil {
-		detail := fmt.Sprintf("Could not write hosts file: %v", err)
+		detail = fmt.Sprintf("Could not write hosts file: %v", err)
 		rawResult["error"] = "WRITEERROR"
 		rawResult["full_error"] = detail
-		output.UserOut.WithField("raw", rawResult).Info(detail)
+		output.UserOut.WithField("raw", rawResult).Fatal(detail)
 
 		return
 	}
 
-	detail := "Hostname removed from hosts file"
+	detail = "Hostname removed from hosts file"
+	rawResult["error"] = "SUCCESS"
+	rawResult["detail"] = detail
+	output.UserOut.WithField("raw", rawResult).Info(detail)
+
+	return
+}
+
+// removeInactiveHostnames will remove all host names except those current in use by active projects.
+func removeInactiveHostnames(hosts goodhosts.Hosts) {
+	var detail string
+	rawResult := make(map[string]interface{})
+
+	// Get the list active hosts names to preserve, always including localhost
+	activeHostNames := map[string]bool{"localhost": true}
+	for _, app := range ddevapp.GetApps() {
+		for _, h := range app.GetHostnames() {
+			activeHostNames[h] = true
+		}
+	}
+
+	// Find all current host names for the local IP address
+	dockerIP, err := dockerutil.GetDockerIP()
+	if err != nil {
+		detail = fmt.Sprintf("Failed to get Docker IP: %v", err)
+		rawResult["error"] = "DOCKERERROR"
+		rawResult["full_error"] = detail
+		output.UserOut.WithField("raw", rawResult).Fatal(detail)
+	}
+
+	// Iterate through each host line
+	for _, line := range hosts.Lines {
+		// Checking if it concerns the local IP address
+		if line.IP == dockerIP {
+			// Iterate through each registered host
+			for _, h := range line.Hosts {
+				internalResult := make(map[string]interface{})
+
+				// Ignore those we want to preserve
+				if isActiveHost := activeHostNames[h]; isActiveHost {
+					detail = fmt.Sprintf("Hostname %s at %s is active, preserving", h, line.IP)
+					internalResult["error"] = "SUCCESS"
+					internalResult["detail"] = detail
+					output.UserOut.WithField("raw", internalResult).Info(detail)
+					continue
+				}
+
+				if err := hosts.Remove(line.IP, h); err != nil {
+					detail = fmt.Sprintf("Could not remove hostname %s at %s: %v", h, line.IP, err)
+					internalResult["error"] = "REMOVEERROR"
+					internalResult["full_error"] = detail
+					output.UserOut.WithField("raw", internalResult).Fatal(detail)
+				}
+
+				detail = fmt.Sprintf("Removed hostname %s at %s", h, line.IP)
+				internalResult["error"] = "SUCCESS"
+				internalResult["detail"] = detail
+				output.UserOut.WithField("raw", internalResult).Info(detail)
+			}
+		}
+	}
+
+	if err := hosts.Flush(); err != nil {
+		detail = fmt.Sprintf("Could not write hosts file: %v", err)
+		rawResult["error"] = "WRITEERROR"
+		rawResult["full_error"] = detail
+		output.UserOut.WithField("raw", rawResult).Fatal(detail)
+	}
+
+	detail = "Cleaned up inactive host names"
 	rawResult["error"] = "SUCCESS"
 	rawResult["detail"] = detail
 	output.UserOut.WithField("raw", rawResult).Info(detail)
@@ -124,6 +213,7 @@ func removeHostname(hosts goodhosts.Hosts, ip, hostname string) {
 }
 
 func init() {
-	HostNameCmd.Flags().BoolVarP(&removeHostName, "remove", "R", false, "Remove the provided host name - ip correlation")
+	HostNameCmd.Flags().BoolVarP(&removeHostName, "remove", "r", false, "Remove the provided host name - ip correlation")
+	HostNameCmd.Flags().BoolVarP(&removeInactive, "remove-inactive", "R", false, "Remove host names of inactive projects")
 	RootCmd.AddCommand(HostNameCmd)
 }

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -39,7 +39,7 @@ to allow ddev to modify your hosts file.`,
 		// Attempt to write the hosts file first to catch any permissions issues early
 		if err := hosts.Flush(); err != nil {
 			rawResult := make(map[string]interface{})
-			detail := fmt.Sprintf("Could not write hosts file: %v", err)
+			detail := fmt.Sprintf("Please use sudo or execute with administrative privileges: %v", err)
 			rawResult["error"] = "WRITEERROR"
 			rawResult["full_error"] = detail
 			output.UserOut.WithField("raw", rawResult).Fatal(detail)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1058,7 +1058,7 @@ func (app *DdevApp) RemoveHostsEntries() error {
 		output.UserOut.Println("Please enter your password if prompted.")
 
 		if _, err = exec.RunCommandPipe("sudo", hostnameArgs); err != nil {
-			util.Warning("Faield to execute sudo command, you will need to manually execute '%s' with administrative privileges", command)
+			util.Warning("Failed to execute sudo command, you will need to manually execute '%s' with administrative privileges", command)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -996,6 +996,7 @@ func (app *DdevApp) AddHostsEntries() error {
 	if err != nil {
 		util.Failed("could not open hostfile: %v", err)
 	}
+
 	for _, name := range app.GetHostnames() {
 
 		if hosts.Has(dockerIP, name) {
@@ -1036,6 +1037,7 @@ func (app *DdevApp) RemoveHostsEntries() error {
 	if err != nil {
 		util.Failed("could not open hostfile: %v", err)
 	}
+
 	for _, name := range app.GetHostnames() {
 		if !hosts.Has(dockerIP, name) {
 			continue


### PR DESCRIPTION
## The Problem/Issue/Bug:
#831: The user's hosts file eventually becomes polluted after having many project hostnames added to it. Currently, ddev makes no effort to remove a hostname entry after it has been added.

## How this PR Solves The Problem:
Add the ability to remove a hostname via the `ddev hostname` command:
```
ddev hostname --remove my.host 127.0.0.1 
```


Remove hostname entries from the user's hosts file on `ddev remove --remove-data`.  Removing a hostname on `ddev remove --remove-data` and `ddev hostname --remove` mimic the output and structure of existing hostname addition code.

User-facing output in `ddev hostname` has been improved.

## Manual Testing Instructions:
- Add a hostname via `ddev hostname test.host 1.2.3.4` and ensure the hostname has been added to the hosts file
- Remove the same hostname via `ddev hostname test.host 1.2.3.4 --remove` and ensure the hostname has been removed from the hosts file

Test the above steps with and without `sudo` and the `--json-output` to inspect output and error logging.

- Add a new and unique FQDN or hostname to a ddev project's .ddev/config.yaml
- Execute `ddev start` on the project and ensure the new hostnames have been added to the hosts files
- Execute `ddev remove --remove-data` on the project and ensure the project's hostnames have been removed from the hosts file

Test the above steps with and without `DRUD_NONINTERACTIVE` to see non-interactive instruction logging.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

