### PR TITLE
Add config flags to specify image values, closes #1181

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -53,6 +53,27 @@ var (
 
 	// webserverTypeArgs allows a user to set the project's webserver type
 	webserverTypeArg string
+
+	// webImageArg allows a user to set the project's web server container image
+	webImageArg string
+
+	// webImageDefaultArg allows a user to unset the specific web server container image
+	webImageDefaultArg bool
+
+	// dbImageArg allows a user to set the project's db server container image
+	dbImageArg string
+
+	// dbImageDefaultArg allows a user to uset the specific db server container image
+	dbImageDefaultArg bool
+
+	// dbaImageArg allows a user to set the project's dba container image
+	dbaImageArg string
+
+	// dbaImageDefaultArg allows a user to unset the specific dba container image
+	dbaImageDefaultArg bool
+
+	// imageDefaultsArg allows a user to unset all specific container images
+	imageDefaultsArg bool
 )
 
 var providerName = ddevapp.ProviderDefault
@@ -141,6 +162,13 @@ func init() {
 	ConfigCommand.Flags().BoolVar(&showConfigLocation, "show-config-location", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
 	ConfigCommand.Flags().StringVar(&uploadDirArg, "upload-dir", "", "Sets the project's upload directory, the destination directory of the import-files command.")
 	ConfigCommand.Flags().StringVar(&webserverTypeArg, "webserver-type", "", "Sets the project's desired webserver type: nginx-fpm, apache-fpm, or apache-cgi")
+	ConfigCommand.Flags().StringVar(&webImageArg, "web-image", "", "Sets the web container image")
+	ConfigCommand.Flags().BoolVar(&webImageDefaultArg, "web-image-default", false, "Sets the default web container image for this ddev version")
+	ConfigCommand.Flags().StringVar(&dbImageArg, "db-image", "", "Sets the db container image")
+	ConfigCommand.Flags().BoolVar(&dbImageDefaultArg, "db-image-default", false, "Sets the default db container image for this ddev version")
+	ConfigCommand.Flags().StringVar(&dbaImageArg, "dba-image", "", "Sets the dba container image")
+	ConfigCommand.Flags().BoolVar(&dbaImageDefaultArg, "dba-image-default", false, "Sets the default dba container image for this ddev version")
+	ConfigCommand.Flags().BoolVar(&imageDefaultsArg, "image-defaults", false, "Sets the default web, db, and dba container images")
 
 	// apptype flag exists for backwards compatibility.
 	ConfigCommand.Flags().StringVar(&appTypeArg, "apptype", "", apptypeUsage+" This is the same as --projecttype and is included only for backwards compatibility.")
@@ -295,6 +323,36 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if webserverTypeArg != "" {
 		app.WebserverType = webserverTypeArg
+	}
+
+	if webImageArg != "" {
+		app.WebImage = webImageArg
+	}
+
+	if webImageDefaultArg {
+		app.WebImage = ""
+	}
+
+	if dbImageArg != "" {
+		app.DBImage = dbImageArg
+	}
+
+	if dbImageDefaultArg {
+		app.DBImage = ""
+	}
+
+	if dbaImageArg != "" {
+		app.DBAImage = dbaImageArg
+	}
+
+	if dbaImageDefaultArg {
+		app.DBAImage = ""
+	}
+
+	if imageDefaultsArg {
+		app.WebImage = ""
+		app.DBImage = ""
+		app.DBAImage = ""
 	}
 
 	// Ensure the configuration passes validation before writing config file.

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -101,12 +101,12 @@ If you get a 404 with "No input file specified" (nginx) or a 403 with "Forbidden
 
 Database snapshot from before v1.3.0 are not compatible with ddev v1.3+ because the mariabackup with MariaDB 10.2 is not compatible with earlier backups. However, if you really need that snapshot and don't have a database dump to run with `ddev import-db`, there's a fairly easy workaround:
 
-1. In .ddev/config.yaml temporarily set `dbimage: drud/ddev-webserver:v1.2.0`
+1. `ddev config --db-image drud/ddev-webserver:v1.2.0`
 2. `ddev rm --remove-data` to remove an existing MariaDB 10.2 database
 3. `ddev start` to start with the new version
 4. Use `ddev restore-snapshot` to restore the snapshot by name
 5. `ddev rm`
-6. Remove the `dbimage` line from .ddev/config.yaml
+6. `ddev config --db-image default`
 7. `ddev start`
 8. Make a new snapshot with `ddev snapshot`
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -106,10 +106,18 @@ func (app *DdevApp) WriteConfig() error {
 	// Update the "APIVersion" to be the ddev version.
 	appcopy.APIVersion = version.DdevVersion
 
-	// We don't want to even set the images on write, even though we'll respect them on read.
-	appcopy.DBAImage = ""
-	appcopy.DBImage = ""
-	appcopy.WebImage = ""
+	// Only set the images on write if non-default values have been specified.
+	if appcopy.WebImage == fmt.Sprintf("%s:%s", version.WebImg, version.WebTag) {
+		appcopy.WebImage = ""
+	}
+
+	if appcopy.DBImage == fmt.Sprintf("%s:%s", version.DBImg, version.DBTag) {
+		appcopy.DBImage = ""
+	}
+
+	if appcopy.DBAImage == fmt.Sprintf("%s:%s", version.DBAImg, version.DBATag) {
+		appcopy.DBAImage = ""
+	}
 
 	err := PrepDdevDirectory(filepath.Dir(appcopy.ConfigPath))
 	if err != nil {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -65,9 +65,9 @@ func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	app.RouterHTTPSPort = DdevDefaultRouterHTTPSPort
 
 	// These should always default to the latest image/tag names from the Version package.
-	app.WebImage = version.WebImg + ":" + version.WebTag
-	app.DBImage = version.DBImg + ":" + version.DBTag
-	app.DBAImage = version.DBAImg + ":" + version.DBATag
+	app.WebImage = version.GetWebImage()
+	app.DBImage = version.GetDBImage()
+	app.DBAImage = version.GetDBAImage()
 
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
@@ -107,15 +107,15 @@ func (app *DdevApp) WriteConfig() error {
 	appcopy.APIVersion = version.DdevVersion
 
 	// Only set the images on write if non-default values have been specified.
-	if appcopy.WebImage == fmt.Sprintf("%s:%s", version.WebImg, version.WebTag) {
+	if appcopy.WebImage == version.GetWebImage() {
 		appcopy.WebImage = ""
 	}
 
-	if appcopy.DBImage == fmt.Sprintf("%s:%s", version.DBImg, version.DBTag) {
+	if appcopy.DBImage == version.GetDBImage() {
 		appcopy.DBImage = ""
 	}
 
-	if appcopy.DBAImage == fmt.Sprintf("%s:%s", version.DBAImg, version.DBATag) {
+	if appcopy.DBAImage == version.GetDBAImage() {
 		appcopy.DBAImage = ""
 	}
 
@@ -130,7 +130,7 @@ func (app *DdevApp) WriteConfig() error {
 	}
 
 	// Append current image information
-	cfgbytes = append(cfgbytes, []byte(fmt.Sprintf("\n\n# This config.yaml was created with ddev version %s \n# webimage: %s:%s\n# dbimage: %s:%s\n# dbaimage: %s:%s\n# However we do not recommend explicitly wiring these images into the\n# config.yaml as they may break future versions of ddev.\n# You can update this config.yaml using 'ddev config'.\n", version.DdevVersion, version.WebImg, version.WebTag, version.DBImg, version.DBTag, version.DBAImg, version.DBATag))...)
+	cfgbytes = append(cfgbytes, []byte(fmt.Sprintf("\n\n# This config.yaml was created with ddev version %s \n# webimage: %s\n# dbimage: %s\n# dbaimage: %s\n# However we do not recommend explicitly wiring these images into the\n# config.yaml as they may break future versions of ddev.\n# You can update this config.yaml using 'ddev config'.\n", version.DdevVersion, version.GetWebImage(), version.GetDBImage(), version.GetDBAImage()))...)
 
 	// Append hook information and sample hook suggestions.
 	cfgbytes = append(cfgbytes, []byte(ConfigInstructions)...)
@@ -202,13 +202,15 @@ func (app *DdevApp) ReadConfig() error {
 	}
 
 	if app.WebImage == "" {
-		app.WebImage = version.WebImg + ":" + version.WebTag
+		app.WebImage = version.GetWebImage()
 	}
+
 	if app.DBImage == "" {
-		app.DBImage = version.DBImg + ":" + version.DBTag
+		app.DBImage = version.GetDBImage()
 	}
+
 	if app.DBAImage == "" {
-		app.DBAImage = version.DBAImg + ":" + version.DBATag
+		app.DBAImage = version.GetDBAImage()
 	}
 
 	dirPath := filepath.Join(util.GetGlobalDdevDir(), app.Name)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,7 @@
 package version
 
+import "fmt"
+
 // VERSION is supplied with the git committish this is built from
 var VERSION = ""
 
@@ -68,4 +70,19 @@ func GetVersionInfo() map[string]string {
 	versionInfo["build info"] = BUILDINFO
 
 	return versionInfo
+}
+
+// GetWebImage returns the correctly formatted web image:tag reference
+func GetWebImage() string {
+	return fmt.Sprintf("%s:%s", WebImg, WebTag)
+}
+
+// GetDBImage returns the correctly formatted db image:tag reference
+func GetDBImage() string {
+	return fmt.Sprintf("%s:%s", DBImg, DBTag)
+}
+
+// GetDBAImage returns the correctly formatted dba image:tag reference
+func GetDBAImage() string {
+	return fmt.Sprintf("%s:%s", DBAImg, DBATag)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
Giving troubleshooting/debugging instructions can be complicated when it involves changing web/db/dba image values because it requires editing .ddev/config.yaml.

## How this PR Solves The Problem:
Adds several configuration flags to `ddev config` that will set the images being used:

- `--web-image`
- `--db-image`
- `--dba-image`

To unset these custom image configurations, the following flags have been added:

- `--web-image-default`
- `--db-image-default`
- `--dba-image-default`

And the following flag has been added to unset all custom image configurations in one go:

- `--image-defaults`

Some image reference getters have been added to `versions.go` to standardize things.

## Manual Testing Instructions:
Provide custom image names to `ddev config`:

- `ddev config --web-image my-web-image`
- `ddev config --db-image my-db-image:v1.2.3`
- `ddev config --dba-image my-dba-image:latest`

And combinations of the above. Ensure after each execution that .ddev/config.yaml has been updated to reflect the updated image, then test unsetting image values:

- `ddev config --web-image-default`
- `ddev config --db-image-default`
- `ddev config --dba-image-default`
- `ddev config --image-defaults`

## Automated Testing Overview:
Automated tests have been expanded to test the new flags.

## Related Issue Link(s):


