### PR TITLE
Add php-imagick to web container, fixes #949 again

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -71,7 +71,8 @@ RUN apt-get -qq update && \
         unzip \
         rsync \
         locales-all \
-        libpcre3 && \
+        libpcre3 \
+        php-imagick && \
     for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
     apt-get -qq autoremove -y && \

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,7 +23,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20180913_locales" // Note that this can be overridden by make
+var WebTag = "20180915_php_imagick" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#949 actually requested the php-imagick package and we didn't do it there, and we might as well. This adds that package. The cost in size is about 2MB.

## Manual Testing Instructions:

* Use `webimage: drud/ddev-webserver:20180915_php_imagick` in your config.yaml (and ddev start).
* Configure a drupal site to use ImageMagick for its image processing. (Requires the imagemagick module; `drush dl imagemagick` and `drush en -y imagemagick`. Config is in admin/config/media/image-toolkit
* Verify that it can do image processing.

## Automated Testing Overview:
This should not require anything extra

## Related Issue Link(s):

Request was in #949 

