### PR TITLE
Circleci: Go back to older image and install docker ourselves

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -15,6 +15,7 @@ sudo tar -C /usr/local -xzf /tmp/golang.tgz
 
 
 # docker-compose
+sudo rm -f /usr/local/bin/docker-compose
 sudo curl -s -L "https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -18,19 +18,18 @@ sudo tar -C /usr/local -xzf /tmp/golang.tgz
 sudo curl -s -L "https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
-# Remove existing docker. This section should not be required after switch to
-# circleci/classic:201808-01 image
-#sudo apt-get remove docker docker-engine docker.io
-#sudo apt-get install \
-#    apt-transport-https \
-#    ca-certificates \
-#    curl \
-#    software-properties-common
-#curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-#sudo add-apt-repository \
-#   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-#   $(lsb_release -cs) \
-#   stable"
-#sudo apt-get update -qq
-#sudo apt-get install -qq docker-ce
-#
+# Remove existing docker and install from their apt package
+sudo apt-get remove docker docker-engine docker.io
+sudo apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+sudo apt-get update -qq
+sudo apt-get install -qq docker-ce
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,9 @@ jobs:
     steps:
     - attach_workspace:
         at: ~/
-    # Run the built-in ddev tests with the executables just built.
+    - run:
+        command: ./.circleci/circle_vm_setup.sh
+        name: Circle VM setup - tools, docker, golang
     - run:
         command: make -s test
         name: ddev tests
@@ -49,6 +51,9 @@ jobs:
     - attach_workspace:
         at: ~/
     # Run the built-in ddev tests with the executables just built.
+    - run:
+        command: ./.circleci/circle_vm_setup.sh
+        name: Circle VM setup - tools, docker, golang
     - run:
         command: make staticrequired
         name: staticrequired

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   golang_build:
     machine:
-      image: circleci/classic:201808-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       GOPATH: /home/circleci/go
@@ -24,7 +24,7 @@ jobs:
 
   golang_test:
     machine:
-      image: circleci/classic:201808-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       GOPATH: /home/circleci/go
@@ -40,7 +40,7 @@ jobs:
 
   staticrequired:
     machine:
-      image: circleci/classic:201808-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       GOPATH: /home/circleci/go
@@ -55,7 +55,7 @@ jobs:
 
   artifacts:
     machine:
-      image: circleci/classic:201808-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       GOPATH: /home/circleci/go
@@ -74,7 +74,7 @@ jobs:
 
   nightly_build:
     machine:
-      image: circleci/classic:201808-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       DRUD_DEBUG: "true"
@@ -122,7 +122,7 @@ jobs:
   # 'tag_build' is used to build a tag for release.
   tag_build:
     machine:
-      image: circleci/classic:201808-01
+      image: circleci/classic:201711-01
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       DRUD_DEBUG: "true"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The 201808-01 Circleci build image has not been working for us at all; Revert to the older image and install docker ourselves.

