### PR TITLE
Docs - change docker and docker-compose req version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@
 
 ## System Requirements
 
-- [Docker](https://www.docker.com/community-edition) version 18.03 or higher. Linux users make sure you do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
-- docker-compose 1.18.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
+- [Docker](https://www.docker.com/community-edition) version 18.06 or higher. Linux users make sure you do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
+- docker-compose 1.22.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
 - OS Support
   - macOS Sierra and higher (macOS 10.12 and higher but it should runs anywhere docker-ce runs)
   - Linux: Most recent Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 ## System Requirements
 
 - [Docker](https://www.docker.com/community-edition) version 18.06 or higher. Linux users make sure you do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
-- docker-compose 1.18.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
+- docker-compose 1.20.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
 - OS Support
   - macOS Sierra and higher (macOS 10.12 and higher but it should runs anywhere docker-ce runs)
   - Linux: Most recent Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 ## System Requirements
 
 - [Docker](https://www.docker.com/community-edition) version 18.06 or higher. Linux users make sure you do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
-- docker-compose 1.22.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
+- docker-compose 1.18.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
 - OS Support
   - macOS Sierra and higher (macOS 10.12 and higher but it should runs anywhere docker-ce runs)
   - Linux: Most recent Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,9 +11,11 @@ var DdevVersion = "v0.0.0-overridden-by-make" // Note that this is overridden by
 // DockerVersionConstraint is the current minimum version of docker required for ddev.
 // See https://godoc.org/github.com/Masterminds/semver#hdr-Checking_Version_Constraints
 // for examples defining version constraints.
+// REMEMBER TO CHANGE docs/index.md if you touch this!
 var DockerVersionConstraint = ">= 18.06.0-ce"
 
 // DockerComposeVersionConstraint is the current minimum version of docker-compose required for ddev.
+// REMEMBER TO CHANGE docs/index.md if you touch this!
 var DockerComposeVersionConstraint = ">= 1.18.0-alpha1"
 
 // DockerComposeFileFormatVersion is the compose version to be used

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var DockerVersionConstraint = ">= 18.06.0-ce"
 
 // DockerComposeVersionConstraint is the current minimum version of docker-compose required for ddev.
 // REMEMBER TO CHANGE docs/index.md if you touch this!
-var DockerComposeVersionConstraint = ">= 1.18.0-alpha1"
+var DockerComposeVersionConstraint = ">= 1.20.0"
 
 // DockerComposeFileFormatVersion is the compose version to be used
 var DockerComposeFileFormatVersion = "3.6"


### PR DESCRIPTION
## The Problem/Issue/Bug:
With ddev in version 1.20.0, you need Docker 18.06. With ddev in version 1.20.0, file docker-compose.yaml require version: '3.6', but that property is only available from docker-compose in version 1.20, which supports Docker in version 18.02 or higher. Version 1.22.0 of docker-compose supports Docker 18.06 or higher, which is also required for ddev to run, so I propose to change docs to require Docker in version 18.06 or above, and docker-compose in version 1.22.0 or above.
## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:

## Related Issue Link(s):

## Release/Deployment notes:

