### PR TITLE
Set additional config values with flags, closes #1051

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -249,6 +249,13 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	}
 	app.Type = appTypeArg
 
+	// App overrides are done after app type is detected, but
+	// before user-defined flags are set.
+	err = app.ConfigFileOverrideAction()
+	if err != nil {
+		util.Failed("failed to run ConfigFileOverrideAction: %v", err)
+	}
+
 	if phpVersionArg != "" {
 		app.PHPVersion = phpVersionArg
 	}
@@ -261,6 +268,7 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		app.RouterHTTPSPort = httpsPortArg
 	}
 
+	// This bool flag is false by default, so only use the value if the flag was explicity set.
 	if cmd.Flag("xdebug-enabled").Changed {
 		app.XdebugEnabled = xdebugEnabledArg
 	}
@@ -273,14 +281,10 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		app.AdditionalFQDNs = strings.Split(additionalFQDNsArg, ",")
 	}
 
-	err = app.ConfigFileOverrideAction()
-	if err != nil {
-		util.Failed("failed to run ConfigFileOverrideAction: %v", err)
-	}
-
 	err = app.WriteConfig()
 	if err != nil {
 		return fmt.Errorf("could not write ddev config file %s: %v", app.ConfigPath, err)
 	}
+
 	return nil
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -45,8 +45,11 @@ var (
 	// additionalFQDNsArg allows a user to provide a comma-delimited list of FQDNs from a command flag.
 	additionalFQDNsArg string
 
-	// showConfigLocation if set causes the command to show the config location
+	// showConfigLocation, if set, causes the command to show the config location.
 	showConfigLocation bool
+
+	// uploadDirArg allows a user to set the project's upload directory, the destination directory for import-files.
+	uploadDirArg string
 )
 
 var providerName = ddevapp.DefaultProviderName
@@ -133,6 +136,7 @@ func init() {
 	ConfigCommand.Flags().StringVar(&additionalFQDNsArg, "additional-fqdns", "", "A comma-delimited list of FQDNs for the project")
 	ConfigCommand.Flags().BoolVar(&createDocroot, "create-docroot", false, "Prompts ddev to create the docroot if it doesn't exist")
 	ConfigCommand.Flags().BoolVar(&showConfigLocation, "show-config-location", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
+	ConfigCommand.Flags().StringVar(&uploadDirArg, "upload-dir", "", "Sets the project's upload directoy, the destination directory of the import-files command.")
 
 	// apptype flag exists for backwards compatibility.
 	ConfigCommand.Flags().StringVar(&appTypeArg, "apptype", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
@@ -279,6 +283,10 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if additionalFQDNsArg != "" {
 		app.AdditionalFQDNs = strings.Split(additionalFQDNsArg, ",")
+	}
+
+	if uploadDirArg != "" {
+		app.UploadDir = uploadDirArg
 	}
 
 	err = app.WriteConfig()

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -33,6 +33,13 @@ var extraFlagsHandlingFunc func(cmd *cobra.Command, args []string, app *ddevapp.
 
 var providerName = ddevapp.DefaultProviderName
 
+var phpVersionArg string
+var httpPortArg int
+var httpsPortArg int
+var xdebugEnabledArg bool
+var additionalHostnamesArg string
+var additionalFQDNsArg string
+
 // ConfigCommand represents the `ddev config` command
 var ConfigCommand *cobra.Command = &cobra.Command{
 	Use:     "config [provider]",

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -18,23 +18,23 @@ var (
 	// createDocroot will allow a nonexistent docroot to be created
 	createDocroot bool
 
-	// docrootRelPath is the relative path to the docroot where index.php is.
-	docrootRelPath string
+	// docrootRelPathArg is the relative path to the docroot where index.php is.
+	docrootRelPathArg string
 
-	// siteName is the name of the site.
-	siteName string
+	// siteNameArg is the name of the site.
+	siteNameArg string
 
-	// appType is the ddev app type, like drupal7/drupal8/wordpress.
-	appType string
+	// appTypeArg is the ddev app type, like drupal7/drupal8/wordpress.
+	appTypeArg string
 
 	// phpVersionArg overrides the default version of PHP to be used in the web container, like 5.6/7.0/7.1/7.2.
 	phpVersionArg string
 
 	// httpPortArg overrides the default HTTP port (80).
-	httpPortArg int
+	httpPortArg string
 
 	// httpsPortArg overrides the default HTTPS port (443).
-	httpsPortArg int
+	httpsPortArg string
 
 	// xdebugEnabledArg allows a user to enable XDebug from a command flag.
 	xdebugEnabledArg bool
@@ -122,25 +122,25 @@ func init() {
 	apptypeUsage := fmt.Sprintf("Provide the project type (one of %s). This is autodetected and this flag is necessary only to override the detection.", validAppTypes)
 	projectNameUsage := fmt.Sprintf("Provide the project name of project to configure (normally the same as the last part of directory name)")
 
-	ConfigCommand.Flags().StringVar(&siteName, "projectname", "", projectNameUsage)
-	ConfigCommand.Flags().StringVar(&docrootRelPath, "docroot", "", "Provide the relative docroot of the project, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory")
-	ConfigCommand.Flags().StringVar(&appType, "projecttype", "", apptypeUsage)
+	ConfigCommand.Flags().StringVar(&siteNameArg, "projectname", "", projectNameUsage)
+	ConfigCommand.Flags().StringVar(&docrootRelPathArg, "docroot", "", "Provide the relative docroot of the project, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory")
+	ConfigCommand.Flags().StringVar(&appTypeArg, "projecttype", "", apptypeUsage)
 	ConfigCommand.Flags().StringVar(&phpVersionArg, "php-version", "", "The version of PHP that will be enabled in the web container")
-	ConfigCommand.Flags().IntVar(&httpPortArg, "http-port", 80, "The web container's exposed HTTP port")
-	ConfigCommand.Flags().IntVar(&httpsPortArg, "https-port", 443, "The web container's exposed HTTPS port")
+	ConfigCommand.Flags().StringVar(&httpPortArg, "http-port", "", "The web container's exposed HTTP port")
+	ConfigCommand.Flags().StringVar(&httpsPortArg, "https-port", "", "The web container's exposed HTTPS port")
 	ConfigCommand.Flags().BoolVar(&xdebugEnabledArg, "xdebug-enabled", false, "Whether or not XDebug is enabled in the web container")
 	ConfigCommand.Flags().StringVar(&additionalHostnamesArg, "additional-hostnames", "", "A comma-delimited list of hostnames for the project")
 	ConfigCommand.Flags().StringVar(&additionalFQDNsArg, "additional-fqdns", "", "A comma-delimited list of FQDNs for the project")
-	ConfigCommand.Flags().BoolVarP(&showConfigLocation, "show-config-location", "", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
 	ConfigCommand.Flags().BoolVar(&createDocroot, "create-docroot", false, "Prompts ddev to create the docroot if it doesn't exist")
+	ConfigCommand.Flags().BoolVar(&showConfigLocation, "show-config-location", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
 
 	// apptype flag exists for backwards compatibility.
-	ConfigCommand.Flags().StringVarP(&appType, "apptype", "", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
+	ConfigCommand.Flags().StringVar(&appTypeArg, "apptype", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
 	err = ConfigCommand.Flags().MarkDeprecated("apptype", "The apptype flag is deprecated in favor of --projecttype")
 	util.CheckErr(err)
 
 	// sitename flag exists for backwards compatibility.
-	ConfigCommand.Flags().StringVarP(&siteName, "sitename", "", "", projectNameUsage+" This is the same as projectname and is included only for backwards compatibility")
+	ConfigCommand.Flags().StringVar(&siteNameArg, "sitename", "", projectNameUsage+" This is the same as projectname and is included only for backwards compatibility")
 	err = ConfigCommand.Flags().MarkDeprecated("sitename", "The sitename flag is deprecated in favor of --projectname")
 	util.CheckErr(err)
 
@@ -192,12 +192,12 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	// Let them know if we're replacing the config.yaml
 	app.WarnIfConfigReplace()
 
-	// app.Name gets set to basename if not provided, or set to siteName if provided
-	if app.Name != "" && siteName == "" { // If we already have a c.Name and no siteName, leave c.Name alone
+	// app.Name gets set to basename if not provided, or set to siteNameArg if provided
+	if app.Name != "" && siteNameArg == "" { // If we already have a c.Name and no siteNameArg, leave c.Name alone
 		// Sorry this is empty but it makes the logic clearer.
-	} else if siteName != "" { // if we have a siteName passed in, use it for c.Name
-		app.Name = siteName
-	} else { // No siteName passed, c.Name not set: use c.Name from the directory
+	} else if siteNameArg != "" { // if we have a siteNameArg passed in, use it for c.Name
+		app.Name = siteNameArg
+	} else { // No siteNameArg passed, c.Name not set: use c.Name from the directory
 		// nolint: vetshadow
 		pwd, err := os.Getwd()
 		util.CheckErr(err)
@@ -205,18 +205,18 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	}
 
 	// Ensure that the docroot exists
-	if docrootRelPath != "" {
-		app.Docroot = docrootRelPath
-		if _, err = os.Stat(docrootRelPath); os.IsNotExist(err) {
+	if docrootRelPathArg != "" {
+		app.Docroot = docrootRelPathArg
+		if _, err = os.Stat(docrootRelPathArg); os.IsNotExist(err) {
 			// If the user has indicated that the docroot should be created, create it.
 			if !createDocroot {
-				util.Failed("The provided docroot %s does not exist. Allow ddev to create it with the --create-docroot flag.", docrootRelPath)
+				util.Failed("The provided docroot %s does not exist. Allow ddev to create it with the --create-docroot flag.", docrootRelPathArg)
 			}
 
 			var docrootAbsPath string
 			docrootAbsPath, err = filepath.Abs(app.Docroot)
 			if err != nil {
-				util.Failed("Could not create docroot at %s: %v", docrootRelPath, err)
+				util.Failed("Could not create docroot at %s: %v", docrootRelPathArg, err)
 			}
 
 			if err = os.MkdirAll(docrootAbsPath, 0755); err != nil {
@@ -229,7 +229,7 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		app.Docroot = ddevapp.DiscoverDefaultDocroot(app)
 	}
 
-	if appType != "" && !ddevapp.IsValidAppType(appType) {
+	if appTypeArg != "" && !ddevapp.IsValidAppType(appTypeArg) {
 		validAppTypes := strings.Join(ddevapp.GetValidAppTypes(), ", ")
 		util.Failed("apptype must be one of %s", validAppTypes)
 	}
@@ -239,15 +239,39 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	if pathErr != nil {
 		util.Failed("Failed to get absolute path to Docroot %s: %v", app.Docroot, pathErr)
 	}
-	if appType == "" || appType == detectedApptype { // Found an app, matches passed-in or no apptype passed
-		appType = detectedApptype
+	if appTypeArg == "" || appTypeArg == detectedApptype { // Found an app, matches passed-in or no apptype passed
+		appTypeArg = detectedApptype
 		util.Success("Found a %s codebase at %s", detectedApptype, fullPath)
-	} else if appType != "" { // apptype was passed, but we found no app at all
-		util.Warning("You have specified a project type of %s but no project of that type is found in %s", appType, fullPath)
-	} else if appType != "" && detectedApptype != appType { // apptype was passed, app was found, but not the same type
-		util.Warning("You have specified a project type of %s but a project of type %s was discovered in %s", appType, detectedApptype, fullPath)
+	} else if appTypeArg != "" { // apptype was passed, but we found no app at all
+		util.Warning("You have specified a project type of %s but no project of that type is found in %s", appTypeArg, fullPath)
+	} else if appTypeArg != "" && detectedApptype != appTypeArg { // apptype was passed, app was found, but not the same type
+		util.Warning("You have specified a project type of %s but a project of type %s was discovered in %s", appTypeArg, detectedApptype, fullPath)
 	}
-	app.Type = appType
+	app.Type = appTypeArg
+
+	if phpVersionArg != "" {
+		app.PHPVersion = phpVersionArg
+	}
+
+	if httpPortArg != "" {
+		app.RouterHTTPPort = httpPortArg
+	}
+
+	if httpsPortArg != "" {
+		app.RouterHTTPSPort = httpsPortArg
+	}
+
+	if cmd.Flag("xdebug-enabled").Changed {
+		app.XdebugEnabled = xdebugEnabledArg
+	}
+
+	if additionalHostnamesArg != "" {
+		app.AdditionalHostnames = strings.Split(additionalHostnamesArg, ",")
+	}
+
+	if additionalFQDNsArg != "" {
+		app.AdditionalFQDNs = strings.Split(additionalFQDNsArg, ",")
+	}
 
 	err = app.ConfigFileOverrideAction()
 	if err != nil {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -113,6 +113,7 @@ func TestConfigSetValues(t *testing.T) {
 	additionalHostnames := strings.Join(additionalHostnamesSlice, ",")
 	additionalFQDNsSlice := []string{"abc.com", "123.pizza", "xyz.co.uk"}
 	additionalFQDNs := strings.Join(additionalFQDNsSlice, ",")
+	uploadDir := filepath.Join("custom", "config", "path")
 
 	args := []string{
 		"config",
@@ -124,7 +125,9 @@ func TestConfigSetValues(t *testing.T) {
 		"--https-port", httpsPort,
 		fmt.Sprintf("--xdebug-enabled=%t", xdebugEnabled),
 		"--additional-hostnames", additionalHostnames,
-		"--additional-fqdns", additionalFQDNs}
+		"--additional-fqdns", additionalFQDNs,
+		"--upload-dir", uploadDir,
+	}
 
 	_, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
@@ -150,4 +153,5 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(xdebugEnabled, app.XdebugEnabled)
 	assert.Equal(additionalHostnamesSlice, app.AdditionalHostnames)
 	assert.Equal(additionalFQDNsSlice, app.AdditionalFQDNs)
+	assert.Equal(uploadDir, app.UploadDir)
 }

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -3,11 +3,20 @@ package cmd
 import (
 	"testing"
 
+	"os"
+	"path/filepath"
+
+	"strings"
+
+	"fmt"
+
+	"io/ioutil"
+
+	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
-	"os"
-	"path/filepath"
+	"gopkg.in/yaml.v2"
 )
 
 // TestConfigDescribeLocation tries out the --show-config-location flag.
@@ -74,4 +83,71 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 	assert.Contains(string(out), "Found a drupal8 codebase")
+}
+
+// TestConfigSetValues sets all available configuration values using command flags, then confirms that the
+// values have been correctly written to the config file.
+func TestConfigSetValues(t *testing.T) {
+	var err error
+	assert := asrt.New(t)
+
+	// Create a temporary directory and switch to it.
+	tmpdir := testcommon.CreateTmpDir(t.Name())
+	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
+
+	// Create an existing docroot
+	docroot := "web"
+	if err = os.MkdirAll(filepath.Join(tmpdir, docroot), 0755); err != nil {
+		t.Errorf("Could not create docroot %s in %s", docroot, tmpdir)
+	}
+
+	// Build config args
+	projectName := "my-project-name"
+	projectType := "typo3"
+	phpVersion := "7.1"
+	httpPort := "81"
+	httpsPort := "444"
+	xdebugEnabled := true
+	additionalHostnamesSlice := []string{"abc", "123", "xyz"}
+	additionalHostnames := strings.Join(additionalHostnamesSlice, ",")
+	additionalFQDNsSlice := []string{"abc.com", "123.pizza", "xyz.co.uk"}
+	additionalFQDNs := strings.Join(additionalFQDNsSlice, ",")
+
+	args := []string{
+		"config",
+		"--projectname", projectName,
+		"--docroot", docroot,
+		"--projecttype", projectType,
+		"--php-version", phpVersion,
+		"--http-port", httpPort,
+		"--https-port", httpsPort,
+		fmt.Sprintf("--xdebug-enabled=%t", xdebugEnabled),
+		"--additional-hostnames", additionalHostnames,
+		"--additional-fqdns", additionalFQDNs}
+
+	_, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+
+	configFile := filepath.Join(tmpdir, ".ddev", "config.yaml")
+	configContents, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Unable to read %s: %v", configFile, err)
+	}
+
+	assert.NoError(err, "Unable to read config file at %s", configFile)
+	app := &ddevapp.DdevApp{}
+	if err = yaml.Unmarshal(configContents, app); err != nil {
+		t.Errorf("Could not unmarshal config.yaml %s: %v", configFile, err)
+	}
+
+	assert.Equal(projectName, app.Name)
+	assert.Equal(docroot, app.Docroot)
+	assert.Equal(projectType, app.Type)
+	assert.Equal(phpVersion, app.PHPVersion)
+	assert.Equal(httpPort, app.RouterHTTPPort)
+	assert.Equal(httpsPort, app.RouterHTTPSPort)
+	assert.Equal(xdebugEnabled, app.XdebugEnabled)
+	assert.Equal(additionalHostnamesSlice, app.AdditionalHostnames)
+	assert.Equal(additionalFQDNsSlice, app.AdditionalFQDNs)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1051 
There was no way to programmatically set config values through `ddev config`.

## How this PR Solves The Problem:
This provides flags to define relevant values from the `ddev config` command.

## Manual Testing Instructions:
You can find available flags through `ddev config -h`. Configure a project using combinations of these flags and ensure that the correct values are being set in `.ddev/config.yaml`.

Note that flag validation is currently WIP.

## Automated Testing Overview:
An automated test has been added that tries each of the new flags and confirms the value written to config.yaml.

## Related Issue Link(s):
#1051 
