### PR TITLE
Inspect mysql version before failing when restoring a snapshot, #1170

### DIFF
--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -101,13 +101,14 @@ If you get a 404 with "No input file specified" (nginx) or a 403 with "Forbidden
 
 Database snapshot from before v1.3.0 are not compatible with ddev v1.3+ because the mariabackup with MariaDB 10.2 is not compatible with earlier backups. However, if you really need that snapshot and don't have a database dump to run with `ddev import-db`, there's a fairly easy workaround:
 
-1. In .ddev/config.yaml temporarily set `dbimage: drud/ddev-webserver:v1.2.0`.
-2. `ddev start` to start with the new version
-3. Use `ddev restore-snapshot` to restore the snapshot by name.
-4. `ddev rm`
-5. Remove the `dbimage` line from .ddev/config.yaml.
-6. `ddev start`
-7. Make a new snapshot with `ddev snapshot`.
+1. In .ddev/config.yaml temporarily set `dbimage: drud/ddev-webserver:v1.2.0`
+2. `ddev rm --remove-data` to remove an existing MariaDB 10.2 database
+3. `ddev start` to start with the new version
+4. Use `ddev restore-snapshot` to restore the snapshot by name
+5. `ddev rm`
+6. Remove the `dbimage` line from .ddev/config.yaml
+7. `ddev start`
+8. Make a new snapshot with `ddev snapshot`
 
 ## More Support
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -909,7 +909,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 
 	if !fileutil.FileExists(filepath.Join(hostSnapshotDir, "db_mariadb_version.txt")) {
 		// This command returning an error indicates grep has failed to find the value
-		if _, _, err := app.Exec("db", "sh", "-c", "mariabackup --verison 2>&1 >/dev/null | grep 10.1"); err != nil {
+		if _, _, err := app.Exec("db", "sh", "-c", "mariabackup --version 2>&1 | grep 10.1"); err != nil {
 			return fmt.Errorf("snapshot %s is not compatible with this version of ddev and mariadb. Please use the instructions at %s for a workaround to restore it", snapshotDir, "https://ddev.readthedocs.io/en/latest/users/troubleshooting/#old-snapshot")
 		}
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -914,7 +914,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	}
 
 	if app.SiteStatus() == SiteRunning || app.SiteStatus() == SiteStopped {
-		err := app.Down(false, false)
+		err = app.Down(false, false)
 		if err != nil {
 			return fmt.Errorf("Failed to rm  project for RestoreSnapshot: %v", err)
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -909,7 +909,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 
 	if !fileutil.FileExists(filepath.Join(hostSnapshotDir, "db_mariadb_version.txt")) {
 		// This command returning an error indicates grep has failed to find the value
-		if _, _, err := app.Exec("db", "sh", "-c", "mariabackup --version 2>&1 | grep 10.1"); err != nil {
+		if _, _, err := app.Exec("db", "sh", "-c", "mariabackup --version 2>&1 | grep '10\\.1'"); err != nil {
 			return fmt.Errorf("snapshot %s is not compatible with this version of ddev and mariadb. Please use the instructions at %s for a workaround to restore it", snapshotDir, "https://ddev.readthedocs.io/en/latest/users/troubleshooting/#old-snapshot")
 		}
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -909,7 +909,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 
 	if !fileutil.FileExists(filepath.Join(hostSnapshotDir, "db_mariadb_version.txt")) {
 		// This command returning an error indicates grep has failed to find the value
-		if _, _, err := app.Exec("db", "sh", "-c", "mysql -V | grep 10.2"); err == nil {
+		if _, _, err := app.Exec("db", "sh", "-c", "mariabackup --verison 2>&1 >/dev/null | grep 10.1"); err != nil {
 			return fmt.Errorf("snapshot %s is not compatible with this version of ddev and mariadb. Please use the instructions at %s for a workaround to restore it", snapshotDir, "https://ddev.readthedocs.io/en/latest/users/troubleshooting/#old-snapshot")
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1170

## How this PR Solves The Problem:
This allows the snapshot error help text method of recovery to work by inspecting the mysql version currently being used and only failing if the current database version requires the `db_mariadb_version.txt` file to exist.

## Manual Testing Instructions:
- Configure and start a project using ddev v1.2.0
- Populate the database
- `ddev snapshot`
- `ddev rm`
- Switch to ddev v1.3.0
- `ddev config`
- `ddev start`
- `ddev restore-snapshot <snapshot>`; this will fail - below are the steps recommended in the help link
- `ddev rm`
- Edit the database image in .ddev/config.yaml to be v1.2.0
- `ddev restore-snapshot <snapshot>`; this should succeed
- `ddev rm`
- Edit the database image in .ddev/config.yaml to be v1.3.0, or comment out the specific image to use the default
- `ddev start`
- Project should start successfully
- `ddev logs -s db` will show "Running mysql_upgrade" 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#1170 

