### PR TITLE
Fix nightly build - TestMain in dockerutil should not pull if exists (tests only)

### DIFF
--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -26,12 +26,18 @@ func TestMain(m *testing.M) {
 
 	// prep docker container for docker util tests
 	client := GetDockerClient()
-	err := client.PullImage(docker.PullImageOptions{
-		Repository: version.WebImg,
-		Tag:        version.WebTag,
-	}, docker.AuthConfiguration{})
+	imageExists, err := ImageExistsLocally(version.WebImg + ":" + version.WebTag)
 	if err != nil {
-		logOutput.Fatal("failed to pull test image ", err)
+		logOutput.Fatalf("Failed to check for local image %s: %v", version.WebImg+":"+version.WebTag, err)
+	}
+	if !imageExists {
+		err := client.PullImage(docker.PullImageOptions{
+			Repository: version.WebImg,
+			Tag:        version.WebTag,
+		}, docker.AuthConfiguration{})
+		if err != nil {
+			logOutput.Fatal("failed to pull test image ", err)
+		}
 	}
 
 	foundContainer, _ := FindContainerByLabels(map[string]string{"com.ddev.site-name": "dockerutils-test"})


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our nightly build failed last night because of a newly introduced item in dockerutils TestMain where we pull the current web container... but forgot to check if it already exists (in nightly build it already exists, but is not available to pull)

## How this PR Solves The Problem:

Check first.

