### PR TITLE
Improve archive extraction path error handling

### DIFF
--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -48,15 +48,13 @@ imported.`,
 
 		importPath, isArchive, err := appimport.ValidateAsset(sourcePath, "files")
 		if err != nil {
-			// Ensure we prompt for extraction path if an archive is provided, while still allowing
-			// non-interactive use of --src flag without providing a --extract-path flag.
-			if isArchive && showExtPathPrompt {
-				promptForExtPath(&extPath)
-			}
+			util.Failed("Failed to import files for %s: %v", app.GetName(), err)
+		}
 
-			if err != nil {
-				util.Failed("Failed to import files for %s: %v", app.GetName(), err)
-			}
+		// Ensure we prompt for extraction path if an archive is provided, while still allowing
+		// non-interactive use of --src flag without providing a --extract-path flag.
+		if isArchive && showExtPathPrompt {
+			promptForExtPath(&extPath)
 		}
 
 		if err = app.ImportFiles(importPath, extPath); err != nil {

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -65,7 +65,7 @@ imported.`,
 	},
 }
 
-const importPathPrompt = `Provide the path to the directory or archive you wish to import.`
+const importPathPrompt = `Provide the path to the source directory or archive you wish to import.`
 
 const importPathWarn = `Please note: if the destination directory exists, it will be replaced with the
 import assets specified here.`
@@ -100,7 +100,7 @@ func promptForExtPath(val *string) {
 }
 
 func init() {
-	ImportFileCmd.Flags().StringVarP(&sourcePath, "src", "", "", "Provide the path to a directory or tar/tar.gz/tgz/zip archive of files to import")
+	ImportFileCmd.Flags().StringVarP(&sourcePath, "src", "", "", "Provide the path to the source directory or tar/tar.gz/tgz/zip archive of files to import")
 	ImportFileCmd.Flags().StringVarP(&extPath, "extract-path", "", "", "If provided asset is an archive, optionally provide the path to extract within the archive.")
 	RootCmd.AddCommand(ImportFileCmd)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
The review in #994 describes some issues with import-files, namely one where a bad extraction path would return a success despite having extracted zero files into the project. 

Additionally, a regression was identified where a user would no longer be prompted for an archive extraction path when using the import-files interactive mode.

## How this PR Solves The Problem:
If no files match the extraction path in an archive, an error is returned to the user.

The interactive extraction path regression was fixed as well.

## Manual Testing Instructions:
Provide an archive in interactive mode and ensure the extraction path prompt is presented.

Provide an invalid extraction dir and ensure an error is generated.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#944


