### PR TITLE
Validate config before writing .yaml or starting project, resolves #1095

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -55,7 +55,7 @@ var (
 	webserverTypeArg string
 )
 
-var providerName = ddevapp.DefaultProviderName
+var providerName = ddevapp.ProviderDefault
 
 // extraFlagsHandlingFunc does specific handling for additional flags, and is different per provider.
 var extraFlagsHandlingFunc func(cmd *cobra.Command, args []string, app *ddevapp.DdevApp) error
@@ -297,15 +297,12 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		app.WebserverType = webserverTypeArg
 	}
 
-	provider, err := app.GetProvider()
-	util.CheckErr(err)
-	err = provider.ValidateField("Name", app.Name)
-	if err != nil {
-		return fmt.Errorf("failed to validate configuration: %v", err)
+	// Ensure the configuration passes validation before writing config file.
+	if err := app.ValidateConfig(); err != nil {
+		return fmt.Errorf("failed to validate config: %v", err)
 	}
 
-	err = app.WriteConfig()
-	if err != nil {
+	if err := app.WriteConfig(); err != nil {
 		return fmt.Errorf("could not write ddev config file %s: %v", app.ConfigPath, err)
 	}
 

--- a/cmd/ddev/cmd/config_druds3.go
+++ b/cmd/ddev/cmd/config_druds3.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +21,7 @@ var drudS3ConfigCommand *cobra.Command = &cobra.Command{
 	Short:   "Create or modify a ddev project drud-s3 configuration in the current directory",
 	Example: `"ddev config drud-s3" or "ddev config drud-s3 --access-key-id=AKIAISOMETHINGMAGIC --secret-access-key=rweeMAGICSECRET --docroot=. --projectname=d7-kickstart --projecttype=drupal7 --bucket-name=my_aws_s3_bucket --environment=production"`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		providerName = "drud-s3"
+		providerName = ddevapp.ProviderDrudS3
 		extraFlagsHandlingFunc = handleDrudS3Flags
 	},
 	Run: handleConfigRun,

--- a/cmd/ddev/cmd/config_pantheon.go
+++ b/cmd/ddev/cmd/config_pantheon.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,7 @@ var pantheonConfigCommand *cobra.Command = &cobra.Command{
 	Short:   "Create or modify a ddev project pantheon configuration in the current directory",
 	Example: `"ddev config pantheon" or "ddev config pantheon --docroot=. --projectname=myproject --pantheon-environment=dev"`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		providerName = "pantheon"
+		providerName = ddevapp.ProviderPantheon
 		extraFlagsHandlingFunc = handlePantheonFlags
 	},
 	Run: handleConfigRun,

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -104,8 +104,8 @@ func TestConfigSetValues(t *testing.T) {
 
 	// Build config args
 	projectName := "my-project-name"
-	projectType := "typo3"
-	phpVersion := "7.1"
+	projectType := ddevapp.AppTypeTYPO3
+	phpVersion := ddevapp.PHP71
 	httpPort := "81"
 	httpsPort := "444"
 	xdebugEnabled := true
@@ -114,7 +114,7 @@ func TestConfigSetValues(t *testing.T) {
 	additionalFQDNsSlice := []string{"abc.com", "123.pizza", "xyz.co.uk"}
 	additionalFQDNs := strings.Join(additionalFQDNsSlice, ",")
 	uploadDir := filepath.Join("custom", "config", "path")
-	webserverType := "apache-fpm"
+	webserverType := ddevapp.WebserverApacheFPM
 
 	args := []string{
 		"config",

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -29,7 +29,7 @@ var (
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		HTTPProbeURI:                  "wp-admin/setup-config.php",
 		Docroot:                       "htdocs",
-		Type:                          "wordpress",
+		Type:                          ddevapp.AppTypeWordpress,
 		Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 	},
 	}

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -29,7 +29,7 @@ var (
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		HTTPProbeURI:                  "wp-admin/setup-config.php",
 		Docroot:                       "htdocs",
-		Type:                          ddevapp.AppTypeWordpress,
+		Type:                          ddevapp.AppTypeWordPress,
 		Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 	},
 	}

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -163,7 +163,7 @@ func (app *DdevApp) DetectAppType() string {
 			return appName
 		}
 	}
-	return "php"
+	return AppTypePHP
 }
 
 // PostImportDBAction calls each apptype's detector until it finds a match,

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -81,15 +81,6 @@ func init() {
 	}
 }
 
-// GetValidAppTypes returns the valid apptype keys from the appTypeMatrix
-func GetValidAppTypes() []string {
-	keys := make([]string, 0, len(appTypeMatrix))
-	for k := range appTypeMatrix {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
 // CreateSettingsFile creates the settings file (like settings.php) for the
 // provided app is the apptype has a settingsCreator function.
 func (app *DdevApp) CreateSettingsFile() (string, error) {

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -59,23 +59,23 @@ var appTypeMatrix map[string]AppTypeFuncs
 
 func init() {
 	appTypeMatrix = map[string]AppTypeFuncs{
-		"php": {},
-		"drupal6": {
+		AppTypePHP: {},
+		AppTypeDrupal6: {
 			settingsCreator: createDrupal6SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal6Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal6App, postImportDBAction: nil, configOverrideAction: drupal6ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal6PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
-		"drupal7": {
+		AppTypeDrupal7: {
 			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: drupal7ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
-		"drupal8": {
+		AppTypeDrupal8: {
 			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
-		"wordpress": {
+		AppTypeWordpress: {
 			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: wordpressImportFilesAction,
 		},
-		"typo3": {
+		AppTypeTYPO3: {
 			settingsCreator: createTypo3SettingsFile, uploadDir: getTypo3UploadDir, hookDefaultComments: getTypo3Hooks, apptypeSettingsPaths: setTypo3SiteSettingsPaths, appTypeDetect: isTypo3App, postImportDBAction: nil, configOverrideAction: typo3ConfigOverrideAction, postConfigAction: nil, postStartAction: nil, importFilesAction: typo3ImportFilesAction,
 		},
-		"backdrop": {
+		AppTypeBackdrop: {
 			settingsCreator: createBackdropSettingsFile, uploadDir: getBackdropUploadDir, hookDefaultComments: getBackdropHooks, apptypeSettingsPaths: setBackdropSiteSettingsPaths, appTypeDetect: isBackdropApp, postImportDBAction: backdropPostImportDBAction, configOverrideAction: nil, postConfigAction: nil, postStartAction: backdropPostStartAction, importFilesAction: backdropImportFilesAction,
 		},
 	}
@@ -88,15 +88,6 @@ func GetValidAppTypes() []string {
 		keys = append(keys, k)
 	}
 	return keys
-}
-
-// IsValidAppType checks to see if the given apptype string is a valid configured
-// apptype.
-func IsValidAppType(apptype string) bool {
-	if _, ok := appTypeMatrix[apptype]; ok {
-		return true
-	}
-	return false
 }
 
 // CreateSettingsFile creates the settings file (like settings.php) for the

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -69,7 +69,7 @@ func init() {
 		AppTypeDrupal8: {
 			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
-		AppTypeWordpress: {
+		AppTypeWordPress: {
 			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: wordpressImportFilesAction,
 		},
 		AppTypeTYPO3: {

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -21,11 +21,11 @@ func TestApptypeDetection(t *testing.T) {
 	assert := asrt.New(t)
 
 	fileLocations := map[string]string{
-		"drupal6":   "misc/ahah.js",
-		"drupal7":   "misc/ajax.js",
-		"drupal8":   "core/scripts/drupal.sh",
-		"wordpress": "wp-settings.php",
-		"backdrop":  "core/scripts/backdrop.sh",
+		ddevapp.AppTypeDrupal6:   "misc/ahah.js",
+		ddevapp.AppTypeDrupal7:   "misc/ajax.js",
+		ddevapp.AppTypeDrupal8:   "core/scripts/drupal.sh",
+		ddevapp.AppTypeWordpress: "wp-settings.php",
+		ddevapp.AppTypeBackdrop:  "core/scripts/backdrop.sh",
 	}
 
 	for expectedType, expectedPath := range fileLocations {
@@ -55,11 +55,11 @@ func TestPostConfigAction(t *testing.T) {
 	assert := asrt.New(t)
 
 	appTypes := map[string]string{
-		"drupal6":   "5.6",
-		"drupal7":   "7.1",
-		"drupal8":   ddevapp.PHPDefault,
-		"wordpress": ddevapp.PHPDefault,
-		"backdrop":  ddevapp.PHPDefault,
+		ddevapp.AppTypeDrupal6:   ddevapp.PHP56,
+		ddevapp.AppTypeDrupal7:   ddevapp.PHP71,
+		ddevapp.AppTypeDrupal8:   ddevapp.PHPDefault,
+		ddevapp.AppTypeWordpress: ddevapp.PHPDefault,
+		ddevapp.AppTypeBackdrop:  ddevapp.PHPDefault,
 	}
 
 	for appType, expectedPHPVersion := range appTypes {

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -24,7 +24,7 @@ func TestApptypeDetection(t *testing.T) {
 		ddevapp.AppTypeDrupal6:   "misc/ahah.js",
 		ddevapp.AppTypeDrupal7:   "misc/ajax.js",
 		ddevapp.AppTypeDrupal8:   "core/scripts/drupal.sh",
-		ddevapp.AppTypeWordpress: "wp-settings.php",
+		ddevapp.AppTypeWordPress: "wp-settings.php",
 		ddevapp.AppTypeBackdrop:  "core/scripts/backdrop.sh",
 	}
 
@@ -58,7 +58,7 @@ func TestPostConfigAction(t *testing.T) {
 		ddevapp.AppTypeDrupal6:   ddevapp.PHP56,
 		ddevapp.AppTypeDrupal7:   ddevapp.PHP71,
 		ddevapp.AppTypeDrupal8:   ddevapp.PHPDefault,
-		ddevapp.AppTypeWordpress: ddevapp.PHPDefault,
+		ddevapp.AppTypeWordPress: ddevapp.PHPDefault,
 		ddevapp.AppTypeBackdrop:  ddevapp.PHPDefault,
 	}
 

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -41,7 +41,7 @@ func TestApptypeDetection(t *testing.T) {
 		_, err = os.OpenFile(filepath.Join(testDir, expectedPath), os.O_RDONLY|os.O_CREATE, 0666)
 		assert.NoError(err)
 
-		app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+		app, err := ddevapp.NewApp(testDir, ddevapp.ProviderDefault)
 		assert.NoError(err)
 
 		foundType := app.DetectAppType()
@@ -57,9 +57,9 @@ func TestPostConfigAction(t *testing.T) {
 	appTypes := map[string]string{
 		"drupal6":   "5.6",
 		"drupal7":   "7.1",
-		"drupal8":   ddevapp.DdevDefaultPHPVersion,
-		"wordpress": ddevapp.DdevDefaultPHPVersion,
-		"backdrop":  ddevapp.DdevDefaultPHPVersion,
+		"drupal8":   ddevapp.PHPDefault,
+		"wordpress": ddevapp.PHPDefault,
+		"backdrop":  ddevapp.PHPDefault,
 	}
 
 	for appType, expectedPHPVersion := range appTypes {
@@ -69,7 +69,7 @@ func TestPostConfigAction(t *testing.T) {
 		defer testcommon.CleanupDir(testDir)
 		defer testcommon.Chdir(testDir)()
 
-		app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+		app, err := ddevapp.NewApp(testDir, ddevapp.ProviderDefault)
 		assert.NoError(err)
 
 		// Prompt for apptype as a way to get it into the config.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -263,10 +263,6 @@ func (app *DdevApp) PromptForConfig() error {
 
 // ValidateConfig ensures the configuration meets ddev's requirements.
 func (app *DdevApp) ValidateConfig() error {
-	if _, err := os.Stat(app.ConfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("no valid project config.yaml was found at %s", app.ConfigPath).(invalidConfigFile)
-	}
-
 	// validate hostnames
 	for _, hn := range app.GetHostnames() {
 		if !hostRegex.MatchString(hn) {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -23,12 +23,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// DdevDefaultRouterHTTPPort is the starting router port, 80
-const DdevDefaultRouterHTTPPort = "80"
-
-// DdevDefaultRouterHTTPSPort is the starting https router port, 443
-const DdevDefaultRouterHTTPSPort = "443"
-
 // Regexp pattern to determine if a hostname is valid per RFC 1123.
 var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
 
@@ -373,12 +367,12 @@ func (app *DdevApp) CheckCustomConfig() {
 	ddevDir := filepath.Dir(app.ConfigPath)
 
 	customConfig := false
-	if _, err := os.Stat(filepath.Join(ddevDir, "nginx-site.conf")); err == nil && app.WebserverType == "nginx-fpm" {
+	if _, err := os.Stat(filepath.Join(ddevDir, "nginx-site.conf")); err == nil && app.WebserverType == WebserverNginxFPM {
 		util.Warning("Using custom nginx configuration in nginx-site.conf")
 		customConfig = true
 	}
 
-	if _, err := os.Stat(filepath.Join(ddevDir, "apache", "apache-site.conf")); err == nil && app.WebserverType != "nginx-fpm" {
+	if _, err := os.Stat(filepath.Join(ddevDir, "apache", "apache-site.conf")); err == nil && app.WebserverType != WebserverNginxFPM {
 		util.Warning("Using custom apache configuration in apache/apache-site.conf")
 		customConfig = true
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -259,7 +259,7 @@ func (app *DdevApp) PromptForConfig() error {
 func (app *DdevApp) ValidateConfig() error {
 	provider, err := app.GetProvider()
 	if err != nil {
-		return err
+		return err.(invalidProvider)
 	}
 
 	// validate project name
@@ -281,17 +281,12 @@ func (app *DdevApp) ValidateConfig() error {
 
 	// validate PHP version
 	if !IsValidPHPVersion(app.PHPVersion) {
-		return fmt.Errorf("invalid PHP version: %s", app.PHPVersion).(invalidPHPVersion)
+		return fmt.Errorf("invalid PHP version: %s, must be one of %v", app.PHPVersion, GetValidPHPVersions()).(invalidPHPVersion)
 	}
 
 	// validate webserver type
 	if !IsValidWebserverType(app.WebserverType) {
-		return fmt.Errorf("invalid webserver type: %s", app.WebserverType).(invalidWebserverType)
-	}
-
-	// validate provider
-	if !IsValidProvider(app.Provider) {
-		return fmt.Errorf("invalid provider: %s", app.Provider).(invalidProvider)
+		return fmt.Errorf("invalid webserver type: %s, must be one of %s", app.WebserverType, GetValidWebserverTypes()).(invalidWebserverType)
 	}
 
 	return nil

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -257,6 +257,16 @@ func (app *DdevApp) PromptForConfig() error {
 
 // ValidateConfig ensures the configuration meets ddev's requirements.
 func (app *DdevApp) ValidateConfig() error {
+	provider, err := app.GetProvider()
+	if err != nil {
+		return err
+	}
+
+	// validate project name
+	if err = provider.ValidateField("Name", app.Name); err != nil {
+		return err.(invalidAppName)
+	}
+
 	// validate hostnames
 	for _, hn := range app.GetHostnames() {
 		if !hostRegex.MatchString(hn) {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -467,7 +467,7 @@ func TestValidate(t *testing.T) {
 	app.Name = "Invalid!"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "invalid hostname")
+	assert.Contains(err.Error(), "not a valid project name")
 
 	app.Docroot = "testdata"
 	app.Name = "valid"
@@ -475,6 +475,30 @@ func TestValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	assert.Error(err)
 	assert.Contains(err.Error(), "invalid app type")
+
+	app.Type = AppTypeWordpress
+	app.PHPVersion = "1.1"
+	err = app.ValidateConfig()
+	assert.Error(err)
+	assert.Contains(err.Error(), "invalid PHP")
+
+	app.PHPVersion = PHPDefault
+	app.WebserverType = "server"
+	err = app.ValidateConfig()
+	assert.Error(err)
+	assert.Contains(err.Error(), "invalid webserver type")
+
+	app.WebserverType = WebserverDefault
+	app.AdditionalHostnames = []string{"good", "b@d"}
+	err = app.ValidateConfig()
+	assert.Error(err)
+	assert.Contains(err.Error(), "invalid hostname")
+
+	app.AdditionalHostnames = []string{}
+	app.AdditionalFQDNs = []string{"good.com", "b@d.com"}
+	err = app.ValidateConfig()
+	assert.Error(err)
+	assert.Contains(err.Error(), "invalid hostname")
 }
 
 // TestWriteConfig tests writing config values to file

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -449,11 +449,14 @@ func TestValidate(t *testing.T) {
 	assert.NoError(err)
 
 	app := &DdevApp{
-		Name:       "TestValidate",
-		ConfigPath: filepath.Join("testdata", "config.yaml"),
-		AppRoot:    cwd,
-		Docroot:    "testdata",
-		Type:       "wordpress",
+		Name:          "TestValidate",
+		ConfigPath:    filepath.Join("testdata", "config.yaml"),
+		AppRoot:       cwd,
+		Docroot:       "testdata",
+		Type:          AppTypeWordpress,
+		PHPVersion:    PHPDefault,
+		WebserverType: WebserverDefault,
+		Provider:      ProviderDefault,
 	}
 
 	err = app.ValidateConfig()
@@ -463,13 +466,15 @@ func TestValidate(t *testing.T) {
 
 	app.Name = "Invalid!"
 	err = app.ValidateConfig()
-	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a project name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", app.GetHostname()))
+	assert.Error(err)
+	assert.Contains(err.Error(), "invalid hostname")
 
 	app.Docroot = "testdata"
 	app.Name = "valid"
 	app.Type = "potato"
 	err = app.ValidateConfig()
-	assert.EqualError(err, fmt.Sprintf("'%s' is not a valid apptype", app.Type))
+	assert.Error(err)
+	assert.Contains(err.Error(), "invalid app type")
 }
 
 // TestWriteConfig tests writing config values to file
@@ -486,7 +491,7 @@ func TestWriteConfig(t *testing.T) {
 		WebImage:   version.WebImg + ":" + version.WebTag,
 		DBImage:    version.DBImg + ":" + version.DBTag,
 		DBAImage:   version.DBAImg + ":" + version.DBATag,
-		Type:       "drupal8",
+		Type:       AppTypeDrupal8,
 		Provider:   ProviderDefault,
 	}
 
@@ -498,7 +503,7 @@ func TestWriteConfig(t *testing.T) {
 	assert.Contains(string(out), "TestWrite")
 	assert.Contains(string(out), `exec: drush cr`)
 
-	app.Type = "wordpress"
+	app.Type = AppTypeWordpress
 	err = app.WriteConfig()
 	assert.NoError(err)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -453,7 +453,7 @@ func TestValidate(t *testing.T) {
 		ConfigPath:    filepath.Join("testdata", "config.yaml"),
 		AppRoot:       cwd,
 		Docroot:       "testdata",
-		Type:          AppTypeWordpress,
+		Type:          AppTypeWordPress,
 		PHPVersion:    PHPDefault,
 		WebserverType: WebserverDefault,
 		Provider:      ProviderDefault,
@@ -476,7 +476,7 @@ func TestValidate(t *testing.T) {
 	assert.Error(err)
 	assert.Contains(err.Error(), "invalid app type")
 
-	app.Type = AppTypeWordpress
+	app.Type = AppTypeWordPress
 	app.PHPVersion = "1.1"
 	err = app.ValidateConfig()
 	assert.Error(err)
@@ -527,7 +527,7 @@ func TestWriteConfig(t *testing.T) {
 	assert.Contains(string(out), "TestWrite")
 	assert.Contains(string(out), `exec: drush cr`)
 
-	app.Type = AppTypeWordpress
+	app.Type = AppTypeWordPress
 	err = app.WriteConfig()
 	assert.NoError(err)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -28,7 +28,7 @@ func TestNewConfig(t *testing.T) {
 	defer testcommon.Chdir(testDir)()
 
 	// Load a new Config
-	app, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, ProviderDefault)
 	assert.NoError(err)
 
 	// Ensure the config uses specified defaults.
@@ -45,7 +45,7 @@ func TestNewConfig(t *testing.T) {
 	_, err = os.Stat(app.ConfigPath)
 	assert.NoError(err)
 
-	loadedConfig, err := NewApp(testDir, DefaultProviderName)
+	loadedConfig, err := NewApp(testDir, ProviderDefault)
 	assert.NoError(err)
 	assert.Equal(app.Name, loadedConfig.Name)
 	assert.Equal(app.Type, loadedConfig.Type)
@@ -73,7 +73,7 @@ func TestPrepDirectory(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	app, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, ProviderDefault)
 	assert.NoError(err)
 
 	// Prep the directory.
@@ -91,7 +91,7 @@ func TestHostName(t *testing.T) {
 	testDir := testcommon.CreateTmpDir("TestHostName")
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
-	app, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, ProviderDefault)
 	assert.NoError(err)
 	app.Name = util.RandString(32)
 
@@ -106,7 +106,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	app, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, ProviderDefault)
 	assert.NoError(err)
 	app.Name = util.RandString(32)
 	app.Type = GetValidAppTypes()[0]
@@ -161,7 +161,7 @@ func TestConfigCommand(t *testing.T) {
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
-		app, err := NewApp(testDir, DefaultProviderName)
+		app, err := NewApp(testDir, ProviderDefault)
 		assert.NoError(err)
 
 		// Randomize some values to use for Stdin during testing.
@@ -229,7 +229,7 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
-		app, err := NewApp(testDir, DefaultProviderName)
+		app, err := NewApp(testDir, ProviderDefault)
 		assert.NoError(err)
 
 		// Randomize some values to use for Stdin during testing.
@@ -275,7 +275,7 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
-		app, err := NewApp(testDir, DefaultProviderName)
+		app, err := NewApp(testDir, ProviderDefault)
 		assert.NoError(err)
 
 		// Randomize some values to use for Stdin during testing.
@@ -331,7 +331,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
-		app, err := NewApp(testDir, DefaultProviderName)
+		app, err := NewApp(testDir, ProviderDefault)
 		assert.NoError(err)
 
 		// Randomize some values to use for Stdin during testing.
@@ -386,7 +386,7 @@ func TestConfigCommandDocrootDetectionIndexVerification(t *testing.T) {
 
 	// Create the ddevapp we'll use for testing.
 	// This will not return an error, since there is no existing configuration.
-	app, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, ProviderDefault)
 	assert.NoError(err)
 
 	// Randomize some values to use for Stdin during testing.
@@ -423,7 +423,7 @@ func TestReadConfig(t *testing.T) {
 		ConfigPath: filepath.Join("testdata", "config.yaml"),
 		AppRoot:    "testdata",
 		Name:       "TestRead",
-		Provider:   DefaultProviderName,
+		Provider:   ProviderDefault,
 	}
 
 	err := app.ReadConfig()
@@ -487,7 +487,7 @@ func TestWriteConfig(t *testing.T) {
 		DBImage:    version.DBImg + ":" + version.DBTag,
 		DBAImage:   version.DBAImg + ":" + version.DBATag,
 		Type:       "drupal8",
-		Provider:   DefaultProviderName,
+		Provider:   ProviderDefault,
 	}
 
 	err := app.WriteConfig()
@@ -526,7 +526,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	app, err := NewApp(testDir, DefaultProviderName)
+	app, err := NewApp(testDir, ProviderDefault)
 	assert.NoError(err)
 
 	err = app.ReadConfig()

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -37,7 +37,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(app.WebImage, version.WebImg+":"+version.WebTag)
 	assert.Equal(app.DBAImage, version.DBAImg+":"+version.DBATag)
 	app.Name = util.RandString(32)
-	app.Type = "drupal8"
+	app.Type = AppTypeDrupal8
 
 	// WriteConfig the app.
 	err = app.WriteConfig()
@@ -140,9 +140,9 @@ func TestConfigCommand(t *testing.T) {
 	const apptypePos = 0
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
-		"drupal6phpversion": {"drupal6", "5.6"},
-		"drupal7phpversion": {"drupal7", "7.1"},
-		"drupal8phpversion": {"drupal8", "7.1"},
+		"drupal6phpversion": {AppTypeDrupal6, PHP56},
+		"drupal7phpversion": {AppTypeDrupal7, PHP71},
+		"drupal8phpversion": {AppTypeDrupal8, PHP71},
 	}
 
 	for testName, testValues := range testMatrix {
@@ -215,9 +215,9 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 	assert := asrt.New(t)
 
 	testMatrix := map[string][]string{
-		"drupal6phpversion": {"drupal6", "5.6"},
-		"drupal7phpversion": {"drupal7", "7.1"},
-		"drupal8phpversion": {"drupal8", "7.1"},
+		"drupal6phpversion": {AppTypeDrupal6, PHP56},
+		"drupal7phpversion": {AppTypeDrupal7, PHP71},
+		"drupal8phpversion": {AppTypeDrupal8, PHP71},
 	}
 
 	for testName := range testMatrix {
@@ -261,9 +261,9 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 	const apptypePos = 0
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
-		"drupal6phpversion": {"drupal6", "5.6"},
-		"drupal7phpversion": {"drupal7", "7.1"},
-		"drupal8phpversion": {"drupal8", "7.1"},
+		"drupal6phpversion": {AppTypeDrupal6, PHP56},
+		"drupal7phpversion": {AppTypeDrupal7, PHP71},
+		"drupal8phpversion": {AppTypeDrupal8, PHP71},
 	}
 
 	for testName, testValues := range testMatrix {
@@ -352,7 +352,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 
 		// Ensure values were properly set on the app struct.
 		assert.Equal(name, app.Name)
-		assert.Equal("drupal8", app.Type)
+		assert.Equal(AppTypeDrupal8, app.Type)
 		assert.Equal(testDocrootName, app.Docroot)
 		err = PrepDdevDirectory(testDir)
 		assert.NoError(err)
@@ -407,7 +407,7 @@ func TestConfigCommandDocrootDetectionIndexVerification(t *testing.T) {
 
 	// Ensure values were properly set on the app struct.
 	assert.Equal(name, app.Name)
-	assert.Equal("drupal8", app.Type)
+	assert.Equal(AppTypeDrupal8, app.Type)
 	assert.Equal("docroot", app.Docroot)
 	err = PrepDdevDirectory(testDir)
 	assert.NoError(err)
@@ -436,7 +436,7 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(app.APIVersion, version.DdevVersion)
 
 	// Values defined in file, we should have values from file
-	assert.Equal(app.Type, "drupal8")
+	assert.Equal(app.Type, AppTypeDrupal8)
 	assert.Equal(app.Docroot, "test")
 	assert.Equal(app.WebImage, "test/testimage:latest")
 }
@@ -546,7 +546,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 	assert.Contains(out, "my-php.ini")
 
 	switch app.WebserverType {
-	case "nginx-fpm":
+	case WebserverNginxFPM:
 		assert.Contains(out, "nginx-site.conf")
 		assert.NotContains(out, "apache-site.conf")
 	default:

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1207,19 +1207,7 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 	// incomplete one we have to add to it.
 	if err = app.Init(activeAppRoot); err != nil {
 		switch err.(type) {
-		case webContainerExists:
-			return app, err
-		case invalidConfigFile:
-			return app, err
-		case invalidHostname:
-			return app, err
-		case invalidAppType:
-			return app, err
-		case invalidPHPVersion:
-			return app, err
-		case invalidWebserverType:
-			return app, err
-		case invalidProvider:
+		case webContainerExists, invalidConfigFile, invalidHostname, invalidAppType, invalidPHPVersion, invalidWebserverType, invalidProvider:
 			return app, err
 		}
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -122,7 +122,7 @@ func (app *DdevApp) Init(basePath string) error {
 	if err == nil {
 		containerApproot := web.Labels["com.ddev.approot"]
 		if containerApproot != app.AppRoot {
-			return fmt.Errorf("a project (web container) in %s state already exists for %s that was created at %s", web.State, app.Name, containerApproot)
+			return fmt.Errorf("a project (web container) in %s state already exists for %s that was created at %s", web.State, app.Name, containerApproot).(webContainerExists)
 		}
 		return nil
 	} else if strings.Contains(err.Error(), "unable to find any running or stopped containers") {
@@ -225,7 +225,7 @@ func (app *DdevApp) GetName() string {
 
 // GetPhpVersion returns the app's php version
 func (app *DdevApp) GetPhpVersion() string {
-	v := DdevDefaultPHPVersion
+	v := PHPDefault
 	if app.PHPVersion != "" {
 		v = app.PHPVersion
 	}
@@ -234,7 +234,7 @@ func (app *DdevApp) GetPhpVersion() string {
 
 // GetWebserverType returns the app's webserver type (nginx-fpm/apache-fpm/apache-cgi)
 func (app *DdevApp) GetWebserverType() string {
-	v := DdevDefaultWebserverType
+	v := WebserverDefault
 	if app.WebserverType != "" {
 		v = app.WebserverType
 	}
@@ -1205,9 +1205,23 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 	// Mostly ignore app.Init() error, since app.Init() fails if no directory found. Some errors should be handled though.
 	// We already were successful with *finding* the app, and if we get an
 	// incomplete one we have to add to it.
-	err = app.Init(activeAppRoot)
-	if err != nil && (strings.Contains(err.Error(), "is not a valid hostname") || strings.Contains(err.Error(), "is not a valid apptype") || strings.Contains(err.Error(), "config.yaml exists but cannot be read.") || strings.Contains(err.Error(), "a project (web container) in ")) {
-		return app, err
+	if err := app.Init(activeAppRoot); err != nil {
+		switch err.(type) {
+		case webContainerExists:
+			return app, err
+		case invalidConfigFile:
+			return app, err
+		case invalidHostname:
+			return app, err
+		case invalidAppType:
+			return app, err
+		case invalidPHPVersion:
+			return app, err
+		case invalidWebserverType:
+			return app, err
+		case invalidProvider:
+			return app, err
+		}
 	}
 
 	if app.Name == "" {
@@ -1240,13 +1254,13 @@ func (app *DdevApp) GetProvider() (Provider, error) {
 	err := fmt.Errorf("unknown provider type: %s", app.Provider)
 
 	switch app.Provider {
-	case "pantheon":
+	case ProviderPantheon:
 		provider = &PantheonProvider{}
 		err = provider.Init(app)
-	case "drud-s3":
+	case ProviderDrudS3:
 		provider = &DrudS3Provider{}
 		err = provider.Init(app)
-	case DefaultProviderName:
+	case ProviderDefault:
 		provider = &DefaultProvider{}
 		err = nil
 	default:

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1251,7 +1251,7 @@ func (app *DdevApp) GetProvider() (Provider, error) {
 	}
 
 	var provider Provider
-	err := fmt.Errorf("unknown provider type: %s", app.Provider)
+	err := fmt.Errorf("unknown provider type: %s, must be one of %v", app.Provider, GetValidProviders())
 
 	switch app.Provider {
 	case ProviderPantheon:

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1205,7 +1205,7 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 	// Mostly ignore app.Init() error, since app.Init() fails if no directory found. Some errors should be handled though.
 	// We already were successful with *finding* the app, and if we get an
 	// incomplete one we have to add to it.
-	if err := app.Init(activeAppRoot); err != nil {
+	if err = app.Init(activeAppRoot); err != nil {
 		switch err.(type) {
 		case webContainerExists:
 			return app, err

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -39,10 +39,7 @@ var (
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_db.tar.gz",
 			Docroot:                       "htdocs",
-			Type:                          "wordpress",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "this post has a photo"},
-			FilesImageURI:                 "/wp-content/uploads/2017/04/pexels-photo-265186-1024x683.jpeg",
+			Type:                          ddevapp.AppTypeWordpress,
 		},
 		{
 			Name:                          "TestPkgDrupal8",
@@ -53,7 +50,7 @@ var (
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/drupal8_6_1_db.tar.gz",
 			DBZipURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/drupal8_db.zip",
 			FullSiteTarballURL:            "",
-			Type:                          "drupal8",
+			Type:                          ddevapp.AppTypeDrupal8,
 			Docroot:                       "",
 			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "Drupal is an open source content management platform"},
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/node/1", Expect: "this is a post with an image"},
@@ -61,16 +58,13 @@ var (
 		},
 		{
 			Name:                          "TestPkgDrupal7", // Drupal Kickstart on D7
-			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-7.59.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-7.59/",
-			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d7test-7.59.files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d7test-7.59-db.tar.gz",
-			FullSiteTarballURL:            "",
-			Docroot:                       "",
-			Type:                          "drupal7",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "Drupal is an open source content management platform"},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/node/1", Expect: "D7 test project, kittens edition"},
-			FilesImageURI:                 "/sites/default/files/field/image/kittens-large.jpg",
+			SourceURL:                     "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-kickstart-0.4.0/",
+			FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
+			FullSiteTarballURL:            "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/site.tar.gz",
+			Docroot:                       "docroot",
+			Type:                          ddevapp.AppTypeDrupal7,
 			FullSiteArchiveExtPath:        "docroot/sites/default/files",
 		},
 		{
@@ -81,10 +75,7 @@ var (
 			FullSiteTarballURL:            "",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/drupal6_files.tar.gz",
 			Docroot:                       "",
-			Type:                          "drupal6",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/CHANGELOG.txt", Expect: "Drupal 6.38, 2016-02-24"},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/node/2", Expect: "This is a story. The story is somewhat shaky"},
-			FilesImageURI:                 "/sites/default/files/garland_logo.jpg",
+			Type:                          ddevapp.AppTypeDrupal6,
 		},
 		{
 			Name:                          "TestPkgBackdrop",
@@ -94,10 +85,7 @@ var (
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/backdrop_files.11.0.tar.gz",
 			FullSiteTarballURL:            "",
 			Docroot:                       "",
-			Type:                          "backdrop",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.md", Expect: "Backdrop is a full-featured content management system"},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/posts/first-post-all-about-kittens", Expect: "Lots of kittens are a good thing"},
-			FilesImageURI:                 "/files/styles/large/public/field/image/kittens-large.jpg",
+			Type:                          ddevapp.AppTypeBackdrop,
 		},
 		{
 			Name:                          "TestPkgTypo3",
@@ -106,11 +94,8 @@ var (
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3_v9.5_introduction_db.tar.gz",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3_v9.5_introduction_files.tar.gz",
 			FullSiteTarballURL:            "",
-			Docroot:                       "public",
-			Type:                          "typo3",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "junk readme simply for reading"},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/index.php?id=65", Expect: "Boxed Content"},
-			FilesImageURI:                 "/fileadmin/introduction/images/streets/nikita-maru-70928.jpg",
+			Docroot:                       "",
+			Type:                          ddevapp.AppTypeTYPO3,
 		},
 	}
 	FullTestSites = TestSites
@@ -1001,15 +986,15 @@ func TestDdevExec(t *testing.T) {
 		assert.NoError(err)
 
 		switch app.GetType() {
-		case "drupal6":
+		case ddevapp.AppTypeDrupal6:
 			fallthrough
-		case "drupal7":
+		case ddevapp.AppTypeDrupal7:
 			fallthrough
-		case "drupal8":
+		case ddevapp.AppTypeDrupal8:
 			out, _, err = app.Exec("web", "drush", "status")
 			assert.NoError(err)
 			assert.Regexp("PHP configuration[ :]*/etc/php/[0-9].[0-9]/fpm/php.ini", out)
-		case "wordpress":
+		case ddevapp.AppTypeWordpress:
 			out, _, err = app.Exec("web", "wp", "--info")
 			assert.NoError(err)
 			assert.Regexp("/etc/php.*/php.ini", out)
@@ -1534,7 +1519,7 @@ func TestHttpsRedirection(t *testing.T) {
 	err = os.Chdir(appDir)
 	assert.NoError(err)
 
-	app, err := ddevapp.NewApp(appDir, ddevapp.DefaultProviderName)
+	app, err := ddevapp.NewApp(appDir, ddevapp.ProviderDefault)
 	assert.NoError(err)
 	app.Name = "proj"
 	app.Type = "php"

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -526,17 +526,17 @@ func TestDdevImportDB(t *testing.T) {
 
 			// Test that a settings file has correct hash_salt format
 			switch app.Type {
-			case "drupal7":
+			case ddevapp.AppTypeDrupal7:
 				// nolint: vetshadow
 				drupalHashSalt, err := fileutil.FgrepStringInFile(app.SiteLocalSettingsPath, "$drupal_hash_salt")
 				assert.NoError(err)
 				assert.True(drupalHashSalt)
-			case "drupal8":
+			case ddevapp.AppTypeDrupal8:
 				// nolint: vetshadow
 				settingsHashSalt, err := fileutil.FgrepStringInFile(app.SiteLocalSettingsPath, "settings['hash_salt']")
 				assert.NoError(err)
 				assert.True(settingsHashSalt)
-			case "wordpress":
+			case ddevapp.AppTypeWordpress:
 				// nolint: vetshadow
 				hasAuthSalt, err := fileutil.FgrepStringInFile(app.SiteSettingsPath, "SECURE_AUTH_SALT")
 				assert.NoError(err)
@@ -1461,7 +1461,7 @@ func TestListWithoutDir(t *testing.T) {
 	app, err := ddevapp.NewApp(testDir, ddevapp.ProviderDefault)
 	assert.NoError(err)
 	app.Name = "junk"
-	app.Type = "drupal7"
+	app.Type = ddevapp.AppTypeDrupal7
 	err = app.WriteConfig()
 	assert.NoError(err)
 
@@ -1537,7 +1537,7 @@ func TestHttpsRedirection(t *testing.T) {
 	app, err := ddevapp.NewApp(appDir, ddevapp.ProviderDefault)
 	assert.NoError(err)
 	app.Name = "proj"
-	app.Type = "php"
+	app.Type = ddevapp.AppTypePHP
 
 	expectations := []URLRedirectExpectations{
 		{"https", "/subdir", "/subdir/"},
@@ -1548,7 +1548,7 @@ func TestHttpsRedirection(t *testing.T) {
 		{"http", "/redir_relative.php", "/landed.php"},
 	}
 
-	for _, webserverType := range []string{"nginx-fpm", "apache-fpm", "apache-cgi"} {
+	for _, webserverType := range []string{ddevapp.WebserverNginxFPM, ddevapp.WebserverApacheFPM, ddevapp.WebserverApacheCGI} {
 		app.WebserverType = webserverType
 		err = app.WriteConfig()
 		assert.NoError(err)
@@ -1572,7 +1572,7 @@ func TestHttpsRedirection(t *testing.T) {
 
 				expectedRedirect := parts.expectedRedirectURI
 				// However, if we're hitting redir_abs.php (or apache hitting directory), the redirect will be the whole url.
-				if strings.Contains(parts.uri, "redir_abs.php") || webserverType != "nginx-fpm" {
+				if strings.Contains(parts.uri, "redir_abs.php") || webserverType != ddevapp.WebserverNginxFPM {
 					expectedRedirect = parts.scheme + "://" + app.GetHostname() + parts.expectedRedirectURI
 				}
 				// Except the php relative redirect is always relative.
@@ -1744,7 +1744,7 @@ func TestWebserverType(t *testing.T) {
 		err = fileutil.CopyFile(filepath.Join(pwd, "testdata", "servertype.php"), filepath.Join(app.AppRoot, app.Docroot, "servertype.php"))
 
 		assert.NoError(err)
-		for _, app.WebserverType = range []string{"apache-fpm", "apache-cgi", "nginx-fpm"} {
+		for _, app.WebserverType = range []string{ddevapp.WebserverApacheFPM, ddevapp.WebserverApacheCGI, ddevapp.WebserverNginxFPM} {
 
 			err = app.WriteConfig()
 			assert.NoError(err)
@@ -1759,7 +1759,7 @@ func TestWebserverType(t *testing.T) {
 			assert.NoError(err)
 
 			expectedServerType := "Apache/2"
-			if app.WebserverType == "nginx-fpm" {
+			if app.WebserverType == ddevapp.WebserverNginxFPM {
 				expectedServerType = "nginx"
 			}
 			assert.Contains(resp.Header["Server"][0], expectedServerType, "Server header for project=%s, app.WebserverType=%s should be %s", app.Name, app.WebserverType, expectedServerType)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -40,6 +40,9 @@ var (
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_db.tar.gz",
 			Docroot:                       "htdocs",
 			Type:                          ddevapp.AppTypeWordpress,
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "this post has a photo"},
+			FilesImageURI:                 "/wp-content/uploads/2017/04/pexels-photo-265186-1024x683.jpeg",
 		},
 		{
 			Name:                          "TestPkgDrupal8",
@@ -58,13 +61,16 @@ var (
 		},
 		{
 			Name:                          "TestPkgDrupal7", // Drupal Kickstart on D7
-			SourceURL:                     "https://github.com/drud/drupal-kickstart/archive/v0.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-kickstart-0.4.0/",
-			FilesTarballURL:               "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/db.tar.gz",
-			FullSiteTarballURL:            "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/site.tar.gz",
-			Docroot:                       "docroot",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-7.59.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-7.59/",
+			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d7test-7.59.files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d7test-7.59-db.tar.gz",
+			FullSiteTarballURL:            "",
+			Docroot:                       "",
 			Type:                          ddevapp.AppTypeDrupal7,
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "Drupal is an open source content management platform"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/node/1", Expect: "D7 test project, kittens edition"},
+			FilesImageURI:                 "/sites/default/files/field/image/kittens-large.jpg",
 			FullSiteArchiveExtPath:        "docroot/sites/default/files",
 		},
 		{
@@ -76,6 +82,9 @@ var (
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/drupal6_files.tar.gz",
 			Docroot:                       "",
 			Type:                          ddevapp.AppTypeDrupal6,
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/CHANGELOG.txt", Expect: "Drupal 6.38, 2016-02-24"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/node/2", Expect: "This is a story. The story is somewhat shaky"},
+			FilesImageURI:                 "/sites/default/files/garland_logo.jpg",
 		},
 		{
 			Name:                          "TestPkgBackdrop",
@@ -86,6 +95,9 @@ var (
 			FullSiteTarballURL:            "",
 			Docroot:                       "",
 			Type:                          ddevapp.AppTypeBackdrop,
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.md", Expect: "Backdrop is a full-featured content management system"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/posts/first-post-all-about-kittens", Expect: "Lots of kittens are a good thing"},
+			FilesImageURI:                 "/files/styles/large/public/field/image/kittens-large.jpg",
 		},
 		{
 			Name:                          "TestPkgTypo3",
@@ -94,8 +106,11 @@ var (
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3_v9.5_introduction_db.tar.gz",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3_v9.5_introduction_files.tar.gz",
 			FullSiteTarballURL:            "",
-			Docroot:                       "",
+			Docroot:                       "public",
 			Type:                          ddevapp.AppTypeTYPO3,
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "junk readme simply for reading"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/index.php?id=65", Expect: "Boxed Content"},
+			FilesImageURI:                 "/fileadmin/introduction/images/streets/nikita-maru-70928.jpg",
 		},
 	}
 	FullTestSites = TestSites

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1091,7 +1091,7 @@ func TestProcessHooks(t *testing.T) {
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ProcessHooks", site.Name))
 
 		testcommon.ClearDockerEnv()
-		app, err := ddevapp.NewApp(site.Dir, ddevapp.DefaultProviderName)
+		app, err := ddevapp.NewApp(site.Dir, ddevapp.ProviderDefault)
 		assert.NoError(err)
 		err = app.Start()
 		assert.NoError(err)
@@ -1458,7 +1458,7 @@ func TestListWithoutDir(t *testing.T) {
 	err = os.Chdir(testDir)
 	assert.NoError(err)
 
-	app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+	app, err := ddevapp.NewApp(testDir, ddevapp.ProviderDefault)
 	assert.NoError(err)
 	app.Name = "junk"
 	app.Type = "drupal7"

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -39,7 +39,7 @@ var (
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_db.tar.gz",
 			Docroot:                       "htdocs",
-			Type:                          ddevapp.AppTypeWordpress,
+			Type:                          ddevapp.AppTypeWordPress,
 			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "this post has a photo"},
 			FilesImageURI:                 "/wp-content/uploads/2017/04/pexels-photo-265186-1024x683.jpeg",
@@ -536,7 +536,7 @@ func TestDdevImportDB(t *testing.T) {
 				settingsHashSalt, err := fileutil.FgrepStringInFile(app.SiteLocalSettingsPath, "settings['hash_salt']")
 				assert.NoError(err)
 				assert.True(settingsHashSalt)
-			case ddevapp.AppTypeWordpress:
+			case ddevapp.AppTypeWordPress:
 				// nolint: vetshadow
 				hasAuthSalt, err := fileutil.FgrepStringInFile(app.SiteSettingsPath, "SECURE_AUTH_SALT")
 				assert.NoError(err)
@@ -1009,7 +1009,7 @@ func TestDdevExec(t *testing.T) {
 			out, _, err = app.Exec("web", "drush", "status")
 			assert.NoError(err)
 			assert.Regexp("PHP configuration[ :]*/etc/php/[0-9].[0-9]/fpm/php.ini", out)
-		case ddevapp.AppTypeWordpress:
+		case ddevapp.AppTypeWordPress:
 			out, _, err = app.Exec("web", "wp", "--info")
 			assert.NoError(err)
 			assert.Regexp("/etc/php.*/php.ini", out)

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -571,14 +571,14 @@ func isDrupal6App(app *DdevApp) bool {
 
 // drupal7ConfigOverrideAction sets a safe php_version for D7
 func drupal7ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = "7.1"
+	app.PHPVersion = PHP71
 	return nil
 }
 
 // drupal6ConfigOverrideAction overrides php_version for D6, since it is incompatible
 // with php7+
 func drupal6ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = "5.6"
+	app.PHPVersion = PHP56
 	return nil
 }
 

--- a/pkg/ddevapp/errors.go
+++ b/pkg/ddevapp/errors.go
@@ -1,6 +1,7 @@
 package ddevapp
 
 type invalidConfigFile error
+type invalidAppName error
 type invalidHostname error
 type invalidAppType error
 type invalidPHPVersion error

--- a/pkg/ddevapp/errors.go
+++ b/pkg/ddevapp/errors.go
@@ -1,0 +1,9 @@
+package ddevapp
+
+type invalidConfigFile error
+type invalidHostname error
+type invalidAppType error
+type invalidPHPVersion error
+type invalidWebserverType error
+type invalidProvider error
+type webContainerExists error

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -86,7 +86,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 
 	// Ensure values were properly set on the app struct.
 	assert.Equal(pantheonTestSiteName, app.Name)
-	assert.Equal("drupal8", app.Type)
+	assert.Equal(AppTypeDrupal8, app.Type)
 	assert.Equal("docroot", app.Docroot)
 	err = PrepDdevDirectory(testDir)
 	assert.NoError(err)
@@ -153,7 +153,7 @@ func TestPantheonPull(t *testing.T) {
 	app, err := NewApp(siteDir, ProviderPantheon)
 	assert.NoError(err)
 	app.Name = pantheonTestSiteName
-	app.Type = "drupal8"
+	app.Type = AppTypeDrupal8
 	err = app.WriteConfig()
 	assert.NoError(err)
 

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -46,7 +46,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	}
 
 	// Create the ddevapp we'll use for testing.
-	app, err := NewApp(testDir, "pantheon")
+	app, err := NewApp(testDir, ProviderPantheon)
 	assert.NoError(err)
 
 	// Randomize some values to use for Stdin during testing.
@@ -106,7 +106,7 @@ func TestPantheonBackupLinks(t *testing.T) {
 	defer testcommon.CleanupDir(testDir)
 	defer testcommon.Chdir(testDir)()
 
-	app, err := NewApp(testDir, "pantheon")
+	app, err := NewApp(testDir, ProviderPantheon)
 	assert.NoError(err)
 	app.Name = pantheonTestSiteName
 
@@ -150,7 +150,7 @@ func TestPantheonPull(t *testing.T) {
 	err = os.Chdir(siteDir)
 	assert.NoError(err)
 
-	app, err := NewApp(siteDir, "pantheon")
+	app, err := NewApp(siteDir, ProviderPantheon)
 	assert.NoError(err)
 	app.Name = pantheonTestSiteName
 	app.Type = "drupal8"

--- a/pkg/ddevapp/providerDrudS3_test.go
+++ b/pkg/ddevapp/providerDrudS3_test.go
@@ -167,7 +167,7 @@ func TestDrudS3ValidDownloadObjects(t *testing.T) {
 	app, err := ddevapp.NewApp(testDir, "drud-s3")
 	assert.NoError(err)
 	app.Name = drudS3TestSiteName
-	app.Type = "drupal7"
+	app.Type = ddevapp.AppTypeDrupal7
 
 	err = provider.Init(app)
 	assert.NoError(err)

--- a/pkg/ddevapp/providerDrudS3_test.go
+++ b/pkg/ddevapp/providerDrudS3_test.go
@@ -45,7 +45,7 @@ func TestDrudS3ConfigCommand(t *testing.T) {
 	defer testcommon.Chdir(testDir)()
 
 	// Create the app we'll use for testing.
-	app, err := ddevapp.NewApp(testDir, "drud-s3")
+	app, err := ddevapp.NewApp(testDir, ddevapp.ProviderDrudS3)
 	assert.NoError(err)
 
 	// Attempt config with the whole config setup, including access keys.

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -37,7 +37,7 @@ func (p *PantheonProvider) Init(app *DdevApp) error {
 		err = p.Read(configPath)
 	}
 
-	p.ProviderType = "pantheon"
+	p.ProviderType = ProviderPantheon
 	return err
 }
 

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -1,13 +1,14 @@
 package ddevapp_test
 
 import (
+	"strconv"
+	"testing"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
-	"strconv"
-	"testing"
 )
 
 // TestPortOverride makes sure that the router_http_port and router_https_port
@@ -28,7 +29,7 @@ func TestPortOverride(t *testing.T) {
 
 		testcommon.ClearDockerEnv()
 
-		app, err := ddevapp.NewApp(testDir, ddevapp.DefaultProviderName)
+		app, err := ddevapp.NewApp(testDir, ddevapp.ProviderDefault)
 		assert.NoError(err)
 		app.RouterHTTPPort = strconv.Itoa(80 + i)
 		// Note that we start with port 453 instead of 443 here because Windows

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -37,7 +37,7 @@ func TestPortOverride(t *testing.T) {
 		// So the test will fail because of that.
 		app.RouterHTTPSPort = strconv.Itoa(453 + i)
 		app.Name = "TestPortOverride-" + strconv.Itoa(i)
-		app.Type = "php"
+		app.Type = ddevapp.AppTypePHP
 		err = app.WriteConfig()
 		assert.NoError(err)
 		err = app.ReadConfig()

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -47,7 +47,7 @@ func TestWriteSettings(t *testing.T) {
 	}
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, DefaultProviderName)
+	app, err := NewApp(dir, ProviderDefault)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -146,7 +146,7 @@ func TestDrupalBackdropIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, DefaultProviderName)
+	app, err := NewApp(dir, ProviderDefault)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -191,7 +191,7 @@ func TestDrupalBackdropIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, DefaultProviderName)
+	app, err := NewApp(dir, ProviderDefault)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -248,7 +248,7 @@ func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, DefaultProviderName)
+	app, err := NewApp(dir, ProviderDefault)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -287,7 +287,7 @@ func TestDrupalBackdropGitIgnoreAlreadyExists(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, DefaultProviderName)
+	app, err := NewApp(dir, ProviderDefault)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -330,7 +330,7 @@ func TestDrupalBackdropOverwriteDdevSettings(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, DefaultProviderName)
+	app, err := NewApp(dir, ProviderDefault)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -42,7 +42,7 @@ func TestWriteSettings(t *testing.T) {
 		AppTypeDrupal6:   "sites/default/settings.ddev.php",
 		AppTypeDrupal7:   "sites/default/settings.ddev.php",
 		AppTypeDrupal8:   "sites/default/settings.ddev.php",
-		AppTypeWordpress: "wp-config-ddev.php",
+		AppTypeWordPress: "wp-config-ddev.php",
 		AppTypeTYPO3:     "typo3conf/AdditionalConfiguration.php",
 	}
 	dir := testcommon.CreateTmpDir(t.Name())

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -26,10 +26,10 @@ type settingsLocations struct {
 }
 
 var drupalBackdropSettingsLocations = map[string]settingsLocations{
-	"drupal6":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
-	"drupal7":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
-	"drupal8":  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
-	"backdrop": {main: "settings.php", local: "settings.ddev.php"},
+	AppTypeDrupal6:  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
+	AppTypeDrupal7:  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
+	AppTypeDrupal8:  {main: "sites/default/settings.php", local: "sites/default/settings.ddev.php"},
+	AppTypeBackdrop: {main: "settings.php", local: "settings.ddev.php"},
 }
 
 // TestWriteSettings tests writing app settings (like Drupal
@@ -38,12 +38,12 @@ func TestWriteSettings(t *testing.T) {
 	assert := asrt.New(t)
 
 	expectations := map[string]string{
-		"backdrop":  "settings.ddev.php",
-		"drupal6":   "sites/default/settings.ddev.php",
-		"drupal7":   "sites/default/settings.ddev.php",
-		"drupal8":   "sites/default/settings.ddev.php",
-		"wordpress": "wp-config-ddev.php",
-		"typo3":     "typo3conf/AdditionalConfiguration.php",
+		AppTypeBackdrop:  "settings.ddev.php",
+		AppTypeDrupal6:   "sites/default/settings.ddev.php",
+		AppTypeDrupal7:   "sites/default/settings.ddev.php",
+		AppTypeDrupal8:   "sites/default/settings.ddev.php",
+		AppTypeWordpress: "wp-config-ddev.php",
+		AppTypeTYPO3:     "typo3conf/AdditionalConfiguration.php",
 	}
 	dir := testcommon.CreateTmpDir(t.Name())
 
@@ -116,7 +116,7 @@ func TestWriteDrushConfig(t *testing.T) {
 		drushFilePath := filepath.Join(filepath.Dir(app.SiteSettingsPath), "ddev_drush_settings.php")
 
 		switch app.Type {
-		case "drupal6", "drupal7", "drupal8", "backdrop":
+		case AppTypeDrupal6, AppTypeDrupal7, AppTypeDrupal8, AppTypeBackdrop:
 			require.True(t, fileutil.FileExists(drushFilePath))
 			//nolint: vetshadow
 			hostFound, err := fileutil.FgrepStringInFile(drushFilePath, fmt.Sprintf("'host' => \"%s\"", dockerIP))

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -144,7 +144,7 @@ func isTypo3App(app *DdevApp) bool {
 
 // typo3ConfigOverrideAction sets a safe php_version for TYPO3
 func typo3ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = "7.2"
+	app.PHPVersion = PHP72
 	return nil
 }
 

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -116,3 +116,12 @@ func IsValidAppType(apptype string) bool {
 
 	return true
 }
+
+// GetValidAppTypes returns the valid apptype keys from the appTypeMatrix
+func GetValidAppTypes() []string {
+	keys := make([]string, 0, len(appTypeMatrix))
+	for k := range appTypeMatrix {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -63,7 +63,7 @@ const (
 	AppTypeDrupal8   = "drupal8"
 	AppTypePHP       = "php"
 	AppTypeTYPO3     = "typo3"
-	AppTypeWordpress = "wordpress"
+	AppTypeWordPress = "wordpress"
 )
 
 // Ports

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -87,7 +87,7 @@ func IsValidProvider(provider string) bool {
 
 // GetValidProviders is a helper function that returns a list of valid providers.
 func GetValidProviders() []string {
-	s := make([]string, len(ValidProviders))
+	s := make([]string, 0, len(ValidProviders))
 
 	for p := range ValidProviders {
 		s = append(s, p)
@@ -106,6 +106,17 @@ func IsValidPHPVersion(phpVersion string) bool {
 	return true
 }
 
+// GetValidPHPVersions is a helper function that returns a list of valid PHP versions.
+func GetValidPHPVersions() []string {
+	s := make([]string, 0, len(ValidPHPVersions))
+
+	for p := range ValidPHPVersions {
+		s = append(s, p)
+	}
+
+	return s
+}
+
 // IsValidWebserverType is a helper function to determine if a webserver type is valid, returning
 // true if the supplied webserver type is valid and false otherwise.
 func IsValidWebserverType(webserverType string) bool {
@@ -114,6 +125,17 @@ func IsValidWebserverType(webserverType string) bool {
 	}
 
 	return true
+}
+
+// GetValidWebserverTypes is a helper function that returns a list of valid webserver types.
+func GetValidWebserverTypes() []string {
+	s := make([]string, 0, len(ValidWebserverTypes))
+
+	for p := range ValidWebserverTypes {
+		s = append(s, p)
+	}
+
+	return s
 }
 
 // IsValidAppType is a helper function to determine if an app type is valid, returning

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -66,6 +66,15 @@ const (
 	AppTypeWordpress = "wordpress"
 )
 
+// Ports
+const (
+	// DdevDefaultRouterHTTPPort is the default router HTTP port
+	DdevDefaultRouterHTTPPort = "80"
+
+	// DdevDefaultRouterHTTPSPort is the default router HTTPS port
+	DdevDefaultRouterHTTPSPort = "443"
+)
+
 // IsValidProvider is a helper function to determine if a provider value is valid, returning
 // true if the supplied provider is valid and false otherwise.
 func IsValidProvider(provider string) bool {

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -1,0 +1,118 @@
+package ddevapp
+
+// Providers
+const (
+	ProviderDrudS3   = "drud-s3"
+	ProviderPantheon = "pantheon"
+
+	// ProviderDefault contains the name of the default provider which will be used if one is not otherwise specified.
+	ProviderDefault = "default"
+)
+
+// ValidProviders should be updated whenever provider plugins are added or removed, and should
+// be used to ensure user-supplied values are valid.
+var ValidProviders = map[string]bool{
+	ProviderDefault:  true,
+	ProviderDrudS3:   true,
+	ProviderPantheon: true,
+}
+
+// PHP Versions
+const (
+	PHP56 = "5.6"
+	PHP70 = "7.0"
+	PHP71 = "7.1"
+	PHP72 = "7.2"
+)
+
+// PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
+const PHPDefault = PHP71
+
+// ValidPHPVersions should be updated whenever PHP versions are added or removed, and should
+// be used to ensure user-supplied values are valid.
+var ValidPHPVersions = map[string]bool{
+	PHP56: true,
+	PHP70: true,
+	PHP71: true,
+	PHP72: true,
+}
+
+// Webserver types
+const (
+	WebserverNginxFPM  = "nginx-fpm"
+	WebserverApacheFPM = "apache-fpm"
+	WebserverApacheCGI = "apache-cgi"
+)
+
+// WebserverDefault is the default webserver type, overridden by $DDEV_WEBSERVER_TYPE
+var WebserverDefault = WebserverNginxFPM
+
+// ValidWebserverTypes should be updated whenever supported webserver types are added or
+// removed, and should be used to ensure user-supplied values are valid.
+var ValidWebserverTypes = map[string]bool{
+	WebserverNginxFPM:  true,
+	WebserverApacheFPM: true,
+	WebserverApacheCGI: true,
+}
+
+// App types
+const (
+	AppTypeBackdrop  = "backdrop"
+	AppTypeDrupal6   = "drupal6"
+	AppTypeDrupal7   = "drupal7"
+	AppTypeDrupal8   = "drupal8"
+	AppTypePHP       = "php"
+	AppTypeTYPO3     = "typo3"
+	AppTypeWordpress = "wordpress"
+)
+
+// IsValidProvider is a helper function to determine if a provider value is valid, returning
+// true if the supplied provider is valid and false otherwise.
+func IsValidProvider(provider string) bool {
+	if _, ok := ValidProviders[provider]; !ok {
+		return false
+	}
+
+	return true
+}
+
+// GetValidProviders is a helper function that returns a list of valid providers.
+func GetValidProviders() []string {
+	s := make([]string, len(ValidProviders))
+
+	for p := range ValidProviders {
+		s = append(s, p)
+	}
+
+	return s
+}
+
+// IsValidPHPVersion is a helper function to determine if a PHP version is valid, returning
+// true if the supplied PHP version is valid and false otherwise.
+func IsValidPHPVersion(phpVersion string) bool {
+	if _, ok := ValidPHPVersions[phpVersion]; !ok {
+		return false
+	}
+
+	return true
+}
+
+// IsValidWebserverType is a helper function to determine if a webserver type is valid, returning
+// true if the supplied webserver type is valid and false otherwise.
+func IsValidWebserverType(webserverType string) bool {
+	if _, ok := ValidWebserverTypes[webserverType]; !ok {
+		return false
+	}
+
+	return true
+}
+
+// IsValidAppType is a helper function to determine if an app type is valid, returning
+// true if the given app type is valid and configured and false otherwise.
+func IsValidAppType(apptype string) bool {
+	if _, ok := appTypeMatrix[apptype]; !ok {
+		return false
+	}
+
+	return true
+}

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -26,7 +26,7 @@ var (
 			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.5.3.tar.gz",
 			ArchiveInternalExtractionPath: "drupal-8.5.3/",
 			Docroot:                       "",
-			Type:                          "drupal8",
+			Type:                          ddevapp.AppTypeDrupal8,
 		},
 	}
 	ServiceFiles []string

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -22,7 +22,7 @@ var TestSites = []TestSite{
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		Docroot:                       "htdocs",
-		Type:                          ddevapp.AppTypeWordpress,
+		Type:                          ddevapp.AppTypeWordPress,
 		Safe200URIWithExpectation:     URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 	},
 }

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -22,7 +22,7 @@ var TestSites = []TestSite{
 		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		Docroot:                       "htdocs",
-		Type:                          "wordpress",
+		Type:                          ddevapp.AppTypeWordpress,
 		Safe200URIWithExpectation:     URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 	},
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
Only certain config values were being validated before attempting to start a project, which could lead to cryptic errors. When supplying config value flags to `ddev config`, no validation was done before writing the config file. 

## How this PR Solves The Problem:
These changes do more to ensure that configuration values are valid before either 1) writing a config file, or 2) attempting to start a project. Additionally, many string values in the source code were constantized and a few helper functions were added as a requirement for valid value lookup.

Similarly, instead of inspecting error values, a small set of error types has been added allowing for error type comparisons, decoupling the error from its text value.

## Manual Testing Instructions:
Using the CLI's config flags, ensure that invalid choices lead to validation errors:

- `--projectname invalid!name`
- `--php-version 1.9`
- `--projecttype typo4`
- `--webserver-type nginx-cgi`
- `--additional-hostnames valid,in_valid`
- `--additional-fqdns valid.com,in_valid.com`

Provide combinations of these invalid values alongside valid values to ensure ddev rejects invalid values and, when appropriate, outputs the valid values for that flag.

Using config.yaml, ensure that invalid values lead to validation errors after saving the file and when attempting to `ddev start` the project:

- `name: "invalid name"`
- `type: drupal10`
- `php-version: 9.9`
- `webserver-type: nginx-cgi`
- `additional-hostnames: [valid, in_valid]`
- `additional-fqdns: [valid.com, in_valid.com]`
- `provider: unknown`

## Automated Testing Overview:
Constantization updates will largely rely on the build process completing successfully, ensuring all new 
symbols are resolved correctly.

Test cases have been added to ensure invalid config values generated appropriate errors.

## Related Issue Link(s):
#1095 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
