### PR TITLE
Use command instead of which in install script, fixes #1114

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ brew upgrade ddev
 Linux and macOS end-users can use this line of code to your terminal to download, verify, and install (or upgrade) ddev using our [install script](https://github.com/drud/ddev/blob/master/install_ddev.sh):
 
 ```
-curl https://raw.githubusercontent.com/drud/ddev/master/install_ddev.sh | bash
+curl -L https://raw.githubusercontent.com/drud/ddev/master/install_ddev.sh | bash
 ```
 
 Later, to upgrade ddev to the latest version, just run this again.

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -55,7 +55,7 @@ else
     sudo mv /tmp/ddev /usr/local/bin/
 fi
 
-if which brew &&  [ -f `brew --prefix`/etc/bash_completion ]; then
+if command -v brew >/dev/null &&  [ -f `brew --prefix`/etc/bash_completion ]; then
 	bash_completion_dir=$(brew --prefix)/etc/bash_completion.d
     cp /tmp/ddev_bash_completion.sh $bash_completion_dir/ddev
     printf "${GREEN}Installed ddev bash completions in $bash_completion_dir${RESET}\n"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1114 points out that the output of "which" in the install script is shown to the user (although the script works fine). 

## How this PR Solves The Problem:

* Use 'command -v' and redirect the output instead of using which
* Change the suggested curl command to `curl -L`, so it follows redirects.

## Manual Testing Instructions:

Run the install script as in the [Linux or macOS install section](https://ddev.readthedocs.io/en/latest/#installation)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

