### PR TITLE
Provide access to router within web container by hostname, fixes #842

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -30,6 +30,7 @@ var (
 		HTTPProbeURI:                  "wp-admin/setup-config.php",
 		Docroot:                       "htdocs",
 		Type:                          "wordpress",
+		Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 	},
 	}
 )

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1671,6 +1671,7 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		err := app.Init(site.Dir)
 		assert.NoError(err)
 
+		//nolint: vet
 		for _, pair := range []testcommon.PortPair{{"80", "443"}, {"8080", "8443"}} {
 			testcommon.ClearDockerEnv()
 			app.RouterHTTPPort = pair.HTTPPort
@@ -1686,8 +1687,8 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 			testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
 
 			// Ensure that we can access the same URL from within the web container (via router)
-			//nolint: vetshadow
-			out, _, err := app.Exec("web", "curl", "-sk", app.GetHTTPURL()+site.Safe200URIWithExpectation.URI)
+			var out string
+			out, _, err = app.Exec("web", "curl", "-sk", app.GetHTTPURL()+site.Safe200URIWithExpectation.URI)
 			assert.NoError(err)
 			assert.Contains(out, site.Safe200URIWithExpectation.Expect)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -40,7 +40,7 @@ var (
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_db.tar.gz",
 			Docroot:                       "htdocs",
 			Type:                          "wordpress",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{"/readme.html", "Welcome. WordPress is a very special project to me."},
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 		},
 		{
 			Name:                          "TestPkgDrupal8",
@@ -53,7 +53,7 @@ var (
 			FullSiteTarballURL:            "",
 			Type:                          "drupal8",
 			Docroot:                       "",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{"/README.txt", "Drupal is an open source content management platform"},
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "Drupal is an open source content management platform"},
 		},
 		{
 			Name:                          "TestPkgDrupal7", // Drupal Kickstart on D7
@@ -64,7 +64,7 @@ var (
 			FullSiteTarballURL:            "https://github.com/drud/drupal-kickstart/releases/download/v0.4.0/site.tar.gz",
 			Docroot:                       "docroot",
 			Type:                          "drupal7",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{"/README.txt", "Drupal is an open source content management platform"},
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "Drupal is an open source content management platform"},
 			FullSiteArchiveExtPath:        "docroot/sites/default/files",
 		},
 		{
@@ -75,7 +75,7 @@ var (
 			FullSiteTarballURL:            "",
 			Docroot:                       "",
 			Type:                          "drupal6",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{"/CHANGELOG.txt", "Drupal 6.38, 2016-02-24"},
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/CHANGELOG.txt", Expect: "Drupal 6.38, 2016-02-24"},
 		},
 		{
 			Name:                          "TestPkgBackdrop",
@@ -85,7 +85,7 @@ var (
 			FullSiteTarballURL:            "",
 			Docroot:                       "",
 			Type:                          "backdrop",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{"/README.md", "Backdrop is a full-featured content management system"},
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.md", Expect: "Backdrop is a full-featured content management system"},
 		},
 		{
 			Name:                          "TestPkgTypo3",
@@ -95,7 +95,7 @@ var (
 			FullSiteTarballURL:            "",
 			Docroot:                       "",
 			Type:                          "typo3",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{"/INSTALL.md", "TYPO3 is an open source PHP based web content management"},
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/INSTALL.md", Expect: "TYPO3 is an open source PHP based web content management"},
 		},
 	}
 	FullTestSites = TestSites
@@ -1691,6 +1691,7 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 			testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
 
 			// Ensure that we can access the same URL from within the web container (via router)
+			//nolint: vetshadow
 			out, _, err := app.Exec("web", "curl", "-sk", app.GetHTTPURL()+site.Safe200URIWithExpectation.URI)
 			assert.NoError(err)
 			assert.Contains(out, site.Safe200URIWithExpectation.Expect)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1659,11 +1659,6 @@ func TestDbMigration(t *testing.T) {
 	switchDir()
 }
 
-type portPair struct {
-	httpPort  string
-	httpsPort string
-}
-
 // TestInternalAndExternalAccessToURL checks we can access content from host and from inside container by URL (with port)
 func TestInternalAndExternalAccessToURL(t *testing.T) {
 	assert := asrt.New(t)
@@ -1676,10 +1671,10 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		err := app.Init(site.Dir)
 		assert.NoError(err)
 
-		for _, pair := range []portPair{{"80", "443"}, {"8080", "8443"}} {
+		for _, pair := range []testcommon.PortPair{{"80", "443"}, {"8080", "8443"}} {
 			testcommon.ClearDockerEnv()
-			app.RouterHTTPPort = pair.httpPort
-			app.RouterHTTPSPort = pair.httpsPort
+			app.RouterHTTPPort = pair.HTTPPort
+			app.RouterHTTPSPort = pair.HTTPSPort
 			err = app.WriteConfig()
 			assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -310,9 +310,7 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		err = app.WriteConfig()
 		assert.NoError(err)
 
-		err = app.Stop()
-		assert.NoError(err)
-		err = app.Down(false, false)
+		err = app.Down(true, false)
 		assert.NoError(err)
 
 		runTime()
@@ -1521,6 +1519,13 @@ func TestGetAllURLs(t *testing.T) {
 
 		assert.True(exists, "URL list for app: %s does not contain direct web container address: %s", app.Name, expectedDirectAddress)
 
+		// Multiple projects can't run at the same time with the fqdns, so we need to clean
+		// up these for tests that run later.
+		app.AdditionalFQDNs = []string{}
+		app.AdditionalHostnames = []string{}
+		err = app.WriteConfig()
+		assert.NoError(err)
+
 		err = app.Stop()
 		assert.NoError(err)
 
@@ -1679,6 +1684,10 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 			err = app.WriteConfig()
 			assert.NoError(err)
 
+			if app.SiteStatus() == ddevapp.SiteStopped || app.SiteStatus() == ddevapp.SiteRunning {
+				err = app.Down(true, false)
+				assert.NoError(err)
+			}
 			err = app.Start()
 			assert.NoError(err)
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -78,6 +78,9 @@ services:
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
     extra_hosts: ["{{ .extra_host }}"]
+    external_links:
+      - ddev-router:$DDEV_HOSTNAME
+
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -361,8 +361,13 @@ func GetLocalHTTPResponse(t *testing.T, rawurl string) (string, *http.Response, 
 	dockerIP, err := dockerutil.GetDockerIP()
 	assert.NoError(err)
 
-	fakeHost := u.Hostname() + ":" + port
-	u.Host = dockerIP + ":" + port
+	fakeHost := u.Hostname()
+	u.Host = dockerIP
+	// Add the port if there is one.
+	if port != "" {
+		fakeHost = u.Hostname() + ":" + port
+		u.Host = dockerIP + ":" + port
+	}
 	localAddress := u.String()
 
 	timeout := time.Duration(10 * time.Second)
@@ -413,4 +418,10 @@ func EnsureLocalHTTPContent(t *testing.T, rawurl string, expectedContent string)
 	body, _, err := GetLocalHTTPResponse(t, rawurl)
 	assert.NoError(err, "GetLocalHTTPResponse returned err on rawurl %s: %v", rawurl, err)
 	assert.Contains(body, expectedContent)
+}
+
+// PortPair is for tests to use naming portsets for tests
+type PortPair struct {
+	HTTPPort  string
+	HTTPSPort string
 }

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -28,6 +28,12 @@ import (
 	"testing"
 )
 
+// URIWithExpect pairs a URI like "/readme.html" with some substring content "should be found in URI"
+type URIWithExpect struct {
+	URI    string
+	Expect string
+}
+
 // TestSite describes a site for testing, with name, URL of tarball, and optional dir.
 type TestSite struct {
 	// Name is the generic name of the site, and is used as the default dir.
@@ -55,9 +61,8 @@ type TestSite struct {
 	// Type is the type of application. This can be specified when a config file is not present
 	// for a test site.
 	Type string
-	// Safe200URL is a string of a url that can be accessed for testing a site
-	// that has not yet been installed
-	Safe200URL string
+	// Safe200URIWithExpectation provides a static URI with contents that it can be expected to contain.
+	Safe200URIWithExpectation URIWithExpect
 	// FullSiteArchiveExtPath is the path that should be extracted from inside an archive when
 	// importing the files from a full site archive
 	FullSiteArchiveExtPath string
@@ -351,12 +356,13 @@ func GetLocalHTTPResponse(t *testing.T, rawurl string) (string, *http.Response, 
 	if err != nil {
 		t.Fatalf("Failed to parse url %s: %v", rawurl, err)
 	}
+	port := u.Port()
 
 	dockerIP, err := dockerutil.GetDockerIP()
 	assert.NoError(err)
 
-	fakeHost := u.Hostname()
-	u.Host = dockerIP
+	fakeHost := u.Hostname() + ":" + port
+	u.Host = dockerIP + ":" + port
 	localAddress := u.String()
 
 	timeout := time.Duration(10 * time.Second)

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -166,16 +166,35 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 
-	err = app.Start()
+	for _, pair := range []PortPair{{"80", "443"}, {"8080", "8443"}} {
+		ClearDockerEnv()
+		app.RouterHTTPPort = pair.HTTPPort
+		app.RouterHTTPSPort = pair.HTTPSPort
+		err = app.WriteConfig()
+		assert.NoError(err)
+
+		err = app.Start()
+		assert.NoError(err)
+
+		safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI
+		out, _, err := GetLocalHTTPResponse(t, safeURL)
+		assert.NoError(err)
+		assert.Contains(out, site.Safe200URIWithExpectation.Expect)
+
+		safeURL = app.GetHTTPSURL() + site.Safe200URIWithExpectation.URI
+		out, _, err = GetLocalHTTPResponse(t, safeURL)
+		assert.NoError(err)
+		assert.Contains(out, site.Safe200URIWithExpectation.Expect)
+
+		// This does the same thing as previous, but worth exercising it here.
+		EnsureLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect)
+	}
+	// Set the ports back to the default was so we don't break any following tests.
+	app.RouterHTTPSPort = "443"
+	app.RouterHTTPPort = "80"
+	err = app.WriteConfig()
 	assert.NoError(err)
 
-	safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI
-	out, _, err := GetLocalHTTPResponse(t, safeURL)
-	assert.NoError(err)
-	assert.Contains(out, site.Safe200URIWithExpectation.Expect)
-
-	// This does the same thing as previous, but worth exercising it here.
-	EnsureLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect)
 	err = app.Down(true, false)
 	assert.NoError(err)
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -177,6 +177,7 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 		assert.NoError(err)
 
 		safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI
+		//nolint: vetshadow
 		out, _, err := GetLocalHTTPResponse(t, safeURL)
 		assert.NoError(err)
 		assert.Contains(out, site.Safe200URIWithExpectation.Expect)

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -23,7 +23,7 @@ var TestSites = []TestSite{
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		Docroot:                       "htdocs",
 		Type:                          "wordpress",
-		Safe200URIWithExpectation:     URIWithExpect{"/readme.html", "Welcome. WordPress is a very special project to me."},
+		Safe200URIWithExpectation:     URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 	},
 }
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -23,7 +23,7 @@ var TestSites = []TestSite{
 		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
 		Docroot:                       "htdocs",
 		Type:                          "wordpress",
-		Safe200URL:                    "/readme.html",
+		Safe200URIWithExpectation:     URIWithExpect{"/readme.html", "Welcome. WordPress is a very special project to me."},
 	},
 }
 
@@ -169,13 +169,13 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 	err = app.Start()
 	assert.NoError(err)
 
-	safeURL := app.GetHTTPURL() + site.Safe200URL
+	safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI
 	out, _, err := GetLocalHTTPResponse(t, safeURL)
 	assert.NoError(err)
-	assert.Contains(out, "Famous 5-minute install")
+	assert.Contains(out, site.Safe200URIWithExpectation.Expect)
 
 	// This does the same thing as previous, but worth exercising it here.
-	EnsureLocalHTTPContent(t, safeURL, "Famous 5-minute install")
+	EnsureLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect)
 	err = app.Down(true, false)
 	assert.NoError(err)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Various web projects require http/s access to the project by the projects scheme/name/port **from within the web container**, which means they have to go through the router. OP #842 

## How this PR Solves The Problem:

Provide access to the router using docker-compose.yaml

## Manual Testing Instructions:

* Start a project
* `ddev ssh`
* Use `curl <fqdn>` to view the project.

For extra credit, use the https URL and use configurable ports. For https you'll need to use `curl -k`.

## Automated Testing Overview:

* Added TestInternalAndExternalAccessToURL(). This tests external and internal url access with a content test and also tests with nonstandard ports
* Reorganized site definition to not only get a safe static URL to hit but also check the returned content.

## Related Issue Link(s):

OP #842 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

