### PR TITLE
Working sample elasticsearch as additional service #1319

### DIFF
--- a/pkg/servicetest/testdata/services/docker-compose-elasticsearch.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose-elasticsearch.yaml
@@ -1,0 +1,28 @@
+version: '3.6'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+    container_name: ddev-${DDEV_SITENAME}-elasticsearch
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - VIRTUAL_HOST=$DDEV_HOSTNAME # This defines the host name the service should be accessible from. This will be sitename.ddev.local
+      - HTTP_EXPOSE=9200
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200
+    labels:
+    # These labels ensure this service is discoverable by ddev
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.app-url: $DDEV_URL
+
+volumes:
+  esdata1:
+    driver: local


### PR DESCRIPTION
## The Problem/Issue/Bug:
Resolves https://github.com/drud/ddev/issues/1319
Provides a sample docker composer file for elasticsearch

## How this PR Solves The Problem:
Provides the sample file.
## Manual Testing Instructions:
Download this file to your ddev's .ddev folder and do `ddev start`

## Automated Testing Overview:
It's a sample config, no tests.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/1319

## Notes
I'm pretty sure this isn't the right location for this file as the SOLR and Memcached samples appear to be used as test data for a test.
Please advice if there's a better location to host this example?