### PR TITLE
Change the TYPO3 AdditionalConfiguration.php template to extend the MAIL array - fixes #1042

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -16,7 +16,7 @@ const typo3AdditionalConfigTemplate = `<?php
 /** ` + DdevFileSignature + `: Automatically generated TYPO3 AdditionalConfiguration.php file.
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
- 
+
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
 
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'], [
@@ -28,10 +28,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($GLOBA
 ]);
 
 // This mail configuration sends all emails to mailhog
-$GLOBALS['TYPO3_CONF_VARS']['MAIL'] = [
-    'transport' => 'smtp',
-    'transport_smtp_server' => 'localhost:1025',
-];
+$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport'] = 'smtp';
+$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_server'] = 'localhost:1025';
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'] = '*';
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = 1;


### PR DESCRIPTION
## The Problem/Issue/Bug:
Problem described in #1042 

## How this PR Solves The Problem:
The code in the template file is changed so that the array is extended instead of overwritten so that we have access to the full $GLOBALS['TYPO3_CONF_VARS']['MAIL'] array in TYPO3. 

## Manual Testing Instructions:
Testing this automatically was not possible as far as I know.

