### PR TITLE
add _apt user back in to /etc/passwd so apt operations do not exit wi…

### DIFF
--- a/containers/ddev-webserver/files/etc/passwd
+++ b/containers/ddev-webserver/files/etc/passwd
@@ -1,5 +1,4 @@
 root:x:0:0:root:/home:/bin/bash
-_apt:x:100:65534::/nonexistent:/bin/false
 nginx:x:0:0:root:/home:/bin/bash
 uid_0:x:0:0:root:/home:/bin/bash
 uid_1:x:1:1:gid_1:/home:/bin/bash
@@ -101,7 +100,8 @@ uid_96:x:96:96:gid_96:/home:/bin/bash
 uid_97:x:97:97:gid_97:/home:/bin/bash
 uid_98:x:98:98:gid_98:/home:/bin/bash
 uid_99:x:99:99:gid_99:/home:/bin/bash
-uid_100:x:100:100:gid_100:/home:/bin/bash
+uid_100:x:100:65534:gid_100:/home:/bin/bash
+_apt:x:100:65534:gid_100:/home:/bin/bash
 uid_101:x:101:101:gid_101:/home:/bin/bash
 uid_102:x:102:102:gid_102:/home:/bin/bash
 uid_103:x:103:103:gid_103:/home:/bin/bash

--- a/containers/ddev-webserver/files/etc/passwd
+++ b/containers/ddev-webserver/files/etc/passwd
@@ -1,4 +1,5 @@
 root:x:0:0:root:/home:/bin/bash
+_apt:x:100:65534::/nonexistent:/bin/false
 nginx:x:0:0:root:/home:/bin/bash
 uid_0:x:0:0:root:/home:/bin/bash
 uid_1:x:1:1:gid_1:/home:/bin/bash
@@ -100,7 +101,7 @@ uid_96:x:96:96:gid_96:/home:/bin/bash
 uid_97:x:97:97:gid_97:/home:/bin/bash
 uid_98:x:98:98:gid_98:/home:/bin/bash
 uid_99:x:99:99:gid_99:/home:/bin/bash
-uid_100:x:100:101:gid_100:/home:/bin/bash
+uid_100:x:100:100:gid_100:/home:/bin/bash
 uid_101:x:101:101:gid_101:/home:/bin/bash
 uid_102:x:102:102:gid_102:/home:/bin/bash
 uid_103:x:103:103:gid_103:/home:/bin/bash
@@ -60001,4 +60002,3 @@ uid_59997:x:59997:59997:gid_59997:/home:/bin/bash
 uid_59998:x:59998:59998:gid_59998:/home:/bin/bash
 uid_59999:x:59999:59999:gid_59999:/home:/bin/bash
 uid_60000:x:60000:60000:gid_60000:/home:/bin/bash
-nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin

--- a/containers/ddev-webserver/files/etc/passwd
+++ b/containers/ddev-webserver/files/etc/passwd
@@ -60002,3 +60002,4 @@ uid_59997:x:59997:59997:gid_59997:/home:/bin/bash
 uid_59998:x:59998:59998:gid_59998:/home:/bin/bash
 uid_59999:x:59999:59999:gid_59999:/home:/bin/bash
 uid_60000:x:60000:60000:gid_60000:/home:/bin/bash
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,13 +27,13 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.4.0" // Note that this can be overridden by make
+var WebTag = "readd_apt_user_to_etc_passwd_file" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "v1.4.0" // Note that this may be overridden by make
+var DBTag = "readd_apt_user_to_etc_passwd_file" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -33,7 +33,7 @@ var WebTag = "readd_apt_user_to_etc_passwd_file" // Note that this can be overri
 var DBImg = "drud/ddev-dbserver"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "readd_apt_user_to_etc_passwd_file" // Note that this may be overridden by make
+var DBTag = "v1.4.0" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
Hi,
The /etc/passwd files in the ddev web image overwrites the _apt user (and various others)
https://github.com/drud/ddev/blob/master/containers/ddev-webserver/files/etc/passwd

This appears to be causing various odd issues such as when trying to add additional packages to the container once booted since there is no sandbox _apt user and the OS cannot create any more users

**To Reproduce**
`ddev start`
`ddev . sudo apt-get update`

response:
`W: No sandbox user '_apt' on the system, can not drop privileges`

**Version and configuration information:**
```
# ddev version
dba   	drud/phpmyadmin:v1.3.0
router	drud/ddev-router:v1.3.0
commit	v1.3.0
domain	ddev.local
cli   	v1.3.0
web   	drud/ddev-webserver:v1.3.0
db    	drud/ddev-dbserver:v1.3.0
```

This PR adds back the _apt user

Thanks

## Manual Testing Instructions:

* `ddev ssh`
* `sudo apt-get update && sudo apt-get install htop`
* You should see htop get installed with no error and no complaint about _apt being missing.