### PR TITLE
Add sequelpro.spf to .ddev gitignore, fixes #1216

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -613,7 +613,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots")
+	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1216 points out that `ddev sequelpro` creates .ddev/sequelpro.spf, which can accidentally get checked in because it's not gitignored.

This adds sequelpro.spf to the gitignore.
