### PR TITLE
Add db_snapshots dir to generated .gitignore, fixes #1084

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -584,7 +584,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml")
+	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1084 

## How this PR Solves The Problem:
Ensures the `db_snapshots/` dir is added to the generated .gitignore.

## Manual Testing Instructions:
Execute `ddev config` and check that db_snapshots is included in `.ddev/.gitignore`.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

