### PR TITLE
Add debugging for TestDdevRestoreSnapshot

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -343,7 +343,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
-		restoreOutput := testcommon.CaptureStdOut()
+		restoreOutput := util.CaptureStdOut()
 		err = app.PromptForConfig()
 		assert.NoError(err, t)
 		out := restoreOutput()
@@ -398,7 +398,7 @@ func TestConfigCommandDocrootDetectionIndexVerification(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 
-	restoreOutput := testcommon.CaptureStdOut()
+	restoreOutput := util.CaptureStdOut()
 	err = app.PromptForConfig()
 	assert.NoError(err, t)
 	out := restoreOutput()

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -174,7 +174,7 @@ func TestConfigCommand(t *testing.T) {
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
-		restoreOutput := testcommon.CaptureUserOut()
+		restoreOutput := util.CaptureUserOut()
 		err = app.PromptForConfig()
 		assert.NoError(err, t)
 		out := restoreOutput()
@@ -190,7 +190,7 @@ func TestConfigCommand(t *testing.T) {
 		scanner = bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
-		restoreOutput = testcommon.CaptureUserOut()
+		restoreOutput = util.CaptureUserOut()
 		err = app.PromptForConfig()
 		assert.NoError(err, t)
 		out = restoreOutput()
@@ -288,7 +288,7 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
-		restoreOutput := testcommon.CaptureUserOut()
+		restoreOutput := util.CaptureUserOut()
 		err = app.PromptForConfig()
 		assert.NoError(err, t)
 		out := restoreOutput()
@@ -561,7 +561,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 	err = app.ReadConfig()
 	assert.NoError(err)
 
-	restoreOutput := testcommon.CaptureUserOut()
+	restoreOutput := util.CaptureUserOut()
 	err = app.Start()
 	out := restoreOutput()
 	assert.NoError(err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -724,6 +724,15 @@ func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines
 	return nil
 }
 
+// CaptureLogs returns logs for a site's given container.
+// See docker.LogsOptions for more information about valid tailLines values.
+func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines string) (string, error) {
+	stdout := util.CaptureUserOut()
+	err := app.Logs(service, false, false, "")
+	out := stdout()
+	return out, err
+}
+
 // DockerEnv sets environment variables for a docker-compose run.
 func (app *DdevApp) DockerEnv() {
 	curUser, err := user.Current()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -728,7 +728,7 @@ func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines
 // See docker.LogsOptions for more information about valid tailLines values.
 func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines string) (string, error) {
 	stdout := util.CaptureUserOut()
-	err := app.Logs(service, false, false, "")
+	err := app.Logs(service, false, timestamps, tailLines)
 	out := stdout()
 	return out, err
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1891,6 +1891,31 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 	}
 }
 
+// TestCaptureLogs checks that app.CaptureLogs() works
+func TestCaptureLogs(t *testing.T) {
+	assert := asrt.New(t)
+
+	site := TestSites[0]
+	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s CaptureLogs", site.Name))
+
+	app := new(ddevapp.DdevApp)
+
+	err := app.Init(site.Dir)
+	assert.NoError(err)
+	err = app.Start()
+	assert.NoError(err)
+
+	logs, err := app.CaptureLogs("web", false, "100")
+	assert.NoError(err)
+
+	assert.Contains(logs, "INFO spawned")
+
+	err = app.Down(true, false)
+	assert.NoError(err)
+
+	runTime()
+}
+
 // constructContainerName builds a container name given the type (web/db/dba) and the app
 func constructContainerName(containerType string, app *ddevapp.DdevApp) (string, error) {
 	container, err := app.FindContainerByType(containerType)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1778,6 +1778,31 @@ func TestWebserverType(t *testing.T) {
 	}
 }
 
+// TestCaptureLogs checks that app.CaptureLogs() works
+func TestCaptureLogs(t *testing.T) {
+	assert := asrt.New(t)
+
+	site := TestSites[0]
+	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s CaptureLogs", site.Name))
+
+	app := new(ddevapp.DdevApp)
+
+	err := app.Init(site.Dir)
+	assert.NoError(err)
+	err = app.Start()
+	assert.NoError(err)
+
+	logs, err := app.CaptureLogs("web", false, "100")
+	assert.NoError(err)
+
+	assert.Contains(logs, "INFO spawned")
+
+	err = app.Down(true, false)
+	assert.NoError(err)
+
+	runTime()
+}
+
 // TestDbMigration tests migration from bind-mounted db to volume-mounted db
 // This should be important around the time of its release, 2018-08-02 or so, but should be increasingly
 // irrelevant after that and can eventually be removed.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -339,8 +339,8 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		}
 
 		for _, hostname := range app.GetHostnames() {
-			testcommon.EnsureLocalHTTPContent(t, "http://"+hostname+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
-			testcommon.EnsureLocalHTTPContent(t, "https://"+hostname+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+			_, _ = testcommon.EnsureLocalHTTPContent(t, "http://"+hostname+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+			_, _ = testcommon.EnsureLocalHTTPContent(t, "https://"+hostname+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
 
 		}
 
@@ -696,7 +696,12 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 
 	err = app.ImportDB(d7testerTest1Dump, "")
 	assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", d7testerTest1Dump, err)
-	testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 1 has 1 node", 45)
+	_, err = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 1 has 1 node", 45)
+	if err != nil {
+		logs, err := app.CaptureLogs("web", false, "20")
+		assert.NoError(err)
+		t.Logf("Failed http content assertion; web container logs:\n=======%s==========\n", logs)
+	}
 
 	// Make a snapshot of d7 tester test 1
 	backupsDir := filepath.Join(app.GetConfigPath(""), "db_snapshots")
@@ -707,7 +712,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 
 	err = app.ImportDB(d7testerTest2Dump, "")
 	assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", d7testerTest2Dump, err)
-	testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 2 has 2 nodes", 45)
+	_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 2 has 2 nodes", 45)
 
 	snapshotName, err = app.SnapshotDatabase("d7testerTest2")
 	assert.NoError(err)
@@ -716,7 +721,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 
 	err = app.RestoreSnapshot("d7testerTest1")
 	assert.NoError(err)
-	testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 1 has 1 node", 45)
+	_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 1 has 1 node", 45)
 	err = app.RestoreSnapshot("d7testerTest2")
 	assert.NoError(err)
 
@@ -1865,8 +1870,8 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 			assert.NoError(err)
 
 			// Ensure that we can access from the host even with extra port specifications.
-			testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
-			testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+			_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+			_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
 
 			// Ensure that we can access the same URL from within the web container (via router)
 			var out string

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1778,31 +1778,6 @@ func TestWebserverType(t *testing.T) {
 	}
 }
 
-// TestCaptureLogs checks that app.CaptureLogs() works
-func TestCaptureLogs(t *testing.T) {
-	assert := asrt.New(t)
-
-	site := TestSites[0]
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s CaptureLogs", site.Name))
-
-	app := new(ddevapp.DdevApp)
-
-	err := app.Init(site.Dir)
-	assert.NoError(err)
-	err = app.Start()
-	assert.NoError(err)
-
-	logs, err := app.CaptureLogs("web", false, "100")
-	assert.NoError(err)
-
-	assert.Contains(logs, "INFO spawned")
-
-	err = app.Down(true, false)
-	assert.NoError(err)
-
-	runTime()
-}
-
 // TestDbMigration tests migration from bind-mounted db to volume-mounted db
 // This should be important around the time of its release, 2018-08-02 or so, but should be increasingly
 // irrelevant after that and can eventually be removed.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -318,7 +318,7 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		err = app.Start()
 		assert.NoError(err)
 		if err != nil && strings.Contains(err.Error(), "db container failed") {
-			stdout := testcommon.CaptureUserOut()
+			stdout := util.CaptureUserOut()
 			err = app.Logs("db", false, false, "")
 			assert.NoError(err)
 			out := stdout()
@@ -625,13 +625,13 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		}
 
 		// Test static content.
-		testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
 		// Test dynamic php + database content.
 		rawurl := app.GetHTTPURL() + site.DynamicURI.URI
 		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, 40)
 		assert.NoError(err, "GetLocalHTTPResponse returned err on rawurl %s, resp=$v: %v", rawurl, resp, err)
 		if err != nil {
-			stdout := testcommon.CaptureUserOut()
+			stdout := util.CaptureUserOut()
 			err = app.Logs("web", false, false, "")
 			assert.NoError(err)
 			out := stdout()
@@ -725,7 +725,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	assert.Contains(body, "d7 tester test 2 has 2 nodes")
 	if err != nil {
 		t.Logf("resp after timeout: %v", resp)
-		stdout := testcommon.CaptureUserOut()
+		stdout := util.CaptureUserOut()
 		err = app.Logs("web", false, false, "")
 		assert.NoError(err)
 		out := stdout()
@@ -1044,13 +1044,13 @@ func TestDdevLogs(t *testing.T) {
 		err = app.Start()
 		assert.NoError(err)
 
-		stdout := testcommon.CaptureUserOut()
+		stdout := util.CaptureUserOut()
 		err = app.Logs("web", false, false, "")
 		assert.NoError(err)
 		out := stdout()
 		assert.Contains(out, "Server started")
 
-		stdout = testcommon.CaptureUserOut()
+		stdout = util.CaptureUserOut()
 		err = app.Logs("db", false, false, "")
 		assert.NoError(err)
 		out = stdout()
@@ -1060,13 +1060,13 @@ func TestDdevLogs(t *testing.T) {
 		err = app.Stop()
 		assert.NoError(err)
 
-		stdout = testcommon.CaptureUserOut()
+		stdout = util.CaptureUserOut()
 		err = app.Logs("web", false, false, "")
 		assert.NoError(err)
 		out = stdout()
 		assert.Contains(out, "Server started")
 
-		stdout = testcommon.CaptureUserOut()
+		stdout = util.CaptureUserOut()
 		err = app.Logs("db", false, false, "")
 		assert.NoError(err)
 		out = stdout()
@@ -1107,7 +1107,7 @@ func TestProcessHooks(t *testing.T) {
 			},
 		}
 
-		stdout := testcommon.CaptureUserOut()
+		stdout := util.CaptureUserOut()
 		err = app.ProcessHooks("hook-test")
 		assert.NoError(err)
 
@@ -1212,7 +1212,7 @@ func TestDescribe(t *testing.T) {
 
 		// If we have a problem starting, get the container logs and output.
 		if err != nil {
-			stdout := testcommon.CaptureUserOut()
+			stdout := util.CaptureUserOut()
 			logsErr := app.Logs("web", false, false, "")
 			assert.NoError(logsErr)
 			out := stdout()

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -68,7 +68,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 
-	restoreOutput := testcommon.CaptureUserOut()
+	restoreOutput := util.CaptureUserOut()
 	err = app.PromptForConfig()
 	assert.NoError(err, t)
 	out := restoreOutput()

--- a/pkg/ddevapp/providerDrudS3_test.go
+++ b/pkg/ddevapp/providerDrudS3_test.go
@@ -54,7 +54,7 @@ func TestDrudS3ConfigCommand(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 
-	restoreOutput := testcommon.CaptureUserOut()
+	restoreOutput := util.CaptureUserOut()
 	err = app.PromptForConfig()
 	assert.NoError(err)
 	_ = restoreOutput()
@@ -75,7 +75,7 @@ func TestDrudS3ConfigCommand(t *testing.T) {
 	scanner = bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 
-	restoreOutput = testcommon.CaptureUserOut()
+	restoreOutput = util.CaptureUserOut()
 	err = app.PromptForConfig()
 	assert.NoError(err)
 	_ = restoreOutput()
@@ -95,7 +95,7 @@ func TestDrudS3ConfigCommand(t *testing.T) {
 	scanner = bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 
-	restoreOutput = testcommon.CaptureUserOut()
+	restoreOutput = util.CaptureUserOut()
 	err = app.PromptForConfig()
 	assert.Error(err)
 	if err != nil {
@@ -109,7 +109,7 @@ func TestDrudS3ConfigCommand(t *testing.T) {
 	scanner = bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 
-	restoreOutput = testcommon.CaptureUserOut()
+	restoreOutput = util.CaptureUserOut()
 	err = app.PromptForConfig()
 	assert.NoError(err)
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -192,34 +192,6 @@ func Chdir(path string) func() {
 	}
 }
 
-// CaptureUserOut captures output written to UserOut to a string.
-// Capturing starts when it is called. It returns an anonymous function that
-// when called, will return a string containing the output during capture, and
-// revert once again to the original value of os.StdOut.
-func CaptureUserOut() func() string {
-	old := output.UserOut.Out // keep backup of the real stdout
-	r, w, _ := os.Pipe()
-	output.UserOut.Out = w
-
-	return func() string {
-		outC := make(chan string)
-		// copy the output in a separate goroutine so printing can't block indefinitely
-		go func() {
-			var buf bytes.Buffer
-			_, err := io.Copy(&buf, r)
-			util.CheckErr(err)
-			outC <- buf.String()
-		}()
-
-		// back to normal state
-		util.CheckClose(w)
-		output.UserOut.Out = old // restoring the real stdout
-
-		out := <-outC
-		return out
-	}
-}
-
 // CaptureStdOut captures Stdout to a string. Capturing starts when it is called. It returns an anonymous function that when called, will return a string
 // containing the output during capture, and revert once again to the original value of os.StdOut.
 func CaptureStdOut() func() string {

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -3,6 +3,7 @@ package testcommon
 import (
 	"bytes"
 	"crypto/tls"
+	"github.com/drud/ddev/pkg/ddevapp"
 	"io"
 	"io/ioutil"
 	"os"
@@ -16,10 +17,8 @@ import (
 	"fmt"
 
 	"github.com/drud/ddev/pkg/archive"
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/pkg/errors"
 	asrt "github.com/stretchr/testify/assert"

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -1,10 +1,8 @@
 package testcommon
 
 import (
-	"bytes"
 	"crypto/tls"
 	"github.com/drud/ddev/pkg/ddevapp"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -188,31 +186,6 @@ func Chdir(path string) func() {
 			// TODO: This should never Fatalf, as it terminates the process without test running finishing cleanup.
 			log.Fatalf("Failed to change directory to original dir=%s, err=%v", curDir, err)
 		}
-	}
-}
-
-// CaptureStdOut captures Stdout to a string. Capturing starts when it is called. It returns an anonymous function that when called, will return a string
-// containing the output during capture, and revert once again to the original value of os.StdOut.
-func CaptureStdOut() func() string {
-	old := os.Stdout // keep backup of the real stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	return func() string {
-		outC := make(chan string)
-		// copy the output in a separate goroutine so printing can't block indefinitely
-		go func() {
-			var buf bytes.Buffer
-			_, err := io.Copy(&buf, r)
-			util.CheckErr(err)
-			outC <- buf.String()
-		}()
-
-		// back to normal state
-		util.CheckClose(w)
-		os.Stdout = old // restoring the real stdout
-		out := <-outC
-		return out
 	}
 }
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -367,16 +367,17 @@ func GetLocalHTTPResponse(t *testing.T, rawurl string, timeoutSecsAry ...int) (s
 }
 
 // EnsureLocalHTTPContent will verify a URL responds with a 200 and expected content string
-func EnsureLocalHTTPContent(t *testing.T, rawurl string, expectedContent string, timeoutSeconds ...int) {
+func EnsureLocalHTTPContent(t *testing.T, rawurl string, expectedContent string, timeoutSeconds ...int) (*http.Response, error) {
 	var httpTimeout = 20
 	if len(timeoutSeconds) > 0 {
 		httpTimeout = timeoutSeconds[0]
 	}
 	assert := asrt.New(t)
 
-	body, _, err := GetLocalHTTPResponse(t, rawurl, httpTimeout)
+	body, resp, err := GetLocalHTTPResponse(t, rawurl, httpTimeout)
 	assert.NoError(err, "GetLocalHTTPResponse returned err on rawurl %s: %v", rawurl, err)
 	assert.Contains(body, expectedContent)
+	return resp, err
 }
 
 // PortPair is for tests to use naming portsets for tests

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 )
 
@@ -165,7 +164,7 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 		assert.Contains(out, site.Safe200URIWithExpectation.Expect)
 
 		// This does the same thing as previous, but worth exercising it here.
-		EnsureLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect)
+		_, _ = EnsureLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect)
 	}
 	// Set the ports back to the default was so we don't break any following tests.
 	app.RouterHTTPSPort = "443"

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -73,28 +72,6 @@ func TestChdir(t *testing.T) {
 	assert.Equal(currentDir, startingDir, "Ensure we have changed back to the starting directory")
 
 	CleanupDir(testDir)
-}
-
-// TestCaptureUserOut ensures capturing of stdout works as expected.
-func TestCaptureUserOut(t *testing.T) {
-	assert := asrt.New(t)
-	restoreOutput := CaptureUserOut()
-	text := util.RandString(128)
-	output.UserOut.Println(text)
-	out := restoreOutput()
-
-	assert.Contains(out, text)
-}
-
-// TestCaptureStdOut ensures capturing of stdout works as expected.
-func TestCaptureStdOut(t *testing.T) {
-	assert := asrt.New(t)
-	restoreOutput := CaptureStdOut()
-	text := util.RandString(128)
-	fmt.Println(text)
-	out := restoreOutput()
-
-	assert.Contains(out, text)
 }
 
 // TestValidTestSite tests the TestSite struct behavior in the case of a valid configuration.

--- a/pkg/util/capture.go
+++ b/pkg/util/capture.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"bytes"
+	"github.com/drud/ddev/pkg/output"
+	"io"
+	"os"
+)
+
+// CaptureUserOut captures output written to UserOut to a string.
+// Capturing starts when it is called. It returns an anonymous function that
+// when called, will return a string containing the output during capture, and
+// revert once again to the original value of os.StdOut.
+func CaptureUserOut() func() string {
+	old := output.UserOut.Out // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	output.UserOut.Out = w
+
+	return func() string {
+		outC := make(chan string)
+		// copy the output in a separate goroutine so printing can't block indefinitely
+		go func() {
+			var buf bytes.Buffer
+			_, err := io.Copy(&buf, r)
+			CheckErr(err)
+			outC <- buf.String()
+		}()
+
+		// back to normal state
+		CheckClose(w)
+		output.UserOut.Out = old // restoring the real stdout
+
+		out := <-outC
+		return out
+	}
+}

--- a/pkg/util/capture.go
+++ b/pkg/util/capture.go
@@ -34,3 +34,28 @@ func CaptureUserOut() func() string {
 		return out
 	}
 }
+
+// CaptureStdOut captures Stdout to a string. Capturing starts when it is called. It returns an anonymous function that when called, will return a string
+// containing the output during capture, and revert once again to the original value of os.StdOut.
+func CaptureStdOut() func() string {
+	old := os.Stdout // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	return func() string {
+		outC := make(chan string)
+		// copy the output in a separate goroutine so printing can't block indefinitely
+		go func() {
+			var buf bytes.Buffer
+			_, err := io.Copy(&buf, r)
+			CheckErr(err)
+			outC <- buf.String()
+		}()
+
+		// back to normal state
+		CheckClose(w)
+		os.Stdout = old // restoring the real stdout
+		out := <-outC
+		return out
+	}
+}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -3,7 +3,7 @@ package util_test
 import (
 	"bufio"
 	"fmt"
-	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"strings"
@@ -56,4 +56,26 @@ func TestGetInput(t *testing.T) {
 	assert.EqualValues("expected default", result)
 	_ = restoreOutput()
 	println() // Just lets goland find the PASS or FAIL
+}
+
+// TestCaptureUserOut ensures capturing of stdout works as expected.
+func TestCaptureUserOut(t *testing.T) {
+	assert := asrt.New(t)
+	restoreOutput := util.CaptureUserOut()
+	text := util.RandString(128)
+	output.UserOut.Println(text)
+	out := restoreOutput()
+
+	assert.Contains(out, text)
+}
+
+// TestCaptureStdOut ensures capturing of stdout works as expected.
+func TestCaptureStdOut(t *testing.T) {
+	assert := asrt.New(t)
+	restoreOutput := util.CaptureStdOut()
+	text := util.RandString(128)
+	fmt.Println(text)
+	out := restoreOutput()
+
+	assert.Contains(out, text)
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -79,4 +79,3 @@ func TestCaptureStdOut(t *testing.T) {
 
 	assert.Contains(out, text)
 }
-c

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -31,7 +31,7 @@ func TestGetInput(t *testing.T) {
 
 	// Try basic GetInput
 	input := "InputIWantToSee"
-	restoreOutput := testcommon.CaptureUserOut()
+	restoreOutput := util.CaptureUserOut()
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 	result := util.GetInput("nodefault")
@@ -40,7 +40,7 @@ func TestGetInput(t *testing.T) {
 
 	// Try Prompt() with a default value which is overridden
 	input = "InputIWantToSee"
-	restoreOutput = testcommon.CaptureUserOut()
+	restoreOutput = util.CaptureUserOut()
 	scanner = bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 	result = util.Prompt("nodefault", "expected default")
@@ -49,7 +49,7 @@ func TestGetInput(t *testing.T) {
 
 	// Try Prompt() with a default value but don't provide a response
 	input = ""
-	restoreOutput = testcommon.CaptureUserOut()
+	restoreOutput = util.CaptureUserOut()
 	scanner = bufio.NewScanner(strings.NewReader(input))
 	util.SetInputScanner(scanner)
 	result = util.Prompt("nodefault", "expected default")

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -79,3 +79,4 @@ func TestCaptureStdOut(t *testing.T) {
 
 	assert.Contains(out, text)
 }
+c


### PR DESCRIPTION
## The Problem/Issue/Bug:

We *very* often see and have to retry TestDevRestoreSnapshot. Something is happening in the web container that we'd rather not have happen. Probably a SIGBUS error on fpm?

## How this PR Solves The Problem:

This ended up moving around a lot more stuff than I had hoped. I was done with the pattern of capturing UserOut every time we needed logs into a string, so refactored and added a ddevapp.CaptureLogs(). But that forced me to move the CaptureUserOut out of testcommon into util to resolve cyclic dependencies. I do apologize for all the moving around, but think that CaptureLogs() will be very useful to us. I still think there should be a pipe-oriented way to do this with the docker client, but I couldn't get it to work.

Most important, at the end I added the code to give us the logs when TestDdevRestoreSnapshot has a fail.

## Manual Testing Instructions:

I  think this just requires looking at the code and the test output.

## Automated Testing Overview:

Added TestCaptureLogs
Moved TestCaptureUserOut and TestCaptureStdout

