### PR TITLE
Change to use the a usable user and group in container test

### DIFF
--- a/containers/ddev-webserver/files/start.sh
+++ b/containers/ddev-webserver/files/start.sh
@@ -67,14 +67,8 @@ fi
 envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-enabled/nginx-site.conf
 envsubst "$APACHE_SITE_VARS" < "$APACHE_SITE_TEMPLATE" > /etc/apache2/sites-enabled/apache-site.conf
 
-# Change the apache run user to current user/group if possible
-APACHE_USER=$(id -u)
-APACHE_GROUP=$(id -g)
-if [ "$APACHE_USER" -ge 60000 ]; then
-  APACHE_USER=1001
-  APACHE_GROUP=1001
-fi
-printf "\nexport APACHE_RUN_USER=uid_${APACHE_USER}\nexport APACHE_RUN_GROUP=gid_${APACHE_GROUP}\n" >>/etc/apache2/envvars
+# Change the apache run user to current user/group
+printf "\nexport APACHE_RUN_USER=uid_$(id -u)\nexport APACHE_RUN_GROUP=gid_$(id -g)\n" >>/etc/apache2/envvars
 if [ "$DDEV_WEBSERVER_TYPE" = "apache-cgi" ] ; then
     a2enmod php${DDEV_PHP_VERSION}
     a2dismod proxy_fcgi

--- a/containers/ddev-webserver/files/start.sh
+++ b/containers/ddev-webserver/files/start.sh
@@ -67,8 +67,14 @@ fi
 envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-enabled/nginx-site.conf
 envsubst "$APACHE_SITE_VARS" < "$APACHE_SITE_TEMPLATE" > /etc/apache2/sites-enabled/apache-site.conf
 
-# Change the apache run user to current user/group
-printf "\nexport APACHE_RUN_USER=uid_$(id -u)\nexport APACHE_RUN_GROUP=gid_$(id -g)\n" >>/etc/apache2/envvars
+# Change the apache run user to current user/group if possible
+APACHE_USER=$(id -u)
+APACHE_GROUP=$(id -g)
+if [ "$APACHE_USER" -ge 60000 ]; then
+  APACHE_USER=1001
+  APACHE_GROUP=1001
+fi
+printf "\nexport APACHE_RUN_USER=uid_${APACHE_USER}\nexport APACHE_RUN_GROUP=gid_${APACHE_GROUP}\n" >>/etc/apache2/envvars
 if [ "$DDEV_WEBSERVER_TYPE" = "apache-cgi" ] ; then
     a2enmod php${DDEV_PHP_VERSION}
     a2dismod proxy_fcgi

--- a/containers/ddev-webserver/test/containertest.sh
+++ b/containers/ddev-webserver/test/containertest.sh
@@ -49,7 +49,7 @@ mkdir -p $composercache && chmod 777 $composercache
 
 export MOUNTUID=$UID
 export MOUNTGID=$(id -g)
-if [ "$UNAME" = "MINGW64_NT-10.0" ] ; then
+if [ "$UNAME" = "MINGW64_NT-10.0" -o "$MOUNTUID" -ge 60000 ] ; then
 	MOUNTUID=1000
 	MOUNTGID=1000
 fi


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our macOS testbots now use a huge UID for the "testbot" user. In the container, we try to use a valid user for apache. But that can't work on those macOS machines. 

So this uses the default 1001 user id where necessary.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

