### PR TITLE
Make large uid users run successfully on macOS, fixes #1281

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -846,7 +846,7 @@ func (app *DdevApp) DockerEnv() {
 	uidInt, gidInt, uidStr, gidStr := util.GetContainerUIDGid()
 
 	// Warn about running as root if we're not on windows.
-	if uidInt > 60000 || gidInt > 60000 || uidInt == 0 {
+	if uidInt == 0 || gidInt == 0 {
 		util.Warning("Warning: containers will run as root. This could be a security risk on Linux.")
 	}
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -155,11 +155,12 @@ func GetContainerUIDGid() (uid int, gid int, uidStr string, gidStr string) {
 	// For windows the uidStr/gidStr are usually way outside linux range (ends at 60000)
 	// so we have to run as arbitrary user 1000. We may have a host uidStr/gidStr greater in other contexts,
 	// 1000 seems not to cause file permissions issues at least on docker-for-windows.
-	if uidInt, err = strconv.Atoi(curUser.Uid); err != nil {
+	// TODO: For large macOS UIDs we might be better to add the UID to /etc/passwd at startup
+	if uidInt, err = strconv.Atoi(curUser.Uid); err != nil || uidInt > 60000 {
 		uidStr = "1000"
 		uidInt = 1000
 	}
-	if gidInt, err = strconv.Atoi(curUser.Gid); err != nil {
+	if gidInt, err = strconv.Atoi(curUser.Gid); err != nil || gidInt > 60000 {
 		gidStr = "1000"
 		gidInt = 1000
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

A regression in v1.4.0 meant that macOS users (and Linux users, though less likely) with UIDs above 60000 couldn't run ddev successfully (sudo failed, see OP #1281 )

## How this PR Solves The Problem:

The basically reverts back to the original behavior, automatically using a uid of 1000 if the UID is above 60000. Otherwise it just tries to use the normal user uid. This is fairly safe on macOS and Windows. It's highly questionable on Linux, where an inappropriate uid can create privileged files.

## Manual Testing Instructions:

* Verify correct behavior with a normal lower-numbered uid (`ddev ssh` and `id`). The uid and gid should be the same as your macOS uid/gid.
* Create a macOS user with a high UID, say 1553427339. You can do this in system prefs, users and groups. You have to right-click the user for advanced options. I called my user "largeuid"
* Copy the necessary ddev copy to /Users/Shared (or you can download from circleci artifacts)
* Log in with the user
* Start docker
* Make a dummy project and `ddev ssh`. and `id`. You should see uid_1000

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

