### PR TITLE
Unset/reset noninteractive env var when testing Confirm()

### DIFF
--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -3,6 +3,7 @@ package util_test
 import (
 	"bufio"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -84,6 +85,13 @@ func TestCaptureStdOut(t *testing.T) {
 // TestConfirm ensures that the confirmation prompt works as expected.
 func TestConfirm(t *testing.T) {
 	assert := asrt.New(t)
+
+	noninteractiveEnv := "DRUD_NONINTERACTIVE"
+	defer os.Setenv(noninteractiveEnv, os.Getenv(noninteractiveEnv))
+	err := os.Unsetenv(noninteractiveEnv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 
 	yesses := []string{"YES", "Yes", "yes", "Y", "y"}
 	for _, y := range yesses {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -86,6 +86,7 @@ func TestCaptureStdOut(t *testing.T) {
 func TestConfirm(t *testing.T) {
 	assert := asrt.New(t)
 
+	// Unset the env var, then reset after the test
 	noninteractiveEnv := "DRUD_NONINTERACTIVE"
 	defer os.Setenv(noninteractiveEnv, os.Getenv(noninteractiveEnv))
 	err := os.Unsetenv(noninteractiveEnv)


### PR DESCRIPTION
## The Problem/Issue/Bug:
DRUD_NONINTERACTIVE being set caused TestConfirm() to fail because Confirm() just returns true when this variable is set.

## How this PR Solves The Problem:
Unsets the variable for the test, then resets it after the test is complete.
