### PR TITLE
Add debugging for intermittent failures on TestDdevRestoreSnapshot

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -598,7 +598,19 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 1 has 1 node")
 	err = app.RestoreSnapshot("d7testerTest2")
 	assert.NoError(err)
-	testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 2 has 2 nodes")
+	//testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 2 has 2 nodes")
+
+	body, resp, err := testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL())
+	assert.NoError(err, "GetLocalHTTPResponse returned err on rawurl %s: %v", app.GetHTTPURL(), err)
+	assert.Contains(body, "d7 tester test 2 has 2 nodes")
+	if err != nil {
+		t.Logf("resp after timeout: %v", resp)
+		stdout := testcommon.CaptureUserOut()
+		err = app.Logs("web", false, false, "")
+		assert.NoError(err)
+		out := stdout()
+		t.Logf("web container logs after timeout: %s", out)
+	}
 
 	err = app.Down(true, false)
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

We see intermittent failures on TestDdevRestoreSnapshot that we've never been able to chase. They happen on Docker Toolbox and I think on macOS as well. This extra debugging info should help us get more information about what is happening.
