### PR TITLE
 Add test to make sure we get the webserver we configure, fixes #1094

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1562,6 +1562,7 @@ func TestWebserverType(t *testing.T) {
 			err = app.Start()
 			assert.NoError(err)
 
+			// nolint: vetshadow
 			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL()+"/phpinfo.php")
 			assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1534,6 +1534,38 @@ func TestGetAllURLs(t *testing.T) {
 	}
 }
 
+// TestWebserverType checks that webserver_type:apache-cgi or apache-fpm does the right thing
+func TestWebserverType(t *testing.T) {
+	assert := asrt.New(t)
+
+	for _, site := range TestSites {
+		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s GetAllURLs", site.Name))
+
+		testcommon.ClearDockerEnv()
+		app := new(ddevapp.DdevApp)
+
+		err := app.Init(site.Dir)
+		assert.NoError(err)
+		for _, app.WebserverType = range []string{"apache-fpm", "apache-cgi", "nginx-fpm"} {
+
+			err = app.WriteConfig()
+			assert.NoError(err)
+
+			err = app.Start()
+			assert.NoError(err)
+
+			out, err := testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL())
+			assert.NoError(err)
+			_ = out
+		}
+
+		err = app.Stop()
+		assert.NoError(err)
+
+		runTime()
+	}
+}
+
 // TestDbMigration tests migration from bind-mounted db to volume-mounted db
 // This should be important around the time of its release, 2018-08-02 or so, but should be increasingly
 // irrelevant after that and can eventually be removed.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1541,24 +1541,46 @@ func TestWebserverType(t *testing.T) {
 	for _, site := range TestSites {
 		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s GetAllURLs", site.Name))
 
-		testcommon.ClearDockerEnv()
 		app := new(ddevapp.DdevApp)
 
 		err := app.Init(site.Dir)
+		assert.NoError(err)
+
+		// Copy our phpinfo into the docroot of testsite.
+		pwd, err := os.Getwd()
+		assert.NoError(err)
+		err = fileutil.CopyFile(filepath.Join(pwd, "testdata", "phpinfo.php"), filepath.Join(app.AppRoot, app.Docroot, "phpinfo.php"))
+
 		assert.NoError(err)
 		for _, app.WebserverType = range []string{"apache-fpm", "apache-cgi", "nginx-fpm"} {
 
 			err = app.WriteConfig()
 			assert.NoError(err)
 
+			testcommon.ClearDockerEnv()
+
 			err = app.Start()
 			assert.NoError(err)
 
-			out, err := testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL())
+			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL()+"/phpinfo.php")
 			assert.NoError(err)
-			_ = out
+
+			expectedServerType := "Apache/2.4"
+			if app.WebserverType == "nginx-fpm" {
+				expectedServerType = "nginx/1"
+			}
+			//assert.Contains(resp.Header["Server"], expectedServerType, "Server header for project=%s, app.WebserverType=%s should be %s", app.Name, app.WebserverType, expectedServerType)
+			assert.Contains(out, "$_SERVER['SERVER_SOFTWARE']</td><td class=\"v\">"+expectedServerType, "For app.WebserverType=%s expected $_SERVER['SERVER_SOFTWARE'] to show %s", app.WebserverType, expectedServerType)
+
 		}
 
+		// Set the apptype back to whatever the default was so we don't break any following tests.
+		testVar := os.Getenv("DDEV_TEST_WEBSERVER_TYPE")
+		if testVar != "" {
+			app.WebserverType = testVar
+			err = app.WriteConfig()
+			assert.NoError(err)
+		}
 		err = app.Stop()
 		assert.NoError(err)
 

--- a/pkg/ddevapp/testdata/phpinfo.php
+++ b/pkg/ddevapp/testdata/phpinfo.php
@@ -1,0 +1,3 @@
+<?php
+
+phpinfo();


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1094 promises tests for Apache webserver_type. We already run all tests against each webserver_type but this adds an explicit test to bring up under each webserver_type and make sure the results are what we expect.

If the code is OK and the test passes, we're good enough, no manual testing is probably required.