### PR TITLE
Add huge COMPOSER_PROCESS_TIMEOUT for Win10 reasons

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -21,6 +21,8 @@ ENV NGINX_DOCROOT $WEBSERVER_DOCROOT
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_CACHE_DIR /mnt/composer_cache
+# Windows, especially Win10 Home/Docker toolbox, can take forever on composer build.
+ENV COMPOSER_PROCESS_TIMEOUT 2000
 
 # Defines vars in colon-separated notation to be subsituted with values for NGINX_SITE_TEMPLATE on start
 # NGINX_DOCROOT is for backward compatibility only, to break less people.


### PR DESCRIPTION
## The Problem/Issue/Bug:

In testing on Win 10 Home, Drupal composer builds would always time out getting the Drupal 8 core unzipped. It seems to work if the COMPOSER_PROCESS_TIMEOUT is bumped up. This shouldn't do anybody any harm.

I am pushing the updated ddev-webserver v1.4.0 image right now. So in a sense this is already in the final result even before it gets pulled. 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

