### PR TITLE
Add configuration flags to ddev pull, fixes #405

### DIFF
--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -15,8 +15,8 @@ var dbExtPath string
 // ImportDBCmd represents the `ddev import-db` command.
 var ImportDBCmd = &cobra.Command{
 	Use:   "import-db",
-	Short: "Import the database of an existing project to the dev environment.",
-	Long: `Import the database of an existing project to the development environment.
+	Short: "Pull the database of an existing project to the dev environment.",
+	Long: `Pull the database of an existing project to the development environment.
 The database can be provided as a SQL dump in a .sql, .sql.gz, .zip, .tgz, or .tar.gz
 format. For the zip and tar formats, the path to a .sql file within the archive
 can be provided if it is not located at the top level of the archive.`,

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -17,8 +17,8 @@ var extPath string
 // ImportFileCmd represents the `ddev import-db` command.
 var ImportFileCmd = &cobra.Command{
 	Use:   "import-files",
-	Short: "Import the uploaded files directory of an existing project to the default public upload directory of your project.",
-	Long: `Import the uploaded files directory of an existing project to the default
+	Short: "Pull the uploaded files directory of an existing project to the default public upload directory of your project.",
+	Long: `Pull the uploaded files directory of an existing project to the default
 public upload directory of your project. The files can be provided as a
 directory path or an archive in .tar, .tar.gz, .tgz, or .zip format. For the
 .zip and tar formats, the path to a directory within the archive can be
@@ -82,7 +82,7 @@ func promptForFileSource(val *string) {
 	// An empty string isn't acceptable here, keep
 	// prompting until something is entered
 	for {
-		fmt.Print("Import path: ")
+		fmt.Print("Pull path: ")
 		*val = util.GetInput("")
 		if len(*val) > 0 {
 			break

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -94,9 +94,9 @@ func appPull(skipConfirmation bool) {
 
 func init() {
 	PullCmd.Flags().BoolVarP(&skipConfirmationArg, "skip-confirmation", "y", false, "Skip confirmation step")
-	PullCmd.Flags().BoolVar(&skipDbArg, "skip-db", false, "Skip database download step")
-	PullCmd.Flags().BoolVar(&skipFilesArg, "skip-files", false, "Skip file archive download step")
-	PullCmd.Flags().BoolVar(&skipImportArg, "skip-import", false, "Downloads files and/or databases, but skips the import step")
-	PullCmd.Flags().StringVar(&envArg, "env", "", "Overrides the provider environment being pulled")
+	PullCmd.Flags().BoolVar(&skipDbArg, "skip-db", false, "Skip pulling database archive")
+	PullCmd.Flags().BoolVar(&skipFilesArg, "skip-files", false, "Skip pulling file archive")
+	PullCmd.Flags().BoolVar(&skipImportArg, "skip-import", false, "Downloads file and/or database archives, but does not import them")
+	PullCmd.Flags().StringVar(&envArg, "env", "", "Overrides the default provider environment being pulled")
 	RootCmd.AddCommand(PullCmd)
 }

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -22,6 +22,9 @@ var (
 
 	// skipImportArg allows a user to pull remote assets, but not import them into the project.
 	skipImportArg bool
+
+	// envArg allows a user to override the provider environment being pulled.
+	envArg string
 )
 
 // PullCmd represents the `ddev pull` command.
@@ -76,9 +79,10 @@ func appPull(skipConfirmation bool) {
 	}
 
 	pullOpts := &ddevapp.PullOptions{
-		SkipDb:     skipDbArg,
-		SkipFiles:  skipFilesArg,
-		SkipImport: skipImportArg,
+		SkipDb:      skipDbArg,
+		SkipFiles:   skipFilesArg,
+		SkipImport:  skipImportArg,
+		Environment: envArg,
 	}
 
 	if err := app.Pull(provider, pullOpts); err != nil {
@@ -93,5 +97,6 @@ func init() {
 	PullCmd.Flags().BoolVar(&skipDbArg, "skip-db", false, "Skip database download step")
 	PullCmd.Flags().BoolVar(&skipFilesArg, "skip-files", false, "Skip file archive download step")
 	PullCmd.Flags().BoolVar(&skipImportArg, "skip-import", false, "Downloads files and/or databases, but skips the import step")
+	PullCmd.Flags().StringVar(&envArg, "env", "", "Overrides the provider environment being pulled")
 	RootCmd.AddCommand(PullCmd)
 }

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -51,7 +51,7 @@ func appPull(skipConfirmation bool) {
 	}
 
 	// If we're not performing the import step, we won't be deleting the existing db or files.
-	if !skipConfirmation && !skipImportArg {
+	if !skipConfirmation && !skipImportArg && os.Getenv("DRUD_NONINTERACTIVE") == "" {
 		// Only warn the user about relevant risks.
 		var message string
 		if skipDbArg && skipFilesArg {

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -11,7 +11,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var skipConfirmation bool
+var (
+	skipConfirmationArg bool
+
+	skipDbArg bool
+
+	skipFilesArg bool
+
+	skipImportArg bool
+)
 
 // PullCmd represents the `ddev pull` command.
 var PullCmd = &cobra.Command{
@@ -29,7 +37,7 @@ var PullCmd = &cobra.Command{
 		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		appImport(skipConfirmation)
+		appImport(skipConfirmationArg)
 	},
 }
 
@@ -51,7 +59,12 @@ func appImport(skipConfirmation bool) {
 		}
 	}
 
-	err = app.Import()
+	err = app.Import(&ddevapp.ImportOptions{
+		SkipDb:     skipDbArg,
+		SkipFiles:  skipFilesArg,
+		SkipImport: skipImportArg,
+	})
+
 	if err != nil {
 		util.Failed("Could not perform import: %v", err)
 	}
@@ -61,6 +74,9 @@ func appImport(skipConfirmation bool) {
 }
 
 func init() {
-	PullCmd.Flags().BoolVarP(&skipConfirmation, "skip-confirmation", "y", false, "Skip confirmation step.")
+	PullCmd.Flags().BoolVarP(&skipConfirmationArg, "skip-confirmation", "y", false, "Skip confirmation step")
+	PullCmd.Flags().BoolVar(&skipDbArg, "ignore-db", false, "Skip database download step")
+	PullCmd.Flags().BoolVar(&skipFilesArg, "ignore-files", false, "Skip file archive download step")
+	PullCmd.Flags().BoolVar(&skipImportArg, "skip-import", false, "Downloads files and/or databases, but skips the import step")
 	RootCmd.AddCommand(PullCmd)
 }

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
-	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -66,8 +66,8 @@ func appPull(skipConfirmation bool) {
 		}
 
 		util.Warning("You're about to delete the current %s and replace with the results of a fresh pull.", message)
-		output.UserOut.Printf("Would you like to continue? [y/N]")
-		if !util.AskForConfirmation() {
+		resp := strings.ToLower(util.Prompt("Would you like to continue? [Y/n]", "yes"))
+		if resp != "y" && resp != "yes" {
 			util.Warning("Pull cancelled.")
 			os.Exit(2)
 		}

--- a/docs/users/providers/drud-s3.md
+++ b/docs/users/providers/drud-s3.md
@@ -22,4 +22,8 @@ If you have ddev installed, and have an active DDEV-Live account, you can follow
 
 4. Run `ddev pull`. The ddev environment will spin up, download the latest backup, and import the database and files into the ddev environment. You should now be able to access the project locally.
 
+### Imports
+
+Running `ddev pull` will connect to Drud-S3 to find the latest versions of the database and files backups from the specified environment. If new versions are available, they are downloaded and stored in ~/.ddev/drud-s3. If the stored copies there are the latest copies, ddev will use these cached copies instead of downloading them again. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags. Use the `--env` flag to specify the Drud-S3 environment being pulled from.
+
 _**Note for WordPress Users:** In order for your local project to load file assets from your local environment rather than the Drud-S3 environment it was pulled from, the URL of the project must be changed in the database by performing a search and replace. ddev provides an example `wp search-replace` as a post-pull hook in the config.yaml for your project. It is recommended to populate and uncomment this example so that replacement is done any time a backup is pulled from Drud-S3._

--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -50,7 +50,7 @@ After you copy your Pantheon project’s codebase locally, you can use `ddev con
 
 ### Imports
 
-Running `ddev pull` will connect to Pantheon through their API to find the latest versions of the database and files backups from the specified environment. If new versions are available on Pantheon, they are downloaded and stored in ~/.ddev/pantheon. If the stored copies there are the latest copies, ddev will use these cached copies instead of downloading them again.
+Running `ddev pull` will connect to Pantheon through their API to find the latest versions of the database and files backups from the specified environment. If new versions are available on Pantheon, they are downloaded and stored in ~/.ddev/pantheon. If the stored copies there are the latest copies, ddev will use these cached copies instead of downloading them again. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags. Use the `--env` flag to specify the Pantheon environment being pulled from.
 
 _**Note for WordPress Users:** In order for your local project to load file assets from your local environment rather than the Pantheon environment it was pulled from, the URL of the project must be changed in the database by performing a search and replace. ddev provides an example `wp search-replace` as a post-pull hook in the config.yaml for your project. It is recommended to populate and uncomment this example so that replacement is done any time a backup is pulled from Pantheon._
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -56,7 +56,7 @@ type Provider interface {
 	Write(string) error
 	Read(string) error
 	Validate() error
-	GetBackup(string) (fileLocation string, importPath string, err error)
+	GetBackup(string, string) (fileLocation string, importPath string, err error)
 }
 
 // init() is for testing situations only, allowing us to override the default webserver type

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -403,9 +403,10 @@ func (app *DdevApp) SiteStatus() string {
 
 // PullOptions allows for customization of the pull process.
 type PullOptions struct {
-	SkipDb     bool
-	SkipFiles  bool
-	SkipImport bool
+	SkipDb      bool
+	SkipFiles   bool
+	SkipImport  bool
+	Environment string
 }
 
 // Pull performs an import from the a configured provider plugin, if one exists.
@@ -429,7 +430,7 @@ func (app *DdevApp) Pull(provider Provider, opts *PullOptions) error {
 		output.UserOut.Println("Skipping database pull.")
 	} else {
 		output.UserOut.Println("Downloading database...")
-		fileLocation, importPath, err := provider.GetBackup("database")
+		fileLocation, importPath, err := provider.GetBackup("database", opts.Environment)
 		if err != nil {
 			return err
 		}
@@ -451,7 +452,7 @@ func (app *DdevApp) Pull(provider Provider, opts *PullOptions) error {
 		output.UserOut.Println("Skipping files pull.")
 	} else {
 		output.UserOut.Println("Downloading file archive...")
-		fileLocation, importPath, err := provider.GetBackup("files")
+		fileLocation, importPath, err := provider.GetBackup("files", opts.Environment)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -171,7 +171,7 @@ func TestPantheonPull(t *testing.T) {
 	// Ensure we can do a pull on the configured site.
 	app, err = GetActiveApp("")
 	assert.NoError(err)
-	err = app.Import(&ImportOptions{})
+	err = app.Pull(&provider, &PullOptions{})
 	assert.NoError(err)
 	err = app.Down(true, false)
 	assert.NoError(err)

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -118,11 +118,11 @@ func TestPantheonBackupLinks(t *testing.T) {
 	provider.EnvironmentName = pantheonTestEnvName
 
 	// Ensure GetBackup triggers an error for unknown backup types.
-	_, _, err = provider.GetBackup(util.RandString(8))
+	_, _, err = provider.GetBackup(util.RandString(8), "")
 	assert.Error(err)
 
 	// Ensure we can get a
-	backupLink, importPath, err := provider.GetBackup("database")
+	backupLink, importPath, err := provider.GetBackup("database", "")
 
 	assert.Equal(importPath, "")
 	assert.Contains(backupLink, "database.sql.gz")

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -171,7 +171,7 @@ func TestPantheonPull(t *testing.T) {
 	// Ensure we can do a pull on the configured site.
 	app, err = GetActiveApp("")
 	assert.NoError(err)
-	err = app.Import()
+	err = app.Import(&ImportOptions{})
 	assert.NoError(err)
 	err = app.Down(true, false)
 	assert.NoError(err)

--- a/pkg/ddevapp/providerDefault.go
+++ b/pkg/ddevapp/providerDefault.go
@@ -43,6 +43,6 @@ func (p *DefaultProvider) Validate() error {
 }
 
 // GetBackup provides a no-op for the GetBackup operation.
-func (p *DefaultProvider) GetBackup(backupType string) (fileLocation string, importPath string, err error) {
+func (p *DefaultProvider) GetBackup(backupType, environment string) (fileLocation string, importPath string, err error) {
 	return "", "", nil
 }

--- a/pkg/ddevapp/providerDrudS3_test.go
+++ b/pkg/ddevapp/providerDrudS3_test.go
@@ -181,7 +181,7 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 	assert.NoError(err)
 
 	// Ensure we can get a db backup on the happy path.
-	backupLink, importPath, err := provider.GetBackup("database")
+	backupLink, importPath, err := provider.GetBackup("database", "")
 	assert.NoError(err)
 	assert.Equal(importPath, "")
 	assert.True(strings.HasSuffix(backupLink, "sql.gz"))
@@ -196,7 +196,7 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 
 	// Make sure invalid access key gets correct behavior
 	provider.AWSAccessKey = "AKIAIBSTOTALLYINVALID"
-	_, _, err = provider.GetBackup("database")
+	_, _, err = provider.GetBackup("database", "")
 	assert.Error(err)
 	if err != nil {
 		assert.Contains(err.Error(), "InvalidAccessKeyId")
@@ -205,7 +205,7 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 	// Make sure invalid secret key gets correct behavior
 	provider.AWSAccessKey = accessKeyID
 	provider.AWSSecretKey = "rweeHGZ5totallyinvalidsecretkey"
-	_, _, err = provider.GetBackup("database")
+	_, _, err = provider.GetBackup("database", "")
 	assert.Error(err)
 	if err != nil {
 		assert.Contains(err.Error(), "SignatureDoesNotMatch")
@@ -214,7 +214,7 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 	// Make sure bad environment gets correct behavior.
 	provider.AWSSecretKey = secretAccessKey
 	provider.EnvironmentName = "someInvalidUnknownEnvironment"
-	_, _, err = provider.GetBackup("database")
+	_, _, err = provider.GetBackup("database", "")
 	assert.Error(err)
 	if err != nil {
 		assert.Contains(err.Error(), "could not find an environment")
@@ -223,7 +223,7 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 	// Make sure bad bucket gets correct behavior.
 	provider.S3Bucket = drudS3TestBucket
 	provider.S3Bucket = "someInvalidUnknownBucket"
-	_, _, err = provider.GetBackup("database")
+	_, _, err = provider.GetBackup("database", "")
 	assert.Error(err)
 	if err != nil {
 		assert.Contains(err.Error(), "NoSuchBucket")

--- a/pkg/ddevapp/providerDrudS3_test.go
+++ b/pkg/ddevapp/providerDrudS3_test.go
@@ -3,13 +3,14 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
-	"os"
-	"strings"
-	"testing"
 )
 
 /**
@@ -188,7 +189,7 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 	// Ensure we can do a pull on the configured site.
 	app, err = ddevapp.GetActiveApp("")
 	assert.NoError(err)
-	err = app.Import()
+	err = app.Import(&ddevapp.ImportOptions{})
 	assert.NoError(err)
 	err = app.Down(true, false)
 	assert.NoError(err)

--- a/pkg/ddevapp/providerDrudS3_test.go
+++ b/pkg/ddevapp/providerDrudS3_test.go
@@ -189,7 +189,7 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 	// Ensure we can do a pull on the configured site.
 	app, err = ddevapp.GetActiveApp("")
 	assert.NoError(err)
-	err = app.Import(&ddevapp.ImportOptions{})
+	err = app.Pull(&provider, &ddevapp.PullOptions{})
 	assert.NoError(err)
 	err = app.Down(true, false)
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:
#405 

The entire pull process was required for each invocation of `ddev pull`, which is not ideal when file and database assets can be in the many gigabytes.

## How this PR Solves The Problem:
This adds several configuration flags to `ddev pull`:
- `--skip-db` does not download or import the remote database backup asset 
- `--skip-files` does not download or import the remote file backup asset 
- `--env` determines the remote environment to pull from
- `--skip-confirmation` will bypass the interactive confirmation and begin the pull
- `--skip-import` will download file or database backup assets, but skip the import

Additionally, an update was made to respect the `DRUD_NONINTERACTIVE` environment variable to bypass confirmation, and is functionally equivalent to the `--skip-confirmation` flag.

## Manual Testing Instructions:
With a remote environment configured, execute `ddev pull` with combinations of the above flags. These changes are not adding much _new_ functionality other than the ability to configure the environment being pulled from, but are adding options to bypass default steps of the pull process.

- Ensure that the `--skip-db` flag only pulls the files archive
- Ensure that the `--skip-files` flag only pull the database archive
- Ensure that the `--env` flag switched the default environment to be pulled from
- Ensure that the `--skip-confirmation` flag bypasses the interactive confirmation step
- Ensure that the `--skip-import` flag only downloads the relevant archives and skips the import step

## Automated Testing Overview:
There remain to be no automated tests for `ddev pull`. I plan to refactor the Provider code into an interface to allow for easy mocking and improved testability.

## Related Issue Link(s):
#405 
