### PR TITLE
Add openssh-client to web container for #414

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -72,6 +72,7 @@ RUN apt-get -qq update && \
         rsync \
         locales-all \
         libpcre3 \
+        openssh-client \
         php-imagick && \
     for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-sqlite3 $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,7 +27,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.3.0" // Note that this can be overridden by make
+var WebTag = "20181017_add_ssh" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#414 points out that we lost the Debian package openssh-client in the v1.3.0 ddev-webserver. This puts it back in there.

This image can be used with ddev v1.3.0 by adding `webimage: drud/ddev-webserver:20181017_add_ssh` to config.yaml. 

