### PR TITLE
Add staticrequired to pre-push hooks

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -3,6 +3,10 @@
 Hook scripts in this directory can be placed in .git/hooks to get git to help with our workflow. These are for developer use only, and have no impact by just being here in .githooks.
 
 You should also be able to link them, for example (if you don't mind if they change upstream, and don't introduce any changes of your own)
+
+The easiest way to do it is to use the script: `.githooks/linkallchecks.sh` and `.githooks/unlinkprepush.sh`. If you have a situation where you want to push without the checks, just `unlinkprepush.sh` and then put it back with `linkallchecks.sh`.
+
+But what you're actually doing is this:
 ```
 cd .git/hooks
 # For all the static checks:

--- a/.githooks/linkallchecks.sh
+++ b/.githooks/linkallchecks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Find the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+ln -sf $DIR/pre-push.allchecks $DIR/../.git/hooks/pre-push
+
+echo "Linked pre-push.allchecks as pre-push git hook"

--- a/.githooks/linkgofmt.sh
+++ b/.githooks/linkgofmt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Find the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+ln -sf $DIR/pre-push.gofmt $DIR/../.git/hooks/pre-push
+
+echo "Linked pre-push.gofmt as pre-push git hook"

--- a/.githooks/pre-push.allchecks
+++ b/.githooks/pre-push.allchecks
@@ -8,4 +8,5 @@ git diff-index --quiet HEAD || (echo "There are uncommitted files" && exit 1)
 # Look for unstaged files
 test -z "$(git ls-files --exclude-standard --others)" || (echo "There are unstaged files" && exit 2)
 
-make -s gofmt govet golint errcheck staticcheck codecoroner
+# And check make staticrequired
+make -s staticrequired

--- a/.githooks/pre-push.gofmt
+++ b/.githooks/pre-push.gofmt
@@ -9,6 +9,3 @@ test -z "$(git ls-files --exclude-standard --others)" || (echo "There are unstag
 
 # Make sure gofmt has been done
 make -s gofmt
-
-# And check make staticrequired
-make -s staticrequired

--- a/.githooks/pre-push.gofmt
+++ b/.githooks/pre-push.gofmt
@@ -9,3 +9,6 @@ test -z "$(git ls-files --exclude-standard --others)" || (echo "There are unstag
 
 # Make sure gofmt has been done
 make -s gofmt
+
+# And check make staticrequired
+make -s staticrequired

--- a/.githooks/unlinkprepush.sh
+++ b/.githooks/unlinkprepush.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Find the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+rm -f $DIR/../.git/hooks/pre-push
+
+echo "Unlinked pre-push git hook"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The provided (optional) githooks don't provide `make staticrequired` which is one thing we'd like them to have.

## How this PR Solves The Problem:

Adds it.

This change affects only developers who link the pre-push hooks, it doesn't affect users, testing, etc.