### PR TITLE
Add step to ensure new versions are listed on ReadTheDocs

### DIFF
--- a/docs/developers/release-checklist.md
+++ b/docs/developers/release-checklist.md
@@ -14,6 +14,7 @@
 - [ ] Upload the signed Windows installer and SHA checksum to the release page
 - [ ] Finish updating the release page, some copy-and-paste from previous release
 - [ ] Publish the release
+- [ ] Ensure the new version is marked as active on [ReadTheDocs](https://readthedocs.org/dashboard/ddev/versions/)
 
 ### Signing with Windows installer
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
Checking a box allows version to be explicitly listed in the ReaTheDocs version switcher.

## How this PR Solves The Problem:
Adds a step to the release checklist to make sure the version is listed.

## Related Issue Link(s):
#1212


