### PR TITLE
Improve reliability of TestDevLogs (in cmd)

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -18,13 +18,9 @@ import (
 // the directory has not been configured (and no project name is given)
 func TestDevLogsNoConfig(t *testing.T) {
 	assert := asrt.New(t)
-
 	testDir := testcommon.CreateTmpDir("no-valid-ddev-config")
-
-	err := os.Chdir(testDir)
-	if err != nil {
-		t.Skipf("Could not change to temporary directory %s: %v", testDir, err)
-	}
+	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
 
 	args := []string{"logs"}
 	out, err := exec.RunCommand(DdevBin, args)

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
-	"time"
 )
 
 // TestDevLogsNoConfig tests what happens with when running "ddev logs" when
@@ -36,24 +35,20 @@ func TestDevLogs(t *testing.T) {
 		// Copy our fatal error php into the docroot of testsite.
 		pwd, err := os.Getwd()
 		assert.NoError(err)
-		err = fileutil.CopyFile(filepath.Join(pwd, "testdata", "fatal.php"), filepath.Join(v.Dir, v.Docroot, "fatal.php"))
+		err = fileutil.CopyFile(filepath.Join(pwd, "testdata", "logtest.php"), filepath.Join(v.Dir, v.Docroot, "logtest.php"))
 		assert.NoError(err)
 		cleanup := v.Chdir()
 
-		url := "http://" + v.Name + "." + version.DDevTLD + "/fatal.php"
+		url := "http://" + v.Name + "." + version.DDevTLD + "/logtest.php"
 		out, err := testcommon.GetLocalHTTPResponse(t, url)
-		_ = out
 		assert.NoError(err)
-		// Because php display_errors = On the error results in a 200 anyway.
 
-		// logs may not respond exactly right away, wait a tiny bit.
-		time.Sleep(2 * time.Second)
 		args := []string{"logs"}
 		out, err = exec.RunCommand(DdevBin, args)
 
 		assert.NoError(err)
 		assert.Contains(string(out), "Server started")
-		assert.Contains(string(out), "PHP Fatal error:", "PHP Fatal error not found for project %s output='%s", v.Name, string(out))
+		assert.Contains(string(out), "Notice to demonstrate logging", "PHP notice not found for project %s output='%s", v.Name, string(out))
 		cleanup()
 	}
 }

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -40,11 +40,11 @@ func TestDevLogs(t *testing.T) {
 		cleanup := v.Chdir()
 
 		url := "http://" + v.Name + "." + version.DDevTLD + "/logtest.php"
-		out, err := testcommon.GetLocalHTTPResponse(t, url)
+		_, err = testcommon.GetLocalHTTPResponse(t, url)
 		assert.NoError(err)
 
 		args := []string{"logs"}
-		out, err = exec.RunCommand(DdevBin, args)
+		out, err := exec.RunCommand(DdevBin, args)
 
 		assert.NoError(err)
 		assert.Contains(string(out), "Server started")

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -38,7 +38,9 @@ func TestDevLogs(t *testing.T) {
 
 	for _, v := range DevTestSites {
 		// Copy our fatal error php into the docroot of testsite.
-		err := fileutil.CopyFile(filepath.Join("testdata", "fatal.php"), filepath.Join(v.Dir, v.Docroot, "fatal.php"))
+		pwd, err := os.Getwd()
+		assert.NoError(err)
+		err = fileutil.CopyFile(filepath.Join(pwd, "testdata", "fatal.php"), filepath.Join(v.Dir, v.Docroot, "fatal.php"))
 		assert.NoError(err)
 		cleanup := v.Chdir()
 

--- a/cmd/ddev/cmd/testdata/fatal.php
+++ b/cmd/ddev/cmd/testdata/fatal.php
@@ -1,3 +1,0 @@
-<?php
-
-trigger_error("Fatal error to demonstrate logging", E_USER_ERROR);

--- a/cmd/ddev/cmd/testdata/fatal.php
+++ b/cmd/ddev/cmd/testdata/fatal.php
@@ -1,0 +1,3 @@
+<?php
+
+trigger_error("Fatal error to demonstrate logging", E_USER_ERROR);

--- a/cmd/ddev/cmd/testdata/logtest.php
+++ b/cmd/ddev/cmd/testdata/logtest.php
@@ -1,0 +1,4 @@
+<?php
+
+trigger_error("Notice to demonstrate logging", E_USER_NOTICE);
+


### PR DESCRIPTION
## The Problem/Issue/Bug:

We see regular failures of TestDevLogs (in cmd) like [this in buildkite](https://buildkite.com/drud/ddev-macos/builds/699#3b017412-feff-4644-847b-7525633310c5) - basically a million warnings like `[29-Sep-2018 22:22:36] WARNING: [pool www] child 488 said into stderr: "NOTICE: PHP message: PHP Warning:  Unexpected character in input:  ' in /var/www/html/htdocs/index.php on line 1"` which (seem?) to flood the item we're looking at, so the test fails. It's intermittent, so hard to chase. 
 
## How this PR Solves The Problem:

Simplify the test, use some of our newer tools (testcommon.GetLocalHTTPResponse()), and use a static fatal.php instead of writing it out.

## Manual Testing Instructions:

Probably if it tests OK then it's not going to be any worse.

