### PR TITLE
Improve TestWebserverType()

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -977,27 +977,36 @@ func (app *DdevApp) GetAllURLs() []string {
 		URLs = append(URLs, "http://"+name+httpPort, "https://"+name+httpsPort)
 	}
 
+	URLs = append(URLs, app.GetWebContainerDirectURL())
+
+	return URLs
+}
+
+// GetWebContainerDirectURL returns the URL that can be used without the router to get to web container.
+func (app *DdevApp) GetWebContainerDirectURL() string {
 	// Get direct address of web container
 	dockerIP, err := dockerutil.GetDockerIP()
 	if err != nil {
-		util.Error("Unable to get Docker IP: %v", err)
-		return URLs
+		util.Warning("Unable to get Docker IP: %v", err)
 	}
+	port, err := app.GetWebContainerPublicPort()
+	return fmt.Sprintf("http://%s:%d", dockerIP, port)
+}
+
+// GetWebContainerPublicPort returns the direct-access public tcp port for http
+func (app *DdevApp) GetWebContainerPublicPort() (int, error) {
 
 	webContainer, err := app.FindContainerByType("web")
 	if err != nil {
-		util.Error("Unable to find web container for app: %s, err %v", app.Name, err)
-		return URLs
+		return -1, fmt.Errorf("Unable to find web container for app: %s, err %v", app.Name, err)
 	}
 
 	for _, p := range webContainer.Ports {
 		if p.PrivatePort == 80 {
-			URLs = append(URLs, fmt.Sprintf("http://%s:%d", dockerIP, p.PublicPort))
-			break
+			return int(p.PublicPort), nil
 		}
 	}
-
-	return URLs
+	return -1, fmt.Errorf("No public port found for private port 80")
 }
 
 // HostName returns the hostname of a given application.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -989,7 +989,7 @@ func (app *DdevApp) GetWebContainerDirectURL() string {
 	if err != nil {
 		util.Warning("Unable to get Docker IP: %v", err)
 	}
-	port, err := app.GetWebContainerPublicPort()
+	port, _ := app.GetWebContainerPublicPort()
 	return fmt.Sprintf("http://%s:%d", dockerIP, port)
 }
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1574,14 +1574,14 @@ func TestWebserverType(t *testing.T) {
 			assert.NoError(err)
 
 			// nolint: vetshadow
-			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL()+"/phpinfo.php")
+			out, resp, err := testcommon.GetLocalHTTPResponse(t, app.GetWebContainerDirectURL()+"/phpinfo.php")
 			assert.NoError(err)
 
-			expectedServerType := "Apache/2.4"
+			expectedServerType := "Apache/2"
 			if app.WebserverType == "nginx-fpm" {
-				expectedServerType = "nginx/1"
+				expectedServerType = "nginx"
 			}
-			//assert.Contains(resp.Header["Server"], expectedServerType, "Server header for project=%s, app.WebserverType=%s should be %s", app.Name, app.WebserverType, expectedServerType)
+			assert.Contains(resp.Header["Server"][0], expectedServerType, "Server header for project=%s, app.WebserverType=%s should be %s", app.Name, app.WebserverType, expectedServerType)
 			assert.Contains(out, "$_SERVER['SERVER_SOFTWARE']</td><td class=\"v\">"+expectedServerType, "For app.WebserverType=%s expected $_SERVER['SERVER_SOFTWARE'] to show %s", app.WebserverType, expectedServerType)
 
 		}


### PR DESCRIPTION
## The Problem/Issue/Bug:

In #1148 (Adding TestWebserverType() to test to make sure we get the type of webserver we're expecting), I was stuck on the fact that the "Server" header was always nginx, so didn't do everything in the test I wanted. Of course the Server header was always nginx, because that's what the router runs.  Anyway, I wanted to test for the Server header!

## How this PR Solves The Problem:

This PR uses the direct-to-web-container approach and can check for the Server header coming directly from the web container.

It also does minor refactoring to provide easy access to the local-direct URL and port; those were previously done in inline code in app.Describe().

## Manual Testing Instructions:

I think if you like the code and it passes that's good enough.

## Automated Testing Overview:

This improves TestWebserverType()

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

