### PR TITLE
Include empty array in JSON output when no projects are active, fixes #588

### DIFF
--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -11,7 +11,7 @@ import (
 
 var continuous bool
 
-// DevListCmd represents the list command
+// DdevListCmd represents the list command
 var DdevListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List projects",

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -12,17 +12,17 @@ import (
 var continuous bool
 
 // DevListCmd represents the list command
-var DevListCmd = &cobra.Command{
+var DdevListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List projects",
 	Long:  `List projects.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for {
 			apps := ddevapp.GetApps()
-			var appDescs []map[string]interface{}
+			appDescs := make([]map[string]interface{}, 0)
 
 			if len(apps) < 1 {
-				output.UserOut.Println("There are no running ddev projects.")
+				output.UserOut.WithField("raw", appDescs).Println("There are no running ddev projects.")
 			} else {
 				table := ddevapp.CreateAppTable()
 				for _, app := range apps {
@@ -42,11 +42,10 @@ var DevListCmd = &cobra.Command{
 
 			time.Sleep(time.Second)
 		}
-
 	},
 }
 
 func init() {
-	DevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted once per second")
-	RootCmd.AddCommand(DevListCmd)
+	DdevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted once per second")
+	RootCmd.AddCommand(DdevListCmd)
 }

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -22,7 +22,7 @@ var DdevListCmd = &cobra.Command{
 			appDescs := make([]map[string]interface{}, 0)
 
 			if len(apps) < 1 {
-				output.UserOut.WithField("raw", appDescs).Println("There are no running ddev projects.")
+				output.UserOut.WithField("raw", appDescs).Println("There are no active ddev projects.")
 			} else {
 				table := ddevapp.CreateAppTable()
 				for _, app := range apps {

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -46,7 +46,7 @@ func TestDevRemove(t *testing.T) {
 	assert.NoError(err, "ddev remove --all should succeed but failed, err: %v, output: %s", err, out)
 	out, err = exec.RunCommand(DdevBin, []string{"list"})
 	assert.NoError(err)
-	assert.Contains(out, "no running ddev projects")
+	assert.Contains(out, "no active ddev projects")
 	assert.Equal(0, len(ddevapp.GetApps()), "Not all apps were removed after ddev remove --all")
 
 	// Now put the sites back together so other tests can use them.


### PR DESCRIPTION
## The Problem/Issue/Bug:
#588

## How this PR Solves The Problem:
Prints the raw output array even if no projects are active.

## Manual Testing Instructions:
Execute `ddev list -j` both with and without active projects.

