### PR TITLE
Don't use err when it's nil

### DIFF
--- a/pkg/appimport/appimport_test.go
+++ b/pkg/appimport/appimport_test.go
@@ -57,7 +57,9 @@ func TestValidateAsset(t *testing.T) {
 	// db no sql
 	gofilePath := filepath.Join(testdata, "junk.go")
 	_, isArchive, err = appimport.ValidateAsset(gofilePath, "db")
-	assert.Contains(err.Error(), "provided path is not a .sql file or archive")
+	if err != nil {
+		assert.Contains(err.Error(), "provided path is not a .sql file or archive")
+	}
 	assert.Error(err)
 	assert.False(isArchive)
 
@@ -65,5 +67,7 @@ func TestValidateAsset(t *testing.T) {
 	_, isArchive, err = appimport.ValidateAsset(gofilePath, "files")
 	assert.False(isArchive)
 	assert.Error(err)
-	assert.Contains(err.Error(), "provided path is not a directory or archive")
+	if err != nil {
+		assert.Contains(err.Error(), "provided path is not a directory or archive")
+	}
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -242,13 +242,17 @@ func TestDdevStart(t *testing.T) {
 
 	err = app.Init(another.Dir)
 	assert.Error(err)
-	assert.Contains(err.Error(), fmt.Sprintf("a project (web container) in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
+	if err != nil {
+		assert.Contains(err.Error(), fmt.Sprintf("a project (web container) in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
+	}
 
 	// Make sure that GetActiveApp() also fails when trying to start app of duplicate name in current directory.
 	switchDir := another.Chdir()
 	_, err = ddevapp.GetActiveApp("")
 	assert.Error(err)
-	assert.Contains(err.Error(), fmt.Sprintf("a project (web container) in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
+	if err != nil {
+		assert.Contains(err.Error(), fmt.Sprintf("a project (web container) in running state already exists for %s that was created at %s", TestSites[0].Name, TestSites[0].Dir))
+	}
 	testcommon.CleanupDir(another.Dir)
 	switchDir()
 }
@@ -416,7 +420,9 @@ func TestStartWithoutDdevConfig(t *testing.T) {
 
 	_, err = ddevapp.GetActiveApp("")
 	assert.Error(err)
-	assert.Contains(err.Error(), "Could not find a project")
+	if err != nil {
+		assert.Contains(err.Error(), "Could not find a project")
+	}
 }
 
 // TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.
@@ -1283,7 +1289,9 @@ func TestMultipleComposeFiles(t *testing.T) {
 
 	_, err = app.ComposeFiles()
 	assert.Error(err)
-	assert.Contains(err.Error(), "there are more than one docker-compose.y*l")
+	if err != nil {
+		assert.Contains(err.Error(), "there are more than one docker-compose.y*l")
+	}
 
 	// Make sure that some docker-compose.override.yml and docker-compose.override.yaml conflict gets noted properly
 	app, err = ddevapp.NewApp("./testdata/testConflictingOverrideYaml", "")
@@ -1291,7 +1299,9 @@ func TestMultipleComposeFiles(t *testing.T) {
 
 	_, err = app.ComposeFiles()
 	assert.Error(err)
-	assert.Contains(err.Error(), "there are more than one docker-compose.override.y*l")
+	if err != nil {
+		assert.Contains(err.Error(), "there are more than one docker-compose.override.y*l")
+	}
 
 	// Make sure the error gets pointed out of there's no main docker-compose.yaml
 	app, err = ddevapp.NewApp("./testdata/testNoDockerCompose", "")
@@ -1299,7 +1309,9 @@ func TestMultipleComposeFiles(t *testing.T) {
 
 	_, err = app.ComposeFiles()
 	assert.Error(err)
-	assert.Contains(err.Error(), "failed to find a docker-compose.yml or docker-compose.yaml")
+	if err != nil {
+		assert.Contains(err.Error(), "failed to find a docker-compose.yml or docker-compose.yaml")
+	}
 
 	// Catch if we have no docker files at all.
 	// This should also fail if the docker-compose.yaml.bak gets loaded.
@@ -1308,7 +1320,9 @@ func TestMultipleComposeFiles(t *testing.T) {
 
 	_, err = app.ComposeFiles()
 	assert.Error(err)
-	assert.Contains(err.Error(), "failed to load any docker-compose.*y*l files")
+	if err != nil {
+		assert.Contains(err.Error(), "failed to load any docker-compose.*y*l files")
+	}
 }
 
 // TestGetAllURLs ensures the GetAllURLs function returns the expected number of URLs,

--- a/pkg/ddevapp/providerDrudS3_test.go
+++ b/pkg/ddevapp/providerDrudS3_test.go
@@ -97,7 +97,9 @@ func TestDrudS3ConfigCommand(t *testing.T) {
 	restoreOutput = testcommon.CaptureUserOut()
 	err = app.PromptForConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "NoSuchBucket")
+	if err != nil {
+		assert.Contains(err.Error(), "NoSuchBucket")
+	}
 	_ = restoreOutput()
 
 	// Now try with an invalid environment name, should fail
@@ -116,7 +118,9 @@ func TestDrudS3ConfigCommand(t *testing.T) {
 	assert.NoError(err)
 	err = provider.Validate()
 	assert.Error(err)
-	assert.Contains(err.Error(), "could not find an environment with backups")
+	if err != nil {
+		assert.Contains(err.Error(), "could not find an environment with backups")
+	}
 }
 
 // assertEqualProviderValues is just a helper function to avoid repeating assertions.
@@ -193,26 +197,34 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 	provider.AWSAccessKey = "AKIAIBSTOTALLYINVALID"
 	_, _, err = provider.GetBackup("database")
 	assert.Error(err)
-	assert.Contains(err.Error(), "InvalidAccessKeyId")
+	if err != nil {
+		assert.Contains(err.Error(), "InvalidAccessKeyId")
+	}
 
 	// Make sure invalid secret key gets correct behavior
 	provider.AWSAccessKey = accessKeyID
 	provider.AWSSecretKey = "rweeHGZ5totallyinvalidsecretkey"
 	_, _, err = provider.GetBackup("database")
 	assert.Error(err)
-	assert.Contains(err.Error(), "SignatureDoesNotMatch")
+	if err != nil {
+		assert.Contains(err.Error(), "SignatureDoesNotMatch")
+	}
 
 	// Make sure bad environment gets correct behavior.
 	provider.AWSSecretKey = secretAccessKey
 	provider.EnvironmentName = "someInvalidUnknownEnvironment"
 	_, _, err = provider.GetBackup("database")
 	assert.Error(err)
-	assert.Contains(err.Error(), "could not find an environment")
+	if err != nil {
+		assert.Contains(err.Error(), "could not find an environment")
+	}
 
 	// Make sure bad bucket gets correct behavior.
 	provider.S3Bucket = drudS3TestBucket
 	provider.S3Bucket = "someInvalidUnknownBucket"
 	_, _, err = provider.GetBackup("database")
 	assert.Error(err)
-	assert.Contains(err.Error(), "NoSuchBucket")
+	if err != nil {
+		assert.Contains(err.Error(), "NoSuchBucket")
+	}
 }

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -102,11 +102,15 @@ func TestContainerWait(t *testing.T) {
 
 	err := ContainerWait(0, labels)
 	assert.Error(err)
-	assert.Contains(err.Error(), "health check timed out")
+	if err != nil {
+		assert.Contains(err.Error(), "health check timed out")
+	}
 
 	err = ContainerWait(5, labels)
 	assert.Error(err)
-	assert.Contains(err.Error(), "failed to query container")
+	if err != nil {
+		assert.Contains(err.Error(), "failed to query container")
+	}
 }
 
 // TestComposeCmd tests execution of docker-compose commands.
@@ -181,10 +185,14 @@ func TestRunSimpleContainer(t *testing.T) {
 	// Try the case of running nonexistent script
 	_, err = RunSimpleContainer("busybox", "TestRunSimpleContainer"+basename, []string{"nocommandbythatname"}, nil, []string{"TEMPENV=someenv"}, []string{testdata + ":/tempmount"}, "25")
 	assert.Error(err)
-	assert.Contains(err.Error(), "failed to StartContainer")
+	if err != nil {
+		assert.Contains(err.Error(), "failed to StartContainer")
+	}
 
 	// Try the case of running a script that fails
 	_, err = RunSimpleContainer("busybox", "TestRunSimpleContainer"+basename, []string{"/tempmount/simplescript.sh"}, nil, []string{"TEMPENV=someenv", "ERROROUT=true"}, []string{testdata + ":/tempmount"}, "25")
 	assert.Error(err)
-	assert.Contains(err.Error(), "container run failed with exit code 5")
+	if err != nil {
+		assert.Contains(err.Error(), "container run failed with exit code 5")
+	}
 }

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -25,12 +25,16 @@ func TestCopyDir(t *testing.T) {
 	// test source not a directory
 	err = fileutil.CopyDir(testFileLocation, sourceDir)
 	assert.Error(err)
-	assert.Contains(err.Error(), "source is not a directory")
+	if err != nil {
+		assert.Contains(err.Error(), "source is not a directory")
+	}
 
 	// test destination exists
 	err = fileutil.CopyDir(sourceDir, targetDir)
 	assert.Error(err)
-	assert.Contains(err.Error(), "destination already exists")
+	if err != nil {
+		assert.Contains(err.Error(), "destination already exists")
+	}
 	err = os.RemoveAll(subdir)
 	assert.NoError(err)
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -40,7 +40,7 @@ func TestTmpDir(t *testing.T) {
 	// Clean up tempoary directory and ensure it no longer exists.
 	CleanupDir(testDir)
 	_, err = os.Stat(testDir)
-	assert.True(err != nil, "Could not stat temporary directory")
+	assert.Error(err, "Could not stat temporary directory")
 	if err != nil {
 		assert.True(os.IsNotExist(err), "Error is of type IsNotExists")
 	}
@@ -191,15 +191,17 @@ func TestGetCachedArchive(t *testing.T) {
 
 	sourceURL := "https://raw.githubusercontent.com/drud/ddev/master/.gitignore"
 	exPath, archPath, err := GetCachedArchive("TestInvalidArchive", "test", "", sourceURL)
-	assert.True(err != nil)
-	assert.Contains(err.Error(), fmt.Sprintf("archive extraction of %s failed", archPath))
+	assert.Error(err)
+	if err != nil {
+		assert.Contains(err.Error(), fmt.Sprintf("archive extraction of %s failed", archPath))
+	}
 
 	err = os.RemoveAll(filepath.Dir(exPath))
 	assert.NoError(err)
 
 	sourceURL = "http://invalid_domain/somefilethatdoesnotexists"
 	exPath, archPath, err = GetCachedArchive("TestInvalidDownloadURL", "test", "", sourceURL)
-	assert.True(err != nil)
+	assert.Error(err)
 	if err != nil {
 		assert.Contains(err.Error(), fmt.Sprintf("Failed to download url=%s into %s", sourceURL, archPath))
 	}

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -40,8 +40,10 @@ func TestTmpDir(t *testing.T) {
 	// Clean up tempoary directory and ensure it no longer exists.
 	CleanupDir(testDir)
 	_, err = os.Stat(testDir)
-	assert.Error(err, "Could not stat temporary directory")
-	assert.True(os.IsNotExist(err), "Error is of type IsNotExists")
+	assert.True(err != nil, "Could not stat temporary directory")
+	if err != nil {
+		assert.True(os.IsNotExist(err), "Error is of type IsNotExists")
+	}
 }
 
 // TestChdir tests the Chdir function and ensures it will change to a temporary directory and then properly return
@@ -139,7 +141,6 @@ func TestValidTestSite(t *testing.T) {
 	site.Cleanup()
 	_, err = os.Stat(site.Dir)
 	assert.Error(err, "Could not stat temporary directory after cleanup")
-
 }
 
 // TestGetLocalHTTPResponse() brings up a project and hits a URL to get the response
@@ -190,7 +191,7 @@ func TestGetCachedArchive(t *testing.T) {
 
 	sourceURL := "https://raw.githubusercontent.com/drud/ddev/master/.gitignore"
 	exPath, archPath, err := GetCachedArchive("TestInvalidArchive", "test", "", sourceURL)
-	assert.Error(err)
+	assert.True(err != nil)
 	assert.Contains(err.Error(), fmt.Sprintf("archive extraction of %s failed", archPath))
 
 	err = os.RemoveAll(filepath.Dir(exPath))
@@ -198,8 +199,10 @@ func TestGetCachedArchive(t *testing.T) {
 
 	sourceURL = "http://invalid_domain/somefilethatdoesnotexists"
 	exPath, archPath, err = GetCachedArchive("TestInvalidDownloadURL", "test", "", sourceURL)
-	assert.Error(err)
-	assert.Contains(err.Error(), fmt.Sprintf("Failed to download url=%s into %s", sourceURL, archPath))
+	assert.True(err != nil)
+	if err != nil {
+		assert.Contains(err.Error(), fmt.Sprintf("Failed to download url=%s into %s", sourceURL, archPath))
+	}
 
 	err = os.RemoveAll(filepath.Dir(exPath))
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

In a couple of our tests we occasionally get panics because we get a nil for err and then use err.Error(). We shouldn't use a nil err.

## How this PR Solves The Problem:

* If err == nil, make sure we don't try to use err.Error()

This affects only tests, and only occasionally, so is a code-review.

See the fail/panic in https://buildkite.com/drud/ddev-macos/builds/489#6c3c127b-8d24-40f2-861e-9ea7704c07e3