### PR TITLE
Fix problem running "ddev auth ssh" from PS, fixes #1284

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -60,7 +60,7 @@ var AuthSSHCommand = &cobra.Command{
 		}
 		sshKeyPath = dockerutil.MassageWindowsHostMountpoint(sshKeyPath)
 
-		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user="+uidStr, "--mount=type=bind,src="+sshKeyPath+",dst=/tmp/.ssh", version.SSHAuthImage + ":" + version.SSHAuthTag, "ssh-add"}
+		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--mount=type=bind,src=" + sshKeyPath + ",dst=/tmp/.ssh", version.SSHAuthImage + ":" + version.SSHAuthTag, "ssh-add"}
 		err = exec.RunInteractiveCommand("docker", dockerCmd)
 
 		if err != nil {

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
@@ -60,12 +59,12 @@ var AuthSSHCommand = &cobra.Command{
 			util.Failed("Failed to start ddev-ssh-agent container: %v", err)
 		}
 		sshKeyPath = dockerutil.MassageWindowsHostMountpoint(sshKeyPath)
-		dockerCmd := fmt.Sprintf("docker run -it --rm --volumes-from=%s --mount 'type=bind,src=%s,dst=/tmp/.ssh' -u %s %s:%s ssh-add", ddevapp.SSHAuthName, sshKeyPath, uidStr, version.SSHAuthImage, version.SSHAuthTag)
 
-		err = exec.RunInteractiveCommand("sh", []string{"-c", dockerCmd})
+		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user="+uidStr, "--mount=type=bind,src="+sshKeyPath+",dst=/tmp/.ssh", version.SSHAuthImage + ":" + version.SSHAuthTag, "ssh-add"}
+		err = exec.RunInteractiveCommand("docker", dockerCmd)
 
 		if err != nil {
-			util.Failed("Docker command '%s' failed: %v", dockerCmd, err)
+			util.Failed("Docker command 'docker %v' failed: %v", dockerCmd, err)
 		}
 	},
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1284 points out the `ddev auth ssh` doesn't work in a context that doesn't have "sh", like PowerShell. It was a silly oversight that I used "sh" in there. 

## How this PR Solves The Problem:

Use an array for the docker args, instead of trying to put them in a shell script.

## Manual Testing Instructions:

Try `ddev auth ssh` and `ddev auth ssh -d /path/to/keys` in a few contexts, including bash, cmd, and PS.

## Automated Testing Overview:

I don't think this needs more test coverage.

## Related Issue Link(s):

OP #1284 "ddev auth ssh fails in Windows Powershell"

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

