### PR TITLE
Fix problem where ddev-ssh-agent volume causes error, fixes #1312

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -1,20 +1,16 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"os"
 	"testing"
 
-	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/drud/ddev/pkg/util"
 	log "github.com/sirupsen/logrus"
 
 	"path/filepath"
 
-	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/output"
@@ -162,35 +158,6 @@ func addSites() error {
 		if err != nil {
 			log.Fatalln("Error Output from ddev start:", out, "err:", err)
 		}
-
-		app, err := ddevapp.GetActiveApp("")
-		if err != nil {
-			log.Fatalln("Could not find an active ddev configuration:", err)
-		}
-
-		// Warning: assumes web at port 80, will need adjustment in the future.
-		dockerIP, err := dockerutil.GetDockerIP()
-		if err != nil {
-			util.Warning("Unable to GetDockerIP: %v", err)
-		}
-
-		urls := []string{
-			"http://" + dockerIP + "/" + site.HTTPProbeURI,
-			"http://" + dockerIP + ":" + appports.GetPort("mailhog"),
-			"http://" + dockerIP + ":" + appports.GetPort("dba"),
-		}
-
-		for _, url := range urls {
-			o := util.NewHTTPOptions(url)
-			o.ExpectedStatus = 200
-			o.Timeout = 180
-			o.Headers["Host"] = app.HostName()
-			err = util.EnsureHTTPStatus(o)
-			if err != nil {
-				return fmt.Errorf("failed to ensureHTTPStatus on %s url=%s", app.HostName(), url)
-			}
-		}
-
 	}
 	return nil
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -469,8 +469,8 @@ type composeYAMLVars struct {
 	ComposeVersion  string
 	MountType       string
 	WebMount        string
-	IncludeDBA      bool
-	IncludeSSHAgent bool
+	OmitDBA         bool
+	OmitSSHAgent    bool
 	WebcacheEnabled bool
 	IsWindowsFS     bool
 }
@@ -514,8 +514,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		DdevGenerated:   DdevFileSignature,
 		ExtraHost:       docker0Hostname + `:` + docker0Addr,
 		ComposeVersion:  version.DockerComposeFileFormatVersion,
-		IncludeDBA:      !util.ArrayContainsString(app.OmitContainers, "dba"),
-		IncludeSSHAgent: !util.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent"),
+		OmitDBA:         util.ArrayContainsString(app.OmitContainers, "dba"),
+		OmitSSHAgent:    util.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent"),
 		WebcacheEnabled: app.WebcacheEnabled,
 		IsWindowsFS:     runtime.GOOS == "windows",
 		MountType:       "bind",

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -501,6 +501,11 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	if runtime.GOOS == "windows" {
 		isWindowsFS = "true"
 	}
+	var includeSSHAgent = "includeItByDefault"
+	if util.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent") {
+		includeSSHAgent = ""
+	}
+
 	templateVars := map[string]string{
 		"name":            app.Name,
 		"plugin":          "ddev",
@@ -516,6 +521,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		"IncludeBGSYNC":   includeBGSYNC,
 		"IsWindowsFS":     isWindowsFS,
 		"mountType":       mountType,
+		"includeSSHAgent": includeSSHAgent,
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -3,12 +3,13 @@ package ddevapp
 import (
 	"bytes"
 	"fmt"
-	"github.com/drud/ddev/pkg/globalconfig"
 	"html/template"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/drud/ddev/pkg/globalconfig"
 
 	"regexp"
 
@@ -456,6 +457,24 @@ func (app *DdevApp) CheckCustomConfig() {
 
 }
 
+type composeYAMLVars struct {
+	Name            string
+	Plugin          string
+	AppType         string
+	MailhogPort     string
+	DBAPort         string
+	DBPort          string
+	DdevGenerated   string
+	ExtraHost       string
+	ComposeVersion  string
+	MountType       string
+	WebMount        string
+	IncludeDBA      bool
+	IncludeSSHAgent bool
+	WebcacheEnabled bool
+	IsWindowsFS     bool
+}
+
 // RenderComposeYAML renders the contents of docker-compose.yaml.
 func (app *DdevApp) RenderComposeYAML() (string, error) {
 	var doc bytes.Buffer
@@ -467,6 +486,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	// Docker 18.03 on linux doesn't define host.docker.internal
 	// so we need to go get the ip address of docker0
 	// We would hope to be able to remove this when
@@ -484,44 +504,26 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		}
 	}
 
-	var includeDBA = "includeItByDefault"
-	if util.ArrayContainsString(app.OmitContainers, "dba") {
-		includeDBA = ""
+	templateVars := composeYAMLVars{
+		Name:            app.Name,
+		Plugin:          "ddev",
+		AppType:         app.Type,
+		MailhogPort:     appports.GetPort("mailhog"),
+		DBAPort:         appports.GetPort("dba"),
+		DBPort:          appports.GetPort("db"),
+		DdevGenerated:   DdevFileSignature,
+		ExtraHost:       docker0Hostname + `:` + docker0Addr,
+		ComposeVersion:  version.DockerComposeFileFormatVersion,
+		IncludeDBA:      !util.ArrayContainsString(app.OmitContainers, "dba"),
+		IncludeSSHAgent: !util.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent"),
+		WebcacheEnabled: app.WebcacheEnabled,
+		IsWindowsFS:     runtime.GOOS == "windows",
+		MountType:       "bind",
+		WebMount:        "../",
 	}
-	var includeBGSYNC = ""
-	var mountType = "bind"
-	webMount := "../"
-	if app.WebcacheEnabled {
-		includeBGSYNC = "true"
-		webMount = "webcachevol"
-		mountType = "volume"
-	}
-
-	isWindowsFS := "false"
-	if runtime.GOOS == "windows" {
-		isWindowsFS = "true"
-	}
-	var includeSSHAgent = "includeItByDefault"
-	if util.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent") {
-		includeSSHAgent = ""
-	}
-
-	templateVars := map[string]string{
-		"name":            app.Name,
-		"plugin":          "ddev",
-		"appType":         app.Type,
-		"webMount":        webMount,
-		"mailhogport":     appports.GetPort("mailhog"),
-		"dbaport":         appports.GetPort("dba"),
-		"dbport":          appports.GetPort("db"),
-		"ddevgenerated":   DdevFileSignature,
-		"extra_host":      docker0Hostname + `:` + docker0Addr,
-		"compose_version": version.DockerComposeFileFormatVersion,
-		"IncludeDBA":      includeDBA,
-		"IncludeBGSYNC":   includeBGSYNC,
-		"IsWindowsFS":     isWindowsFS,
-		"mountType":       mountType,
-		"includeSSHAgent": includeSSHAgent,
+	if templateVars.WebcacheEnabled {
+		templateVars.MountType = "volume"
+		templateVars.WebMount = "webcachevol"
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -556,6 +556,8 @@ func TestConfigOverrideDetection(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
+	defer switchDir()
+
 	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ConfigOverrideDetection", site.Name))
 
 	// Copy test overrides into the project .ddev directory
@@ -577,7 +579,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 	assert.NoError(err)
 
 	restoreOutput := util.CaptureUserOut()
-	startErr := app.Start()
+	startErr := app.StartAndWaitForSync(2)
 	out := restoreOutput()
 	//nolint: errcheck
 	defer app.Down(true, false)
@@ -587,7 +589,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 		logs, _ = GetErrLogsFromApp(app, startErr)
 	}
 
-	require.NoError(t, startErr, "app.Start() did not succeed: output:\n=====\n%s\n===== logs:\n========= logs =======\n%s\n========\n", out, logs)
+	require.NoError(t, startErr, "app.StartAndWaitForSync() did not succeed: output:\n=====\n%s\n===== logs:\n========= logs =======\n%s\n========\n", out, logs)
 
 	assert.Contains(out, "utf.cnf")
 	assert.Contains(out, "my-php.ini")
@@ -601,6 +603,5 @@ func TestConfigOverrideDetection(t *testing.T) {
 		assert.NotContains(out, "nginx-site.conf")
 	}
 	assert.Contains(out, "Custom configuration takes effect")
-	switchDir()
 	runTime()
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1841,7 +1841,7 @@ func TestHttpsRedirection(t *testing.T) {
 		// Do a start on the configured site.
 		app, err = ddevapp.GetActiveApp("")
 		assert.NoError(err)
-		err = app.StartAndWaitForSync(2)
+		err = app.StartAndWaitForSync(5)
 		assert.NoError(err, "failed to StartAndWaitForSync on project %s webserverType=%s: %v", app.Name, webserverType, err)
 		if err != nil {
 			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1968,8 +1968,8 @@ func TestGetAllURLs(t *testing.T) {
 		err = app.WriteConfig()
 		assert.NoError(err)
 
-		err = app.Start()
-		assert.NoError(err)
+		err = app.StartAndWaitForSync(0)
+		require.NoError(t, err)
 
 		urls := app.GetAllURLs()
 
@@ -1986,9 +1986,10 @@ func TestGetAllURLs(t *testing.T) {
 		// Ensure urlMap contains direct address of the web container
 		webContainer, err := app.FindContainerByType("web")
 		assert.NoError(err)
+		require.NotEmpty(t, webContainer)
 
 		dockerIP, err := dockerutil.GetDockerIP()
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		// Find HTTP port of web container
 		var port docker.APIPort

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -580,6 +580,9 @@ func TestDdevImportDB(t *testing.T) {
 			path := filepath.Join(testDir, "testdata", file)
 			err = app.ImportDB(path, "")
 			assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", path, err)
+			if err != nil {
+				continue
+			}
 
 			// Test that a settings file has correct hash_salt format
 			switch app.Type {
@@ -665,7 +668,7 @@ func TestDdevOldMariaDB(t *testing.T) {
 	assert.NoError(err)
 	app.MariaDBVersion = ddevapp.MariaDB101
 	app.DBImage = version.GetDBImage(app.MariaDBVersion)
-	err = app.Start()
+	err = app.StartAndWaitForSync(2)
 	//nolint: errcheck
 	defer app.Down(true, false)
 
@@ -746,7 +749,7 @@ func TestDdevExportDB(t *testing.T) {
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
 	assert.NoError(err)
-	err = app.Start()
+	err = app.StartAndWaitForSync(0)
 	assert.NoError(err)
 	//nolint: errcheck
 	defer app.Down(true, false)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -52,7 +52,7 @@ services:
           nocopy: true
         {{ end }}
       - ".:/mnt/ddev_config:ro"
-      {{ if .IncludeSSHAgent }}
+      {{ if not .OmitSSHAgent }}
       - type: "volume"
         source: ddev-ssh-agent_socket_dir
         target: "/home/.ssh-agent"
@@ -131,7 +131,7 @@ services:
 
 {{end}}
 
-{{if  .IncludeDBA }}
+{{if not .OmitDBA }}
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
@@ -165,7 +165,7 @@ networks:
 volumes:
   mariadb-database:
     name: "${DDEV_SITENAME}-mariadb"
-  {{ if .IncludeSSHAgent }}
+  {{ if .OmitSSHAgent }}
   ddev-ssh-agent_socket_dir:
     external: true
   {{ end }}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -2,11 +2,11 @@ package ddevapp
 
 // DDevComposeTemplate is used to create the main docker-compose.yaml
 // file for a ddev site.
-const DDevComposeTemplate = `version: '{{ .compose_version }}'
-{{ .ddevgenerated }}
+const DDevComposeTemplate = `version: '{{ .ComposeVersion }}'
+{{ .DdevGenerated }}
 services:
   db:
-    container_name: {{ .plugin }}-${DDEV_SITENAME}-db
+    container_name: {{ .Plugin }}-${DDEV_SITENAME}-db
     image: $DDEV_DBIMAGE
     stop_grace_period: 60s
     volumes:
@@ -27,8 +27,8 @@ services:
       - "3306"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.platform: {{ .plugin }}
-      com.ddev.app-type: {{ .appType }}
+      com.ddev.platform: {{ .Plugin }}
+      com.ddev.app-type: {{ .AppType }}
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
     environment:
@@ -39,20 +39,20 @@ services:
       interval: 5s
       retries: 3
   web:
-    container_name: {{ .plugin }}-${DDEV_SITENAME}-web
+    container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE
     cap_add:
       - SYS_PTRACE
     volumes:
-      - type: {{ .mountType }}
-        source: {{ .webMount }}
+      - type: {{ .MountType }}
+        source: {{ .WebMount }}
         target: /var/www/html
-        {{ if eq .mountType "volume" }}
+        {{ if eq .MountType "volume" }}
         volume:
           nocopy: true
         {{ end }}
       - ".:/mnt/ddev_config:ro"
-      {{ if .includeSSHAgent }}
+      {{ if .IncludeSSHAgent }}
       - type: "volume"
         source: ddev-ssh-agent_socket_dir
         target: "/home/.ssh-agent"
@@ -62,7 +62,6 @@ services:
         target: "/mnt/composer_cache"
         volume:
           nocopy: true
-        {{ end }}
       - ddev-ssh-agent_socket_dir:/home/.ssh-agent
       - ddev-composer-cache:/mnt/composer_cache
     restart: "no"
@@ -72,7 +71,7 @@ services:
     # ports is list of exposed *container* ports
     ports:
       - "80"
-      - "{{ .mailhogport }}"
+      - "{{ .MailhogPort }}"
     environment:
       - DDEV_URL=$DDEV_URL
       - DOCROOT=$DDEV_DOCROOT
@@ -88,21 +87,21 @@ services:
       - LINES=$LINES
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
-      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,{{ .mailhogport }}
+      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,{{ .MailhogPort }}
       # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
       # To expose an HTTPS port, define the port as securePort:containerPort.
       - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80
       - SSH_AUTH_SOCK=/home/.ssh-agent/socket
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.platform: {{ .plugin }}
-      com.ddev.app-type: {{ .appType }}
+      com.ddev.platform: {{ .Plugin }}
+      com.ddev.app-type: {{ .AppType }}
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
-    extra_hosts: ["{{ .extra_host }}"]
+    extra_hosts: ["{{ .ExtraHost }}"]
     external_links:
       - ddev-router:$DDEV_HOSTNAME
-{{ if  .IncludeBGSYNC }}
+{{ if .WebcacheEnabled }}
   bgsync:
     container_name: ddev-${DDEV_SITENAME}-bgsync
     image: $DDEV_BGSYNCIMAGE
@@ -139,8 +138,8 @@ services:
     restart: "no"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.platform: {{ .plugin }}
-      com.ddev.app-type: {{ .appType }}
+      com.ddev.platform: {{ .Plugin }}
+      com.ddev.app-type: {{ .AppType }}
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
     links:
@@ -152,7 +151,7 @@ services:
       - PMA_PASSWORD=db
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
-      - HTTP_EXPOSE={{ .dbaport }}
+      - HTTP_EXPOSE={{ .DBAPort }}
     healthcheck:
       interval: 90s
       timeout: 2s
@@ -166,13 +165,13 @@ networks:
 volumes:
   mariadb-database:
     name: "${DDEV_SITENAME}-mariadb"
-  {{ if .includeSSHAgent }}
+  {{ if .IncludeSSHAgent }}
   ddev-ssh-agent_socket_dir:
     external: true
   {{ end }}
   ddev-composer-cache:
     name: ddev-composer-cache
-  {{ if eq .mountType "volume" }}
+  {{ if eq .MountType "volume" }}
   webcachevol:
   unisoncatalogvol:
   {{ end }}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -44,11 +44,22 @@ services:
     cap_add:
       - SYS_PTRACE
     volumes:
-      - .:/mnt/ddev_config:ro
       - type: {{ .mountType }}
         source: {{ .webMount }}
         target: /var/www/html
         {{ if eq .mountType "volume" }}
+        volume:
+          nocopy: true
+        {{ end }}
+      - ".:/mnt/ddev_config:ro"
+      {{ if .includeSSHAgent }}
+      - type: "volume"
+        source: ddev-ssh-agent_socket_dir
+        target: "/home/.ssh-agent"
+      {{ end }}
+      - type: "volume"
+        source: ddev-composer-cache
+        target: "/mnt/composer_cache"
         volume:
           nocopy: true
         {{ end }}
@@ -155,8 +166,10 @@ networks:
 volumes:
   mariadb-database:
     name: "${DDEV_SITENAME}-mariadb"
+  {{ if .includeSSHAgent }}
   ddev-ssh-agent_socket_dir:
     external: true
+  {{ end }}
   ddev-composer-cache:
     name: ddev-composer-cache
   {{ if eq .mountType "volume" }}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -52,18 +52,11 @@ services:
           nocopy: true
         {{ end }}
       - ".:/mnt/ddev_config:ro"
-      {{ if not .OmitSSHAgent }}
-      - type: "volume"
-        source: ddev-ssh-agent_socket_dir
-        target: "/home/.ssh-agent"
-      {{ end }}
-      - type: "volume"
-        source: ddev-composer-cache
-        target: "/mnt/composer_cache"
-        volume:
-          nocopy: true
-      - ddev-ssh-agent_socket_dir:/home/.ssh-agent
       - ddev-composer-cache:/mnt/composer_cache
+      {{ if not .OmitSSHAgent }}
+      - ddev-ssh-agent_socket_dir:/home/.ssh-agent
+      {{ end }}
+
     restart: "no"
     user: "$DDEV_UID:$DDEV_GID"
     links:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -119,7 +119,7 @@ services:
       com.ddev.app-url: $DDEV_URL
     healthcheck:
       interval: 10s
-      retries: 3
+      retries: 5
       start_period: 180s
 
 {{end}}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -165,7 +165,7 @@ networks:
 volumes:
   mariadb-database:
     name: "${DDEV_SITENAME}-mariadb"
-  {{ if .OmitSSHAgent }}
+  {{ if not .OmitSSHAgent }}
   ddev-ssh-agent_socket_dir:
     external: true
   {{ end }}
@@ -231,6 +231,8 @@ const ConfigInstructions = `
 # omit_containers: ["dba", "ddev-ssh-agent"]
 # would omit the dba (phpMyAdmin) and ddev-ssh-agent containers. Currently
 # only those two containers can be omitted here.
+# Note that these containers can also be omitted globally in the 
+# ~/.ddev/global_config.yaml or with the "ddev config global" command.
 
 
 # provider: default # Currently either "default" or "pantheon"

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -384,9 +384,8 @@ func EnsureLocalHTTPContent(t *testing.T, rawurl string, expectedContent string,
 		time.Sleep(time.Second)
 		body, resp, err = GetLocalHTTPResponse(t, rawurl, httpTimeout)
 	}
-	t.Logf("request %s got resp=%v, body:\n========\n%s\n==========\n", rawurl, resp, body)
 	assert.NoError(err, "GetLocalHTTPResponse returned err on rawurl %s: %v", rawurl, err)
-	assert.Contains(body, expectedContent)
+	assert.Contains(body, expectedContent, "request %s got resp=%v, body:\n========\n%s\n==========\n", rawurl, resp, body)
 	return resp, err
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1312 there was an edge case that resulted in a complaint about ssh-agent volume not existing.

## How this PR Solves The Problem:

If omit_containers["ddev-ssh-agent"] then don't refer the the volumes

## Manual Testing Instructions:

* Make sure normal use of ssh authing works correctly. `ddev auth ssh` and access a host requiring ssh auth from within the web container.
* Start with omit_containers: ["ddev-ssh-agent"]  in the ~/.ddev/global_config.yaml; the ssh agent should not start, and you should get no errors.
* Start with omit_containers: ["ddev-ssh-agent"] at the project level. You should get no errors.

## Automated Testing Overview:
Nothing was added for this one.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

