### PR TITLE
Adds " around the version parameter to avoid trouble with zsh, update to TYPO3 v9 (docs only)

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -133,7 +133,7 @@ If necessary, run build steps that you may require, like `composer install` in t
 *Do not use this technique with Windows, as composer on an NTFS filesystem can result in major problems with NTFS symlinks that can't be read in the Linux web container. Instead, use the [community-provided hints on Stack Overflow](https://stackoverflow.com/questions/49660082/how-can-i-run-composer-with-ddev)*
 
 ```
-composer create-project typo3/cms-base-distribution my-typo3-site ^8
+composer create-project typo3/cms-base-distribution my-typo3-site "^9"
 cd my-typo3-site
 ```
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
For me on macOS it doesn't work without "" around the version string.. 
Further more I would suggest to update the documentation to TYPO3 9LTS.

