### PR TITLE
Add open CORS to ddev-router nginx config.

### DIFF
--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -78,6 +78,10 @@ proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
 
 # Mitigate httpoxy attack (see README for details)
 proxy_set_header Proxy "";
+
+# Open CORS
+proxy_set_header Origin "";
+add_header "Access-Control-Allow-Origin" "*" always;
 {{ end }}
 
 {{ $enable_ipv6 := eq (or ($.Env.ENABLE_IPV6) "") "true" }}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DBATag = "v1.3.0" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.3.0" // Note that this can be overridden by make
+var RouterTag = "Mogtofu33-master" // Note that this can be overridden by make
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Setting up a ddev stack for Drupal 8 with [ContentaCMS](https://github.com/contentacms) (a headless Drupal distribution) and a separated frontend as a new service (with a different hostname as _additional_hostnames_), the ddev-router container do not allow access from the frontend because of a different _Origin_ (403).
In the same time using CORS, ddev-router do not provide or relay any _Access-Control-Allow-Origin_ information.

Here is an installation instruction used to setup ddev with Contenta:
* https://github.com/Mogtofu33/contenta-ddev

I assume the same kind of problem can occur with ddev on any type of stack when dealing with CORS on a project.

## How this PR Solves The Problem:

Clean the header _Origin_ for all request to the router and add an open _Access-Control-Allow-Origin_.

This configuration is full open and not safe for production, so perhaps could be a better approach to allow _proxy.conf_ override on ddev directly.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

* https://github.com/Mogtofu33/contenta-ddev/issues/1

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

