### PR TITLE
Reintroduce docker-compose upgrade for circleci

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -14,6 +14,10 @@ wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz 
 sudo tar -C /usr/local -xzf /tmp/golang.tgz
 
 
+# docker-compose
+sudo curl -s -L "https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
 # Remove existing docker. This section should not be required after switch to
 # circleci/classic:201808-01 image
 #sudo apt-get remove docker docker-engine docker.io
@@ -30,6 +34,3 @@ sudo tar -C /usr/local -xzf /tmp/golang.tgz
 #sudo apt-get update -qq
 #sudo apt-get install -qq docker-ce
 #
-## docker-compose
-#sudo curl -s -L "https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-#sudo chmod +x /usr/local/bin/docker-compose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
 
   nightly_build:
     machine:
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       DRUD_DEBUG: "true"
@@ -122,7 +122,7 @@ jobs:
   # 'tag_build' is used to build a tag for release.
   tag_build:
     machine:
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       DRUD_DEBUG: "true"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* In https://github.com/drud/ddev/pull/1076 I removed the explicit install of docker-compose with a recent version. The version on Circleci (1.17.1) doesn't seem to be adequate because we require a minimum of 1.18.0. At least in https://circleci.com/gh/drud/ddev/3280?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link we see a lot of complaints about version numbers and failure. (I don't know why this could have worked earlier, but it seems to have)
* The nightly and tag builds had the wrong image in them from #1076 - the new builds had it updated. But that meant that the nightly and tag builds ran with entirely wrong docker version and docker-compose version.

