### PR TITLE
Update 'ddev composer create' install directory

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -148,6 +148,9 @@ project root will be deleted when creating a project.`,
 			Service: "web",
 			Cmd:     []string{"sh", "-c", fmt.Sprintf("rm -rf %s", installDir)},
 		})
+		if err != nil {
+			util.Warning("Failed to remove the temporary install directory %s: %v", installDir, err)
+		}
 	},
 }
 

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -146,7 +146,7 @@ project root will be deleted when creating a project.`,
 		output.UserOut.Println("Removing temporary install directory")
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
-			Cmd: []string{"sh", "-c", fmt.Sprintf("rm -rf %s", installDir)},
+			Cmd:     []string{"sh", "-c", fmt.Sprintf("rm -rf %s", installDir)},
 		})
 	},
 }

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -71,19 +71,25 @@ project root will be deleted when creating a project.`,
 
 		// The install directory may be populated if the command has been
 		// previously executed using the same container.
-		output.UserOut.Printf("Ensuring temporary composer install directory in web container is empty")
-		installDir := "/tmp/composer"
-		_, _, _ = app.Exec(&ddevapp.ExecOpts{
+		output.UserOut.Printf("Ensuring temporary install directory in web container is empty")
+		installDir := "/var/www/html/.tmp-install"
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
 			Cmd:     []string{"sh", "-c", fmt.Sprintf("rm -rf %s", installDir)},
 		})
+		if err != nil {
+			util.Failed("Failed to create project: %v", err)
+		}
 
 		// Remove any contents of project root
 		util.Warning("Removing any existing files in project root")
-		_, _, _ = app.Exec(&ddevapp.ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
 			Cmd:     []string{"sh", "-c", "rm -rf /var/www/html/*"},
 		})
+		if err != nil {
+			util.Failed("Failed to create project: %v", err)
+		}
 
 		// Build container composer command
 		composerCmd := []string{
@@ -129,9 +135,18 @@ project root will be deleted when creating a project.`,
 
 		output.UserOut.Printf("Moving installation to project root")
 		bashCmdString := fmt.Sprintf("if [ -d %s ]; then mv %s /var/www/html/; fi", installDir, path.Join(installDir, "*"))
-		_, _, _ = app.Exec(&ddevapp.ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
 			Cmd:     []string{"sh", "-c", bashCmdString},
+		})
+		if err != nil {
+			util.Failed("Failed to create project: %v", err)
+		}
+
+		output.UserOut.Println("Removing temporary install directory")
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
+			Service: "web",
+			Cmd: []string{"sh", "-c", fmt.Sprintf("rm -rf %s", installDir)},
 		})
 	},
 }

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -37,7 +37,7 @@ func TestComposerCmd(t *testing.T) {
 	args = []string{"composer", "create", "--dev", "typo3/cms-base-distribution", "^9"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	assert.Contains(out, "Created project in /tmp/composer")
+	assert.Contains(out, "Created project in ")
 
 	// Test a composer require
 	args = []string{"composer", "require", "twitter/bootstrap"}


### PR DESCRIPTION
## The Problem/Issue/Bug:
- Some errors weren't being correctly captured, causing silent failures
- `composer create-project` was using /tmp/composer as a target dir, causing issues on Windows

## How this PR Solves The Problem:
- Capture errors and fail when `mv` and `rm` fail
- Update the install directory to `/var/www/html/.tmp-composer`, deleting after install

## Manual Testing Instructions:
`ddev composer create <package> [<version>]` on Windows, specifically

## Automated Testing Overview:
Errors being correctly captured mean that this should no longer fail silently on automated testing.
