### PR TITLE
Respect an existing user-managed AdditionalConfiguration.php, fixes #1053

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -821,16 +821,17 @@ func (app *DdevApp) Wait(containerTypes ...string) error {
 func (app *DdevApp) DetermineSettingsPathLocation() (string, error) {
 	possibleLocations := []string{app.SiteSettingsPath, app.SiteLocalSettingsPath}
 	for _, loc := range possibleLocations {
-		// If the file is found we need to check for a signature to determine if it's safe to use.
-		if fileutil.FileExists(loc) {
-			signatureFound, err := fileutil.FgrepStringInFile(loc, DdevFileSignature)
-			util.CheckErr(err) // Really can't happen as we already checked for the file existence
+		// If the file doesn't exist, it's safe to use
+		if !fileutil.FileExists(loc) {
+			return loc, nil
+		}
 
-			if signatureFound {
-				return loc, nil
-			}
-		} else {
-			// If the file is not found it's safe to use.
+		// If the file does exist, check for a signature indicating it's managed by ddev.
+		signatureFound, err := fileutil.FgrepStringInFile(loc, DdevFileSignature)
+		util.CheckErr(err) // Really can't happen as we already checked for the file existence
+
+		// If the signature was found, it's safe to use.
+		if signatureFound {
 			return loc, nil
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:
Our documentation claimed that we'd only write an AdditionalConfiguration.php when the file either didn't exist or was ddev-managed, but that wasn't the case. 

## How this PR Solves The Problem:
If AdditionalConfiguration.php exists, ddev will now check that the file is ddev-managed by ensuring the usual ddev file signature exists.

## Manual Testing Instructions:
Use #1053's issue recreation method to ensure that a user-managed AdditionalConfiguration.php is respected and that a warning is emitted to the user indicating this:

1. `composer create-project typo3/cms-base-distribution my-typo3-site ^8`
2. `cd my-typo3-site`
3. `echo "<?php" > public/typo3conf/AdditionalConfiguration.php`
4. `ddev config`

Now, ensure ddev can create the config file in the usual case:

1. `rm public/typo3conf/AdditionalConfiguration.php`
2. `ddev config`

AdditionalConfiguration.php should have been generated by ddev.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#1053 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

