### PR TITLE
Fix Windows mount of .ddev/mysql configuration (Support for Docker 18.06)

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod ugo+x /healthcheck.sh
 # Security-sensitive changes: Make sure our start script can do what is needed
 # But make sure these are right
 RUN chmod ugo+wx /mnt /var/tmp
-RUN chmod -R ugo+wx /var/log /var/tmp/mysqlbase
+RUN chmod -R ugo+wx /var/log /var/tmp/mysqlbase /etc/mysql/conf.d
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -3,8 +3,8 @@ set -x
 set -eu
 set -o pipefail
 
-# If we have extra mariadb config, copy it to where it goes.,
-if [ -d /mnt/ddev_config/mysql ] ; then
+# If we have extra mariadb cnf files,, copy them to where they go.
+if [ -d /mnt/ddev_config/mysql -a "$(echo /mnt/ddev_config/mysql/*.cnf)" != "/mnt/ddev_config/mysql/*.cnf" ] ; then
   cp /mnt/ddev_config/mysql/*.cnf /etc/mysql/conf.d
   chmod ugo-w /etc/mysql/conf.d/*
 fi

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -3,11 +3,10 @@ set -x
 set -eu
 set -o pipefail
 
-# Normally /mnt/ddev_config will be mounted; config file requires it,
-# so create it if it doesn't exist.
-if [ ! -d /mnt/ddev_config/mysql ] ; then
-  mkdir -p /mnt/ddev_config/mysql
-  chmod ugo+rx /mnt/ddev_config /mnt/ddev_config/mysql
+# If we have extra mariadb config, copy it to where it goes.,
+if [ -d /mnt/ddev_config/mysql ] ; then
+  cp /mnt/ddev_config/mysql/*.cnf /etc/mysql/conf.d
+  chmod ugo-w /etc/mysql/conf.d/*
 fi
 
 # If mariadb has not been initialized, copy in the base image.

--- a/containers/ddev-dbserver/files/etc/my.cnf
+++ b/containers/ddev-dbserver/files/etc/my.cnf
@@ -81,5 +81,4 @@ log-queries-not-using-indexes  = 1
 slow-query-log                 = 1
 slow-query-log-file            = /var/lib/mysql/mysql-slow.log
 
-!includedir /mnt/ddev_config/mysql
-
+!includedir /etc/mysql/conf.d

--- a/containers/ddev-dbserver/test/testserver.sh
+++ b/containers/ddev-dbserver/test/testserver.sh
@@ -97,7 +97,8 @@ mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$H
 cleanup
 
 # Run with alternate configuration my.cnf mounted
-if ! docker run -u "$MOUNTUID:$MOUNTGID" -v /$MYTMPDIR:/var/lib/mysql -v /$PWD/test/testdata:/mnt/ddev_config --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
+# mysqld will ignore world-writeable config file, so we make it ro for sure
+if ! docker run -u "$MOUNTUID:$MOUNTGID" -v /$MYTMPDIR:/var/lib/mysql -v /$PWD/test/testdata:/mnt/ddev_config:ro --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE; then
 	echo "MySQL server start failed with error code $?"
 	exit 3
 fi

--- a/containers/ddev-webserver/test/containertest.sh
+++ b/containers/ddev-webserver/test/containertest.sh
@@ -130,7 +130,7 @@ for project_type in drupal6 drupal7 drupal8 typo3 backdrop wordpress default; do
 done
 
 echo "testing use of custom nginx and php configs"
-docker run  -u "$(id -u):$(id -g)" -p $HOST_PORT:$CONTAINER_PORT -e "DOCROOT=potato" -e "DDEV_PHP_VERSION=7.2" -v "/$PWD/test/testdata:/mnt/ddev_config" -d --name $CONTAINER_NAME -d $DOCKER_IMAGE
+docker run  -u "$(id -u):$(id -g)" -p $HOST_PORT:$CONTAINER_PORT -e "DOCROOT=potato" -e "DDEV_PHP_VERSION=7.2" -v "/$PWD/test/testdata:/mnt/ddev_config:ro" -d --name $CONTAINER_NAME -d $DOCKER_IMAGE
 docker exec -t $CONTAINER_NAME grep "docroot is /var/www/html/potato in custom conf" //etc/nginx/sites-enabled/nginx-site.conf
 
 # Enable xdebug (and then disable again) and make sure it does the right thing.

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -12,7 +12,7 @@ services:
     volumes:
       - "${DDEV_IMPORTDIR}:/db"
       - "${DDEV_DATADIR}:/var/lib/mysql"
-      - ".:/mnt/ddev_config"
+      - ".:/mnt/ddev_config:ro"
     restart: "no"
     user: "$DDEV_UID:$DDEV_GID"
     ports:
@@ -32,7 +32,7 @@ services:
     image: $DDEV_WEBIMAGE
     volumes:
       - "../:/var/www/html:cached"
-      - ".:/mnt/ddev_config"
+      - ".:/mnt/ddev_config:ro"
     restart: "no"
     user: "$DDEV_UID:$DDEV_GID"
     depends_on:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var WebTag = "v1.0.0" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "v1.0.0" // Note that this may be overridden by make
+var DBTag = "20180726_fix_dbserver_test" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

With the move to Docker 18.06 *something* had to break, and our container test for ddev-dbserver broke on windows. It turns out that mysqld won't (at least now) read config that is world-writable, as we've run into other places on ~/.my.cnf; I don't know why this would show up with a docker version change.

## How this PR Solves The Problem:

* Change the *test* to mount ro
* Change so ddev generates a docker-compose.yaml that has this mount set to ro so our users don't discover this. 

## Manual Testing Instructions:

* If the tests success on the windows container that's good
* For extra credit try changing config in `.ddev/mysql/<something.cnf>` ON WINDOWS and see that your change takes effect.

