### PR TITLE
Add support for pre-gzipped CSS and JS files

### DIFF
--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
@@ -48,6 +48,16 @@ server {
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }
+    
+    # Compression: Support gzipped js/css files
+    location ~ \.js\.gzip {
+        add_header Content-Encoding gzip;
+        add_header Content-Type application/javascript;
+    }
+    location ~ \.css\.gzip {
+        add_header Content-Encoding gzip;
+        add_header Content-Type text/css;
+    }
 
     # Expire rules for static content
     # Feed


### PR DESCRIPTION
## The Problem/Issue/Bug:

Like in the TYPO3 .htaccess file which supports gzip compression this should also be supported by the nginx configuration.
Solution found in Slack posted by @supergrav https://typo3.slack.com/archives/C8TRNQ601/p1528290423000106

## How this PR Solves The Problem:

Adds headers for .js.gzip and .css.gzip files

## Manual Testing Instructions:

Run a TYPO3 project in ddev with nginx-fpm
Include some gzipped files
```
page.includeJSFooter.jsFile = EXT:example/Resources/Public/JavaScript/file.js.gzip
page.includeCSS.cssFile = EXT:example/Resources/Public/Styles/file.css.gzip
```
Network analyze in any browser if the files get deflated correctly

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
none

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

