### PR TITLE
Fix for loop that installs php packages

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/minideb:jessie
 
-ENV PHP_VERSIONS="5.6 7.0 7.1 7.2"
+ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2"
 ENV PHP_DEFAULT_VERSION="7.1"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 
@@ -65,7 +65,7 @@ RUN apt-get -qq update && \
         unzip \
         rsync \
         libpcre3 && \
-    for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
+    for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our ddev-webserver Dockerfile has a (long-term?) scripting bug. I noticed and fixed it over in https://github.com/drud/ddev/pull/1007, but of course that one will be a while. 

I have no idea how this could ever have worked, or why a php upgrade would trigger failures that we hadn't seen before.

## How this PR Solves The Problem:

Fix the Dockerfile; script was completely wrong.
