### PR TITLE
Remove vet and vetshadow nolint declarations

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -238,7 +238,6 @@ func TestDdevStart(t *testing.T) {
 		assert.True(composeFile)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
-			//nolint: vetshadow
 			containerName, err := constructContainerName(containerType, app)
 			assert.NoError(err)
 			check, err := testcommon.ContainerCheck(containerName, "running")
@@ -331,7 +330,6 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		assert.True(composeFile)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
-			//nolint: vetshadow
 			containerName, err := constructContainerName(containerType, app)
 			assert.NoError(err)
 			check, err := testcommon.ContainerCheck(containerName, "running")
@@ -1286,7 +1284,6 @@ func TestDdevStop(t *testing.T) {
 		assert.NoError(err)
 
 		for _, containerType := range [3]string{"web", "db", "dba"} {
-			//nolint: vetshadow
 			containerName, err := constructContainerName(containerType, app)
 			assert.NoError(err)
 			check, err := testcommon.ContainerCheck(containerName, "exited")
@@ -1985,7 +1982,6 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		err := app.Init(site.Dir)
 		assert.NoError(err)
 
-		//nolint: vet
 		for _, pair := range []testcommon.PortPair{{"80", "443"}, {"8080", "8443"}} {
 			testcommon.ClearDockerEnv()
 			app.RouterHTTPPort = pair.HTTPPort

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -118,7 +118,6 @@ func TestWriteDrushConfig(t *testing.T) {
 		switch app.Type {
 		case AppTypeDrupal6, AppTypeDrupal7, AppTypeDrupal8, AppTypeBackdrop:
 			require.True(t, fileutil.FileExists(drushFilePath))
-			//nolint: vetshadow
 			hostFound, err := fileutil.FgrepStringInFile(drushFilePath, fmt.Sprintf("'host' => \"%s\"", dockerIP))
 			assert.NoError(err)
 			assert.True(hostFound)

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -156,7 +156,6 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 		assert.NoError(err)
 
 		safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI
-		//nolint: vetshadow
 		out, _, err := GetLocalHTTPResponse(t, safeURL)
 		assert.NoError(err)
 		assert.Contains(out, site.Safe200URIWithExpectation.Expect)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Since moving to just golangci-lint for our staticrequired, we've gotten a warning on every build about the "vet" and "vetshadow" lint declarations. Obviously we don't need them.

## How this PR Solves The Problem:

Remove them.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

