### PR TITLE
Fix panic in GetWebContainerPublicPort()

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1138,7 +1138,7 @@ func (app *DdevApp) GetWebContainerDirectURL() string {
 func (app *DdevApp) GetWebContainerPublicPort() (int, error) {
 
 	webContainer, err := app.FindContainerByType("web")
-	if err != nil {
+	if err != nil || webContainer == nil {
 		return -1, fmt.Errorf("Unable to find web container for app: %s, err %v", app.Name, err)
 	}
 

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -126,6 +126,9 @@ func findDdevRouter() (*docker.APIContainers, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute findContainersByLabels, %v", err)
 	}
+	if container == nil {
+		return nil, fmt.Errorf("No ddev-router was found")
+	}
 	return container, nil
 }
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -96,6 +96,7 @@ func TestGetContainerHealth(t *testing.T) {
 	}
 	container, err := FindContainerByLabels(labels)
 	require.NoError(t, err)
+	require.NotNil(t, container)
 
 	err = client.StopContainer(container.ID, 10)
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

@mafriend caught a bad panic doing a `ddev list`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x15ea4ed]

goroutine 1 [running]:
github.com/drud/ddev/pkg/ddevapp.(*DdevApp).GetWebContainerPublicPort(0xc000186540, 0x9, 0x0, 0x0)
    /go/src/github.com/drud/ddev/pkg/ddevapp/ddevapp.go:1145 +0x6d
github.com/drud/ddev/pkg/ddevapp.(*DdevApp).GetWebContainerDirectURL(0xc000186540, 0x0, 0x0)
    /go/src/github.com/drud/ddev/pkg/ddevapp/ddevapp.go:1133 +0xb4
github.com/drud/ddev/pkg/ddevapp.(*DdevApp).GetAllURLs(0xc000186540, 0xc0002d7a40, 0x190ecc3, 0x8)
    /go/src/github.com/drud/ddev/pkg/ddevapp/ddevapp.go:1121 +0x2f5
github.com/drud/ddev/pkg/ddevapp.(*DdevApp).Describe(0xc000186540, 0xc00025ff20, 0x0, 0x0)
    /go/src/github.com/drud/ddev/pkg/ddevapp/ddevapp.go:147 +0x7f0
github.com/drud/ddev/cmd/ddev/cmd.glob..func20(0x201d6e0, 0x204a0e0, 0x0, 0x0)
    /go/src/github.com/drud/ddev/cmd/ddev/cmd/list.go:29 +0x221
github.com/drud/ddev/vendor/github.com/spf13/cobra.(*Command).execute(0x201d6e0, 0x204a0e0, 0x0, 0x0, 0x201d6e0, 0x204a0e0)
    /go/src/github.com/drud/ddev/vendor/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/drud/ddev/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x201e520, 0xc00022df88, 0x10053a0, 0xc00007c058)
    /go/src/github.com/drud/ddev/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/drud/ddev/vendor/github.com/spf13/cobra.(*Command).Execute(0x201e520, 0x0, 0x0)
    /go/src/github.com/drud/ddev/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/drud/ddev/cmd/ddev/cmd.Execute()
    /go/src/github.com/drud/ddev/cmd/ddev/cmd/root.go:105 +0x3b
main.main()
    /go/src/github.com/drud/ddev/cmd/ddev/main.go:6 +0x20
```

## How this PR Solves The Problem:

There was an unchecked nil container in GetWebContainerPublicPort()

## Manual Testing Instructions:

I don't think it's easy to recreate this.

Thanks for the catch @mafriend ! Nice work. 💯 
