### PR TITLE
Add some debugging so we know which project fails in TestDevLogs

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -54,7 +54,7 @@ func TestDevLogs(t *testing.T) {
 		o.Timeout = 30
 		o.Headers["Host"] = v.Name + "." + version.DDevTLD
 		err = util.EnsureHTTPStatus(o)
-		assert.NoError(err)
+		assert.NoError(err, "expected 200 status not found for project %s: %v", v.Name, err)
 
 		// logs may not respond exactly right away, wait a tiny bit.
 		time.Sleep(2 * time.Second)
@@ -63,7 +63,7 @@ func TestDevLogs(t *testing.T) {
 
 		assert.NoError(err)
 		assert.Contains(string(out), "Server started")
-		assert.Contains(string(out), "PHP Fatal error:")
+		assert.Contains(string(out), "PHP Fatal error:", "PHP Fatal error not found for project %s output='%s", v.Name, string(out))
 
 		cleanup()
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

We have regular failures in TestDevLogs, such as https://buildkite.com/drud/ddev-macos/builds/524#11fd5348-c02c-45eb-ab31-9c3444953b0d, but a retry usually sorts it out. We would save ourselves a lot of time by understanding this.

It seems to happen on only one project, so the first step here is to add output identifying the project.

I've manually tested and the procedure in this test works fine on d8 and wordpress. Wordpress is likely the culprit, since I think buildkite is just building one testsite on macos.