### PR TITLE
Bump ddev-webserver tag to reflect addition of php-redis and fix of Dockerfile for loop

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,7 +20,7 @@ var DockerComposeVersionConstraint = ">= 1.18.0-alpha1"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.0.0" // Note that this can be overridden by make
+var WebTag = "20180726_webserver_bump" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION

## The Problem/Issue/Bug:

There were changes made to ddev-webserver in https://github.com/drud/ddev/commit/ba7f1df0d6e5373223707fb67865e8bc132f137f
and
https://github.com/drud/ddev/commit/f6784fe02d9ba02d2a96fc0ab96939e2b538a924 and neither one got a new version pushed or version update. This just does that so we're clear that the container is changing.
