### PR TITLE
Improve healthchecks, especially ddev-router, fixes #774, fixes #1237

### DIFF
--- a/containers/ddev-router/Dockerfile
+++ b/containers/ddev-router/Dockerfile
@@ -24,9 +24,10 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
 
 ADD . /app/
+RUN chmod ugo+x /app/healthcheck.sh
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["forego", "start", "-r"]
 WORKDIR /app/
 
-HEALTHCHECK --interval=5s --retries=5 CMD curl --fail http://127.0.0.1/healthcheck || exit 1
+HEALTHCHECK --interval=5s --retries=5 CMD /app/healthcheck.sh

--- a/containers/ddev-router/Dockerfile
+++ b/containers/ddev-router/Dockerfile
@@ -29,4 +29,4 @@ ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["forego", "start", "-r"]
 WORKDIR /app/
 
-HEALTHCHECK --interval=5s --retries=5 CMD curl --fail http://localhost/healthcheck || exit 1
+HEALTHCHECK --interval=5s --retries=5 CMD curl --fail http://127.0.0.1/healthcheck || exit 1

--- a/containers/ddev-router/healthcheck.sh
+++ b/containers/ddev-router/healthcheck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+# Check nginx config
+nginx -t || exit 1
+# Check our healthcheck endpoint
+curl -s --fail http://127.0.0.1/healthcheck >/dev/null || (echo "healthcheck endpoint not responding" && exit 2)

--- a/containers/ddev-webserver/files/healthcheck.sh
+++ b/containers/ddev-webserver/files/healthcheck.sh
@@ -4,6 +4,6 @@
 
 set -eo pipefail
 
-curl --fail -s localhost/phpstatus >/dev/null && printf "phpstatus: OK, " || (printf "phpstatus FAILED" && exit 1)
+curl --fail -s 127.0.0.1/phpstatus >/dev/null && printf "phpstatus: OK, " || (printf "phpstatus FAILED" && exit 1)
 ls /var/www/html >/dev/null && printf "/var/www/html: OK, " || (printf "/var/www/html access FAILED" && exit 2)
 curl --fail -s localhost:8025 >/dev/null && printf "mailhog: OK" || (printf "mailhog FAILED" && exit 3)

--- a/containers/ddev-webserver/test/testdata/nginx-site.conf
+++ b/containers/ddev-webserver/test/testdata/nginx-site.conf
@@ -1,1 +1,40 @@
-docroot is $WEBSERVER_DOCROOT in custom conf
+# docroot is $WEBSERVER_DOCROOT in custom conf
+
+
+server {
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
+    # The WEBSERVER_DOCROOT variable is substituted with
+    # its value when the container is started.
+    root $WEBSERVER_DOCROOT;
+    index index.php index.htm index.html;
+
+    # Make site accessible from http://localhost/
+    server_name _;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    ## provide a health check endpoint
+    location /healthcheck {
+        access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
+        return 200;
+    }
+
+    location ~ ^/(phpstatus|ping)$ {
+        access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
+        allow 127.0.0.1;
+        allow all;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+        fastcgi_pass unix:/run/php-fpm.sock;
+    }
+
+}

--- a/containers/ddev-webserver/test/testdata/php/my-php.ini
+++ b/containers/ddev-webserver/test/testdata/php/my-php.ini
@@ -1,2 +1,3 @@
 [PHP]
 assert.active = 0
+

--- a/containers/phpmyadmin/Dockerfile
+++ b/containers/phpmyadmin/Dockerfile
@@ -2,5 +2,5 @@ FROM phpmyadmin/phpmyadmin:4.7.4-1
 
 RUN apk add --no-cache curl curl-dev bash vim
 
-HEALTHCHECK --interval=5s --retries=5 CMD curl --fail http://localhost || exit 1
+HEALTHCHECK --interval=5s --retries=5 CMD curl --fail http://127.0.0.1 || exit 1
 

--- a/containers/phpmyadmin/Dockerfile
+++ b/containers/phpmyadmin/Dockerfile
@@ -2,5 +2,5 @@ FROM phpmyadmin/phpmyadmin:4.7.4-1
 
 RUN apk add --no-cache curl curl-dev bash vim
 
-HEALTHCHECK --interval=5s --retries=5 CMD curl --fail http://127.0.0.1 || exit 1
+HEALTHCHECK --interval=5s --retries=5 CMD curl -s --fail http://127.0.0.1  >/dev/null || exit 1
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -166,11 +166,10 @@ func (app *DdevApp) Describe() (map[string]interface{}, error) {
 		}
 	}
 
-	appDesc["ssh_agent_status"] = GetSSHAuthStatus()
-	routerStatus, log := GetRouterStatus()
+	routerStatus, logOutput := GetRouterStatus()
 	appDesc["router_status"] = routerStatus
-	appDesc["router_status_log"] = log
-
+	appDesc["router_status_log"] = logOutput
+	appDesc["ssh_agent_status"] = GetSSHAuthStatus()
 	appDesc["php_version"] = app.GetPhpVersion()
 	appDesc["webserver_type"] = app.GetWebserverType()
 
@@ -932,9 +931,9 @@ func (app *DdevApp) Wait(containerTypes ...string) error {
 			"com.ddev.site-name":         app.GetName(),
 			"com.docker.compose.service": containerType,
 		}
-		log, err := dockerutil.ContainerWait(containerWaitTimeout, labels)
+		logOutput, err := dockerutil.ContainerWait(containerWaitTimeout, labels)
 		if err != nil {
-			return fmt.Errorf("%s container failed: log=%s, err=%v", containerType, log, err)
+			return fmt.Errorf("%s container failed: log=%s, err=%v", containerType, logOutput, err)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -166,8 +166,11 @@ func (app *DdevApp) Describe() (map[string]interface{}, error) {
 		}
 	}
 
-	appDesc["router_status"] = GetRouterStatus()
 	appDesc["ssh_agent_status"] = GetSSHAuthStatus()
+	routerStatus, log := GetRouterStatus()
+	appDesc["router_status"] = routerStatus
+	appDesc["router_status_log"] = log
+
 	appDesc["php_version"] = app.GetPhpVersion()
 	appDesc["webserver_type"] = app.GetWebserverType()
 
@@ -401,7 +404,7 @@ func (app *DdevApp) SiteStatus() string {
 			services[service] = SiteNotFound
 			siteStatus = service + " service " + SiteNotFound
 		} else {
-			status := dockerutil.GetContainerHealth(*container)
+			status, _ := dockerutil.GetContainerHealth(container)
 
 			switch status {
 			case "exited":
@@ -929,9 +932,9 @@ func (app *DdevApp) Wait(containerTypes ...string) error {
 			"com.ddev.site-name":         app.GetName(),
 			"com.docker.compose.service": containerType,
 		}
-		err := dockerutil.ContainerWait(containerWaitTimeout, labels)
+		log, err := dockerutil.ContainerWait(containerWaitTimeout, labels)
 		if err != nil {
-			return fmt.Errorf("%s container failed: %v", containerType, err)
+			return fmt.Errorf("%s container failed: log=%s, err=%v", containerType, log, err)
 		}
 	}
 

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -143,7 +143,7 @@ func RenderRouterStatus() string {
 	case "exited":
 		fallthrough
 	default:
-		renderedStatus = color.RedString(status) + badRouter + ":" + logOutput
+		renderedStatus = color.RedString(status) + badRouter + ":\n" + logOutput
 	}
 	return fmt.Sprintf("\nDDEV ROUTER STATUS: %v", renderedStatus)
 }

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -133,7 +133,7 @@ func findDdevRouter() (*docker.APIContainers, error) {
 func RenderRouterStatus() string {
 	status, logOutput := GetRouterStatus()
 	var renderedStatus string
-	badRouter := "\nThe router is not currently healthy. Your projects may not be inaccessible.\nTry running 'ddev start' on a site to recreate the router."
+	badRouter := "\nThe router is not currently healthy. Your projects may not be accessible.\nTry running 'ddev start' on a site to recreate the router."
 
 	switch status {
 	case SiteNotFound:

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -107,9 +107,9 @@ func StartDdevRouter() error {
 
 	// ensure we have a happy router
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
-	err = dockerutil.ContainerWait(containerWaitTimeout, label)
+	log, err := dockerutil.ContainerWait(containerWaitTimeout, label)
 	if err != nil {
-		return fmt.Errorf("ddev-router failed to become ready: %v", err)
+		return fmt.Errorf("ddev-router failed to become ready: log=%s, err=%v", log, err)
 	}
 
 	return nil
@@ -131,9 +131,9 @@ func findDdevRouter() (*docker.APIContainers, error) {
 
 // RenderRouterStatus returns a user-friendly string showing router-status
 func RenderRouterStatus() string {
-	status := GetRouterStatus()
+	status, log := GetRouterStatus()
 	var renderedStatus string
-	badRouter := "\nThe router is not currently running. Your sites are likely inaccessible at this time.\nTry running 'ddev start' on a site to recreate the router."
+	badRouter := "\nThe router is not currently healthy. Your projects may not be inaccessible.\nTry running 'ddev start' on a site to recreate the router."
 
 	switch status {
 	case SiteNotFound:
@@ -143,30 +143,27 @@ func RenderRouterStatus() string {
 	case "exited":
 		fallthrough
 	default:
-		renderedStatus = color.RedString(status) + badRouter
+		renderedStatus = color.RedString(status) + badRouter + ":" + log
 	}
 	return fmt.Sprintf("\nDDEV ROUTER STATUS: %v", renderedStatus)
 }
 
-// GetRouterStatus outputs router status and warning if not
+// GetRouterStatus retur s router status and warning if not
 // running or healthy, as applicable.
-func GetRouterStatus() string {
-	var status string
+// return status and most recent log
+func GetRouterStatus() (string, string) {
+	var status, log string
 
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
 	container, err := dockerutil.FindContainerByLabels(label)
 
 	if err != nil {
-		util.Error("Failed to FindContainerByLabels(%v)", label)
-		return "error"
-	}
-	if container == nil {
-		return "no ddev-router found"
+		status = SiteNotFound
+	} else {
+		status, log = dockerutil.GetContainerHealth(container)
 	}
 
-	status = dockerutil.GetContainerHealth(*container)
-
-	return status
+	return status, log
 }
 
 // determineRouterPorts returns a list of port mappings retrieved from running site

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -107,9 +107,9 @@ func StartDdevRouter() error {
 
 	// ensure we have a happy router
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
-	log, err := dockerutil.ContainerWait(containerWaitTimeout, label)
+	logOutput, err := dockerutil.ContainerWait(containerWaitTimeout, label)
 	if err != nil {
-		return fmt.Errorf("ddev-router failed to become ready: log=%s, err=%v", log, err)
+		return fmt.Errorf("ddev-router failed to become ready: logOutput=%s, err=%v", logOutput, err)
 	}
 
 	return nil
@@ -131,7 +131,7 @@ func findDdevRouter() (*docker.APIContainers, error) {
 
 // RenderRouterStatus returns a user-friendly string showing router-status
 func RenderRouterStatus() string {
-	status, log := GetRouterStatus()
+	status, logOutput := GetRouterStatus()
 	var renderedStatus string
 	badRouter := "\nThe router is not currently healthy. Your projects may not be inaccessible.\nTry running 'ddev start' on a site to recreate the router."
 
@@ -143,7 +143,7 @@ func RenderRouterStatus() string {
 	case "exited":
 		fallthrough
 	default:
-		renderedStatus = color.RedString(status) + badRouter + ":" + log
+		renderedStatus = color.RedString(status) + badRouter + ":" + logOutput
 	}
 	return fmt.Sprintf("\nDDEV ROUTER STATUS: %v", renderedStatus)
 }
@@ -152,7 +152,7 @@ func RenderRouterStatus() string {
 // running or healthy, as applicable.
 // return status and most recent log
 func GetRouterStatus() (string, string) {
-	var status, log string
+	var status, logOutput string
 
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
 	container, err := dockerutil.FindContainerByLabels(label)
@@ -160,10 +160,10 @@ func GetRouterStatus() (string, string) {
 	if err != nil {
 		status = SiteNotFound
 	} else {
-		status, log = dockerutil.GetContainerHealth(container)
+		status, logOutput = dockerutil.GetContainerHealth(container)
 	}
 
-	return status, log
+	return status, logOutput
 }
 
 // determineRouterPorts returns a list of port mappings retrieved from running site

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -157,7 +157,7 @@ func GetRouterStatus() (string, string) {
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
 	container, err := dockerutil.FindContainerByLabels(label)
 
-	if err != nil {
+	if err != nil || container == nil {
 		status = SiteNotFound
 	} else {
 		status, logOutput = dockerutil.GetContainerHealth(container)

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -52,7 +52,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 
 	// ensure we have a happy sshAuth
 	label := map[string]string{"com.docker.compose.project": SSHAuthName}
-	err = dockerutil.ContainerWait(containerWaitTimeout, label)
+	_, err = dockerutil.ContainerWait(containerWaitTimeout, label)
 	if err != nil {
 		return fmt.Errorf("ddev-ssh-agent failed to become ready: %v", err)
 	}
@@ -163,6 +163,7 @@ func GetSSHAuthStatus() string {
 	if container == nil {
 		return SiteNotFound
 	}
-	return dockerutil.GetContainerHealth(*container)
+	health, _ := dockerutil.GetContainerHealth(container)
+	return health
 
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -133,7 +133,7 @@ func NetExists(client *docker.Client, name string) bool {
 // ContainerWait provides a wait loop to check for container in "healthy" status.
 // timeout is in seconds.
 // This is modeled on https://gist.github.com/ngauthier/d6e6f80ce977bedca601
-func ContainerWait(waittime time.Duration, labels map[string]string) error {
+func ContainerWait(waittime time.Duration, labels map[string]string) (string, error) {
 
 	timeoutChan := time.After(waittime * time.Second)
 	tickChan := time.NewTicker(500 * time.Millisecond)
@@ -144,31 +144,30 @@ func ContainerWait(waittime time.Duration, labels map[string]string) error {
 	for {
 		select {
 		case <-timeoutChan:
-			return fmt.Errorf("health check timed out: labels %v timed out without becoming healthy, status=%v", labels, status)
+			return "", fmt.Errorf("health check timed out: labels %v timed out without becoming healthy, status=%v", labels, status)
 
 		case <-tickChan.C:
 			container, err := FindContainerByLabels(labels)
 			if err != nil {
-				return fmt.Errorf("failed to query container labels %v", labels)
+				return "", fmt.Errorf("failed to query container labels %v", labels)
 			}
-			if container == nil {
-				continue
-			}
-			status = GetContainerHealth(*container)
+			status, log := GetContainerHealth(container)
 
 			switch status {
 			case "healthy":
-				return nil
+				return log, nil
+			case "unhealthy":
+				return log, fmt.Errorf("container %s unhealthy: %s", container.Names[0], log)
 			case "exited":
 				service := container.Labels["com.docker.compose.service"]
-				return fmt.Errorf("container start failed, please use 'ddev logs -s %s` to find out why it failed", service)
+				return log, fmt.Errorf("container exited, please use 'ddev logs -s %s` to find out why it failed", service)
 			}
 		}
 	}
 
 	// We should never get here.
-	// nolint: vet, govet
-	return fmt.Errorf("inappropriate break out of for loop in ContainerWait() waiting for container labels %v", labels)
+	//nolint: govet
+	return "", fmt.Errorf("inappropriate break out of for loop in ContainerWait() waiting for container labels %v", labels)
 }
 
 // ContainerName returns the containers human readable name.
@@ -176,26 +175,25 @@ func ContainerName(container docker.APIContainers) string {
 	return container.Names[0][1:]
 }
 
-// GetContainerHealth retrieves the status of a given container. The status string returned
-// by docker contains uptime and the health status in parens. This function will filter the uptime and
-// return only the health status.
-func GetContainerHealth(container docker.APIContainers) string {
+// GetContainerHealth retrieves the status of a given container.
+// returns status, most-recent-log
+func GetContainerHealth(container docker.APIContainers) (string, string) {
 	// If the container is not running, then return exited as the health.
 	// "exited" means stopped.
 	if container.State == "exited" || container.State == "restarting" {
-		return container.State
+		return container.State, ""
 	}
 
-	// Otherwise parse the container status.
-	status := container.Status
-	re := regexp.MustCompile(`\(([^\)]+)\)`)
-	match := re.FindString(status)
-	match = strings.Trim(match, "()")
-	pre := "health: "
-	if strings.HasPrefix(match, pre) {
-		match = strings.TrimPrefix(match, pre)
+	client := GetDockerClient()
+	inspect, err := client.InspectContainer(container.ID)
+
+	status := inspect.State.Health.Status
+	log := ""
+	if err == nil && len(inspect.State.Health.Log) > 0 {
+		log = inspect.State.Health.Log[0].Output
 	}
-	return match
+
+	return status, log
 }
 
 // ComposeWithStreams executes a docker-compose command but allows the caller to specify

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -148,8 +148,8 @@ func ContainerWait(waittime time.Duration, labels map[string]string) (string, er
 
 		case <-tickChan.C:
 			container, err := FindContainerByLabels(labels)
-			if err != nil {
-				return "", fmt.Errorf("failed to query container labels %v", labels)
+			if err != nil || container == nil {
+				return "", fmt.Errorf("failed to query container labels=%v: %v", labels, err)
 			}
 			status, logOutput := GetContainerHealth(container)
 
@@ -177,7 +177,11 @@ func ContainerName(container docker.APIContainers) string {
 
 // GetContainerHealth retrieves the status of a given container.
 // returns status, most-recent-log
-func GetContainerHealth(container docker.APIContainers) (string, string) {
+func GetContainerHealth(container *docker.APIContainers) (string, string) {
+	if container == nil {
+		return "no container", ""
+	}
+
 	// If the container is not running, then return exited as the health.
 	// "exited" means stopped.
 	if container.State == "exited" || container.State == "restarting" {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -151,16 +151,16 @@ func ContainerWait(waittime time.Duration, labels map[string]string) (string, er
 			if err != nil {
 				return "", fmt.Errorf("failed to query container labels %v", labels)
 			}
-			status, log := GetContainerHealth(container)
+			status, logOutput := GetContainerHealth(container)
 
 			switch status {
 			case "healthy":
-				return log, nil
+				return logOutput, nil
 			case "unhealthy":
-				return log, fmt.Errorf("container %s unhealthy: %s", container.Names[0], log)
+				return logOutput, fmt.Errorf("container %s unhealthy: %s", container.Names[0], logOutput)
 			case "exited":
 				service := container.Labels["com.docker.compose.service"]
-				return log, fmt.Errorf("container exited, please use 'ddev logs -s %s` to find out why it failed", service)
+				return logOutput, fmt.Errorf("container exited, please use 'ddev logs -s %s` to find out why it failed", service)
 			}
 		}
 	}
@@ -188,12 +188,12 @@ func GetContainerHealth(container docker.APIContainers) (string, string) {
 	inspect, err := client.InspectContainer(container.ID)
 
 	status := inspect.State.Health.Status
-	log := ""
+	logOutput := ""
 	if err == nil && len(inspect.State.Health.Log) > 0 {
-		log = inspect.State.Health.Log[0].Output
+		logOutput = inspect.State.Health.Log[0].Output
 	}
 
-	return status, log
+	return status, logOutput
 }
 
 // ComposeWithStreams executes a docker-compose command but allows the caller to specify

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -133,6 +133,7 @@ func NetExists(client *docker.Client, name string) bool {
 // ContainerWait provides a wait loop to check for container in "healthy" status.
 // timeout is in seconds.
 // This is modeled on https://gist.github.com/ngauthier/d6e6f80ce977bedca601
+// Returns status, error
 func ContainerWait(waittime time.Duration, labels map[string]string) (string, error) {
 
 	timeoutChan := time.After(waittime * time.Second)

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -102,13 +102,13 @@ func TestContainerWait(t *testing.T) {
 		"com.docker.compose.service": "web",
 	}
 
-	err := ContainerWait(0, labels)
+	_, err := ContainerWait(0, labels)
 	assert.Error(err)
 	if err != nil {
 		assert.Contains(err.Error(), "health check timed out")
 	}
 
-	err = ContainerWait(5, labels)
+	_, err = ContainerWait(5, labels)
 	assert.Error(err)
 	if err != nil {
 		assert.Contains(err.Error(), "health check timed out")

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -164,7 +164,7 @@ func TestComposeWithStreams(t *testing.T) {
 	//nolint: errcheck
 	defer ComposeCmd(composeFiles, "down")
 
-	err = ContainerWait(10, map[string]string{"com.ddev.site-name": "test-compose-with-streams"})
+	_, err = ContainerWait(10, map[string]string{"com.ddev.site-name": "test-compose-with-streams"})
 	assert.NoError(err)
 
 	// Point stdout to os.Stdout and do simple ps -ef in web container

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 
 	foundContainer, _ := FindContainerByLabels(map[string]string{"com.ddev.site-name": "dockerutils-test"})
 
-	if foundContainer.ID != "" {
+	if foundContainer != nil {
 		_ = client.StopContainer(foundContainer.ID, 10)
 
 		err = client.RemoveContainer(docker.RemoveContainerOptions{ID: foundContainer.ID})

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -111,21 +111,28 @@ func TestContainerWait(t *testing.T) {
 	assert := asrt.New(t)
 
 	labels := map[string]string{
-		"com.ddev.site-name":         "foo",
-		"com.docker.compose.service": "web",
+		"com.ddev.site-name": "dockerutils-test",
 	}
 
+	// Try a zero-wait, should show timed-out
 	_, err := ContainerWait(0, labels)
 	assert.Error(err)
 	if err != nil {
 		assert.Contains(err.Error(), "health check timed out")
 	}
 
-	_, err = ContainerWait(5, labels)
-	assert.Error(err)
-	if err != nil {
-		assert.Contains(err.Error(), "health check timed out")
+	// Try 5-second wait, should show OK
+	status, err := ContainerWait(5, labels)
+	assert.NoError(err)
+	assert.Contains(status, "phpstatus: OK")
+
+	// Try a nonexistent container, should get error
+	labels = map[string]string{
+		"com.ddev.site-name": "nothing-there",
 	}
+	_, err = ContainerWait(1, labels)
+	require.Error(t, err)
+	assert.Contains(err.Error(), "failed to query container")
 }
 
 // TestComposeCmd tests execution of docker-compose commands.

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
+	logOutput "github.com/sirupsen/logrus"
 
 	"path/filepath"
 
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 		Tag:        version.WebTag,
 	}, docker.AuthConfiguration{})
 	if err != nil {
-		log.Fatal("failed to pull test image ", err)
+		logOutput.Fatal("failed to pull test image ", err)
 	}
 
 	foundContainer, _ := FindContainerByLabels(map[string]string{"com.ddev.site-name": "dockerutils-test"})
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 
 		err = client.RemoveContainer(docker.RemoveContainerOptions{ID: foundContainer.ID})
 		if err != nil {
-			log.Fatalf("Failed to remove container %s: %v", foundContainer.ID, err)
+			logOutput.Fatalf("Failed to remove container %s: %v", foundContainer.ID, err)
 		}
 	}
 
@@ -56,24 +56,24 @@ func TestMain(m *testing.M) {
 		},
 	})
 	if err != nil {
-		log.Fatal("failed to create/start docker container ", err)
+		logOutput.Fatal("failed to create/start docker container ", err)
 	}
 	err = client.StartContainer(container.ID, nil)
 	if err != nil {
-		log.Fatalf("failed to StartContainer: %v", err)
+		logOutput.Fatalf("failed to StartContainer: %v", err)
 	}
 	exitStatus := m.Run()
 	// teardown docker container from docker util tests
 	err = client.StopContainer(container.ID, 10)
 	if err != nil {
-		log.Fatalf("Failed to stop container: %v", err)
+		logOutput.Fatalf("Failed to stop container: %v", err)
 	}
 	err = client.RemoveContainer(docker.RemoveContainerOptions{
 		ID:    container.ID,
 		Force: true,
 	})
 	if err != nil {
-		log.Fatalf("failed to remove test container: %v", err)
+		logOutput.Fatalf("failed to remove test container: %v", err)
 	}
 
 	os.Exit(exitStatus)
@@ -101,9 +101,9 @@ func TestGetContainerHealth(t *testing.T) {
 	_, err = ContainerWait(10, labels)
 	assert.NoError(err)
 
-	out, log = GetContainerHealth(container)
+	out, logOutput := GetContainerHealth(container)
 	assert.Equal(out, "healthy")
-	assert.Equal(log, "phpstatus: OK, /var/www/html: OK, mailhog: OK")
+	assert.Equal(logOutput, "phpstatus: OK, /var/www/html: OK, mailhog: OK")
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -169,6 +169,7 @@ func TestComposeWithStreams(t *testing.T) {
 	// Use the current actual web container for this, so replace in base docker-compose file
 	composeBase := filepath.Join("testdata", "test-compose-with-streams.yaml")
 	tmp, err := ioutil.TempDir("", "")
+	assert.NoError(err)
 	realComposeFile := filepath.Join(tmp, "replaced-compose-with-streams.yaml")
 
 	err = fileutil.ReplaceStringInFile("TEST-COMPOSE-WITH-STREAMS-IMAGE", version.WebImg+":"+version.WebTag, composeBase, realComposeFile)

--- a/pkg/dockerutil/testdata/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/test-compose-with-streams.yaml
@@ -21,7 +21,7 @@ services:
       HTTP_EXPOSE: 80:80,8025
       LINES: '25'
       VIRTUAL_HOST: junk.ddev.local
-    image: drud/ddev-webserver:v1.3.0
+    image: TEST-COMPOSE-WITH-STREAMS-IMAGE
     labels:
       com.ddev.app-type: php
       com.ddev.app-url: http://test-compose-with-streams.ddev.local

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -1,6 +1,7 @@
 package fileutil
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -188,4 +189,19 @@ func RandomFilenameBase() string {
 	randBytes := make([]byte, 16)
 	_, _ = rand.Read(randBytes)
 	return hex.EncodeToString(randBytes)
+}
+
+// ReplaceStringInFile takes search and replace strings, an original path, and a dest path, returns error
+func ReplaceStringInFile(searchString string, replaceString string, origPath string, destPath string) error {
+	input, err := ioutil.ReadFile(origPath)
+	if err != nil {
+		return err
+	}
+
+	output := bytes.Replace(input, []byte(searchString), []byte(replaceString), -1)
+
+	if err = ioutil.WriteFile(destPath, output, 0666); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -1,6 +1,7 @@
 package fileutil_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -128,4 +129,17 @@ func TestListFilesInDir(t *testing.T) {
 	assert.True(len(fileList) == 2)
 	assert.Contains(fileList[0], "one.txt")
 	assert.Contains(fileList[1], "two.txt")
+}
+
+// TestReplaceStringInFile tests the ReplaceStringInFile utility function.
+func TestReplaceStringInFile(t *testing.T) {
+	assert := asrt.New(t)
+	tmp, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	newFilePath := filepath.Join(tmp, "newfile.txt")
+	err = fileutil.ReplaceStringInFile("some needle we're looking for", "specialJUNKPattern", "testdata/fgrep_has_positive_contents.txt", newFilePath)
+	assert.NoError(err)
+	found, err := fileutil.FgrepStringInFile(newFilePath, "specialJUNKPattern")
+	assert.NoError(err)
+	assert.True(found)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,7 +27,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20181022_add_ssh_auth" // Note that this can be overridden by make
+var WebTag = "20181105_use_localhost_healthcheck" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
@@ -39,13 +39,13 @@ var DBTag = "20181106_export_db" // Note that this may be overridden by make
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "v1.3.0" // Note that this can be overridden by make
+var DBATag = "20181105_use_localhost_healthcheck" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.3.0" // Note that this can be overridden by make
+var RouterTag = "20181105_use_localhost_healthcheck" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Our healthchecks were relying on "localhost", which requires name resolution, and we don't actually need name resolution like that for things to work.
* The router healthcheck (#774) was always questionable about giving adequate info about failures, especially missing nginx config failures.

## How this PR Solves The Problem:

* Use 127.0.0.1 in healthcheck
* Improve ddev-router healthcheck to check nginx config so one can use `docker inspect ddev-router` to see what went wrong.
* Add log information from container checks to give context to failures.

## Manual Testing Instructions:

* Break ddev-router by configuring the same additional_hostnames[] on two projects (or `docker exec -it ddev-router bash` and edit the /etc/nginx/conf.d/default.conf to remove the healthcheck). Examine the result. 
* Break other containers with `ddev exec -it <service>` and breaking the healthcheck one way or another.

## Automated Testing Overview:

No changes were made.

## Related Issue Link(s):

OP #774: Make ddev-router more transparent about failures.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

