### PR TITLE
Stop warning about non-config files in ddev start, fixes #731

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -402,7 +402,7 @@ func (app *DdevApp) CheckCustomConfig() {
 		}
 	}
 	if customConfig {
-		util.Warning("Custom configuration takes effect when container is created, \nusually on start, use 'ddev restart' if you're not seeing it take effect.")
+		util.Warning("Custom configuration takes effect when container is created, \nusually on start, use 'ddev restart' or 'ddev rm  && ddev start' if you're not seeing it take effect.")
 	}
 
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -372,14 +372,19 @@ func (app *DdevApp) CheckCustomConfig() {
 	ddevDir := filepath.Dir(app.ConfigPath)
 
 	customConfig := false
-	if _, err := os.Stat(filepath.Join(ddevDir, "nginx-site.conf")); err == nil {
+	if _, err := os.Stat(filepath.Join(ddevDir, "nginx-site.conf")); err == nil && app.WebserverType == "nginx-fpm" {
 		util.Warning("Using custom nginx configuration in nginx-site.conf")
+		customConfig = true
+	}
+
+	if _, err := os.Stat(filepath.Join(ddevDir, "apache", "apache-site.conf")); err == nil && app.WebserverType != "nginx-fpm" {
+		util.Warning("Using custom apache configuration in apache/apache-site.conf")
 		customConfig = true
 	}
 
 	mysqlPath := filepath.Join(ddevDir, "mysql")
 	if _, err := os.Stat(mysqlPath); err == nil {
-		mysqlFiles, err := fileutil.ListFilesInDir(mysqlPath)
+		mysqlFiles, err := filepath.Glob(mysqlPath + "/*.cnf")
 		util.CheckErr(err)
 		if len(mysqlFiles) > 0 {
 			util.Warning("Using custom mysql configuration: %v", mysqlFiles)
@@ -389,7 +394,7 @@ func (app *DdevApp) CheckCustomConfig() {
 
 	phpPath := filepath.Join(ddevDir, "php")
 	if _, err := os.Stat(phpPath); err == nil {
-		phpFiles, err := fileutil.ListFilesInDir(phpPath)
+		phpFiles, err := filepath.Glob(phpPath + "/*.ini")
 		util.CheckErr(err)
 		if len(phpFiles) > 0 {
 			util.Warning("Using custom PHP configuration: %v", phpFiles)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -534,8 +534,5 @@ func TestConfigOverrideDetection(t *testing.T) {
 	}
 	assert.Contains(out, "Custom configuration takes effect")
 
-	err = app.Start()
-	assert.NoError(err)
-
 	_ = app.Down(true, false)
 }

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -523,7 +523,15 @@ func TestConfigOverrideDetection(t *testing.T) {
 
 	assert.Contains(out, "utf.cnf")
 	assert.Contains(out, "my-php.ini")
-	assert.Contains(out, "nginx-site.conf")
+
+	switch app.WebserverType {
+	case "nginx-fpm":
+		assert.Contains(out, "nginx-site.conf")
+		assert.NotContains(out, "apache-site.conf")
+	default:
+		assert.Contains(out, "apache-site.conf")
+		assert.NotContains(out, "nginx-site.conf")
+	}
 	assert.Contains(out, "Custom configuration takes effect")
 
 	err = app.Start()

--- a/pkg/ddevapp/testdata/.ddev/apache/apache-site.conf
+++ b/pkg/ddevapp/testdata/.ddev/apache/apache-site.conf
@@ -1,0 +1,37 @@
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	#ServerName www.example.com
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot $WEBSERVER_DOCROOT
+	<Directory "$WEBSERVER_DOCROOT/">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog /dev/stdout
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+	# Simple ddev technique to get a phpstatus
+	Alias "/phpstatus" "/var/www/phpstatus.php"
+
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
## The Problem/Issue/Bug:

Previously we were warning about non-config files (anything in a directory) when warning about mysql and php config.

Also there was no warning about apache config overrides.

## How this PR Solves The Problem:

* Use a glob to only warn about files which are actually config overrides.
* Add output for apache overrides.

## Manual Testing Instructions:

* Create config overrides (nginx, apache, mysql, php)
* Put things in those directories which are *not* config overrides.
* Verify that only legitimately named override files are reported.
* nginx config should only be reported for webserver_type=nginx-fpm, converse for apache config.

## Automated Testing Overview:

No new tests

## Related Issue Link(s):

OP #731 

