### PR TITLE
Make TestComposerCmd run faster, fixes #1268

### DIFF
--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -35,7 +35,7 @@ func TestComposerCmd(t *testing.T) {
 
 	// Test create-project
 	// ddev composer create cweagans/composer-patches --prefer-dist --no-interaction
-	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "cweagans/composer-patches"}
+	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "cweagans/composer-patches", "1.6.5"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, out)
 	assert.Contains(out, "Created project in ")

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -34,7 +34,8 @@ func TestComposerCmd(t *testing.T) {
 	assert.Contains(out, "Available commands:")
 
 	// Test create-project
-	args = []string{"composer", "create", "--dev", "typo3/cms-base-distribution", "^9"}
+	// ddev composer create cweagans/composer-patches --prefer-dist --no-interaction
+	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "cweagans/composer-patches"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, out)
 	assert.Contains(out, "Created project in ")

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -56,7 +56,7 @@ func TestComposerCmd(t *testing.T) {
 	// Test a composer remove
 	if util.IsDockerToolbox() {
 		// On docker toolbox, git objects are read-only, causing the composer remove to fail.
-		_, err = exec.RunCommand("bash", []string{"-c", "chmod -R u+w /var/www/html/*"})
+		_, err = exec.RunCommand(DdevBin, []string{"exec", "bash", "-c", "chmod -R u+w /var/www/html/"})
 		assert.NoError(err)
 	}
 	args = []string{"composer", "remove", "twitter/bootstrap"}

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/util"
 	"os"
 	"testing"
 
@@ -53,6 +54,11 @@ func TestComposerCmd(t *testing.T) {
 	assert.Contains(out, "--twitter/bootstrap")
 
 	// Test a composer remove
+	if util.IsDockerToolbox() {
+		// On docker toolbox, git objects are read-only, causing the composer remove to fail.
+		_, err = exec.RunCommand("bash", []string{"-c", "chmod -R u+w /var/www/html/*"})
+		assert.NoError(err)
+	}
 	args = []string{"composer", "remove", "twitter/bootstrap"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, out)


### PR DESCRIPTION
## The Problem/Issue/Bug:

The full TYPO3 composer build in first pass of TestComposerCmd took more time than warranted.

## How this PR Solves The Problem:

Use a simpler build

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

