### PR TITLE
Add persistent composer cache docker volume, fixes #1027

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -20,6 +20,7 @@ ENV NGINX_DOCROOT $WEBSERVER_DOCROOT
 
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_CACHE_DIR /mnt/composer_cache
 
 # Defines vars in colon-separated notation to be subsituted with values for NGINX_SITE_TEMPLATE on start
 # NGINX_DOCROOT is for backward compatibility only, to break less people.
@@ -111,10 +112,11 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/log/apache2 /var/run/apache2 /var/lib
 
 RUN chmod -R 777 /var/log
 
-RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php /etc/apache2 /var/log/apache2/ /var/run/apache2 /var/lib/apache2
+RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php /etc/apache2 /var/log/apache2/ /var/run/apache2 /var/lib/apache2 /mnt/composer_cache
 
 # All users will have their home directory in /home, make it fully writeable
-RUN mkdir -p /home/.composer/cache /home/.drush/commands /home/.drush/aliases && chmod -R ugo+rw /home
+RUN mkdir -p /home/.composer /home/.drush/commands /home/.drush/aliases && chmod -R ugo+rw /home /mnt/composer_cache
+
 # Except that .my.cnf can't be writeable or mysql won't use it.
 RUN chmod 444 /home/.my.cnf
 

--- a/containers/ddev-webserver/files/start.sh
+++ b/containers/ddev-webserver/files/start.sh
@@ -89,6 +89,8 @@ fi
 
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
+sudo sudo chown -R "$(id -u):$(id -g)" /mnt/composer_cache/
+
 echo 'Server started'
 
 exec /usr/bin/supervisord -n -c "/etc/supervisor/supervisord-${DDEV_WEBSERVER_TYPE}.conf"

--- a/containers/ddev-webserver/files/start.sh
+++ b/containers/ddev-webserver/files/start.sh
@@ -89,7 +89,7 @@ fi
 
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
-sudo sudo chown -R "$(id -u):$(id -g)" /mnt/composer_cache/
+sudo chown -R "$(id -u):$(id -g)" /mnt/composer_cache/
 
 echo 'Server started'
 

--- a/containers/ddev-webserver/test/containertest.sh
+++ b/containers/ddev-webserver/test/containertest.sh
@@ -47,9 +47,9 @@ mkdir -p $composercache && chmod 777 $composercache
 
 export MOUNTUID=$UID
 export MOUNTGID=$(id -g)
-if [[ "$MOUNTUID" -gt "60000" || "$MOUNTGID" -gt "60000" ]] ; then
-	MOUNTUID=1
-	MOUNTGID=1
+if [ "$OS" = "Windows_NT" ] ; then
+	MOUNTUID=1000
+	MOUNTGID=1000
 fi
 
 for v in 5.6 7.0 7.1 7.2; do
@@ -131,7 +131,7 @@ for project_type in drupal6 drupal7 drupal8 typo3 backdrop wordpress default; do
 done
 
 echo "--- testing use of custom nginx and php configs"
-docker run  -u "$(id -u):$(id -g)" -p $HOST_PORT:$CONTAINER_PORT -e "DOCROOT=potato" -e "DDEV_PHP_VERSION=7.2" -v "/$PWD/test/testdata:/mnt/ddev_config:ro" -d --name $CONTAINER_NAME -d $DOCKER_IMAGE
+docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_PORT:$CONTAINER_PORT -e "DOCROOT=potato" -e "DDEV_PHP_VERSION=7.2" -v "/$PWD/test/testdata:/mnt/ddev_config:ro" -d --name $CONTAINER_NAME -d $DOCKER_IMAGE
 if ! containercheck; then
     exit 108
 fi

--- a/containers/ddev-webserver/test/containertest.sh
+++ b/containers/ddev-webserver/test/containertest.sh
@@ -143,7 +143,9 @@ docker exec -t $CONTAINER_NAME php --re xdebug | grep "xdebug does not exist"
 
 # Verify that the custom php configuration in ddev_config/php is activated.
 echo "--- Verify that /mnt/ddev_config is mounted and we have php overrides there.
-docker exec -t $CONTAINER_NAME ls -lR //mnt/ddev_config >/dev/null
+
+# First see if /mnt/ddev_config "works"
+docker exec -t $CONTAINER_NAME bash -c "ls -l //mnt/ddev_config/php/my-php.ini || (echo 'Failed to ls /mnt/ddev_config' && exit 201)"
 
 # With overridden value we should have assert.active=0, not the default
 echo "--- Check that assert.active override is working"

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -46,6 +46,11 @@ services:
       - type: "volume"
         source: ddev-ssh-agent_socket_dir
         target: "/home/.ssh-agent"
+      - type: "volume"
+        source: ddev-composer-cache
+        target: "/mnt/composer_cache"
+        volume:
+          nocopy: true
     restart: "no"
     user: "$DDEV_UID:$DDEV_GID"
     depends_on:
@@ -119,6 +124,8 @@ volumes:
     name: "${DDEV_SITENAME}-mariadb"
   ddev-ssh-agent_socket_dir:
     external: true
+  ddev-composer-cache:
+    name: ddev-composer-cache
   
 `
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,7 +27,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20181105_use_localhost_healthcheck" // Note that this can be overridden by make
+var WebTag = "20181109_composer_cache_dir" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Testing our lovely brand-new `ddev composer` reminds one how much cache matters with composer. WE WANT PERSISTENT CACHE!

## How this PR Solves The Problem:

* Add a docker volume for cache to docker-compose.yaml
* Mount it in the web container
* Add COMPOSER_CACHE_DIR environment var in web container to point to it. 
* Bump the version on the web image.

## Manual Testing Instructions:

* Do some composer actions
* rm your container
* Start another project
* Do some related composer actions
* Watch the packages load from cache

## Automated Testing Overview:

I didn't add testing, it's worth considering. I will think about it, it could work.

## Related Issue Link(s):

OP #1027

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

