### PR TITLE
Make ContainerWait and healthchecks smarter, fixes #1287

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -683,7 +683,7 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
-	err = app.Wait("web", "db")
+	err = app.Wait("db", "web")
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -316,6 +316,7 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		assert.NoError(err)
 
 		err = app.Start()
+
 		assert.NoError(err)
 		if err != nil && strings.Contains(err.Error(), "db container failed") {
 			stdout := util.CaptureUserOut()

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -136,8 +136,6 @@ func RenderRouterStatus() string {
 	case SiteNotFound:
 		renderedStatus = color.RedString(status) + badRouter
 	case "healthy":
-		fallthrough
-	case "starting":
 		renderedStatus = color.CyanString(status)
 	case "exited":
 		fallthrough

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -136,11 +136,13 @@ func RenderRouterStatus() string {
 	case SiteNotFound:
 		renderedStatus = color.RedString(status) + badRouter
 	case "healthy":
+		fallthrough
+	case "starting":
 		renderedStatus = color.CyanString(status)
 	case "exited":
 		fallthrough
 	default:
-		renderedStatus = color.RedString(status) + badRouter + ":\n" + logOutput
+		renderedStatus = color.RedString(status) + badRouter + "\n" + logOutput
 	}
 	return fmt.Sprintf("\nDDEV ROUTER STATUS: %v", renderedStatus)
 }

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -130,7 +130,7 @@ func findDdevRouter() (*docker.APIContainers, error) {
 func RenderRouterStatus() string {
 	status, logOutput := GetRouterStatus()
 	var renderedStatus string
-	badRouter := "\nThe router is not currently healthy. Your projects may not be accessible.\nTry running 'ddev start' on a site to recreate the router."
+	badRouter := "\nThe router is not yet healthy. Your projects may not be accessible.\nIf it doesn't become healthy try running 'ddev start' on a project to recreate it."
 
 	switch status {
 	case SiteNotFound:

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -30,7 +30,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 		return err
 	}
 	// If we already have a running ssh container, there's nothing to do.
-	if sshContainer != nil && sshContainer.State == "running" {
+	if sshContainer != nil && (sshContainer.State == "running" || sshContainer.State == "starting") {
 		return nil
 	}
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -35,6 +35,12 @@ services:
       - COLUMNS=$COLUMNS
       - LINES=$LINES
     command: "$DDEV_MARIADB_LOCAL_COMMAND"
+    healthcheck:
+      interval: 30s
+      timeout: 2s
+      retries: 3
+      start_period: 2s
+
   web:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
@@ -90,6 +96,12 @@ services:
     extra_hosts: ["{{ .extra_host }}"]
     external_links:
       - ddev-router:$DDEV_HOSTNAME
+    healthcheck:
+      interval: 30s
+      timeout: 2s
+      retries: 3
+      start_period: 2s
+
 
 {{if  .IncludeDBA }}
   dba:
@@ -114,6 +126,10 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
       - HTTP_EXPOSE={{ .dbaport }}
+    healthcheck:
+      interval: 60s
+      retries: 3
+
 {{end}}
 networks:
   default:
@@ -272,6 +288,7 @@ services:
         volume:
           nocopy: true
     restart: "no"
+
 networks:
    default:
      external:
@@ -297,6 +314,8 @@ services:
       - "socket_dir:/tmp/.ssh-agent"
     environment:
       - SSH_AUTH_SOCK=/tmp/.ssh-agent/socket
+    healthcheck:
+      interval: 60s
 networks:
   default:
     external:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -36,11 +36,8 @@ services:
       - LINES=$LINES
     command: "$DDEV_MARIADB_LOCAL_COMMAND"
     healthcheck:
-      interval: 30s
-      timeout: 2s
+      interval: 5s
       retries: 3
-      start_period: 2s
-
   web:
     container_name: {{ .plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
@@ -59,8 +56,6 @@ services:
           nocopy: true
     restart: "no"
     user: "$DDEV_UID:$DDEV_GID"
-    depends_on:
-      - db
     links:
       - db:db
     # ports is list of exposed *container* ports
@@ -97,11 +92,8 @@ services:
     external_links:
       - ddev-router:$DDEV_HOSTNAME
     healthcheck:
-      interval: 30s
-      timeout: 2s
-      retries: 3
-      start_period: 2s
-
+      interval: 5s
+      retries: 2
 
 {{if  .IncludeDBA }}
   dba:
@@ -114,8 +106,6 @@ services:
       com.ddev.app-type: {{ .appType }}
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
-    depends_on:
-      - db
     links:
       - db:db
     ports:
@@ -127,8 +117,9 @@ services:
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
       - HTTP_EXPOSE={{ .dbaport }}
     healthcheck:
-      interval: 60s
-      retries: 3
+      interval: 90s
+      timeout: 2s
+      retries: 1
 
 {{end}}
 networks:
@@ -288,6 +279,9 @@ services:
         volume:
           nocopy: true
     restart: "no"
+    healthcheck:
+      interval: 5s
+      retries: 1
 
 networks:
    default:
@@ -315,7 +309,8 @@ services:
     environment:
       - SSH_AUTH_SOCK=/tmp/.ssh-agent/socket
     healthcheck:
-      interval: 60s
+      interval: 2s
+      retries: 5
 networks:
   default:
     external:

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -156,9 +156,6 @@ func ContainerWait(waittime time.Duration, labels map[string]string) (string, er
 			status, logOutput := GetContainerHealth(container)
 
 			switch status {
-			// Both "starting" and "healthy" are "OK" checks (to speed up start)
-			case "starting":
-				fallthrough
 			case "healthy":
 				return logOutput, nil
 			case "unhealthy":

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -156,6 +156,9 @@ func ContainerWait(waittime time.Duration, labels map[string]string) (string, er
 			status, logOutput := GetContainerHealth(container)
 
 			switch status {
+			// Both "starting" and "healthy" are "OK" checks (to speed up start)
+			case "starting":
+				fallthrough
 			case "healthy":
 				return logOutput, nil
 			case "unhealthy":


### PR DESCRIPTION
## The Problem/Issue/Bug:

1. ContainerWait() was sometimes waiting for a really long time when one of the containers (usually db) had already exited. (It does seem like the code already handles this. I think the actual problem is waiting too long for an *unhealthy* container; in other words, the container does not display as unhealthy soon enough. )

It turns out that this behavior was mostly because we were polling health of the web container first and waiting for its healthcheck to complete, then tried the db container, which may have long since exited.

2. People have mentioned (and I've noticed) that ddev projects use quite a lot of CPU and battery. And it's mostly the healthcheck.  (I experimented with a number of solutions to this, but all of them result in `ddev start` taking longer, which I think is probably unacceptable. So I backed out my experiments.)

## How this PR Solves The Problem:

* Check db container first.
* Add healthcheck timeouts and retries to the docker-compose.yaml (and related) so we control them at docker-compose level.
* back off how long we'll wait for db container. It was set up for *30* retries, trying every 2 seconds, so 60 seconds before it became "unhealthy". 

## Manual Testing Instructions:

* Try `ddev rm && ddev start`.
* Try breaking a container deliberately. My technique for this was to do a docker-compose.breakit.yaml with contents like this:

```
version: '3.6'
services:
  web:
    command: "bash -c 'sleep 2 && exit '"
```
* Do things to break the db container:
    *  in mysql `DROP DATABASE db;` and then watch behavior as it changes (`ddev list`) then `ddev rm && ddev start` and see how long it takes to fail.
    * In the db container, `rm /var/lib/mysql/mysql/*.MYD`. Watch behavior after you do it. Then try `ddev rm && ddev start`

## Automated Testing Overview:

The overall behavior has not changed, I don't think it needs new tests.

This doesn't make a major change in behavior, so no test changes yet.

## Related Issue Link(s):

OP #1287 

## Release/Deployment notes:

It may be worth
* Writing a stack overflow to tell people how to use longer healthchecks to save battery. Or perhaps adding a `ddev start --slow-healthcheck` or something.