### PR TITLE
Look in parent directories for an existing .ddev/config.yaml, fixes #1158

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -227,11 +227,16 @@ func init() {
 
 // getConfigApp() does the basic setup of the app (with provider) and returns it.
 func getConfigApp(providerName string) (*ddevapp.DdevApp, error) {
-	appRoot, err := os.Getwd()
+	// Find app root
+	cd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	appRoot, err := ddevapp.CheckForConf(cd)
 	if err != nil {
 		return nil, fmt.Errorf("could not determine current working directory: %v", err)
 	}
-	// TODO: Handle case where config may be in parent directories.
 
 	app, err := ddevapp.NewApp(appRoot, providerName)
 	if err != nil {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -233,15 +233,18 @@ func getConfigApp(providerName string) (*ddevapp.DdevApp, error) {
 		return nil, err
 	}
 
+	// Check for an existing config in this or a parent dir
 	appRoot, err := ddevapp.CheckForConf(cd)
 	if err != nil {
-		return nil, fmt.Errorf("could not determine current working directory: %v", err)
+		// An error indicates no config file was found, use current directory
+		appRoot = cd
 	}
 
 	app, err := ddevapp.NewApp(appRoot, providerName)
 	if err != nil {
 		return nil, fmt.Errorf("could not create new config: %v", err)
 	}
+
 	return app, nil
 }
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -283,5 +283,43 @@ func TestConfigInvalidProjectname(t *testing.T) {
 		assert.Contains(out, fmt.Sprintf("%s is not a valid project name", projName))
 		assert.NotContains(out, "You may now run 'ddev start'")
 	}
+}
 
+// TestConfigSubdir ensures an existing config can be found from subdirectories
+func TestConfigSubdir(t *testing.T) {
+	var err error
+	assert := asrt.New(t)
+
+	// Create a temporary directory and switch to it.
+	tmpdir := testcommon.CreateTmpDir(t.Name())
+	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
+
+	// Create a simple config.
+	args := []string{
+		"config",
+		"--project-type",
+		"php",
+	}
+
+	out, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(out, "You may now run 'ddev start'")
+
+	// Create a subdirectory and switch to it.
+	subdir := filepath.Join(tmpdir, "some", "sub", "dir")
+	err = os.MkdirAll(subdir, 0755)
+	assert.NoError(err)
+	defer testcommon.Chdir(subdir)()
+
+	// Confirm that the detected config location is in the original dir.
+	args = []string{
+		"config",
+		"--show-config-location",
+	}
+
+	// Ensure the existing config can be found
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(out, filepath.Join(tmpdir, ".ddev", "config.yaml"))
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -546,7 +546,11 @@ func (app *DdevApp) docrootPrompt() error {
 	// If there is a default docroot, display it in the prompt.
 	if defaultDocroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
+	} else if cd, _ := os.Getwd(); cd == filepath.Join(app.AppRoot, defaultDocroot) {
+		// Preserve the case where the docroot is the current directory
+		docrootPrompt = fmt.Sprintf("%s (current directory)", docrootPrompt)
 	} else {
+		// Explicitly state 'project root' when in a subdirectory
 		docrootPrompt = fmt.Sprintf("%s (project root)", docrootPrompt)
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -518,10 +518,11 @@ func DiscoverDefaultDocroot(app *DdevApp) string {
 	var defaultDocroot = app.Docroot
 	if defaultDocroot == "" {
 		for _, docroot := range AvailableDocrootLocations() {
-			if _, err := os.Stat(docroot); err != nil {
+			if _, err := os.Stat(filepath.Join(app.AppRoot, docroot)); err != nil {
 				continue
 			}
-			if fileutil.FileExists(filepath.Join(docroot, "index.php")) {
+
+			if fileutil.FileExists(filepath.Join(app.AppRoot, docroot, "index.php")) {
 				defaultDocroot = docroot
 				break
 			}
@@ -538,7 +539,7 @@ func (app *DdevApp) docrootPrompt() error {
 	}
 
 	// Determine the document root.
-	output.UserOut.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your project root (%s)", app.AppRoot)
+	util.Warning("\nThe docroot is the directory from which your site is served.\nThis is a relative path from your project root at %s", app.AppRoot)
 	output.UserOut.Println("You may leave this value blank if your site files are in the project root")
 	var docrootPrompt = "Docroot Location"
 	var defaultDocroot = DiscoverDefaultDocroot(app)
@@ -546,7 +547,7 @@ func (app *DdevApp) docrootPrompt() error {
 	if defaultDocroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
 	} else {
-		docrootPrompt = fmt.Sprintf("%s (current directory)", docrootPrompt)
+		docrootPrompt = fmt.Sprintf("%s (project root)", docrootPrompt)
 	}
 
 	fmt.Print(docrootPrompt + ": ")

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -138,12 +138,12 @@ func Cleanup(app *DdevApp) error {
 
 // CheckForConf checks for a config.yaml at the cwd or parent dirs.
 func CheckForConf(confPath string) (string, error) {
-	if fileutil.FileExists(confPath + "/.ddev/config.yaml") {
+	if fileutil.FileExists(filepath.Join(confPath, ".ddev", "config.yaml")) {
 		return confPath, nil
 	}
-	pathList := filepath.SplitList(confPath)
 
-	for range pathList {
+	// Keep going until we can't go any higher
+	for filepath.Dir(confPath) != confPath {
 		confPath = filepath.Dir(confPath)
 		if fileutil.FileExists(filepath.Join(confPath, ".ddev", "config.yaml")) {
 			return confPath, nil

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -10,8 +10,6 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gosuri/uitable"
 
-	"errors"
-
 	"os"
 	"text/template"
 
@@ -143,16 +141,16 @@ func CheckForConf(confPath string) (string, error) {
 	if fileutil.FileExists(confPath + "/.ddev/config.yaml") {
 		return confPath, nil
 	}
-	pathList := strings.Split(confPath, "/")
+	pathList := filepath.SplitList(confPath)
 
 	for range pathList {
 		confPath = filepath.Dir(confPath)
-		if fileutil.FileExists(confPath + "/.ddev/config.yaml") {
+		if fileutil.FileExists(filepath.Join(confPath, ".ddev", "config.yaml")) {
 			return confPath, nil
 		}
 	}
 
-	return "", errors.New("no .ddev/config.yaml file was found in this directory or any parent")
+	return "", fmt.Errorf("no %s file was found in this directory or any parent", filepath.Join(".ddev", "config.yaml"))
 }
 
 // ddevContainersRunning determines if any ddev-controlled containers are currently running.


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1158: `ddev config` fails to look in parent directories for existing configurations.

## How this PR Solves The Problem:
- Searches through parent directories to find an existing .ddev/config.yaml
- Updates the user interaction text to add the "project root" case

## Manual Testing Instructions:
Run `ddev config` in four key scenarios:
- In the project root with no existing .ddev/config.yaml
- In the project root with an existing .ddev/config.yaml
- In a subdirectory of the project root with an existing .ddev/config.yaml
- In a directory where no .ddev/config.yaml exists in any parent directory

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#1158 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

