### PR TITLE
Add rewrites for ssl so apache behaves properly

### DIFF
--- a/containers/ddev-webserver/files/etc/apache2/apache-site-default.conf
+++ b/containers/ddev-webserver/files/etc/apache2/apache-site-default.conf
@@ -8,6 +8,16 @@
 	# However, you must set it for any further virtual host explicitly.
 	#ServerName www.example.com
 
+    # Workaround from https://mail-archives.apache.org/mod_mbox/httpd-users/201403.mbox/%3C49404A24C7FAD94BB7B45E86A9305F6214D04652@MSGEXSV21103.ent.wfb.bank.corp%3E
+    # See also https://gist.github.com/nurtext/b6ac07ac7d8c372bc8eb
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond    %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule    ^(.+[^/])$           https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
 	ServerAdmin webmaster@localhost
 	DocumentRoot $WEBSERVER_DOCROOT
 	<Directory "$WEBSERVER_DOCROOT/">

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1327,10 +1327,10 @@ func TestListWithoutDir(t *testing.T) {
 	assert.NoError(err)
 }
 
-type UrlRedirectExpectations struct {
+type URLRedirectExpectations struct {
 	scheme              string
 	uri                 string
-	expectedRedirectUri string
+	expectedRedirectURI string
 }
 
 // TestHttpsRedirection tests to make sure that webserver and php redirect to correct
@@ -1355,7 +1355,7 @@ func TestHttpsRedirection(t *testing.T) {
 	app.Name = "proj"
 	app.Type = "php"
 
-	expectations := []UrlRedirectExpectations{
+	expectations := []URLRedirectExpectations{
 		{"https", "/subdir", "/subdir/"},
 		{"https", "/redir_abs.php", "/landed.php"},
 		{"https", "/redir_relative.php", "/landed.php"},
@@ -1378,25 +1378,25 @@ func TestHttpsRedirection(t *testing.T) {
 		// Test for directory redirects under https and http
 		for _, parts := range expectations {
 
-			reqUrl := parts.scheme + "://" + app.GetHostname() + parts.uri
+			reqURL := parts.scheme + "://" + app.GetHostname() + parts.uri
 			// nolint: vetshadow
-			_, resp, err := testcommon.GetLocalHTTPResponse(t, reqUrl)
+			_, resp, err := testcommon.GetLocalHTTPResponse(t, reqURL)
 			assert.Error(err)
-			assert.NotNil(resp, "resp was nil for webserver_type=%s url=%s", webserverType, reqUrl)
+			assert.NotNil(resp, "resp was nil for webserver_type=%s url=%s", webserverType, reqURL)
 			if resp != nil {
 				locHeader := resp.Header.Get("Location")
 
-				expectedRedirect := parts.expectedRedirectUri
+				expectedRedirect := parts.expectedRedirectURI
 				// However, if we're hitting redir_abs.php (or apache hitting directory), the redirect will be the whole url.
 				if strings.Contains(parts.uri, "redir_abs.php") || webserverType != "nginx-fpm" {
-					expectedRedirect = parts.scheme + "://" + app.GetHostname() + parts.expectedRedirectUri
+					expectedRedirect = parts.scheme + "://" + app.GetHostname() + parts.expectedRedirectURI
 				}
 				// Except the php relative redirect is always relative.
 				if strings.Contains(parts.uri, "redir_relative.php") {
-					expectedRedirect = parts.expectedRedirectUri
+					expectedRedirect = parts.expectedRedirectURI
 				}
 
-				assert.EqualValues(locHeader, expectedRedirect, "For webserver_type %s url %s expected redirect %s != actual %s", webserverType, reqUrl, expectedRedirect, locHeader)
+				assert.EqualValues(locHeader, expectedRedirect, "For webserver_type %s url %s expected redirect %s != actual %s", webserverType, reqURL, expectedRedirect, locHeader)
 			}
 		}
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1338,7 +1338,6 @@ type URLRedirectExpectations struct {
 func TestHttpsRedirection(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
-	//require := rqr.New(t)
 	testcommon.ClearDockerEnv()
 	packageDir, _ := os.Getwd()
 

--- a/pkg/ddevapp/testdata/TestHttpsRedirection/.htaccess
+++ b/pkg/ddevapp/testdata/TestHttpsRedirection/.htaccess
@@ -1,0 +1,9 @@
+# DirectorySlash off
+# DirectoryIndex index.php
+# DirectorySlash off
+# DirectoryIndexRedirect on
+# Redirect to HTTPS before Apache mod_dir DirectorySlash redirect to HTTP
+RewriteCond %{HTTP:X-Forwarded-Proto} =https
+RewriteCond %{LA-U:REQUEST_FILENAME} -d
+RewriteRule ^/(.*[^/])$ https://%{HTTP_HOST}/$1/ [R=301,L,QSA]
+

--- a/pkg/ddevapp/testdata/TestHttpsRedirection/index.php
+++ b/pkg/ddevapp/testdata/TestHttpsRedirection/index.php
@@ -1,0 +1,5 @@
+<?php
+
+echo "Hi there, this is /index.php<br/>";
+
+echo 'Here are links to <a href="/landed.php">landed.php</a> and <a href="subdir">subdir</a><br/>';

--- a/pkg/ddevapp/testdata/TestHttpsRedirection/landed.php
+++ b/pkg/ddevapp/testdata/TestHttpsRedirection/landed.php
@@ -1,0 +1,15 @@
+<?php
+
+
+echo "You landed at ${_SERVER['REQUEST_URI']}<br/>";
+
+echo 'You can go to <a href="redir_abs.php">redir_abs.php</a> or to <a href="redir_relative.php">redir_relative.php</a><br/>';
+
+echo "When you hit <a href='subdir'>subdir</a> it should redirect to subdir/index.html in subdir without changing scheme (stay with http or https)"
+
+
+if (!empty($_SERVER['HTTPS']) && $_SERVER["HTTPS"] == "on") {
+    echo "You can  <a href='http://${_SERVER['HTTP_HOST']}/landed.php'>switch from https to http</a><br/>";
+} else {
+    echo "You can <a href='https://${_SERVER['HTTP_HOST']}/landed.php'>switch from http to https</a><br/>";
+}

--- a/pkg/ddevapp/testdata/TestHttpsRedirection/landed.php
+++ b/pkg/ddevapp/testdata/TestHttpsRedirection/landed.php
@@ -2,10 +2,9 @@
 
 
 echo "You landed at ${_SERVER['REQUEST_URI']}<br/>";
+echo "HTTPS is {$_SERVER['HTTPS']}<br/>";
 
 echo 'You can go to <a href="redir_abs.php">redir_abs.php</a> or to <a href="redir_relative.php">redir_relative.php</a><br/>';
-
-echo "When you hit <a href='subdir'>subdir</a> it should redirect to subdir/index.html in subdir without changing scheme (stay with http or https)"
 
 
 if (!empty($_SERVER['HTTPS']) && $_SERVER["HTTPS"] == "on") {

--- a/pkg/ddevapp/testdata/TestHttpsRedirection/redir_abs.php
+++ b/pkg/ddevapp/testdata/TestHttpsRedirection/redir_abs.php
@@ -1,5 +1,5 @@
 <?php
 
-$scheme = !empty($_SERVER['HTTPS']) ? "https://" : "http://";
+$scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == "on") ? "https://" : "http://";
 $url = $scheme . $_SERVER['HTTP_HOST'] . "/landed.php";
 header('Location: ' . $url, true, 302);              // Use either 301 or 302

--- a/pkg/ddevapp/testdata/TestHttpsRedirection/redir_abs.php
+++ b/pkg/ddevapp/testdata/TestHttpsRedirection/redir_abs.php
@@ -1,0 +1,5 @@
+<?php
+
+$scheme = !empty($_SERVER['HTTPS']) ? "https://" : "http://";
+$url = $scheme . $_SERVER['HTTP_HOST'] . "/landed.php";
+header('Location: ' . $url, true, 302);              // Use either 301 or 302

--- a/pkg/ddevapp/testdata/TestHttpsRedirection/redir_relative.php
+++ b/pkg/ddevapp/testdata/TestHttpsRedirection/redir_relative.php
@@ -1,0 +1,3 @@
+<?php
+
+header('Location: ' . "/landed.php", true, 302);

--- a/pkg/ddevapp/testdata/TestHttpsRedirection/subdir/index.html
+++ b/pkg/ddevapp/testdata/TestHttpsRedirection/subdir/index.html
@@ -1,0 +1,2 @@
+This is subdir/index.html; When you get here you should still have the scheme where you came from (shouldn't switch between http and https).<br/>
+<a href="/">Go back to the top.</a>

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -170,7 +170,7 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 	assert.NoError(err)
 
 	safeURL := app.GetHTTPURL() + site.Safe200URL
-	out, err := GetLocalHTTPResponse(t, safeURL)
+	out, _, err := GetLocalHTTPResponse(t, safeURL)
 	assert.NoError(err)
 	assert.Contains(out, "Famous 5-minute install")
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -25,7 +25,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20180922_upgrade_debian_stretch" // Note that this can be overridden by make
+var WebTag = "20180922_apache_https" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

@ondrogo in [Typo3 slack](https://typo3.slack.com/archives/C8TRNQ601/p1536766643000100) pointed out that with apache-fpm or apache-cgi he was unable to log into the backend. The reason ended up being that both Apache and TYPO3 were redirecting to plain https, losing the context in the process.

Apache is *not* very good at being on the receiving end of a reverse proxy. But there are workarounds, as in this PR. You have to convince mod_dir not to redirect to http when operating in https, and you have to make sure that the HTTPS environment variable gets propagated to php.

The base problem is described in http://httpd.apache.org/docs/2.4/mod/core.html#servername: 

>Sometimes, the server runs behind a device that processes SSL, such as a reverse proxy, load balancer or SSL offload appliance. When this is the case, specify the https:// scheme and the port number to which the clients connect in the ServerName directive to make sure that the server generates the correct self-referential URLs.

Unfortunately, we are supporting both http and https at the same time, so can't use the ServerName workaround.

The internet is not all that good at solving this problem for us, but these two obscure links provided hints:
* https://mail-archives.apache.org/mod_mbox/httpd-users/201403.mbox/%3C49404A24C7FAD94BB7B45E86A9305F6214D04652@MSGEXSV21103.ent.wfb.bank.corp%3E
* https://gist.github.com/nurtext/b6ac07ac7d8c372bc8eb


## How this PR Solves The Problem:

It tries to do those things.

## Manual Testing Instructions:

You can either use the full ddev download from Circleci or just use `webimage: drud/ddev-webserver:20180922_apache_https` in your config.yaml. 

* Nontrivial explorations on TYPO3 with apache-cgi and apache-fpm, especially using the backend.
* Nontrivial explorations of Drupal with apache-cgi and apache-fpm
* Make sure to use custom ports on both http and https as another permutation.

## Automated Testing Overview:

We may be able to add cases for this into apache-specific tests, but I'm not sure.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

