### PR TITLE
Bump docker-compose min version for project name, fixes #1286

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -16,7 +16,7 @@ sudo tar -C /usr/local -xzf /tmp/golang.tgz
 
 # docker-compose
 sudo rm -f /usr/local/bin/docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -s -L "https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
 # Remove existing docker and install from their apt package

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@
 
 ## System Requirements
 
-- [Docker](https://www.docker.com/community-edition) version 18.06 or higher. Linux users make sure you do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
-- docker-compose 1.20.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
+- [Docker](https://www.docker.com/community-edition) version 18.06 or higher. Linux users make sure you upgrade docker-compose and do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
+- docker-compose 1.21.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
 - OS Support
   - macOS Sierra and higher (macOS 10.12 and higher but it should runs anywhere docker-ce runs)
   - Linux: Most recent Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)

--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -28,9 +28,9 @@ On Docker Toolbox you must by default have your project directory somewhere insi
 
 ## Linux Installation: Docker-ce
 
-__Please don't forget that Linux installation absolutely requires post-install steps (below).__
+* __Please don't forget that Linux installation absolutely requires post-install steps (below).__
 
-__docker-compose must be installed separately, as it is not bundled with docker-ce on Linux, see below.__
+* __docker-compose must be installed or upgraded separately, as it is not bundled with docker-ce on Linux, see below.__
 
 docker-ce installation on Linux depends on what flavor you're using. In all cases using the Ubuntu/Deb/yum repository is the preferred technique.
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,7 +18,7 @@ var DockerVersionConstraint = ">= 18.06.0-ce"
 
 // DockerComposeVersionConstraint is the current minimum version of docker-compose required for ddev.
 // REMEMBER TO CHANGE docs/index.md if you touch this!
-var DockerComposeVersionConstraint = ">= 1.20.0"
+var DockerComposeVersionConstraint = ">= 1.21.0"
 
 // DockerComposeFileFormatVersion is the compose version to be used
 var DockerComposeFileFormatVersion = "3.6"


### PR DESCRIPTION
## The Problem/Issue/Bug:

In OP #1286 we discovered that the project name for a docker-compose project doesn't work as expected in versions before docker-compose 1.21.0, see [1.21.0 release notes](https://github.com/docker/compose/releases/tag/1.21.0). Basically  the project name comes out differently - instead of the expected ddev-ssh-agent, the project name is "ddevsshagent", which breaks ddev looking for the started container. The actual docker-compose issue was https://github.com/docker/compose/issues/4002 and the fix to change the behavior was in https://github.com/docker/compose/pull/5788

So bumping the min version to 1.21.0 would have prevented #1286, and this should fix it. 

If we do a point release (likely) this can go in it.

