### PR TITLE
Minor cleanup of test and buildkite setup (tests only)

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -13,6 +13,7 @@ if [ ! -z "$BUILDKITE_JOB_ID" ]; then
 fi
 
 export GOTEST_SHORT=1
+export DRUD_NONINTERACTIVE=true
 
 echo "--- cleaning up docker and Test directories"
 echo "Warning: deleting all docker containers and deleting ~/.ddev/Test*"

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -20,16 +20,16 @@ if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
 	docker rm -f $(docker ps -aq)
 fi
 docker system prune --volumes --force
-rm -rf ~/.ddev/TestPkg*
 
 # Update all images that could have changed
 docker images | awk '/drud/ {print $1":"$2 }' | xargs -L1 docker pull
-rm -rf ~/.ddev/Test*
 
 set -o errexit
 set -o pipefail
 set -o nounset
 set -x
+
+rm -rf ~/.ddev/Test*
 
 # Our testbot should now be sane, run the testbot checker to make sure.
 ./.buildkite/sanetestbot.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
     working_directory: ~/go/src/github.com/drud/ddev
     environment:
       GOPATH: /home/circleci/go
+      DRUD_NONINTERACTIVE: "true"
     steps:
     - run: mkdir -p ~/go/{lib,pkg,src/github.com/drud/ddev}
     - checkout
@@ -28,6 +29,7 @@ jobs:
     environment:
       GOPATH: /home/circleci/go
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
+      DRUD_NONINTERACTIVE: "true"
     steps:
     - attach_workspace:
         at: ~/
@@ -50,6 +52,7 @@ jobs:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
       # Experiment with only testing TYPO3 with the apache run.
       GOTEST_SHORT: 5
+      DRUD_NONINTERACTIVE: "true"
     steps:
     - attach_workspace:
         at: ~/
@@ -72,6 +75,7 @@ jobs:
       DDEV_TEST_WEBSERVER_TYPE: apache-cgi
       # Experiment with only testing TYPO3 with the apache run.
       GOTEST_SHORT: 5
+      DRUD_NONINTERACTIVE: "true"
     steps:
     - attach_workspace:
         at: ~/
@@ -128,6 +132,7 @@ jobs:
       DRUD_DEBUG: "true"
       GOPATH: /home/circleci/go
       ARTIFACTS: /artifacts
+      DRUD_NONINTERACTIVE: "true"
     steps:
       - checkout
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1952,9 +1952,9 @@ func TestDbMigration(t *testing.T) {
 
 	// Untar the to-migrate db into old-style dataDir (~/.ddev/projectname/mysql)
 	err = os.MkdirAll(dataDir, 0755)
-	assert.NoError(err)
+	require.NoError(t, err)
 	err = archive.Untar(dbMigrationTarball, dataDir, "")
-	assert.NoError(err)
+	require.NoError(t, err)
 	defer os.RemoveAll(dataDir)
 
 	_, err = app.CreateSettingsFile()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1526,12 +1526,6 @@ func TestCleanupWithoutCompose(t *testing.T) {
 		assert.False(volume.Labels["com.docker.compose.project"] == "ddev"+strings.ToLower(app.GetName()))
 	}
 
-	// Cleanup the global site database dirs. This does the work instead of running site.Cleanup()
-	// because site.Cleanup() removes site directories that we'll need in other tests.
-	dir := filepath.Join(util.GetGlobalDdevDir(), site.Name)
-	err = os.RemoveAll(dir)
-	assert.NoError(err)
-
 	revertDir()
 	// Move the site directory back to its original location.
 	err = os.Rename(siteCopyDest, site.Dir)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -176,7 +176,7 @@ func ContainerName(container docker.APIContainers) string {
 	return container.Names[0][1:]
 }
 
-// GetContainerHealth retrieves the status of a given container.
+// GetContainerHealth retrieves the health status of a given container.
 // returns status, most-recent-log
 func GetContainerHealth(container *docker.APIContainers) (string, string) {
 	if container == nil {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -133,7 +133,7 @@ func NetExists(client *docker.Client, name string) bool {
 // ContainerWait provides a wait loop to check for container in "healthy" status.
 // timeout is in seconds.
 // This is modeled on https://gist.github.com/ngauthier/d6e6f80ce977bedca601
-// Returns status, error
+// Returns logoutput, error, returns error if not "healthy"
 func ContainerWait(waittime time.Duration, labels map[string]string) (string, error) {
 
 	timeoutChan := time.After(waittime * time.Second)

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -101,11 +101,17 @@ func TestGetContainerHealth(t *testing.T) {
 	assert.NoError(err)
 	healthDetail, err := ContainerWait(15, labels)
 	assert.NoError(err)
-	assert.Equal(healthDetail, "phpstatus: OK, /var/www/html: OK, mailhog: OK")
+
+	// The log/detail doesn't seem to come through in a timely fashion on Docker Toolbox
+	if !util.IsDockerToolbox() {
+		assert.Equal("phpstatus: OK, /var/www/html: OK, mailhog: OK", healthDetail)
+	}
 
 	status, healthDetail = GetContainerHealth(container)
 	assert.Equal(status, "healthy")
-	assert.Equal(healthDetail, "phpstatus: OK, /var/www/html: OK, mailhog: OK")
+	if !util.IsDockerToolbox() {
+		assert.Equal("phpstatus: OK, /var/www/html: OK, mailhog: OK", healthDetail)
+	}
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.
@@ -126,7 +132,10 @@ func TestContainerWait(t *testing.T) {
 	// Try 15-second wait for "healthy", should show OK
 	healthDetail, err := ContainerWait(15, labels)
 	assert.NoError(err)
-	assert.Contains(healthDetail, "phpstatus: OK")
+
+	if !util.IsDockerToolbox() {
+		assert.Contains(healthDetail, "phpstatus: OK")
+	}
 
 	// Try a nonexistent container, should get error
 	labels = map[string]string{

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -94,17 +94,18 @@ func TestGetContainerHealth(t *testing.T) {
 	err = client.StopContainer(container.ID, 10)
 	assert.NoError(err)
 
-	out, _ := GetContainerHealth(container)
-	assert.Equal(out, "unhealthy")
+	status, _ := GetContainerHealth(container)
+	assert.Equal(status, "unhealthy")
 
 	err = client.StartContainer(container.ID, nil)
 	assert.NoError(err)
-	_, err = ContainerWait(10, labels)
+	healthDetail, err := ContainerWait(15, labels)
 	assert.NoError(err)
+	assert.Equal(healthDetail, "phpstatus: OK, /var/www/html: OK, mailhog: OK")
 
-	out, logOutput := GetContainerHealth(container)
-	assert.Equal(out, "healthy")
-	assert.Equal(logOutput, "phpstatus: OK, /var/www/html: OK, mailhog: OK")
+	status, healthDetail = GetContainerHealth(container)
+	assert.Equal(status, "healthy")
+	assert.Equal(healthDetail, "phpstatus: OK, /var/www/html: OK, mailhog: OK")
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.
@@ -122,10 +123,10 @@ func TestContainerWait(t *testing.T) {
 		assert.Contains(err.Error(), "health check timed out")
 	}
 
-	// Try 5-second wait, should show OK
-	status, err := ContainerWait(5, labels)
+	// Try 15-second wait for "healthy", should show OK
+	healthDetail, err := ContainerWait(15, labels)
 	assert.NoError(err)
-	assert.Contains(status, "phpstatus: OK")
+	assert.Contains(healthDetail, "phpstatus: OK")
 
 	// Try a nonexistent container, should get error
 	labels = map[string]string{


### PR DESCRIPTION
## The Problem/Issue/Bug:

We had some minor issues with tests after #1243 (stop mounting homedir) went in. There are a couple of things showing up:

* There are unnecessary attempts to clean up ~/.ddev/Test* when it shouldn't have been used.
* Only the test for upgrade of bind-mounted databases still should be looking in there. 
* Those directories are showing up as owned by root in our macOS testbots, which really shouldn't be able to happen.  (This ends up being a [PR removal of DRUD_NONINTERACTIVE](https://github.com/drud/ddev/pull/1241/files#r231994483), so will be fixed in that PR.
* There's currently no error checking on the rm -rf ~/.ddev/Test*, so the buildkite-agent startup is not detecting the root ownership problem.

Note that [TestConfigOverrideDetection](https://github.com/drud/ddev/blob/e87a4586fba2bc9d5832e5e8bddc0213b5a78daf/pkg/ddevapp/config_test.go#L543) is trying to use sudo on a build for the composer PR, see [test](https://buildkite.com/drud/ddev-macos/builds/984#5141d296-cffb-4140-be93-d7c6f8e5be40). 

## How this PR Solves The Problem:

* Make sure that non-removable ~/.ddev/Test* directories cause a build start failure on buildkite.
* Explicitly set DRUD_NONINTERACTIVE in buildkite setup

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

