### PR TITLE
Retry 502 errors in tests on macOS, for #1270

### DIFF
--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -379,6 +379,7 @@ func EnsureLocalHTTPContent(t *testing.T, rawurl string, expectedContent string,
 	// We see intermittent php-fpm SIGBUS failures, only on macOS.
 	// That results in a 502. If we get a 502 on macOS, try again.
 	if resp.StatusCode == 502 && runtime.GOOS == "darwin" {
+		t.Log("Received 502 error on macOS, retrying GetLocalHTTPResponse")
 		time.Sleep(time.Second)
 		body, resp, err = GetLocalHTTPResponse(t, rawurl, httpTimeout)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1270 is for fixing or retrying or mitigating some of our intermittent test failures. 

One of the big ones is on macOS we get a 502 resulting from a SIGBUS from php-fpm. This PR is (another) attempt to mitigate that, doing a retry. We have no control (that we understand) of this behavior, so might as well give it 2 tries.

## How this PR Solves The Problem:

If 502 in test, wait a second and try one more time.

## Manual Testing Instructions:

No way to test, as this is intermittent.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

