### PR TITLE
Add move.yml for moving issues out of repo

### DIFF
--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,21 @@
+# Configuration for move-issues - https://github.com/dessant/move-issues
+
+# Delete the command comment when it contains no other content
+deleteCommand: true
+
+# Close the source issue after moving
+closeSourceIssue: true
+
+# Lock the source issue after moving
+lockSourceIssue: false
+
+# Mention issue and comment authors
+mentionAuthors: true
+
+# Preserve mentions in the issue content
+keepContentMentions: false
+
+# Set custom aliases for targets
+# aliases:
+#   r: repo
+#   or: owner/repo


### PR DESCRIPTION
## The Problem/Issue/Bug:

Clean up OKR > Epics in the repo.

## How this PR Solves The Problem:

This is a movebot tool that lives in the .github folder of some of our other repos and allows for moving issues to another repo. I'll use to move the OKR epics out of this repo. https://github.com/dessant/move-issues

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

No.

