### PR TITLE
Don't use -y automatically on drush commands, fixes #1118, fixes #455

### DIFF
--- a/containers/ddev-webserver/files/etc/drush/drushrc.php
+++ b/containers/ddev-webserver/files/etc/drush/drushrc.php
@@ -3,4 +3,6 @@ if (!empty($_ENV['DDEV_URL'])) {
     $options['uri'] = $_ENV['DDEV_URL'];
 }
 # Skip confirmations since `ddev exec` cannot support interactive prompts
-$options['yes'] = 1;
+if (!empty($_ENV['DDEV_EXEC'])) {
+    $options['yes'] = 1;
+}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -640,7 +640,7 @@ func (app *DdevApp) Start() error {
 func (app *DdevApp) Exec(service string, cmd ...string) (string, string, error) {
 	app.DockerEnv()
 
-	exec := []string{"exec", "-T", service}
+	exec := []string{"exec", "-e", "DDEV_EXEC=true", "-T", service}
 	exec = append(exec, cmd...)
 
 	files, err := app.ComposeFiles()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -25,7 +25,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20180913_apache_broken_on_windows" // Note that this can be overridden by make
+var WebTag = "20180920_fix_drush_auto_yes" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

We have long defaulted to the drush -y, assuming people were using `ddev exec` or an exec hook, but it makes people crazy when they use drush inside the container.

## How this PR Solves The Problem:

* Set environment variable DDEV_EXEC when "exec" is being executed
* /etc/drush/drushrc.php looks at DDEV_EXEC and only adds the -y option if in exec context.

## Manual Testing Instructions:

* Run `ddev ssh` and try `drush sql-drop`. It will ask first.
* Reload db
* Run `ddev exec drush sql-drop` and it will just drop the db with -y.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #1118 and #455


