### PR TITLE
Parallelize Circle build

### DIFF
--- a/.buildkite/static.yml
+++ b/.buildkite/static.yml
@@ -1,7 +1,0 @@
-  - command: ".buildkite/test_static.sh"
-    agents:
-      - "os=macos"
-      - "dockertype=dockerformac"
-    env:
-      BUILDKITE_CLEAN_CHECKOUT: true
-    parallelism: 1

--- a/.buildkite/test_static.sh
+++ b/.buildkite/test_static.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o pipefail
-set -o nounset
-set -x
-
-make -s staticrequired

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -10,25 +10,26 @@ sudo apt-get install -qq mysql-client realpath zip nsis
 
 # golang of the version we want
 sudo apt-get remove -qq golang && sudo rm -rf /usr/local/go &&
-wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.2.linux-amd64.tar.gz &&
+wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz &&
 sudo tar -C /usr/local -xzf /tmp/golang.tgz
 
 
-# Remove existing docker
-sudo apt-get remove docker docker-engine docker.io
-sudo apt-get install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-sudo apt-get update -qq
-sudo apt-get install -qq docker-ce
-
-# docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+# Remove existing docker. This section should not be required after switch to
+# circleci/classic:201808-01 image
+#sudo apt-get remove docker docker-engine docker.io
+#sudo apt-get install \
+#    apt-transport-https \
+#    ca-certificates \
+#    curl \
+#    software-properties-common
+#curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+#sudo add-apt-repository \
+#   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+#   $(lsb_release -cs) \
+#   stable"
+#sudo apt-get update -qq
+#sudo apt-get install -qq docker-ce
+#
+## docker-compose
+#sudo curl -s -L "https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+#sudo chmod +x /usr/local/bin/docker-compose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2
 jobs:
-  # 'build' is the default build, the only one triggered automatically by github or anything else.
-  normal_build_and_test:
+  golang_build:
     machine:
       image: circleci/classic:201808-01
     working_directory: ~/go/src/github.com/drud/ddev
@@ -9,44 +8,69 @@ jobs:
       GOPATH: /home/circleci/go
       ARTIFACTS: /artifacts
     steps:
-      - run: mkdir -p ~/go/{lib,pkg,src/github.com/drud/ddev}
+    - run: mkdir -p ~/go/{lib,pkg,src/github.com/drud/ddev}
+    - checkout
+    - run:
+        command: ./.circleci/circle_vm_setup.sh
+        name: NORMAL Circle VM setup - tools, docker, golang
+        # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
+    - run:
+        command: |
+          make -s clean linux darwin windows_install
+        name: Build the ddev executables
+    - persist_to_workspace:
+        root: ~/
+        paths: go
 
-      - checkout
+  golang_test:
+    machine:
+      image: circleci/classic:201808-01
+    working_directory: ~/go/src/github.com/drud/ddev
+    environment:
+      GOPATH: /home/circleci/go
+      ARTIFACTS: /artifacts
+    steps:
+    - attach_workspace:
+        at: ~/
+    # Run the built-in ddev tests with the executables just built.
+    - run:
+        command: make -s test
+        name: ddev tests
+        no_output_timeout: "40m"
 
-      - run:
-          command: ./.circleci/circle_vm_setup.sh
-          name: NORMAL Circle VM setup - tools, docker, golang
+  staticrequired:
+    machine:
+      image: circleci/classic:201808-01
+    working_directory: ~/go/src/github.com/drud/ddev
+    environment:
+      GOPATH: /home/circleci/go
+      ARTIFACTS: /artifacts
+    steps:
+    - attach_workspace:
+        at: ~/
+    # Run the built-in ddev tests with the executables just built.
+    - run:
+        command: make staticrequired
+        name: staticrequired
 
-      - run:
-          command: printf "go version:$(go version)\ndocker version=$(docker --version)\ndocker-compose version=$(docker-compose --version)\nHOME=$HOME USER=$(whoami) PWD=$PWD"
-          name: Installed tool versions
+  artifacts:
+    machine:
+      image: circleci/classic:201808-01
+    working_directory: ~/go/src/github.com/drud/ddev
+    environment:
+      GOPATH: /home/circleci/go
+      ARTIFACTS: /artifacts
+    steps:
+    - attach_workspace:
+        at: ~/
+    - run:
+        command: ./.circleci/generate_artifacts.sh $ARTIFACTS
+        name: tar/zip up artifacts and make hashes
+        no_output_timeout: "40m"
 
-      # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
-      - run:
-          command: |
-            make -s clean linux darwin windows_install
-          name: Build the ddev executables
-
-      # Run the built-in ddev tests with the executables just built.
-      - run:
-          command: make -s test
-          name: ddev tests
-          no_output_timeout: "40m"
-
-      - run: make -s staticrequired
-
-      - run:
-          command: bin/linux/ddev version
-          name: ddev version information
-
-      - run:
-          command: ./.circleci/generate_artifacts.sh $ARTIFACTS
-          name: tar/zip up artifacts and make hashes
-          no_output_timeout: "40m"
-
-      - store_artifacts:
-          path: /artifacts
-          name: Artifact storage
+    - store_artifacts:
+        path: /artifacts
+        name: Artifact storage
 
   nightly_build:
     machine:
@@ -136,7 +160,17 @@ workflows:
   version: 2
   normal_build_and_test:
     jobs:
-      - normal_build_and_test
+    - golang_build
+    - golang_test:
+        requires:
+        - golang_build
+    - staticrequired:
+        requires:
+        - golang_build
+    - artifacts:
+        requires:
+        - golang_build
+
   nightly_build:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   # 'build' is the default build, the only one triggered automatically by github or anything else.
   normal_build_and_test:
     machine:
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       GOPATH: /home/circleci/go


### PR DESCRIPTION
## The Problem/Issue/Bug:

* We're going to need to be able to do more parallel builds for Apache webserver types, and it wouldn't do us any harm to do it for multiple CMSs.
* We need parallel of staticrequired anyway.
* It's been too long coming :)

## How this PR Solves The Problem:

Reorganize the circleci build

## Manual Testing Instructions:

Review the builds (and look at the fancy workflows tab on circleci also, https://circleci.com/gh/drud/workflows/ddev

## Automated Testing Overview:

* This will actually let us lose the buildkite staticrequired build, so will save some resources on our buildkite stuff.

## Related Issue Link(s):

* Apache PR: https://github.com/drud/ddev/pull/1007

## Release/Deployment notes:

* After pulling this, we can disable/remove the buildkite static test.
