### PR TITLE
Do not try to start project for a snapshot, fixes #1129

### DIFF
--- a/cmd/ddev/cmd/remove.go
+++ b/cmd/ddev/cmd/remove.go
@@ -58,7 +58,7 @@ To snapshot the database on remove, use "ddev remove --snapshot"; A snapshot is 
 			// We do the snapshot if either --snapshot or --remove-data UNLESS omit-snapshot is set
 			doSnapshot := ((createSnapshot || removeData) && !omitSnapshot)
 			if err := app.Down(removeData, doSnapshot); err != nil {
-				util.Failed("Failed to remove ddev project %s: %v", app.GetName(), err)
+				util.Failed("Failed to remove project %s: \n%v", app.GetName(), err)
 			}
 
 			util.Success("Project %s has been removed.", app.GetName())

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -856,10 +856,7 @@ func (app *DdevApp) SnapshotDatabase(snapshotName string) (string, error) {
 	}
 
 	if app.SiteStatus() != SiteRunning {
-		err = app.Start()
-		if err != nil {
-			return snapshotName, fmt.Errorf("Failed to start project %s to snapshot database: %v", app.Name, err)
-		}
+		return "", fmt.Errorf("unable to snapshot database, project %v is not running. \nPlease start the project if you want to snapshot it. \nIf removing, you can remove without a snapshot using 'ddev remove --remove-data --omit-snapshot', \nwhich will destroy your database", app.Name)
 	}
 
 	util.Warning("Creating database snapshot %s", snapshotName)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -125,7 +125,7 @@ func (app *DdevApp) Init(basePath string) error {
 			return fmt.Errorf("a project (web container) in %s state already exists for %s that was created at %s", web.State, app.Name, containerApproot)
 		}
 		return nil
-	} else if strings.Contains(err.Error(), "could not find containers") {
+	} else if strings.Contains(err.Error(), "unable to find any running or stopped containers") {
 		// Init() is just putting together the DdevApp struct, the containers do
 		// not have to exist (app doesn't have to have been started, so the fact
 		// we didn't find any is not an error.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -856,7 +856,7 @@ func (app *DdevApp) SnapshotDatabase(snapshotName string) (string, error) {
 	}
 
 	if app.SiteStatus() != SiteRunning {
-		return "", fmt.Errorf("unable to snapshot database, project %v is not running. \nPlease start the project if you want to snapshot it. \nIf removing, you can remove without a snapshot using 'ddev remove --remove-data --omit-snapshot', \nwhich will destroy your database", app.Name)
+		return "", fmt.Errorf("unable to snapshot database, \nyour project %v is not running. \nPlease start the project if you want to snapshot it. \nIf removing, you can remove without a snapshot using \n'ddev remove --remove-data --omit-snapshot', \nwhich will destroy your database", app.Name)
 	}
 
 	util.Warning("Creating database snapshot %s", snapshotName)
@@ -920,7 +920,7 @@ func (app *DdevApp) Down(removeData bool, createSnapshot bool) error {
 	// Remove all the containers and volumes for app.
 	err = Cleanup(app)
 	if err != nil {
-		return fmt.Errorf("failed to remove ddev project %s: %v", app.GetName(), err)
+		return err
 	}
 
 	// Remove data/database/hostname if we need to.

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -112,7 +112,7 @@ func FindContainersByLabels(labels map[string]string) ([]docker.APIContainers, e
 	// If we couldn't find a match return a list with a single (empty) element alongside the error.
 	if len(containerMatches) < 1 {
 		containerMatches = []docker.APIContainers{{}}
-		returnError = fmt.Errorf("could not find containers which matched search criteria: %+v", labels)
+		returnError = fmt.Errorf("unable to find any running or stopped containers")
 	}
 
 	return containerMatches, returnError


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1129 describes the terrible cyclic behavior people have when trying to destroy a project but it's already hurt (like the db is broken, so the db container is down). Essentially you do a `ddev rm -R` and it tries to *start* a broken project (in order to snapshot it), which can't possibly work, therefore people end up broken all the way. (`ddev rm -RO` works in this case, but people shouldn't have to know that). 

## How this PR Solves The Problem:

Don't try to start project to do a snapshot. Require the project to be running in the first place.

## Manual Testing Instructions:

See the break-db instructions in #1129. Break it. Do a `ddev rm --remove-data` to see the correct behavior.


