### PR TITLE
Relocate the misplaced 'Stopping a project' section and give it text.

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -443,7 +443,7 @@ To manually review additional log files use the `ddev ssh` command and review lo
 
 ## Stopping a project
 
-To stop the development environment for a project run `ddev stop` in its working directory. You can also stop a particular project's environment from any directory by running `ddev stop [projectname]` or stop every running project via `ddev stop --all`.
+To stop the development environment for a project run `ddev stop` in its working directory. You can also stop a particular project's environment from any directory by running `ddev stop <projectname>` or stop every running project via `ddev stop --all`.
 
 ## Removing a project
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -355,7 +355,8 @@ Run 'ddev describe' to find the database credentials for this application.
 Successfully imported database for drupal8
 ```
 
-<h4>Non-interactive usage</h4>## Stopping a project
+<h4>Non-interactive usage</h4>
+
 If you want to use import-db without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag. Example:
 
 `ddev import-db --src=/tmp/mydb.sql.gz`
@@ -439,6 +440,10 @@ The `ddev ssh` command will open an interactive bash shell session to the contai
 The `ddev logs` command allows you to easily retrieve error logs from the web container (both nginx and php-fpm logs are concatenated). To follow the log (watch the lines in real time), run `ddev logs -f`. When you are done, press CTRL+C to exit from the log trail.
 
 To manually review additional log files use the `ddev ssh` command and review logs in /var/log and /var/log/nginx. The web server stores access logs at `/var/log/nginx/access.log`, and PHP-FPM logs at `/var/log/php-fpm.log`.
+
+## Stopping a project
+
+To stop the development environment for a project run `ddev stop` in its working directory. You can also stop a particular project's environment from any directory by running `ddev stop [projectname]` or stop every running project via `ddev stop --all`.
 
 ## Removing a project
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

There's a misplaced 'Stopping a project' section in the CLI documentation that was never given content.

## How this PR Solves The Problem:

It moves it down to the section on interacting with a project and gives it text.

## Manual Testing Instructions:

Review my notation for the projectname parameter. When I looked at the diff, I realized I used the brackets from the CLI help text whereas the web based documentation for removing a project used less than / greater than signs.