### PR TITLE
Make apache run properly on Windows, fixes #1109

### DIFF
--- a/containers/ddev-webserver/files/etc/group
+++ b/containers/ddev-webserver/files/etc/group
@@ -1,5 +1,6 @@
 root:x:0:
 nginx:x:0:
+gid_0:x:0:
 gid_1:x:1:
 gid_2:x:2:
 gid_3:x:3:

--- a/containers/ddev-webserver/files/etc/passwd
+++ b/containers/ddev-webserver/files/etc/passwd
@@ -1,5 +1,6 @@
 root:x:0:0:root:/home:/bin/bash
 nginx:x:0:0:root:/home:/bin/bash
+uid_0:x:0:0:root:/home:/bin/bash
 uid_1:x:1:1:gid_1:/home:/bin/bash
 uid_2:x:2:2:gid_2:/home:/bin/bash
 uid_3:x:3:3:gid_3:/home:/bin/bash

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -705,13 +705,13 @@ func (app *DdevApp) DockerEnv() {
 	UIDStr = curUser.Uid
 	GIDStr = curUser.Gid
 	// For windows the UIDStr/GIDStr are usually way outside linux range (ends at 60000)
-	// so we have to run as root. We may have a host UIDStr/GIDStr greater in other contexts,
-	// bail and run as root.
+	// so we have to run as arbitrary user 1000. We may have a host UIDStr/GIDStr greater in other contexts,
+	// 1000 seems not to cause file permissions issues at least on docker-for-windows.
 	if UIDInt, err = strconv.Atoi(curUser.Uid); err != nil {
-		UIDStr = "0"
+		UIDStr = "1000"
 	}
 	if GIDInt, err = strconv.Atoi(curUser.Gid); err != nil {
-		GIDStr = "0"
+		GIDStr = "1000"
 	}
 
 	// Warn about running as root if we're not on windows.
@@ -721,8 +721,8 @@ func (app *DdevApp) DockerEnv() {
 
 	// If the UIDStr or GIDStr is outside the range possible in container, use root
 	if UIDInt > 60000 || GIDInt > 60000 {
-		UIDStr = "0"
-		GIDStr = "0"
+		UIDStr = "1000"
+		GIDStr = "1000"
 	}
 
 	envVars := map[string]string{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,7 +23,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20180911_apache_supervisor" // Note that this can be overridden by make
+var WebTag = "20180913_apache_broken_on_windows" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Apache doesn't work at all on Windows. 

There are two problems. 

First:  https://github.com/drud/ddev/blob/5ed08dc93b285b00fb77ab5ec35fabcaf375ad64/containers/ddev-webserver/files/etc/apache2/envvars#L49-L50 is overwritten with uid_0 (which didn't exist in /etc/passwd)

Second:

Apache just won't run as root. Period. Without recompiling.


## How this PR Solves The Problem:

Use uid 1000 in windows instead of using uid 0. This seems to work fine. I've checked to make sure that at least with docker-for-windows files created by the webserver come through as the correct user on the host.

## Manual Testing Instructions:

Use apache-fpm as webserver_type on Windows.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #1109 

## Release/Deployment notes:

This changes the UID used inside the web container to UID 1000 instead of root (uid 0). Although this seems to have no detectable problems on docker for windows in terms of creating files with improper uid there could be side-effects. But it's sure nice to not be running as root inside the container.

This also might causes issues to some Windows user doing an exec hook without sudo.
