### PR TITLE
Provide a configurable upload dir in config.yaml

### DIFF
--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -24,7 +24,11 @@ directory path or an archive in .tar, .tar.gz, .tgz, or .zip format. For the
 .zip and tar formats, the path to a directory within the archive can be
 provided if it is not located at the top-level of the archive. If the
 destination directory exists, it will be replaced with the assets being
-imported.`,
+imported.
+
+The destination directory can be configured in your project's config.yaml
+under the upload_dir key. If no custom upload directory is defined, the app
+type's default upload directory will be used.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		dockerutil.EnsureDdevNetwork()
 	},

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -363,7 +363,12 @@ If you want to use import-db without answering prompts, you can use the `--src` 
 
 ### Importing static file assets
 
-To import static file assets for a project, such as uploaded images and documents, use the command `ddev import-files`. This command will prompt you to specify the location of your asset import. Next it will import the assets into the default public upload directory of the platform for the project. For Drupal projects, this is the "sites/default/files" directory. For WordPress projects, this is the "wp-content/uploads" directory.
+To import static file assets for a project, such as uploaded images and documents, use the command `ddev import-files`. This command will prompt you to specify the location of your import asset, then import the assets into the project's upload directory. To define a custom upload directory, set the `upload_dir` key in your project's `config.yaml`. If no custom upload directory is defined, the a default will be used:
+
+- For Drupal projects, this is the `sites/default/files` directory
+- For WordPress projects, this is the `wp-content/uploads` directory
+- For TYPO3 projects, this is the `fileadmin` directory
+- For Backdrop projects, this is the `files` directory
 
 ```
 ➜  ddev import-files

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -194,11 +194,11 @@ func writeBackdropDdevSettingsFile(settings *BackdropSettings, filePath string) 
 
 // getBackdropUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getBackdropUploadDir(app *DdevApp) string {
-	if app.UploadPath == "" {
+	if app.UploadDir == "" {
 		return "files"
 	}
 
-	return app.UploadPath
+	return app.UploadDir
 }
 
 // getBackdropHooks for appending as byte array.

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -194,11 +194,11 @@ func writeBackdropDdevSettingsFile(settings *BackdropSettings, filePath string) 
 
 // getBackdropUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getBackdropUploadDir(app *DdevApp) string {
-	if app.ImportFilesPath == "" {
+	if app.UploadPath == "" {
 		return "files"
 	}
 
-	return app.ImportFilesPath
+	return app.UploadPath
 }
 
 // getBackdropHooks for appending as byte array.

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -192,10 +192,13 @@ func writeBackdropDdevSettingsFile(settings *BackdropSettings, filePath string) 
 	return nil
 }
 
-// getBackdropUploadDir returns the path to the directory where uploaded files are
-// stored.
+// getBackdropUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getBackdropUploadDir(app *DdevApp) string {
-	return "files"
+	if app.ImportFilesPath == "" {
+		return "files"
+	}
+
+	return app.ImportFilesPath
 }
 
 // getBackdropHooks for appending as byte array.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -92,7 +92,7 @@ type DdevApp struct {
 	SiteLocalSettingsPath string               `yaml:"-"`
 	providerInstance      Provider             `yaml:"-"`
 	Commands              map[string][]Command `yaml:"hooks,omitempty"`
-	UploadPath            string               `yaml:"upload_path,omitempty"`
+	UploadDir             string               `yaml:"upload_dir,omitempty"`
 }
 
 // GetType returns the application type as a (lowercase) string

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -92,7 +92,7 @@ type DdevApp struct {
 	SiteLocalSettingsPath string               `yaml:"-"`
 	providerInstance      Provider             `yaml:"-"`
 	Commands              map[string][]Command `yaml:"hooks,omitempty"`
-	ImportFilesPath       string               `yaml:"import_files_path,omitempty"`
+	UploadPath            string               `yaml:"upload_path,omitempty"`
 }
 
 // GetType returns the application type as a (lowercase) string

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -16,6 +16,9 @@ import (
 
 	"runtime"
 
+	"path"
+	"time"
+
 	"github.com/drud/ddev/pkg/appimport"
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/archive"
@@ -28,8 +31,6 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/mattn/go-shellwords"
-	"path"
-	"time"
 )
 
 const containerWaitTimeout = 61
@@ -91,6 +92,7 @@ type DdevApp struct {
 	SiteLocalSettingsPath string               `yaml:"-"`
 	providerInstance      Provider             `yaml:"-"`
 	Commands              map[string][]Command `yaml:"hooks,omitempty"`
+	ImportFilesPath       string               `yaml:"import_files_path,omitempty"`
 }
 
 // GetType returns the application type as a (lowercase) string

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -501,11 +501,11 @@ func WriteDrushConfig(drushConfig *DrushConfig, filePath string) error {
 
 // getDrupalUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getDrupalUploadDir(app *DdevApp) string {
-	if app.ImportFilesPath == "" {
+	if app.UploadPath == "" {
 		return "sites/default/files"
 	}
 
-	return app.ImportFilesPath
+	return app.UploadPath
 }
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -499,11 +499,13 @@ func WriteDrushConfig(drushConfig *DrushConfig, filePath string) error {
 	return nil
 }
 
-// getDrupalUploadDir just returns a static upload files (public files) dir.
-// This can be made more sophisticated in the future, for example by adding
-// the directory to the ddev config.yaml.
+// getDrupalUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getDrupalUploadDir(app *DdevApp) string {
-	return "sites/default/files"
+	if app.ImportFilesPath == "" {
+		return "sites/default/files"
+	}
+
+	return app.ImportFilesPath
 }
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -501,11 +501,11 @@ func WriteDrushConfig(drushConfig *DrushConfig, filePath string) error {
 
 // getDrupalUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getDrupalUploadDir(app *DdevApp) string {
-	if app.UploadPath == "" {
+	if app.UploadDir == "" {
 		return "sites/default/files"
 	}
 
-	return app.UploadPath
+	return app.UploadDir
 }
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -135,17 +135,20 @@ const ConfigInstructions = `
 
 # xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
 
-#additional_hostnames:
-# - somename
-# - someothername
+# additional_hostnames:
+#  - somename
+#  - someothername
 # would provide http and https URLs for "somename.ddev.local"
 # and "someothername.ddev.local".
 
-#additional_fqdns:
-# - example.com
-# - sub1.example.com
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
 # would provide http and https URLs for "example.com" and "sub1.example.com"
 # Please take care with this because it can cause great confusion.
+
+# upload_dir: custom/upload/dir
+# would set the destination path for ddev import-files to custom/upload/dir.
 
 # provider: default # Currently either "default" or "pantheon"
 #

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -97,11 +97,11 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 
 // getTypo3UploadDir will return a custom upload dir if defined, returning a default path if not.
 func getTypo3UploadDir(app *DdevApp) string {
-	if app.UploadPath == "" {
+	if app.UploadDir == "" {
 		return "fileadmin"
 	}
 
-	return app.UploadPath
+	return app.UploadDir
 }
 
 // Typo3Hooks adds a TYPO3-specific hooks example for post-import-db

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -97,11 +97,11 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 
 // getTypo3UploadDir will return a custom upload dir if defined, returning a default path if not.
 func getTypo3UploadDir(app *DdevApp) string {
-	if app.ImportFilesPath == "" {
+	if app.UploadPath == "" {
 		return "fileadmin"
 	}
 
-	return app.ImportFilesPath
+	return app.UploadPath
 }
 
 // Typo3Hooks adds a TYPO3-specific hooks example for post-import-db

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -95,12 +95,13 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	return nil
 }
 
-// getTypo3UploadDir just returns a static upload files (public files) dir.
-// This can be made more sophisticated in the future, for example by adding
-// the directory to the ddev config.yaml.
+// getTypo3UploadDir will return a custom upload dir if defined, returning a default path if not.
 func getTypo3UploadDir(app *DdevApp) string {
-	// @todo: Check to see if this gets overridden in LocalConfiguration.php
-	return "fileadmin"
+	if app.ImportFilesPath == "" {
+		return "fileadmin"
+	}
+
+	return app.ImportFilesPath
 }
 
 // Typo3Hooks adds a TYPO3-specific hooks example for post-import-db

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -70,7 +70,7 @@ func getWordpressHooks() []byte {
 	return []byte(wordPressHooks)
 }
 
-// getWordpressUploadDir will check if a custom upload dir has been defined, returning the default if not.
+// getWordpressUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getWordpressUploadDir(app *DdevApp) string {
 	if app.ImportFilesPath == "" {
 		return "wp-content/uploads"

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -72,11 +72,11 @@ func getWordpressHooks() []byte {
 
 // getWordpressUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getWordpressUploadDir(app *DdevApp) string {
-	if app.ImportFilesPath == "" {
+	if app.UploadPath == "" {
 		return "wp-content/uploads"
 	}
 
-	return app.ImportFilesPath
+	return app.UploadPath
 }
 
 const (

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -70,9 +70,13 @@ func getWordpressHooks() []byte {
 	return []byte(wordPressHooks)
 }
 
-// getWordpressUploadDir just returns a static upload files directory string.
+// getWordpressUploadDir will check if a custom upload dir has been defined, returning the default if not.
 func getWordpressUploadDir(app *DdevApp) string {
-	return "wp-content/uploads"
+	if app.ImportFilesPath == "" {
+		return "wp-content/uploads"
+	}
+
+	return app.ImportFilesPath
 }
 
 const (

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -72,11 +72,11 @@ func getWordpressHooks() []byte {
 
 // getWordpressUploadDir will return a custom upload dir if defined, returning a default path if not.
 func getWordpressUploadDir(app *DdevApp) string {
-	if app.UploadPath == "" {
+	if app.UploadDir == "" {
 		return "wp-content/uploads"
 	}
 
-	return app.UploadPath
+	return app.UploadDir
 }
 
 const (


### PR DESCRIPTION
## The Problem/Issue/Bug:
App type upload dirs are currently hard-coded. If a project is using a custom upload dir, `ddev import-files` can't handle it.

## How this PR Solves The Problem:
If an upload dir has been defined in config.yaml (under the `upload_dir` key), that will be the import-files destination. If no custom upload dir is defined, the default will be used instead.

## Manual Testing Instructions:
Attempt importing files in projects using a custom upload dir. Ensure the imported files are sent to the correct destination.  If the upload dir does not exist, the process should fail.

## Automated Testing
I've added an automated test to ensure a custom upload dir is respected.
