### PR TITLE
Validate the project name when it's entered, fixes #514, fixes #86

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -297,6 +297,13 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		app.WebserverType = webserverTypeArg
 	}
 
+	provider, err := app.GetProvider()
+	util.CheckErr(err)
+	err = provider.ValidateField("Name", app.Name)
+	if err != nil {
+		return fmt.Errorf("failed to validate configuration: %v", err)
+	}
+
 	err = app.WriteConfig()
 	if err != nil {
 		return fmt.Errorf("could not write ddev config file %s: %v", app.ConfigPath, err)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -280,7 +280,7 @@ func (app *DdevApp) ValidateConfig() error {
 	// validate hostname
 	match := hostRegex.MatchString(app.GetHostname())
 	if !match {
-		return fmt.Errorf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", app.GetHostname())
+		return fmt.Errorf("%s is not a valid hostname. Please enter a project name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", app.GetHostname())
 	}
 
 	// validate apptype
@@ -451,14 +451,13 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	return doc.String(), err
 }
 
-// Define an application name.
+// prompt for a project name.
 func (app *DdevApp) promptForName() error {
 	provider, err := app.GetProvider()
 	if err != nil {
 		return err
 	}
 
-	namePrompt := "Project name"
 	if app.Name == "" {
 		dir, err := os.Getwd()
 		// if working directory name is invalid for hostnames, we shouldn't suggest it
@@ -468,9 +467,7 @@ func (app *DdevApp) promptForName() error {
 		}
 	}
 
-	namePrompt = fmt.Sprintf("%s (%s)", namePrompt, app.Name)
-	fmt.Print(namePrompt + ": ")
-	app.Name = util.GetInput(app.Name)
+	app.Name = util.Prompt("Project name", app.Name)
 	return provider.ValidateField("Name", app.Name)
 }
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -183,6 +183,22 @@ func TestConfigCommand(t *testing.T) {
 		assert.Contains(out, testDir)
 		assert.Contains(out, fmt.Sprintf("'%s' is not a valid project type", invalidAppType))
 
+		// Create an example input buffer that writes an invalid projectname, then a valid-project-name,
+		// a valid document root,
+		// a valid app type
+		input = fmt.Sprintf("invalid_project_name\n%s\ndocroot\n%s", name, testValues[apptypePos])
+		scanner = bufio.NewScanner(strings.NewReader(input))
+		util.SetInputScanner(scanner)
+
+		restoreOutput = testcommon.CaptureUserOut()
+		err = app.PromptForConfig()
+		assert.NoError(err, t)
+		out = restoreOutput()
+
+		// Ensure we have expected vales in output.
+		assert.Contains(out, testDir)
+		assert.Contains(out, "invalid_project_name is not a valid project name")
+
 		// Ensure values were properly set on the app struct.
 		assert.Equal(name, app.Name)
 		assert.Equal(testValues[apptypePos], app.Type)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -447,7 +447,7 @@ func TestValidate(t *testing.T) {
 
 	app.Name = "Invalid!"
 	err = app.ValidateConfig()
-	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a site name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", app.GetHostname()))
+	assert.EqualError(err, fmt.Sprintf("%s is not a valid hostname. Please enter a project name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", app.GetHostname()))
 
 	app.Docroot = "testdata"
 	app.Name = "valid"

--- a/pkg/ddevapp/providerDefault.go
+++ b/pkg/ddevapp/providerDefault.go
@@ -1,6 +1,9 @@
 package ddevapp
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // DefaultProvider provides a no-op for the provider plugin interface methods.
 type DefaultProvider struct{}
@@ -12,6 +15,14 @@ func (p *DefaultProvider) Init(app *DdevApp) error {
 
 // ValidateField provides a no-op for the ValidateField operation.
 func (p *DefaultProvider) ValidateField(field, value string) error {
+	if field == "Name" {
+		// validate project name
+		match := hostRegex.MatchString(value)
+		if !match {
+			return fmt.Errorf("%s is not a valid project name. Please enter a project name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames for valid hostname requirements", value)
+		}
+
+	}
 	return nil
 }
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -9,6 +9,7 @@ import (
 )
 
 // RunCommand runs a command on the host system.
+// returns the stdout of the command and an err
 func RunCommand(command string, args []string) (string, error) {
 	output.UserOut.WithFields(log.Fields{
 		"Command": command + " " + strings.Join(args[:], " "),


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #514 - It's a standard problem new users have that they will enter a project name like "my project", which spaces or other problems that result in an invalid url. 

We should finally validate it. 

#86 also requests sanitization of hostnames; however this PR merely insists that the user choose an appropriate hostname.

## How this PR Solves The Problem:

The project name is validated at the point of request. If it doesn't work, a correct project name is insisted on.

## Manual Testing Instructions:

* Try `ddev config` with invalid hostnames like "an invalid hostname" or "an_invalid_hostname". 
* Try `ddev config` in a directory which would be invalid
* Try `ddev config --projectname="invalid hostname"` etc

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

