### PR TITLE
Faster failure on startup if container fails, fixes #1135

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -808,7 +808,7 @@ func (app *DdevApp) Wait(containerTypes ...string) error {
 		}
 		err := dockerutil.ContainerWait(containerWaitTimeout, labels)
 		if err != nil {
-			return fmt.Errorf("Container %s failed: %v", containerType, err)
+			return fmt.Errorf("%s container failed: %v", containerType, err)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -808,7 +808,7 @@ func (app *DdevApp) Wait(containerTypes ...string) error {
 		}
 		err := dockerutil.ContainerWait(containerWaitTimeout, labels)
 		if err != nil {
-			return fmt.Errorf("%s service %v", containerType, err)
+			return fmt.Errorf("Container %s failed: %v", containerType, err)
 		}
 	}
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -152,8 +152,11 @@ func ContainerWait(waittime time.Duration, labels map[string]string) error {
 			}
 			status = GetContainerHealth(container)
 
-			if status == "healthy" {
+			switch status {
+			case "healthy":
 				return nil
+			case "exited":
+				return fmt.Errorf("Please use 'ddev logs` or `ddev logs -s db' to find out why the container failed.", labels)
 			}
 		}
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -156,7 +156,8 @@ func ContainerWait(waittime time.Duration, labels map[string]string) error {
 			case "healthy":
 				return nil
 			case "exited":
-				return fmt.Errorf("Please use 'ddev logs` or `ddev logs -s db' to find out why the container failed.", labels)
+				service := container.Labels["com.docker.compose.service"]
+				return fmt.Errorf("container start failed, please use 'ddev logs -s %s` to find out why it failed", service)
 			}
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

We wait more than a minute on `ddev start`, when in reality we usually know in about 12 seconds if something's broken. See #1135.

## How this PR Solves The Problem:

Note when a container fails and report it.

## Manual Testing Instructions:

Break a container. The easiest is to rm /var/lib/mysql/mysql/*.MYD in the db container. It really breaks it. Try a `ddev start`.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

