### PR TITLE
Stop using winpty, let them prompt for it

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -60,11 +60,8 @@ var AuthSSHCommand = &cobra.Command{
 			util.Failed("Failed to start ddev-ssh-agent container: %v", err)
 		}
 		sshKeyPath = dockerutil.MassageWindowsHostMountpoint(sshKeyPath)
-		useWinPty := util.IsCommandAvailable("winpty")
 		dockerCmd := fmt.Sprintf("docker run -it --rm --volumes-from=%s --mount 'type=bind,src=%s,dst=/tmp/.ssh' -u %s %s:%s ssh-add", ddevapp.SSHAuthName, sshKeyPath, uidStr, version.SSHAuthImage, version.SSHAuthTag)
-		if useWinPty {
-			dockerCmd = "winpty" + dockerCmd
-		}
+
 		err = exec.RunInteractiveCommand("sh", []string{"-c", dockerCmd})
 
 		if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Testing item `#3` (ddev auth ssh) on [test plan](https://github.com/drud/ddev/issues/1188#issuecomment-438435072) I find that it completely fails because there's not space between "winpty" and "docker", thus it fails to execute "winptydocker". This is ugly and completely prevents users from doing anything. Not sure how it passed on Win 10 Pro.

It wasn't really our business to add the winpty to the command any way, git-bash will tell them about it, the same as when they use `ddev ssh`.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

