### PR TITLE
ddev auth ssh should auth all available private keys, fixes #1291, fixes #1282

### DIFF
--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -28,6 +28,7 @@ FROM alpine:3.8
 RUN apk add --no-cache \
 	bash \
 	expect \
+	file \
 	openssh \
 	socat \
 	sudo \

--- a/containers/ddev-ssh-agent/files/entry.sh
+++ b/containers/ddev-ssh-agent/files/entry.sh
@@ -49,16 +49,15 @@ case "$1" in
   ;;
 
 	# Manage SSH identities
-	ssh-add)
+  ssh-add)
   shift # remove argument from array
 
   # Add keys id_rsa and id_dsa from /root/.ssh using cat so it will work regardless of permissions
   # docker toolbox mounts files as 0777, which ruins the normal technique.
   set +o errexit
-  keyfiles=$( \ls ~/.ssh/id_[rs]sa 2>/dev/null)
+  keyfiles=$(file ~/.ssh/* | awk -F: '/private key/ {  print $1 }')
   set -o errexit
-  true
-  if [ $keyfiles ] ; then
+  if [ ! -z "$keyfiles" ] ; then
       for key in $keyfiles; do
         perm=$(stat -c %a "$key")
         if [ $perm = "777" ] ; then
@@ -68,7 +67,7 @@ case "$1" in
         fi
       done
   else
-    echo "No keys matching id_[rd]sa were found in the directory."
+    echo "No private keys were found in the directory."
   fi
 
   # Return first command exit code

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var RouterTag = "v1.4.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.4.0"
+var SSHAuthTag = "20181122_load_all_keys"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev auth ssh` only currently loads keys named "id_rsa" and "id_dsa". And that's mighty limited. It should load all private keys.

## How this PR Solves The Problem:

Use the "file" command to find out which files in the directory are private keys, load all of them.

## Manual Testing Instructions:

* Use (or create) some extra private keys. For example `ssh-keygen -t dsa`, `ssh-keygen -t rsa -f juergen_key`, `ssh-keygen -f ~/.ssh/junk`, `ssh-keygen -t ed25519 -f ~/.ssh/ed25519_sample`
* Run `ddev auth ssh`. You should be prompted for passphrases for each key that has a passphrase.
* The keys should now be available for use in the web container.


## Automated Testing Overview:

I haven't added any testing at this point.

## Related Issue Link(s):

#1291: ddev auth ssh does not add my second ssh-key to the container
#1282: ddev auth ssh doesn't work with with ed25519 keys

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

