### PR TITLE
Fix WordPress Abspath detection on Windows, closes #1175

### DIFF
--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -3,7 +3,6 @@ package ddevapp
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -370,7 +369,7 @@ func wordpressGetRelativeAbsPath(app *DdevApp) (string, error) {
 		return "", fmt.Errorf("multiple subdirectories contain %s", needle)
 	}
 
-	absPath := path.Base(path.Dir(subDirMatches[0]))
+	absPath := filepath.Base(filepath.Dir(subDirMatches[0]))
 
 	return absPath, nil
 }

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -154,9 +154,9 @@ Project ddev settings have been written to:
 
 %s
 
-Please comment out all existing database connection settings add the following
-snippet to your wp-config.php file before the include of wp-settings.php near 
-the bottom of the file:
+Please comment out any database connection settings in your wp-config.php and
+add the following snippet to your wp-config.php, near the bottom of the file
+and before the include of wp-settings.php:
 
 // Include for ddev-managed settings in wp-config-ddev.php.
 $ddev_settings = dirname(__FILE__) . '/wp-config-ddev.php';


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1175: Abspath detection was broken on windows

## How this PR Solves The Problem:
Sometimes it takes a month to realize it's a quick oneline fix to use the correct package for Windows support.

## Manual Testing Instructions:
```
mkdir -p mywp/docroot/wp
cd mywp
touch docroot/wp/wp-settings.php
ddev config 
```

`docroot/wp-config-ddev.php` should include:
```
/** WP_SITEURL location */
define('WP_SITEURL', WP_HOME . '/wp');
```

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#1175 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

