### PR TITLE
Fix util.Warning typo in ssh_auth.go ("to to")

### DIFF
--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -57,7 +57,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 		return fmt.Errorf("ddev-ssh-agent failed to become ready: %v", err)
 	}
 
-	util.Warning("ssh-agent container is running: If you want to add authentication to to the ssh-agent container, run 'ddev auth ssh' to enable your keys.")
+	util.Warning("ssh-agent container is running: If you want to add authentication to the ssh-agent container, run 'ddev auth ssh' to enable your keys.")
 	return nil
 }
 


### PR DESCRIPTION
Remove duplicate word

## The Problem/Issue/Bug:
String contains duplicated word ("to to")

## How this PR Solves The Problem:
It removes one of the duplicated words

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

N/A

## Related Issue Link(s):

N/A

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

N/A