### PR TITLE
Add export-db command, fixes #767

### DIFF
--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var outFileName string
+var gzipOption bool
+
+// ImportDBCmd represents the `ddev import-db` command.
+var ExportDBCmd = &cobra.Command{
+	Use:   "export-db",
+	Short: "Dump a database",
+	Long:  `Dump a database`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			err := cmd.Usage()
+			util.CheckErr(err)
+			os.Exit(0)
+		}
+		dockerutil.EnsureDdevNetwork()
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Failed to find project from which to export database: %v", err)
+		}
+
+		if app.SiteStatus() != ddevapp.SiteRunning {
+			err = app.Start()
+			if err != nil {
+				util.Failed("Failed to start app %s to export-db: %v", app.Name, err)
+			}
+		}
+
+		err = app.ExportDB(outFileName, gzipOption)
+		if err != nil {
+			util.Failed("Failed to export database for %s: %v", app.GetName(), err)
+		}
+	},
+}
+
+func init() {
+	ExportDBCmd.Flags().StringVarP(&outFileName, "file", "f", "", "Provide the path to output the dump")
+	ExportDBCmd.Flags().BoolVarP(&gzipOption, "gzip", "z", true, "If provided asset is an archive, provide the path to extract within the archive.")
+	RootCmd.AddCommand(ExportDBCmd)
+}

--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -12,11 +12,12 @@ import (
 var outFileName string
 var gzipOption bool
 
-// ImportDBCmd represents the `ddev import-db` command.
+// ExportDBCmd is the `ddev export-db` command.
 var ExportDBCmd = &cobra.Command{
-	Use:   "export-db",
-	Short: "Dump a database",
-	Long:  `Dump a database`,
+	Use:     "export-db",
+	Short:   "Dump a database to stdout or to a file",
+	Long:    `Dump a database to stdout or to a file.`,
+	Example: "ddev export-db >/tmp/db.sql.gz\nddev export-db --gzip=false >/tmp/db.sql\nddev export-db -f /tmp/db.sql.gz",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/containers/ddev-dbserver/files/etc/my.cnf
+++ b/containers/ddev-dbserver/files/etc/my.cnf
@@ -1,5 +1,4 @@
-[mysql]
-
+[client]
 # CLIENT #
 port                           = 3306
 socket                         = /var/tmp/mysql.sock

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -207,8 +207,6 @@ Here's an example of a database import using ddev:
 ddev import-db --src=dumpfile.sql.gz
 ```
 
-For in-depth application monitoring, use the command `ddev describe` to see details about the status of your ddev app.
-
 **Note for Backdrop users:** In addition to importing a Backdrop database, you will need to extract a copy of your Backdrop project's configuration into the local `active` directory. The location for this directory can vary depending on the contents of your Backdrop `settings.php` file, but the default location is `[docroot]/files/config_[random letters and numbers]/active`. Please refer to the Backdrop documentation for more information on [moving your Backdrop site](https://backdropcms.org/user-guide/moving-backdrop-site) into the `ddev` environment.
 
 ## Getting Started
@@ -365,6 +363,16 @@ Successfully imported database for drupal8
 If you want to use import-db without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you are importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag. Example:
 
 `ddev import-db --src=/tmp/mydb.sql.gz`
+
+### Exporting a Database
+
+You can export a database with `ddev export-db`, which outputs to stdout or with options to a file:
+
+```
+ddev export-db --file /tmp/db.sql.gz
+ddev export-db >/tmp/db.sql.gz
+ddev export-db --gzip=false >/tmp/db.sql
+```
 
 ### Importing static file assets
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -13,8 +13,8 @@ import (
 	"github.com/drud/ddev/pkg/util"
 )
 
-// Ungzip accepts a gzipped file and uncompresses it to the provided destination path.
-func Ungzip(source string, dest string) error {
+// Ungzip accepts a gzipped file and uncompresses it to the provided destination directory.
+func Ungzip(source string, destDirectory string) error {
 	f, err := os.Open(source)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func Ungzip(source string, dest string) error {
 	}()
 
 	fname := strings.TrimSuffix(filepath.Base(f.Name()), ".gz")
-	exFile, err := os.Create(filepath.Join(dest, fname))
+	exFile, err := os.Create(filepath.Join(destDirectory, fname))
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -790,7 +790,7 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 		return err
 	}
 
-	return dockerutil.ComposeNoCapture(files, exec...)
+	return dockerutil.ComposeWithStreams(files, os.Stdin, os.Stdout, os.Stderr, exec...)
 }
 
 // Logs returns logs for a site's given container.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -375,6 +375,8 @@ func (app *DdevApp) ExportDB(outFile string, gzip bool) error {
 			return fmt.Errorf("failed to open %s: %v", outFile, err)
 		}
 		opts.Stdout = f
+		// nolint: errcheck
+		defer f.Close()
 	}
 
 	_, _, err := app.Exec(opts)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -195,30 +195,6 @@ func GetContainerHealth(container docker.APIContainers) string {
 	return match
 }
 
-// ComposeNoCapture executes a docker-compose command while leaving the stdin/stdout/stderr untouched
-// so that people can interact with them directly, for example with ddev ssh. Note that this function
-// will never return an actual error because we don't have a way to distinguish between an error
-// representing a failure to connect to the container and an error representing a command failing
-// inside of the interactive session inside the container.
-func ComposeNoCapture(composeFiles []string, action ...string) error {
-	var arg []string
-
-	for _, file := range composeFiles {
-		arg = append(arg, "-f")
-		arg = append(arg, file)
-	}
-
-	arg = append(arg, action...)
-
-	proc := exec.Command("docker-compose", arg...)
-	proc.Stdout = os.Stdout
-	proc.Stdin = os.Stdin
-	proc.Stderr = os.Stderr
-
-	_ = proc.Run()
-	return nil
-}
-
 // ComposeWithStreams executes a docker-compose command but allows the caller to specify
 // stdin/stdout/stderr
 func ComposeWithStreams(composeFiles []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, action ...string) error {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -213,6 +214,27 @@ func ComposeNoCapture(composeFiles []string, action ...string) error {
 	proc.Stdout = os.Stdout
 	proc.Stdin = os.Stdin
 	proc.Stderr = os.Stderr
+
+	_ = proc.Run()
+	return nil
+}
+
+// ComposeWithStreams executes a docker-compose command but allows the caller to specify
+// stdin/stdout/stderr
+func ComposeWithStreams(composeFiles []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, action ...string) error {
+	var arg []string
+
+	for _, file := range composeFiles {
+		arg = append(arg, "-f")
+		arg = append(arg, file)
+	}
+
+	arg = append(arg, action...)
+
+	proc := exec.Command("docker-compose", arg...)
+	proc.Stdout = stdout
+	proc.Stdin = stdin
+	proc.Stderr = stderr
 
 	_ = proc.Run()
 	return nil

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -151,6 +151,9 @@ func TestComposeWithStreams(t *testing.T) {
 	//nolint: errcheck
 	defer ComposeCmd(composeFiles, "down")
 
+	err = ContainerWait(10, map[string]string{"com.ddev.site-name": "test-compose-with-streams"})
+	assert.NoError(err)
+
 	// Point stdout to os.Stdout and do simple ps -ef in web container
 	stdout := util.CaptureStdOut()
 	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stdout, os.Stderr, "exec", "-T", "web", "ps", "-ef")

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -1,6 +1,8 @@
 package dockerutil_test
 
 import (
+	"github.com/drud/ddev/pkg/util"
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
@@ -137,6 +139,39 @@ func TestComposeCmd(t *testing.T) {
 	composeFiles = []string{"invalid.yml"}
 	_, _, err = ComposeCmd(composeFiles, "config", "--services")
 	assert.Error(err)
+}
+
+// TestComposeWithStreams tests execution of docker-compose commands with streams
+func TestComposeWithStreams(t *testing.T) {
+	assert := asrt.New(t)
+
+	composeFiles := []string{filepath.Join("testdata", "test-compose-with-streams.yaml")}
+	_, _, err := ComposeCmd(composeFiles, "up", "-d")
+	require.NoError(t, err)
+	//nolint: errcheck
+	defer ComposeCmd(composeFiles, "down")
+
+	// Point stdout to os.Stdout and do simple ps -ef in web container
+	stdout := util.CaptureStdOut()
+	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stdout, os.Stderr, "exec", "-T", "web", "ps", "-ef")
+	assert.NoError(err)
+	output := stdout()
+	assert.Contains(output, "supervisord")
+
+	// Reverse stdout and stderr and create an error and normal stdout. We should see only the error captured in stdout
+	stdout = util.CaptureStdOut()
+	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stderr, os.Stdout, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
+	assert.NoError(err)
+	output = stdout()
+	assert.Equal(output, "ls: cannot access 'xx': No such file or directory\n")
+
+	// Flip stdout and stderr and create an error and normal stdout. We should see only the success captured in stdout
+	stdout = util.CaptureStdOut()
+	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stdout, os.Stderr, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
+	assert.NoError(err)
+	output = stdout()
+	assert.Equal(output, "/var/run/apache2\n")
+
 }
 
 // TestCheckCompose tests detection of docker-compose.

--- a/pkg/dockerutil/testdata/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/test-compose-with-streams.yaml
@@ -1,0 +1,32 @@
+networks:
+  default:
+    external: true
+    name: ddev_default
+services:
+
+  web:
+    container_name: ddev-test-compose-with-streams-web
+    environment:
+      COLUMNS: '99'
+      DDEV_PHP_VERSION: '7.1'
+      DDEV_PROJECT_TYPE: typo3
+      DDEV_ROUTER_HTTPS_PORT: '443'
+      DDEV_ROUTER_HTTP_PORT: '80'
+      DDEV_URL: http://test-compose-with-streams.ddev.local
+      DDEV_WEBSERVER_TYPE: nginx-fpm
+      DDEV_XDEBUG_ENABLED: "false"
+      DEPLOY_NAME: local
+      DOCROOT: public
+      HTTPS_EXPOSE: 443:80
+      HTTP_EXPOSE: 80:80,8025
+      LINES: '25'
+      VIRTUAL_HOST: junk.ddev.local
+    image: drud/ddev-webserver:v1.3.0
+    labels:
+      com.ddev.app-type: php
+      com.ddev.app-url: http://test-compose-with-streams.ddev.local
+      com.ddev.approot: .
+      com.ddev.platform: ddev
+      com.ddev.site-name: test-compose-with-streams
+    restart: "no"
+version: '3.6'

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -33,7 +33,7 @@ var WebTag = "20181017_add_ssh" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "v1.3.0" // Note that this may be overridden by make
+var DBTag = "20181106_export_db" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

ddev has always had an import-db, but always lacked the converse export-db. 

## How this PR Solves The Problem:

add `ddev export-db`

## Manual Testing Instructions:

Try and verify results of:
* ddev export-db -h
* ddev export-db
* ddev export-db -f /tmp/junk.sql.gz
* ddev export-db -f /tmp/junk.sql --gzip=false
* ddev export-db --gzip=false | gzip >/tmp/junk.sql.gz


## Automated Testing Overview:

* TestComposeWIthStreams()
* TestDdevExportDB()

## Related Issue Link(s):

OP #767 

## Release/Deployment notes:

* At release time the Stack Overflow article on exporting should be updated to show this technique.
* We'll want to get the upcoming article on snapshot (which also mentions the export alternative) to use this instead of the complex in-container technique.
