### PR TITLE
Bump build-tools to get golang v1.11

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -10,7 +10,7 @@ sudo apt-get install -qq mysql-client realpath zip nsis
 
 # golang of the version we want
 sudo apt-get remove -qq golang && sudo rm -rf /usr/local/go &&
-wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz &&
+wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.11.linux-amd64.tar.gz &&
 sudo tar -C /usr/local -xzf /tmp/golang.tgz
 
 

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -14,7 +14,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.10.3
+BUILD_IMAGE ?= drud/golang-build-container:v1.11
 
 BUILD_BASE_DIR ?= $$PWD
 

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -45,7 +45,7 @@ running 'ddev stop <projectname>.`,
 
 		desc, err := site.Describe()
 		if err != nil {
-			util.Failed("Failed to describe project %s: %v", err)
+			util.Failed("Failed to describe project %s: %v", site.Name, err)
 		}
 
 		renderedDesc, err := renderAppDescribe(desc)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 	for i := range DevTestSites {
 		err = DevTestSites[i].Prepare()
 		if err != nil {
-			log.Fatalln("Prepare() failed in TestMain site=%s, err=", DevTestSites[i].Name, err)
+			log.Fatalf("Prepare() failed in TestMain site=%s, err=%v\n", DevTestSites[i].Name, err)
 		}
 	}
 	addSites()
@@ -185,7 +185,7 @@ func removeSites() {
 		args := []string{"remove", "-R"}
 		out, err := exec.RunCommand(DdevBin, args)
 		if err != nil {
-			log.Fatalln("Failed to run ddev remove -R command, err: %v, output: %s", err, out)
+			log.Fatalf("Failed to run ddev remove -R command, err: %v, output: %s\n", err, out)
 		}
 	}
 }

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -171,7 +171,7 @@ func determineRouterPorts() []string {
 	var routerPorts []string
 	containers, err := dockerutil.GetDockerContainers(false)
 	if err != nil {
-		util.Failed("failed to retrieve containers for determining port mappings", err)
+		util.Failed("failed to retrieve containers for determining port mappings: %v", err)
 	}
 
 	// loop through all containers with site-name label

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -54,7 +54,7 @@ func EnsureDdevNetwork() {
 func GetDockerClient() *docker.Client {
 	client, err := docker.NewClientFromEnv()
 	if err != nil {
-		output.UserOut.Warn("could not get docker client. is docker running? error: %v", err)
+		output.UserOut.Warnf("could not get docker client. is docker running? error: %v", err)
 		// Use os.Exit instead of util.Failed() to avoid import cycle with util.
 		os.Exit(100)
 	}

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -25,8 +25,8 @@ var (
 			Name:                          "TestServicesDrupal8",
 			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.5.3.tar.gz",
 			ArchiveInternalExtractionPath: "drupal-8.5.3/",
-			Docroot: "",
-			Type:    "drupal8",
+			Docroot:                       "",
+			Type:                          "drupal8",
 		},
 	}
 	ServiceFiles []string

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -130,7 +130,7 @@ func EnsureHTTPStatus(o *HTTPOptions) error {
 			"headers":  o.Headers,
 			"expected": o.ExpectedStatus,
 			"got":      resp.StatusCode,
-		}).Info("HTTP Status could not be matched, expected %d, received %d", o.ExpectedStatus, resp.StatusCode)
+		}).Infof("HTTP Status could not be matched, expected %d, received %d", o.ExpectedStatus, resp.StatusCode)
 
 	}
 	return fmt.Errorf("failed to match status code: %d, got: %d", o.ExpectedStatus, resp.StatusCode)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Golang 1.11 is out; golang-build-container and build-tools are updated.

## How this PR Solves The Problem:

Bump to new build-tools

## Release/Deployment notes:

* When this is pulled, we should update the buildkite testbots to golang v1.11
