### PR TITLE
Provide a flag to specify webserver type in ddev config, fixes #1103

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -50,6 +50,9 @@ var (
 
 	// uploadDirArg allows a user to set the project's upload directory, the destination directory for import-files.
 	uploadDirArg string
+
+	// webserverTypeArgs allows a user to set the project's webserver type
+	webserverTypeArg string
 )
 
 var providerName = ddevapp.DefaultProviderName
@@ -136,7 +139,8 @@ func init() {
 	ConfigCommand.Flags().StringVar(&additionalFQDNsArg, "additional-fqdns", "", "A comma-delimited list of FQDNs for the project")
 	ConfigCommand.Flags().BoolVar(&createDocroot, "create-docroot", false, "Prompts ddev to create the docroot if it doesn't exist")
 	ConfigCommand.Flags().BoolVar(&showConfigLocation, "show-config-location", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
-	ConfigCommand.Flags().StringVar(&uploadDirArg, "upload-dir", "", "Sets the project's upload directoy, the destination directory of the import-files command.")
+	ConfigCommand.Flags().StringVar(&uploadDirArg, "upload-dir", "", "Sets the project's upload directory, the destination directory of the import-files command.")
+	ConfigCommand.Flags().StringVar(&webserverTypeArg, "webserver-type", "", "Sets the project's desired webserver type: nginx-fpm, apache-fpm, or apache-cgi")
 
 	// apptype flag exists for backwards compatibility.
 	ConfigCommand.Flags().StringVar(&appTypeArg, "apptype", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
@@ -287,6 +291,10 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if uploadDirArg != "" {
 		app.UploadDir = uploadDirArg
+	}
+
+	if webserverTypeArg != "" {
+		app.WebserverType = webserverTypeArg
 	}
 
 	err = app.WriteConfig()

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -114,6 +114,7 @@ func TestConfigSetValues(t *testing.T) {
 	additionalFQDNsSlice := []string{"abc.com", "123.pizza", "xyz.co.uk"}
 	additionalFQDNs := strings.Join(additionalFQDNsSlice, ",")
 	uploadDir := filepath.Join("custom", "config", "path")
+	webserverType := "apache-fpm"
 
 	args := []string{
 		"config",
@@ -127,6 +128,7 @@ func TestConfigSetValues(t *testing.T) {
 		"--additional-hostnames", additionalHostnames,
 		"--additional-fqdns", additionalFQDNs,
 		"--upload-dir", uploadDir,
+		"--webserver-type", webserverType,
 	}
 
 	_, err = exec.RunCommand(DdevBin, args)
@@ -154,4 +156,5 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(additionalHostnamesSlice, app.AdditionalHostnames)
 	assert.Equal(additionalFQDNsSlice, app.AdditionalFQDNs)
 	assert.Equal(uploadDir, app.UploadDir)
+	assert.Equal(webserverType, app.WebserverType)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
The webserver_type option could not be specified by a command line flag.

## How this PR Solves The Problem:
Allows a user to specify webserver_type with a flag in `ddev config`.

## Manual Testing Instructions:
Test `ddev config` and pass webserver type values (nginx-fpm, apache-cgi, apache-fpm) to `--webserver-type`.  Ensure that the webserver_type value in .ddev/config.yaml is not overwritten when no `--webserver-type` value is provided.

## Automated Testing Overview:
Automated tests have been updated to test this addition.

## Related Issue Link(s):
#1103, but the `--upload-dir` flag already exists.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

