### PR TITLE
Stop mounting from global ddev directory, fixes #883

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -221,8 +221,7 @@ func (app *DdevApp) ReadConfig() error {
 		app.DBAImage = version.GetDBAImage()
 	}
 
-	dirPath := filepath.Join(util.GetGlobalDdevDir(), app.Name)
-	app.ImportDir = filepath.Join(dirPath, "import-db")
+	app.ImportDir = app.GetConfigPath("import-db")
 
 	app.SetApptypeSettingsPaths()
 
@@ -621,7 +620,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf")
+	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -37,7 +37,7 @@ func StopRouterIfNoContainers() error {
 
 	if !containersRunning {
 		dest := RouterComposeYAMLPath()
-		_, _, err = dockerutil.ComposeCmd([]string{dest}, "-p", RouterProjectName, "down", "-v")
+		_, _, err = dockerutil.ComposeCmd([]string{dest}, "-p", RouterProjectName, "down")
 		return err
 	}
 	return nil
@@ -91,7 +91,7 @@ func StartDdevRouter() error {
 	// we can access all ports.
 	// It might be possible to do this instead by reading from docker all the
 	// existing mapped ports.
-	_, _, err = dockerutil.ComposeCmd([]string{routerComposePath}, "-p", RouterProjectName, "down", "-v")
+	_, _, err = dockerutil.ComposeCmd([]string{routerComposePath}, "-p", RouterProjectName, "down")
 	util.CheckErr(err)
 
 	err = CheckRouterPorts()

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -246,10 +246,17 @@ services:
       {{ end }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./certs:/etc/nginx/certs:cached
+      - type: "volume"
+        source: ddev-router-cert-cache
+        target: "/etc/nginx/certs"
+        volume:
+          nocopy: true
     restart: "no"
 networks:
    default:
      external:
        name: ddev_default
+volumes:
+  ddev-router-cert-cache:
+    name: "ddev-router-cert-cache"
 `


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #883: People who have network-mounted home directories have loads of trouble using ddev, and we don't really have any reason to be bind-mounting from there any more.

## How this PR Solves The Problem:

* Stop using bind-mounted router cache and use docker volume instead
* Use import-db directory in project .ddev instead of global ddev dir

## Manual Testing Instructions:

Start a project
Use `docker inspect ddev-router` to check mounts
Use `docker inspect ddev-<project>-db` to check mounts

## Automated Testing Overview:

Nothing has been added. 

## Related Issue Link(s):

OP #883 

## Release/Deployment notes:

This will probably deserve a minor mention in release notes.
