### PR TITLE
Update documentation links to use 'stable' version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ ddev is an open source tool that makes it simple to get local PHP development en
 
 ## Getting Started
 
-1. **Check System Requirements:** We support recent versions of macOS, Windows 10, and Linux distributions that will run docker-ce (ddev requires Docker and docker-compose). ([more info here](https://ddev.readthedocs.io/en/latest/#system-requirements)). 
-2. **Install ddev:** [Options include](https://ddev.readthedocs.io/en/latest/#installation) macOS homebrew (recommended), an install script, or manual installation.
+1. **Check System Requirements:** We support recent versions of macOS, Windows 10, and Linux distributions that will run docker-ce (ddev requires Docker and docker-compose). ([more info here](https://ddev.readthedocs.io/en/stable/#system-requirements)). 
+2. **Install ddev:** [Options include](https://ddev.readthedocs.io/en/stable/#installation) macOS homebrew (recommended), an install script, or manual installation.
 3. **Choose a CMS Quick Start Guide:** 
-  - [WordPress](https://ddev.readthedocs.io/en/latest/users/cli-usage#wordpress-quickstart)
-  - [Drupal 6 and 7](https://ddev.readthedocs.io/en/latest/users/cli-usage#drupal-6/7-quickstart)
-  - [Drupal 8](https://ddev.readthedocs.io/en/latest/users/cli-usage#drupal-8-quickstart)
-  - [Backdrop](https://ddev.readthedocs.io/en/latest/users/cli-usage/#backdrop-quickstart) 
-  - [TYPO3](https://ddev.readthedocs.io/en/latest/users/cli-usage#typo3-quickstart)
+  - [WordPress](https://ddev.readthedocs.io/en/stable/users/cli-usage#wordpress-quickstart)
+  - [Drupal 6 and 7](https://ddev.readthedocs.io/en/stable/users/cli-usage#drupal-6/7-quickstart)
+  - [Drupal 8](https://ddev.readthedocs.io/en/stable/users/cli-usage#drupal-8-quickstart)
+  - [Backdrop](https://ddev.readthedocs.io/en/stable/users/cli-usage/#backdrop-quickstart) 
+  - [TYPO3](https://ddev.readthedocs.io/en/stable/users/cli-usage#typo3-quickstart)
 
-Having trouble? See our [support options below](#support). You might have trouble if [another local development tool is already using port 80 or 443](https://ddev.readthedocs.io/en/latest/#using-ddev-with-other-development-environments).
+Having trouble? See our [support options below](#support). You might have trouble if [another local development tool is already using port 80 or 443](https://ddev.readthedocs.io/en/stable/#using-ddev-with-other-development-environments).
 
 ## Current Feature List
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -19,7 +19,7 @@ import (
 var (
 	updateInterval = time.Hour * 24 * 7 // One week interval between updates
 	serviceType    string
-	updateDocURL   = "https://ddev.readthedocs.io/en/latest/#installation"
+	updateDocURL   = "https://ddev.readthedocs.io/en/stable/#installation"
 )
 
 // RootCmd represents the base command when called without any subcommands

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-backdrop.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-backdrop.conf
@@ -2,7 +2,7 @@
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf
-# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
 
 # Set https to 'on' if x-forwarded-proto is https
 map $http_x_forwarded_proto $fcgi_https {

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-default.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-default.conf
@@ -2,7 +2,7 @@
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf
-# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
 
 # Set https to 'on' if x-forwarded-proto is https
 map $http_x_forwarded_proto $fcgi_https {

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal6.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal6.conf
@@ -2,7 +2,7 @@
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf
-# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
 
 # Parts of this config come from the excellent Perusio config that
 # was fine-tuned for Drupal6 and Drupal7:

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal7.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal7.conf
@@ -2,7 +2,7 @@
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf
-# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
 
 # Set https to 'on' if x-forwarded-proto is https
 map $http_x_forwarded_proto $fcgi_https {

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal8.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal8.conf
@@ -2,7 +2,7 @@
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf
-# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
 
 # Set https to 'on' if x-forwarded-proto is https
 map $http_x_forwarded_proto $fcgi_https {

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
@@ -2,7 +2,7 @@
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf
-# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
 
 # Set https to 'on' if x-forwarded-proto is https
 map $http_x_forwarded_proto $fcgi_https {

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-wordpress.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-wordpress.conf
@@ -5,7 +5,7 @@
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf
-# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
 
 # Set https to 'on' if x-forwarded-proto is https
 map $http_x_forwarded_proto $fcgi_https {

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@
 
 
 ### Using ddev with other development environments
-ddev by default uses ports 80 and 443 on your system when projects are running. If you are using another local development environment you can either stop the other environment or configure ddev to use different ports. See [troubleshooting](https://ddev.readthedocs.io/en/latest/users/troubleshooting/#webserver-ports-are-already-occupied-by-another-webserver) for more detailed problemsolving.
+ddev by default uses ports 80 and 443 on your system when projects are running. If you are using another local development environment you can either stop the other environment or configure ddev to use different ports. See [troubleshooting](https://ddev.readthedocs.io/en/stable/users/troubleshooting/#webserver-ports-are-already-occupied-by-another-webserver) for more detailed problemsolving.
 
 ## Installation
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -150,7 +150,7 @@ _Note: ddev config will prompt you for a project name, docroot, and project type
 * The project name will be part of the URL, so make sure to avoid whitespace, underscores and special characters to avoid problems down the road.
 * After the command runs through, prepare to edit the generated config.yaml file:
 ** Review the PHP version. Available options: 5.6, 7.0, 7.1, and 7.2.
-** Review the ports the system wants to use. If you run a local stack already, you will need to adjust here, or shut down your local stack. See [additional troubleshooting information here](https://ddev.readthedocs.io/en/latest/users/troubleshooting/#unable-listen).
+** Review the ports the system wants to use. If you run a local stack already, you will need to adjust here, or shut down your local stack. See [additional troubleshooting information here](https://ddev.readthedocs.io/en/stable/users/troubleshooting/#unable-listen).
 
 After you've run `ddev config`, you're ready to start running your project. To start running ddev, simply enter:
 
@@ -165,7 +165,7 @@ Successfully started example-typo3-site
 Your application can be reached at: http://example-typo3-site.ddev.local
 ```
 
-For those wanting/needing to connect to the database within the database container directly, please see the [developer tools page](https://ddev.readthedocs.io/en/latest/users/developer-tools/#using-development-tools-on-the-host-machine).
+For those wanting/needing to connect to the database within the database container directly, please see the [developer tools page](https://ddev.readthedocs.io/en/stable/users/developer-tools/#using-development-tools-on-the-host-machine).
 
 ### Backdrop Quickstart
 

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -1,6 +1,6 @@
 <h1>Troubleshooting</h1>
 
-Things might go wrong! Besides the suggestions on this page don't forget about [Stack Overflow](https://stackoverflow.com/tags/ddev) and [the ddev issue queue](https://github.com/drud/ddev/issues) and [other support options](https://ddev.readthedocs.io/en/latest/#support). And see [Docker troubleshooting suggstions](./docker_installation.md#troubleshooting).
+Things might go wrong! Besides the suggestions on this page don't forget about [Stack Overflow](https://stackoverflow.com/tags/ddev) and [the ddev issue queue](https://github.com/drud/ddev/issues) and [other support options](https://ddev.readthedocs.io/en/stable/#support). And see [Docker troubleshooting suggstions](./docker_installation.md#troubleshooting).
 
 <a name="unable-listen"></a>
 ## Webserver ports are already occupied by another webserver
@@ -112,4 +112,4 @@ Database snapshot from before v1.3.0 are not compatible with ddev v1.3+ because 
 
 ## More Support
 
-[Support options](https://ddev.readthedocs.io/en/latest/#support) has a variety of options.
+[Support options](https://ddev.readthedocs.io/en/stable/#support) has a variety of options.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1017,7 +1017,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 		}
 
 		if _, _, err := app.Exec(opts); err != nil {
-			return fmt.Errorf("snapshot %s is not compatible with this version of ddev and mariadb. Please use the instructions at %s for a workaround to restore it", snapshotDir, "https://ddev.readthedocs.io/en/latest/users/troubleshooting/#old-snapshot")
+			return fmt.Errorf("snapshot %s is not compatible with this version of ddev and mariadb. Please use the instructions at %s for a workaround to restore it", snapshotDir, "https://ddev.readthedocs.io/en/stable/users/troubleshooting/#old-snapshot")
 		}
 	}
 

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -96,7 +96,7 @@ func StartDdevRouter() error {
 
 	err = CheckRouterPorts()
 	if err != nil {
-		return fmt.Errorf("Unable to listen on required ports, %v,\nTroubleshooting suggestions at https://ddev.readthedocs.io/en/latest/users/troubleshooting/#unable-listen", err)
+		return fmt.Errorf("Unable to listen on required ports, %v,\nTroubleshooting suggestions at https://ddev.readthedocs.io/en/stable/users/troubleshooting/#unable-listen", err)
 	}
 
 	// run docker-compose up -d in the newly created directory

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -188,7 +188,7 @@ const ConfigInstructions = `
 #
 # Many ddev commands can be extended to run tasks after the ddev command is
 # executed.
-# See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more
+# See https://ddev.readthedocs.io/en/stable/users/extending-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
 #hooks:`

--- a/pkg/ddevapp/testdata/.ddev/nginx-site.conf
+++ b/pkg/ddevapp/testdata/.ddev/nginx-site.conf
@@ -2,7 +2,7 @@
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf
-# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
 
 # Set https to 'on' if x-forwarded-proto is https
 map $http_x_forwarded_proto $fcgi_https {

--- a/pkg/servicetest/testdata/services/README.md
+++ b/pkg/servicetest/testdata/services/README.md
@@ -1,3 +1,3 @@
 # Additional Service Configurations for ddev
 
-This directory contains additional service configurations that can be added to the .ddev directory for a project to enable additional services for the project. Setup instructions for these service files can be found in the [Additional Services Documentation](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/).
+This directory contains additional service configurations that can be added to the .ddev directory for a project to enable additional services for the project. Setup instructions for these service files can be found in the [Additional Services Documentation](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/).


### PR DESCRIPTION
## The Problem/Issue/Bug:
Links to ReadTheDocs pointed to the 'latest' tag, which is the bleeding edge build of the master branch. Almost all users should be directed to the 'stable' tag, which points to the most recent release tag's documentation.

## How this PR Solves The Problem:
Updates the links to use the 'stable' tag.
