### PR TITLE
Add configuratable execution directory to exec command, resolves #1112

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -11,6 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// execDirArg allows a configurable container execution directory
+var execDirArg string
+
 // DdevExecCmd allows users to execute arbitrary bash commands within a container.
 var DdevExecCmd = &cobra.Command{
 	Use:     "exec <command>",
@@ -39,7 +42,12 @@ var DdevExecCmd = &cobra.Command{
 
 		app.DockerEnv()
 
-		out, _, err := app.Exec(serviceType, args...)
+		out, _, err := app.Exec(&ddevapp.ExecOpts{
+			Service: serviceType,
+			Dir:     execDirArg,
+			Cmd:     args,
+		})
+
 		if err != nil {
 			util.Failed("Failed to execute command %s: %v", args, err)
 		}
@@ -49,6 +57,7 @@ var DdevExecCmd = &cobra.Command{
 
 func init() {
 	DdevExecCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to connect to. [e.g. web, db]")
+	DdevExecCmd.Flags().StringVarP(&execDirArg, "dir", "d", "", "Defines the execution directory within the container")
 	// This requires flags for exec to be specified prior to any arguments, allowing for
 	// flags to be ignored by cobra for commands that are to be executed in a container.
 	DdevExecCmd.Flags().SetInterspersed(false)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -323,7 +323,11 @@ func (app *DdevApp) ImportDB(imPath string, extPath string) error {
 		return fmt.Errorf("no .sql or .mysql files found to import")
 	}
 
-	_, _, err = app.Exec("db", "bash", "-c", "mysql --database=mysql -e 'DROP DATABASE IF EXISTS db; CREATE DATABASE db;' && cat /db/*.*sql | mysql db")
+	_, _, err = app.Exec(&ExecOpts{
+		Service: "db",
+		Cmd:     []string{"bash", "-c", "mysql --database=mysql -e 'DROP DATABASE IF EXISTS db; CREATE DATABASE db;' && cat /db/*.*sql | mysql db"},
+	})
+
 	if err != nil {
 		return err
 	}
@@ -552,7 +556,11 @@ func (app *DdevApp) ProcessHooks(hookName string) error {
 				return fmt.Errorf("%s exec failed: %v", hookName, err)
 			}
 
-			stdout, stderr, err := app.Exec("web", args...)
+			stdout, stderr, err := app.Exec(&ExecOpts{
+				Service: "web",
+				Cmd:     args,
+			})
+
 			if err != nil {
 				return fmt.Errorf("%s exec failed: %v, stderr='%s'", hookName, err, stderr)
 			}
@@ -662,18 +670,41 @@ func (app *DdevApp) Start() error {
 	return nil
 }
 
+// ExecOpts contains options for running a command inside a container
+type ExecOpts struct {
+	Service string
+	Dir     string
+	Cmd     []string
+}
+
 // Exec executes a given command in the container of given type without allocating a pty
 // Returns ComposeCmd results of stdout, stderr, err
-func (app *DdevApp) Exec(service string, cmd ...string) (string, string, error) {
+func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	app.DockerEnv()
 
-	exec := []string{"exec", "-e", "DDEV_EXEC=true", "-T", service}
-	exec = append(exec, cmd...)
+	// Build docker-compose comamand
+	exec := []string{"exec", "-e", "DDEV_EXEC=true"}
+	if opts.Dir != "" {
+		exec = append(exec, "-w", opts.Dir)
+	}
+
+	if opts.Service == "" {
+		return "", "", fmt.Errorf("undefined service")
+	}
+
+	exec = append(exec, "-T", opts.Service)
+
+	if opts.Cmd == nil {
+		return "", "", fmt.Errorf("undefined command")
+	}
+
+	exec = append(exec, opts.Cmd...)
 
 	files, err := app.ComposeFiles()
 	if err != nil {
 		return "", "", err
 	}
+
 	return dockerutil.ComposeCmd(files, exec...)
 }
 
@@ -888,7 +919,11 @@ func (app *DdevApp) SnapshotDatabase(snapshotName string) (string, error) {
 	}
 
 	util.Warning("Creating database snapshot %s", snapshotName)
-	stdout, stderr, err := app.Exec("db", "bash", "-c", fmt.Sprintf("mariabackup --backup --target-dir=%s --user root --password root --socket=/var/tmp/mysql.sock 2>/var/log/mariadbackup_backup_%s.log && cp /var/lib/mysql/db_mariadb_version.txt %s", containerSnapshotDir, snapshotName, containerSnapshotDir))
+	stdout, stderr, err := app.Exec(&ExecOpts{
+		Service: "db",
+		Cmd:     []string{"bash", "-c", fmt.Sprintf("mariabackup --backup --target-dir=%s --user root --password root --socket=/var/tmp/mysql.sock 2>/var/log/mariadbackup_backup_%s.log && cp /var/lib/mysql/db_mariadb_version.txt %s", containerSnapshotDir, snapshotName, containerSnapshotDir)},
+	})
+
 	if err != nil {
 		util.Warning("Failed to create snapshot: %v, stdout=%s, stderr=%s", err, stdout, stderr)
 		return "", err
@@ -909,7 +944,12 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 
 	if !fileutil.FileExists(filepath.Join(hostSnapshotDir, "db_mariadb_version.txt")) {
 		// This command returning an error indicates grep has failed to find the value
-		if _, _, err := app.Exec("db", "sh", "-c", "mariabackup --version 2>&1 | grep '10\\.1'"); err != nil {
+		opts := &ExecOpts{
+			Service: "db",
+			Cmd:     []string{"sh", "-c", "mariabackup --version 2>&1 | grep '10\\.1'"},
+		}
+
+		if _, _, err := app.Exec(opts); err != nil {
 			return fmt.Errorf("snapshot %s is not compatible with this version of ddev and mariadb. Please use the instructions at %s for a workaround to restore it", snapshotDir, "https://ddev.readthedocs.io/en/latest/users/troubleshooting/#old-snapshot")
 		}
 	}

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -129,7 +129,10 @@ func checkSolrService(t *testing.T, app *ddevapp.DdevApp) {
 
 	// Ensure service is accessible from web container
 	checkCommand := fmt.Sprintf("curl -sL -w '%%{http_code}' '%s' -o /dev/null", path)
-	out, _, err := app.Exec("web", "sh", "-c", checkCommand)
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
+		Service: "web",
+		Cmd:     []string{"sh", "-c", checkCommand},
+	})
 	assert.NoError(err, "Unable to make request to http://%s:%s/solr/", service, port)
 	assert.Equal("200", out)
 }
@@ -161,7 +164,10 @@ func checkMemcachedService(t *testing.T, app *ddevapp.DdevApp) {
 	// Ensure service is accessible from web container
 	checkCommand := fmt.Sprintf("echo stats | nc -q 1 %s %s", service, port)
 
-	out, _, err := app.Exec("web", "sh", "-c", checkCommand)
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
+		Service: "web",
+		Cmd:     []string{"sh", "-c", checkCommand},
+	})
 	assert.NoError(err)
 	assert.Contains(out, "STAT pid")
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1112: It was difficult to define an execution directory for `ddev exec` commands.

## How this PR Solves The Problem:
Adds the optional `-d/--dir` flag to `ddev exec`, which will specify the directory in which the command should be executed within the service container.

## Manual Testing Instructions:
Ensure commands are executed from the correct directory context:

- `ddev -s web exec -d / ls` should return the contents of the web container's root directory 
- `ddev -s db exec -d /home sudo touch test-file` should create `/home/test-file`
- `ddev -d /does/not/exist ls` should return an error as the execution directory does not exist

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#1112 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

