### PR TITLE
Bump image versions to v1.1.0 for release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,25 +23,25 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20180726_webserver_bump" // Note that this can be overridden by make
+var WebTag = "v1.1.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "20180801_volume" // Note that this may be overridden by make
+var DBTag = "v1.1.0" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "v1.0.0" // Note that this can be overridden by make
+var DBATag = "v1.1.0" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.0.0" // Note that this can be overridden by make
+var RouterTag = "v1.1.0" // Note that this can be overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Temp images labeled v1.1.0 have been pushed, we'll push the real ones after the tag is cut.

## How this PR Solves The Problem:

Change version.go to refer to the v1.1.0 images.

