### PR TITLE
Provide a warning when a nonexistent docroot is supplied, closes #1035

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -172,7 +172,7 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	if docrootRelPath != "" {
 		app.Docroot = docrootRelPath
 		if _, err = os.Stat(docrootRelPath); os.IsNotExist(err) {
-			util.Failed("The docroot provided (%v) does not exist", docrootRelPath)
+			output.UserOut.Warnf("Warning: the provided docroot at %s does not currently exist.", docrootRelPath)
 		}
 	} else if !cmd.Flags().Changed("docroot") {
 		app.Docroot = ddevapp.DiscoverDefaultDocroot(app)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -168,7 +168,7 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		app.Name = filepath.Base(pwd)
 	}
 
-	// docrootRelPath must exist
+	// Warn the user if the supplied docrootRelPath doesn't exist yet
 	if docrootRelPath != "" {
 		app.Docroot = docrootRelPath
 		if _, err = os.Stat(docrootRelPath); os.IsNotExist(err) {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -172,7 +172,7 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	if docrootRelPath != "" {
 		app.Docroot = docrootRelPath
 		if _, err = os.Stat(docrootRelPath); os.IsNotExist(err) {
-			output.UserOut.Warnf("Warning: the provided docroot at %s does not currently exist.", docrootRelPath)
+			util.Warning("Warning: the provided docroot at %s does not currently exist.", docrootRelPath)
 		}
 	} else if !cmd.Flags().Changed("docroot") {
 		app.Docroot = ddevapp.DiscoverDefaultDocroot(app)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -181,7 +181,8 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 				util.Failed("The provided docroot %s does not exist. Allow ddev to create it with the --create-docroot flag.", docrootRelPath)
 			}
 
-			docrootAbsPath, err := filepath.Abs(app.Docroot)
+			var docrootAbsPath string
+			docrootAbsPath, err = filepath.Abs(app.Docroot)
 			if err != nil {
 				util.Failed("Could not create docroot at %s: %v", docrootRelPath, err)
 			}

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -138,9 +138,13 @@ func writeBackdropMainSettingsFile(settings *BackdropSettings, filePath string) 
 		return err
 	}
 
-	// Ensure target directory is writable.
+	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); err != nil {
+	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 
@@ -165,9 +169,13 @@ func writeBackdropDdevSettingsFile(settings *BackdropSettings, filePath string) 
 		return err
 	}
 
-	// Ensure target directory is writable
+	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); err != nil {
+	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -11,6 +11,8 @@ import (
 
 	"regexp"
 
+	"runtime"
+
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
@@ -19,7 +21,6 @@ import (
 	"github.com/drud/ddev/pkg/version"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
-	"runtime"
 )
 
 // DefaultProviderName contains the name of the default provider which will be used if one is not otherwise specified.
@@ -261,12 +262,6 @@ func (app *DdevApp) PromptForConfig() error {
 
 // ValidateConfig ensures the configuration meets ddev's requirements.
 func (app *DdevApp) ValidateConfig() error {
-	// validate docroot
-	fullPath := filepath.Join(app.AppRoot, app.Docroot)
-	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		return fmt.Errorf("no directory could be found at %s. Please enter a valid docroot in your configuration", fullPath)
-	}
-
 	if _, err := os.Stat(app.ConfigPath); os.IsNotExist(err) {
 		return fmt.Errorf("no valid project config.yaml was found at %s", app.ConfigPath)
 	}
@@ -518,10 +513,9 @@ func (app *DdevApp) docrootPrompt() error {
 	// Ensure the docroot exists. If it doesn't, prompt the user to verify they entered it correctly.
 	fullPath := filepath.Join(app.AppRoot, app.Docroot)
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		output.UserOut.Errorf("No directory could be found at %s. Please enter a valid docroot\n", fullPath)
-		app.Docroot = ""
-		return app.docrootPrompt()
+		output.UserOut.Warnf("Warning: the provided docroot at %s does not currently exist.", fullPath)
 	}
+
 	return provider.ValidateField("Docroot", app.Docroot)
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -511,8 +511,7 @@ func (app *DdevApp) docrootPrompt() error {
 
 		// Ask the user for permission to create the docroot
 		for {
-			fmt.Printf("Create docroot at %s? [Y/n]: ", fullPath)
-			resp := util.GetInput("")
+			resp := util.Prompt("Create docroot at %s? [Y/n]", "yes")
 			if strings.ToLower(resp) == "y" || strings.ToLower(resp) == "yes" {
 				break
 			}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -235,14 +235,8 @@ func (app *DdevApp) PromptForConfig() error {
 		output.UserOut.Printf("%v", err)
 	}
 
-	for {
-		err := app.docrootPrompt()
-
-		if err == nil {
-			break
-		}
-
-		output.UserOut.Printf("%v", err)
+	if err := app.docrootPrompt(); err != nil {
+		return err
 	}
 
 	err := app.AppTypePrompt()
@@ -524,12 +518,12 @@ func (app *DdevApp) docrootPrompt() error {
 			}
 
 			if strings.ToLower(resp) == "n" || strings.ToLower(resp) == "no" {
-				util.Failed("Docroot must exist to continue configuration", fullPath)
+				return fmt.Errorf("docroot must exist to continue configuration")
 			}
 		}
 
 		if err = os.MkdirAll(fullPath, 0755); err != nil {
-			util.Failed("Unable to create docroot: %v", err)
+			return fmt.Errorf("unable to create docroot: %v", err)
 		}
 
 		util.Success("Created docroot at %s.", fullPath)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -524,12 +524,12 @@ func (app *DdevApp) docrootPrompt() error {
 			}
 
 			if strings.ToLower(resp) == "n" || strings.ToLower(resp) == "no" {
-				return fmt.Errorf("unable to create docroot")
+				util.Failed("Docroot must exist to continue configuration", fullPath)
 			}
 		}
 
 		if err = os.MkdirAll(fullPath, 0755); err != nil {
-			return fmt.Errorf("unable to create docroot: %v", err)
+			util.Failed("Unable to create docroot: %v", err)
 		}
 
 		util.Success("Created docroot at %s.", fullPath)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -513,7 +513,7 @@ func (app *DdevApp) docrootPrompt() error {
 	// Ensure the docroot exists. If it doesn't, prompt the user to verify they entered it correctly.
 	fullPath := filepath.Join(app.AppRoot, app.Docroot)
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		output.UserOut.Warnf("Warning: the provided docroot at %s does not currently exist.", fullPath)
+		util.Warning("Warning: the provided docroot at %s does not currently exist.", fullPath)
 	}
 
 	return provider.ValidateField("Docroot", app.Docroot)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -514,6 +514,25 @@ func (app *DdevApp) docrootPrompt() error {
 	fullPath := filepath.Join(app.AppRoot, app.Docroot)
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
 		util.Warning("Warning: the provided docroot at %s does not currently exist.", fullPath)
+
+		// Ask the user for permission to create the docroot
+		for {
+			fmt.Printf("Create docroot at %s? [Y/n]: ", fullPath)
+			resp := util.GetInput("")
+			if strings.ToLower(resp) == "y" || strings.ToLower(resp) == "yes" {
+				break
+			}
+
+			if strings.ToLower(resp) == "n" || strings.ToLower(resp) == "no" {
+				return fmt.Errorf("unable to create docroot")
+			}
+		}
+
+		if err = os.MkdirAll(fullPath, 0755); err != nil {
+			return fmt.Errorf("unable to create docroot: %v", err)
+		}
+
+		util.Success("Created docroot at %s.", fullPath)
 	}
 
 	return provider.ValidateField("Docroot", app.Docroot)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -218,7 +218,7 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 
 		// Randomize some values to use for Stdin during testing.
 		name := uuid.New().String()
-		nonexistentDocroot := "does/not/exist"
+		nonexistentDocroot := filepath.Join("does", "not", "exist")
 
 		// Create an example input buffer that writes the sitename, a nonexistent document root,
 		// and a "no"
@@ -264,7 +264,7 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 
 		// Randomize some values to use for Stdin during testing.
 		name := uuid.New().String()
-		nonexistentDocroot := "does/not/exist"
+		nonexistentDocroot := filepath.Join("does", "not", "exist")
 
 		// Create an example input buffer that writes the sitename, a nonexistent document root,
 		// a "yes", and a valid apptype

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -165,13 +165,11 @@ func TestConfigCommand(t *testing.T) {
 
 		// Randomize some values to use for Stdin during testing.
 		name := strings.ToLower(util.RandString(16))
-		invalidDir := strings.ToLower(util.RandString(16))
 		invalidAppType := strings.ToLower(util.RandString(8))
 
-		// Create an example input buffer that writes the sitename, an invalid
-		// document root, a valid document root,
+		// Create an example input buffer that writes the sitename, a valid document root,
 		// an invalid app type, and finally a valid app type (from test matrix)
-		input := fmt.Sprintf("%s\n%s\ndocroot\n%s\n%s", name, invalidDir, invalidAppType, testValues[apptypePos])
+		input := fmt.Sprintf("%s\ndocroot\n%s\n%s", name, invalidAppType, testValues[apptypePos])
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
@@ -182,7 +180,6 @@ func TestConfigCommand(t *testing.T) {
 
 		// Ensure we have expected vales in output.
 		assert.Contains(out, testDir)
-		assert.Contains(out, fmt.Sprintf("No directory could be found at %s", filepath.Join(testDir, invalidDir)))
 		assert.Contains(out, fmt.Sprintf("'%s' is not a valid project type", invalidAppType))
 
 		// Ensure values were properly set on the app struct.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -352,12 +352,8 @@ func TestValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", app.GetHostname()))
 
-	app.Name = "valid"
-	app.Docroot = "invalid"
-	err = app.ValidateConfig()
-	assert.EqualError(err, fmt.Sprintf("no directory could be found at %s. Please enter a valid docroot in your configuration", filepath.Join(cwd, app.Docroot)))
-
 	app.Docroot = "testdata"
+	app.Name = "valid"
 	app.Type = "potato"
 	err = app.ValidateConfig()
 	assert.EqualError(err, fmt.Sprintf("'%s' is not a valid apptype", app.Type))

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -297,9 +297,13 @@ func writeDrupalSettingsFile(drupalConfig *DrupalSettings, filePath string, vers
 		return err
 	}
 
-	// Ensure target directory is writable.
+	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); err != nil {
+	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 
@@ -382,9 +386,13 @@ func writeDrupal8DdevSettingsFile(settings *DrupalSettings, filePath string) err
 		return err
 	}
 
-	// Ensure target directory is writable.
+	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); err != nil {
+	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 
@@ -409,10 +417,13 @@ func writeDrupal7DdevSettingsFile(settings *DrupalSettings, filePath string) err
 		return err
 	}
 
-	// Ensure target directory is writable.
+	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	err = os.Chmod(dir, 0755)
-	if err != nil {
+	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 
@@ -436,10 +447,13 @@ func writeDrupal6DdevSettingsFile(settings *DrupalSettings, filePath string) err
 		return err
 	}
 
-	// Ensure target directory is writable.
+	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	err = os.Chmod(dir, 0755)
-	if err != nil {
+	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 
@@ -463,10 +477,13 @@ func WriteDrushConfig(drushConfig *DrushConfig, filePath string) error {
 		return err
 	}
 
-	// Ensure target directory is writable.
+	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	err = os.Chmod(dir, 0755)
-	if err != nil {
+	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -164,10 +164,13 @@ func WriteWordpressConfig(wordpressConfig *WordpressConfig, filePath string) err
 		return err
 	}
 
-	// Ensure target directory is writable.
+	// Ensure target directory exists and is writeable
 	dir := filepath.Dir(filePath)
-	err = os.Chmod(dir, 0755)
-	if err != nil {
+	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1035: The current brand-new project installation workflow requires the docroot to exist during initial configuration, which means that one can't install a site from a completely empty directory using composer from inside the web container.

This requires the site to be initially configured on the host, meaning the user has to have php and composer installed on the host system. Not unreasonable, but annoying.

## How this PR Solves The Problem:
Warn the user when a non-existent docroot is supplied, but allow the configuration process to continue. This allows site installation to be completed within the container using composer, which ends up being a bit slower but potentially more convenient for the user.

## Manual Testing Instructions:
- Begin with an empty directory
- `ddev config` and define a new project
- Provide a docroot directory that does not exist, like `web/public`
- Create a `composer.json` file like the one below, which defines a TYPO3 project:
```
{
    "repositories": [
        {
            "type": "composer",
            "url": "https://composer.typo3.org/"
        }
    ],
    "require": {
        "typo3/cms": "^8.7"
    },
    "extra": {
        "typo3/cms": {
            "web-dir": "web/public"
        }
    }
}
```
- Execute `ddev start`
- Confirm the docroot has been created
- Invoke composer from inside the web container to install the CMS: 
```
ddev exec composer install -d ../../
```
- Load the project URL and complete installation

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

