### PR TITLE
Remove unnecessary definition from generated WP settings

### DIFF
--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -145,9 +145,6 @@ define('WP_HOME', '{{ $config.DeployURL }}');
 /** WP_SITEURL location */
 define('WP_SITEURL', WP_HOME . '/{{ $config.AbsPath  }}');
 
-/** WP_ENV */
-define('WP_ENV', getenv('DDEV_ENV_NAME') ? getenv('DDEV_ENV_NAME') : 'production');
-
 /** Define the database table prefix */
 $table_prefix  = 'wp_';
 `


### PR DESCRIPTION
## The Problem/Issue/Bug:
`define('WP_ENV'...` is unnecessary for local development and shouldn't be part of the generated WordPress config template.

## How this PR Solves The Problem:
Removes it.

## Manual Testing Instructions:
With no existing wp-config.php, run `ddev config` and ensure the generated wp-config.php does not define WP_ENV.
