### PR TITLE
Add respect for #ddev-generated inside settings.ddev.php, fixes #1310

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -169,6 +169,19 @@ func writeBackdropMainSettingsFile(settings *BackdropSettings, filePath string) 
 // writeBackdropDdevSettingsFile dynamically produces a valid settings.ddev.php file
 // by combining a configuration object with a data-driven template.
 func writeBackdropDdevSettingsFile(settings *BackdropSettings, filePath string) error {
+	if fileutil.FileExists(filePath) {
+		// Check if the file is managed by ddev.
+		signatureFound, err := fileutil.FgrepStringInFile(filePath, DdevFileSignature)
+		if err != nil {
+			return err
+		}
+
+		// If the signature wasn't found, warn the user and return.
+		if !signatureFound {
+			util.Warning("%s already exists and is managed by the user.", filepath.Base(filePath))
+			return nil
+		}
+	}
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(backdropLocalSettingsTemplate)
 	if err != nil {
 		return err

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -307,7 +307,7 @@ func TestDdevStart(t *testing.T) {
 	// Try to start a site of same name at an equivalent but different path. It should work.
 	tmpDir, err := testcommon.OsTempDir()
 	assert.NoError(err)
-	symlink := filepath.Join(tmpDir, "a-symlink")
+	symlink := filepath.Join(tmpDir, fileutil.RandomFilenameBase())
 	err = os.Symlink(app.AppRoot, symlink)
 	assert.NoError(err)
 	//nolint: errcheck

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -668,7 +668,7 @@ func TestDdevOldMariaDB(t *testing.T) {
 	assert.NoError(err)
 
 	// Make sure there isn't an old db laying around
-	_ := dockerutil.RemoveVolume(app.Name + "-mariadb")
+	_ = dockerutil.RemoveVolume(app.Name + "-mariadb")
 	//nolint: errcheck
 	defer dockerutil.RemoveVolume(app.Name + "-mariadb")
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -666,13 +666,24 @@ func TestDdevOldMariaDB(t *testing.T) {
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
 	assert.NoError(err)
+
+	// Make sure there isn't an old db laying around
+	_ := dockerutil.RemoveVolume(app.Name + "-mariadb")
+	//nolint: errcheck
+	defer dockerutil.RemoveVolume(app.Name + "-mariadb")
+
 	app.MariaDBVersion = ddevapp.MariaDB101
 	app.DBImage = version.GetDBImage(app.MariaDBVersion)
-	err = app.StartAndWaitForSync(2)
+	startErr := app.StartAndWaitForSync(5)
+	if startErr != nil {
+		appLogs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		assert.NoError(err)
+		require.NoError(t, err, "app start failure; logs:\n=====\n%s\n=====\n", appLogs)
+	}
+
 	//nolint: errcheck
 	defer app.Down(true, false)
 
-	require.NoError(t, err)
 	importPath := filepath.Join(testDir, "testdata", "users.sql")
 	err = app.ImportDB(importPath, "")
 	require.NoError(t, err)

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -381,6 +381,20 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 // writeDrupal8DdevSettingsFile dynamically produces valid settings.ddev.php file by combining a configuration
 // object with a data-driven template.
 func writeDrupal8DdevSettingsFile(settings *DrupalSettings, filePath string) error {
+	if fileutil.FileExists(filePath) {
+		// Check if the file is managed by ddev.
+		signatureFound, err := fileutil.FgrepStringInFile(filePath, DdevFileSignature)
+		if err != nil {
+			return err
+		}
+
+		// If the signature wasn't found, warn the user and return.
+		if !signatureFound {
+			util.Warning("%s already exists and is managed by the user.", filepath.Base(filePath))
+			return nil
+		}
+	}
+
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(drupal8DdevSettingsTemplate)
 	if err != nil {
 		return err
@@ -412,6 +426,20 @@ func writeDrupal8DdevSettingsFile(settings *DrupalSettings, filePath string) err
 // writeDrupal7DdevSettingsFile dynamically produces valid settings.ddev.php file by combining a configuration
 // object with a data-driven template.
 func writeDrupal7DdevSettingsFile(settings *DrupalSettings, filePath string) error {
+	if fileutil.FileExists(filePath) {
+		// Check if the file is managed by ddev.
+		signatureFound, err := fileutil.FgrepStringInFile(filePath, DdevFileSignature)
+		if err != nil {
+			return err
+		}
+
+		// If the signature wasn't found, warn the user and return.
+		if !signatureFound {
+			util.Warning("%s already exists and is managed by the user.", filepath.Base(filePath))
+			return nil
+		}
+	}
+
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(drupal7DdevSettingsTemplate)
 	if err != nil {
 		return err
@@ -442,6 +470,19 @@ func writeDrupal7DdevSettingsFile(settings *DrupalSettings, filePath string) err
 // writeDrupal6DdevSettingsFile dynamically produces valid settings.ddev.php file by combining a configuration
 // object with a data-driven template.
 func writeDrupal6DdevSettingsFile(settings *DrupalSettings, filePath string) error {
+	if fileutil.FileExists(filePath) {
+		// Check if the file is managed by ddev.
+		signatureFound, err := fileutil.FgrepStringInFile(filePath, DdevFileSignature)
+		if err != nil {
+			return err
+		}
+
+		// If the signature wasn't found, warn the user and return.
+		if !signatureFound {
+			util.Warning("%s already exists and is managed by the user.", filepath.Base(filePath))
+			return nil
+		}
+	}
 	tmpl, err := template.New("settings").Funcs(getTemplateFuncMap()).Parse(drupal6DdevSettingsTemplate)
 	if err != nil {
 		return err

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -120,7 +120,8 @@ const wordpressDdevSettingsTemplate = `<?php
 {{ $config := . }}
 /**
 {{ $config.Signature }}: Automatically generated WordPress settings file.
-This file is managed by ddev and may be deleted or overwritten.
+ ddev manages this file and may delete or overwrite the file unless this comment is removed.
+
 */
 
 /** The name of the database for WordPress */

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -24,6 +24,8 @@ var TestContainerName = "dockerutils-test"
 func TestMain(m *testing.M) {
 	output.LogSetUp()
 
+	EnsureDdevNetwork()
+
 	// prep docker container for docker util tests
 	client := GetDockerClient()
 	imageExists, err := ImageExistsLocally(version.WebImg + ":" + version.WebTag)
@@ -189,7 +191,6 @@ func TestComposeCmd(t *testing.T) {
 func TestComposeWithStreams(t *testing.T) {
 	assert := asrt.New(t)
 
-	EnsureDdevNetwork()
 	// Use the current actual web container for this, so replace in base docker-compose file
 	composeBase := filepath.Join("testdata", "test-compose-with-streams.yaml")
 	tmp, err := ioutil.TempDir("", "")

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -189,6 +189,7 @@ func TestComposeCmd(t *testing.T) {
 func TestComposeWithStreams(t *testing.T) {
 	assert := asrt.New(t)
 
+	EnsureDdevNetwork()
 	// Use the current actual web container for this, so replace in base docker-compose file
 	composeBase := filepath.Join("testdata", "test-compose-with-streams.yaml")
 	tmp, err := ioutil.TempDir("", "")
@@ -229,7 +230,6 @@ func TestComposeWithStreams(t *testing.T) {
 	assert.NoError(err)
 	output = stdout()
 	assert.Equal(output, "/var/run/apache2\n")
-
 }
 
 // TestCheckCompose tests detection of docker-compose.

--- a/pkg/dockerutil/testdata/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/test-compose-with-streams.yaml
@@ -1,9 +1,8 @@
 networks:
   default:
-    external: true
-    name: ddev_default
+    external:
+      name: ddev_default
 services:
-
   web:
     container_name: ddev-test-compose-with-streams-web
     environment:


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1310 is pretty simple: It points out that even though our comment in settings.ddev.local says "managed by ddev unless you remove this comment" we overwrite it anyway.

## How this PR Solves The Problem:

* Greps settings.ddev.local and related files to determine if we have the right to overwrite them.
* It appears that the TYPO3 code already did this, so it's unchanged.

## Manual Testing Instructions:

Per the OP, 
Foreach CMS (drupal8 drupal7 drupal6 backdrop wordpress TYPO3) 
  * Use `ddev config`; verify that the ddev-specific settings file gets created if it doesn't exist
  * Use `ddev config`; verify that the ddev-specific settings file gets regenerated normally (normal changes will be overwritten)
  * Use `ddev config`; verify that the ddev-specific settings file does *not* get overwritten if it exists and does *not* container #ddev-generated

## Automated Testing Overview:

* Updated TestDrupalBackdropOverwriteDdevSettings to reflect this understanding.

## Related Issue Link(s):

OP #1310

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

