### PR TITLE
Make sure we have a db image before running it; fix migration problems in v1.1.0

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -412,6 +412,12 @@ func GetDockerIP() (string, error) {
 // Example code from https://gist.github.com/fsouza/b0bf3043827f8e39c4589e88cec067d8
 func RunSimpleContainer(image string, name string, cmd []string, entrypoint []string, env []string, binds []string, uid string) (string, error) {
 	client := GetDockerClient()
+	var buf bytes.Buffer
+	err := client.PullImage(docker.PullImageOptions{Repository: image, OutputStream: &buf},
+		docker.AuthConfiguration{})
+	if err != nil {
+		return "", fmt.Errorf("failed to pull image %s: %v", image, err)
+	}
 
 	// Windows 10 Docker toolbox won't handle a bind mount like C:\..., so must convert to /c/...
 	for i := range binds {


### PR DESCRIPTION
## The Problem/Issue/Bug:

In the v1.1.0 release, people who did a `ddev start` on an existing project which had a database got this:

`
ddev start
Starting xxxx-xx...
Migrating bind-mounted database in ~/.ddev to docker-volume mounted database
Failed to start xxxx-xx: Failed to migrate db from bind-mounted db: failed to run migrate_file_to_volume.sh, err=failed to create/start docker container ({xxxx-xx_migrate_volume 0xc420268780 0xc42026e400 <nil> <nil>}):no such image output=
`

This seems to be a result of the ddev-dbserver image not being properly automatically pulled.


## How this PR Solves The Problem:

This PR pulls that image before using it.

## Manual Testing Instructions:

* Recreate the user problem with v1.1.0 to understand it.
1. You'll need a bind-mounted db, you probably have some named ~/.ddev/<project>/mysql.bak out there from previous testing. To reuse them, `mv mysql.bak mysql`
2. Delete the v1.1.0 images: `docker rmi $(docker images | awk '/v1.1.0/ {print $3}')`
3. ddev start. It should fail with the error above.

* Test this PR
1. Do the same process, but this time with this PR. It should succeeed.

## Automated Testing Overview:

Still thinking. It may not be worth doing.

## Related Issue Link(s):

## Release/Deployment notes:

We'll need to do a point release quickly.
