### PR TITLE
Fix reported panic in GetContainerHealth()

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -192,13 +192,21 @@ func GetContainerHealth(container *docker.APIContainers) (string, string) {
 
 	client := GetDockerClient()
 	inspect, err := client.InspectContainer(container.ID)
+	if err != nil {
+		output.UserOut.Warnf("Error getting container to inspect: %v", err)
+		return "", ""
+	}
 
-	status := inspect.State.Health.Status
+	status := ""
 	logOutput := ""
-	// The last log is the most recent
-	if err == nil && len(inspect.State.Health.Log) > 0 {
-		numLogs := len(inspect.State.Health.Log)
-		logOutput = inspect.State.Health.Log[numLogs-1].Output
+	if inspect != nil {
+		status = inspect.State.Health.Status
+		logOutput = ""
+		// The last log is the most recent
+		if err == nil && len(inspect.State.Health.Log) > 0 {
+			numLogs := len(inspect.State.Health.Log)
+			logOutput = inspect.State.Health.Log[numLogs-1].Output
+		}
 	}
 
 	return status, logOutput

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -192,21 +192,17 @@ func GetContainerHealth(container *docker.APIContainers) (string, string) {
 
 	client := GetDockerClient()
 	inspect, err := client.InspectContainer(container.ID)
-	if err != nil {
+	if err != nil || inspect == nil {
 		output.UserOut.Warnf("Error getting container to inspect: %v", err)
 		return "", ""
 	}
 
-	status := ""
 	logOutput := ""
-	if inspect != nil {
-		status = inspect.State.Health.Status
-		logOutput = ""
-		// The last log is the most recent
-		if err == nil && len(inspect.State.Health.Log) > 0 {
-			numLogs := len(inspect.State.Health.Log)
-			logOutput = inspect.State.Health.Log[numLogs-1].Output
-		}
+	status := inspect.State.Health.Status
+	// The last log is the most recent
+	if len(inspect.State.Health.Log) > 0 {
+		numLogs := len(inspect.State.Health.Log)
+		logOutput = inspect.State.Health.Log[numLogs-1].Output
 	}
 
 	return status, logOutput


### PR DESCRIPTION
## The Problem/Issue/Bug:

@mafriend reported a panic when testing ddev-ui for release. Full information wasn't available, but this was the gist of it:

<img width="501" alt="screen_shot_2018-12-07_at_1 01 23_pm" src="https://user-images.githubusercontent.com/112444/49670903-629c2600-fa23-11e8-990e-b75ee8b6041f.png">


## How this PR Solves The Problem:

Check the error before using the results.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

