### PR TITLE
GetContainerHealth should use last element of Health array

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -194,8 +194,10 @@ func GetContainerHealth(container *docker.APIContainers) (string, string) {
 
 	status := inspect.State.Health.Status
 	logOutput := ""
+	// The last log is the most recent
 	if err == nil && len(inspect.State.Health.Log) > 0 {
-		logOutput = inspect.State.Health.Log[0].Output
+		numLogs := len(inspect.State.Health.Log)
+		logOutput = inspect.State.Health.Log[numLogs-1].Output
 	}
 
 	return status, logOutput

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -109,16 +109,11 @@ func TestGetContainerHealth(t *testing.T) {
 	healthDetail, err := ContainerWait(15, labels)
 	assert.NoError(err)
 
-	// The log/detail doesn't seem to come through in a timely fashion on Docker Toolbox
-	if !util.IsDockerToolbox() {
-		assert.Equal("phpstatus: OK, /var/www/html: OK, mailhog: OK", healthDetail)
-	}
+	assert.Equal("phpstatus: OK, /var/www/html: OK, mailhog: OK", healthDetail)
 
 	status, healthDetail = GetContainerHealth(container)
 	assert.Equal(status, "healthy")
-	if !util.IsDockerToolbox() {
-		assert.Equal("phpstatus: OK, /var/www/html: OK, mailhog: OK", healthDetail)
-	}
+	assert.Equal("phpstatus: OK, /var/www/html: OK, mailhog: OK", healthDetail)
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.


### PR DESCRIPTION
## The Problem/Issue/Bug:

We had an apparent test failure where the Log output was not as asserted on Docker Toolbox. It turns out that I was using the *first* element of the Health array expecting it to be the most recent, but in reality the *last* element of the Health array is the most recent.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

