### PR TITLE
Nightly build shouldn't use gometalinter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
 
       # Run the built-in ddev tests with the clean binaries just built.
       - run:
-          command: make -s test gometalinter
+          command: make -s test
           name: ddev tests, with normal clean ddev binaries (normal image tags)
           no_output_timeout: "20m"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Makefile for a standard golang repo with associated container
 
 GOMETALINTER_ARGS := --vendored-linters --disable-all --enable=gofmt --enable=vet --enable vetshadow --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode --deadline=4m
+GOLANGCI_LINT_ARGS ?= --out-format=line-number --disable-all --enable=gofmt --enable=govet --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode
 
 WINDOWS_SUDO_VERSION=v0.0.1
 

--- a/cmd/ddev/cmd/compose-config.go
+++ b/cmd/ddev/cmd/compose-config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ComposeConfigCmd implements the ddev debug compose-config command
 var ComposeConfigCmd = &cobra.Command{
 	Use:   "compose-config [project]",
 	Short: "Prints the docker-compose configuration of the current project",

--- a/cmd/ddev/cmd/debug.go
+++ b/cmd/ddev/cmd/debug.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// DebugCmd is the top-level "ddev debug" command
 var DebugCmd = &cobra.Command{
 	Use:   "debug [command]",
 	Short: "A collection of debugging commands",


### PR DESCRIPTION
## The Problem/Issue/Bug:

The nightly build broke last night because it explicitly called gometalinter, which we've stopped using. And there was a golint thing in there to complain about.

## How this PR Solves The Problem:

* Remove the gometalinter from the circle config
* Go ahead and fix the two things it was complaining about (anyway) so it's now clean with gometalinter anyway.

I note in https://github.com/golang/lint/issues/389#issuecomment-407672415 that golangci-lint explicitly disables this particular feature of golint. So that's why we see a difference between what we're using with it and with gometalinter.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

