### PR TITLE
Bump container versions for v1.4.0 release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,29 +27,29 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20181113_add_bz2" // Note that this can be overridden by make
+var WebTag = "v1.4.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // DBTag defines the default db image tag for drud dev
-var DBTag = "20181106_export_db" // Note that this may be overridden by make
+var DBTag = "v1.4.0" // Note that this may be overridden by make
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "20181105_use_localhost_healthcheck" // Note that this can be overridden by make
+var DBATag = "v1.4.0" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20181105_use_localhost_healthcheck" // Note that this can be overridden by make
+var RouterTag = "v1.4.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "20181022_add_ssh_auth"
+var SSHAuthTag = "v1.4.0"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

This is just the temporary v1.4.0 container versions preparing for release.

They should be pushed again when the official tag is cut.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

