### PR TITLE
Add rewrite rule to TYPO3 nginx configuration, fixes #1030

### DIFF
--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
@@ -140,6 +140,10 @@ server {
         deny all;
     }
 
+    if (!-e $request_filename) {
+        rewrite ^/(.+)\.(\d+)\.(php|js|css|png|jpg|gif|gzip)$ /$1.$3 last;
+    }
+
     location ~ ^/(fpmstatus|ping)$ {
          access_log off;
          stub_status     on;


### PR DESCRIPTION
Adds support for TYPO3 'versionNumberInFilename' configuration

## The Problem/Issue/Bug:
#1030 

## How this PR Solves The Problem:
Adds a new rewrite rule to TYPO3 nginx configuration that rewrites generated filenames with enabled TYPO3 configuration `versionNumberInFilename` for backend and frontend.

## Manual Testing Instructions:
1.  Install TYPO3 Version 8 via composer `composer create-project typo3/cms-base-distribution ^8 typo3`
2. Configure ddev `ddev config`
3. Add configuration to `AdditionalConfiguration.php`
    ```
    $GLOBALS['TYPO3_CONF_VARS']['BE']['versionNumberInFilename'] = '1';
    $GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename'] = 'embed';
    ```
4. Call TYPO3 Backend (http://typo3.ddev.local/typo3/)
    You should see a normal rendered backend. Without the nginx configuration, all styles are missing.

## Related Issue Link(s):
#1030 

## Release/Deployment notes:
Adds support for TYPO3 'versionNumberInFilename' configuration