### PR TITLE
Use mysqli in db_url for Drupal 6, fixes #1325

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -252,7 +252,7 @@ if (version_compare($version, "7.0") > 0) {
   );
 } else {
   // or the old db_url format for d6
-  $db_url = 'mysql://db:db@{{ $config.DatabaseHost }}:{{ $config.DatabasePort }}/db';
+  $db_url = 'mysqli://db:db@{{ $config.DatabaseHost }}:{{ $config.DatabasePort }}/db';
 }
 `
 
@@ -366,6 +366,8 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 	// Currently there isn't any customization done for the drupal config, but
 	// we may want to do some kind of customization in the future.
 	drupalConfig := NewDrupalSettings()
+	// mysqli is required in latest D6LTS and works fine in ddev in old D6
+	drupalConfig.DatabaseDriver = "mysqli"
 
 	if err := manageDrupalSettingsFile(app, drupalConfig, drupal6SettingsTemplate, drupal6SettingsAppendTemplate); err != nil {
 		return "", err


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP#1372 points out that our standard drupal 6 config in settings.ddev.php uses the mysql:// db_url, but php 7.2 with D6LTS wants the mysqli:// db_url. 

## How this PR Solves The Problem:

This just changes "mysql://" to "mysqli://" in Drupal6 settings.ddev.php. It doesn't seem to affect traditional Drupal 6 configuration.


## Manual Testing Instructions:

* Configure d6 traditional project, verify that it works
* Configure [D6LTS project](https://github.com/d6lts/drupal) using PHP 7.2, verify that it works. 
* Disable php-mbstring in the web container to solve the problem discussed below:
    * phpdismod php-mbstring
    * killall -1 php-fpm
    * At this point you should be able to install d6lts

Details about php-mbstring.
Note that there is a problem with D6LTS that I don't totally understand at install time. It insists:

> Multibyte string output conversion in PHP is active and must be disabled. Check the php.ini mbstring.http_output setting. Please refer to the PHP mbstring documentation for more information. (Currently using Unicode library Error)

However, in our post-php-5.6 configurations we do *not* have mbstring.http_output set:

```
$ php -i | grep http_output
mbstring.http_output => no value => no value
```

However, you can *import* a d6 db and it lets you walk past this problem.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #1325  

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

