### PR TITLE
Provide value to format string in docroot creation prompt

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -511,7 +511,7 @@ func (app *DdevApp) docrootPrompt() error {
 
 		// Ask the user for permission to create the docroot
 		for {
-			resp := util.Prompt("Create docroot at %s? [Y/n]", "yes")
+			resp := util.Prompt(fmt.Sprintf("Create docroot at %s? [Y/n]", fullPath), "yes")
 			if strings.ToLower(resp) == "y" || strings.ToLower(resp) == "yes" {
 				break
 			}


### PR DESCRIPTION
## The Problem/Issue/Bug:
A format string wasn't being supplied the expected string value.

## How this PR Solves The Problem:
Passes the format string and a value to fmt.Sprintf.

## Manual Testing Instructions:
Check that the path to be created is echoed during the prompt.
