### PR TITLE
Add examples to ddev composer create

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -39,6 +39,7 @@ var ComposerCreateCmd = &cobra.Command{
 web container. Projects will be installed to a temporary directory and moved to
 the project root directory after installation. Any existing files in the
 project root will be deleted when creating a project.`,
+	Example: "ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev\nddev composer create typo3/cms-base-distribution ^9",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 || len(args) > 2 {
 			err := cmd.Usage()

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -39,7 +39,7 @@ var ComposerCreateCmd = &cobra.Command{
 web container. Projects will be installed to a temporary directory and moved to
 the project root directory after installation. Any existing files in the
 project root will be deleted when creating a project.`,
-	Example: "ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev\nddev composer create typo3/cms-base-distribution ^9",
+	Example: "ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev --no-interaction\nddev composer create typo3/cms-base-distribution ^9",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 || len(args) > 2 {
 			err := cmd.Usage()

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -89,7 +89,7 @@ cd my-drupal8-site
 mkdir my-drupal8-site
 cd my-drupal8-site
 ddev config --project-type php --php-version 7.1
-ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev
+ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev --no-interaction
 ```
 
 _Find more information [on composer and how to use it](https://github.com/drupal-composer/drupal-project)._
@@ -217,7 +217,7 @@ Check out the git repository for the project you want to work on. `cd` into the 
 $ mkdir drupal8
 $ cd drupal8
 $ ddev config --project-type php
-$ ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev
+$ ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev --no-interaction
 $ ddev config --project-type drupal8
 ```
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

I keep searching for "ddev composer create" on google to get the right recipe for typo3 and drupal8

## How this PR Solves The Problem:

Add examples to `ddev composer create -h`

```
$ ddev composer create -h
Directs basic invocations of 'composer create-project' within the context of the
web container. Projects will be installed to a temporary directory and moved to
the project root directory after installation. Any existing files in the
project root will be deleted when creating a project.

Usage:
  ddev composer create [flags] <package> [<version>]

Examples:
ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev
ddev composer create typo3/cms-base-distribution ^9

Flags:
      --dev                Pass the --dev flag to composer create-project
  -h, --help               help for create
      --no-dev             Pass the --no-dev flag to composer create-project
      --no-interaction     Pass the --no-interaction flag to composer create-project
      --prefer-dist        Pass the --prefer-dist flag to composer create-project
      --stability string   Pass the --stability <arg> option to composer create-project

Global Flags:
  -j, --json-output   If true, user-oriented output will be in JSON format.
```

## Manual Testing Instructions:

`ddev composer create -h`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

