### PR TITLE
docker-compose example should use 3.6 for version number

### DIFF
--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -24,7 +24,7 @@ Each project can have an unlimited number of .ddev/docker-compose.*.yaml files a
 For example, a `.ddev/docker-compose.environment.yaml` with these contents would add a $TYPO3_CONTEXT environment variable to the web container, and a $SOMETHING environment variable to the db container: 
 
 ```
-version: '3'
+version: '3.6'
 
 services:
   web:


### PR DESCRIPTION
## The Problem/Issue/Bug:

version: '3.6' is required at the top of docker-compose.xxx.yaml files; but we have a docs example that still has version: '3'.

## How this PR Solves The Problem:

Fix it.

