### PR TITLE
Emergency fix to logs_test.go for failed master

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -40,7 +40,7 @@ func TestDevLogs(t *testing.T) {
 		cleanup := v.Chdir()
 
 		url := "http://" + v.Name + "." + version.DDevTLD + "/logtest.php"
-		_, err = testcommon.GetLocalHTTPResponse(t, url)
+		_, _, err = testcommon.GetLocalHTTPResponse(t, url)
 		assert.NoError(err)
 
 		args := []string{"logs"}


### PR DESCRIPTION
## The Problem/Issue/Bug:

I moved too fast... and Github can in fact pull a breaking PR. I did it. 

The incompatible signature change of testcommon.GetLocalHTTPResponse() got into master in logs_test.go. 

I'll pull this when it passes. Which might be a long time.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

