### PR TITLE
Use faster golangci-lint only,  less linting (build/test only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ setup:
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
 
 # Required static analysis targets used in circleci - these cause fail if they don't work
-staticrequired: gometalinter golangci-lint
+staticrequired: golangci-lint
 
 windows_install: windows bin/windows/windows_amd64/sudo.exe bin/windows/windows_amd64/sudo_license.txt
 	makensis -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows


### PR DESCRIPTION
## The Problem/Issue/Bug:

We wait a long time for `make staticrequired`. I've added the pre-push hook, so every push has been close to 2 minutes. 

I think we have consensus that the golangci-lint linters as currently configured do mostly what we need. If we find anything they're not doing, we'll try to improve them.
