### PR TITLE
Extend default wait time for GetLocalHttpResponse to 20 sec

### DIFF
--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -339,9 +339,13 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 }
 
 // GetLocalHTTPResponse takes a URL, hits the local docker for it, returns result
+// takes rawurl and timeout in seconds
 // Returns error (with the body) if not 200 status code.
-func GetLocalHTTPResponse(t *testing.T, rawurl string) (string, error) {
+func GetLocalHTTPResponse(t *testing.T, rawurl string, timeout int) (string, error) {
 	assert := asrt.New(t)
+	if timeout < 0 {
+		timeout = 10
+	}
 
 	u, err := url.Parse(rawurl)
 	if err != nil {
@@ -355,13 +359,13 @@ func GetLocalHTTPResponse(t *testing.T, rawurl string) (string, error) {
 	u.Host = dockerIP
 	localAddress := u.String()
 
-	timeout := time.Duration(10 * time.Second)
+	timeoutSecs := time.Duration(time.Duration(timeout) * time.Second)
 	// Do not follow redirects, https://stackoverflow.com/a/38150816/215713
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
-		Timeout: timeout,
+		Timeout: timeoutSecs,
 	}
 
 	req, err := http.NewRequest("GET", localAddress, nil)
@@ -393,7 +397,7 @@ func GetLocalHTTPResponse(t *testing.T, rawurl string) (string, error) {
 func EnsureLocalHTTPContent(t *testing.T, rawurl string, expectedContent string) {
 	assert := asrt.New(t)
 
-	body, err := GetLocalHTTPResponse(t, rawurl)
+	body, err := GetLocalHTTPResponse(t, rawurl, 20)
 	assert.NoError(err, "GetLocalHTTPResponse returned err on rawurl %s: %v", rawurl, err)
 	assert.Contains(body, expectedContent)
 }

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -169,7 +169,7 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 	assert.NoError(err)
 
 	safeURL := app.GetHTTPURL() + site.Safe200URL
-	out, err := GetLocalHTTPResponse(t, safeURL)
+	out, err := GetLocalHTTPResponse(t, safeURL, 20)
 	assert.NoError(err)
 	assert.Contains(out, "Famous 5-minute install")
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

On Windows testing, we're seeing timeouts on GetLocalHttpResponse on a newly brought-up site. Perhaps the 10-second default isn't enough.

## How this PR Solves The Problem:

Increase the default to 20s. This is only used in testing, but we may want to add a timeout parm to EnsureLocalHTTPContent() for this reason.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

