### PR TITLE
Allow a user to remove a project by name after deleting project directory, closes #1338

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -24,7 +24,7 @@ a project directory to stop that project, or you can specify a project to descri
 running 'ddev stop <projectname>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 1 {
-			util.Failed("Too many arguments provided. Please use 'ddev describe' or 'ddev describe [appname]'")
+			util.Failed("Too many arguments provided. Please use 'ddev describe' or 'ddev describe [projectname]'")
 		}
 
 		projects, err := getRequestedProjects(args, false)

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -33,7 +33,7 @@ running 'ddev stop <projectname>.`,
 		}
 		project := projects[0]
 
-		if err := checkForMissingProjectFiles(project); err != nil {
+		if err := ddevapp.CheckForMissingProjectFiles(project); err != nil {
 			util.Failed("Failed to describe %s: %v", project.Name, err)
 		}
 

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -42,7 +42,7 @@ running 'ddev stop <projectname>.`,
 			util.Failed("Unable to find any active project named %s: %v", project.Name, err)
 		}
 
-		// Do not show any describe output if we can't find the site.
+		// Do not show any describe output if we can't find the project.
 		if project.SiteStatus() == ddevapp.SiteNotFound {
 			util.Failed("no project found. have you run 'ddev start'?")
 		}

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -10,6 +10,8 @@ import (
 
 	"os"
 
+	"path/filepath"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
@@ -223,6 +225,7 @@ func TestDdevDescribeMissingProjectDirectory(t *testing.T) {
 	projectName := util.RandString(6)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
+	defer testcommon.CleanupDir(tmpDir)
 	defer testcommon.Chdir(tmpDir)()
 
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
@@ -233,7 +236,8 @@ func TestDdevDescribeMissingProjectDirectory(t *testing.T) {
 	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
 	assert.NoError(err)
 
-	err = os.RemoveAll(tmpDir)
+	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
+	err = os.Rename(tmpDir, copyDir)
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"describe", projectName})

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -215,9 +215,9 @@ func unmarshalJSONLogs(in string) ([]log.Fields, error) {
 	return logData, nil
 }
 
-// TestDdevDescribeMissingProjectDirectory ensures the `ddev describe` command returns the expected help text when
+// TestCmdDescribeMissingProjectDirectory ensures the `ddev describe` command returns the expected help text when
 // a project's directory no longer exists.
-func TestDdevDescribeMissingProjectDirectory(t *testing.T) {
+func TestCmdDescribeMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -238,6 +238,8 @@ func TestDdevDescribeMissingProjectDirectory(t *testing.T) {
 
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
+	defer testcommon.CleanupDir(copyDir)
+	defer testcommon.Chdir(copyDir)()
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"describe", projectName})

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -222,6 +222,8 @@ func TestCmdDescribeMissingProjectDirectory(t *testing.T) {
 	var out string
 	assert := asrt.New(t)
 
+	projDir, _ := os.Getwd()
+
 	projectName := util.RandString(6)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
@@ -236,13 +238,15 @@ func TestCmdDescribeMissingProjectDirectory(t *testing.T) {
 	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
 	assert.NoError(err)
 
+	err = os.Chdir(projDir)
+	assert.NoError(err)
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
-	defer testcommon.CleanupDir(copyDir)
-	defer testcommon.Chdir(copyDir)()
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"describe", projectName})
 	assert.Error(err, "Expected an error when describing project with no project directory")
 	assert.Contains(out, "ddev can no longer find your project files")
+	err = os.Rename(copyDir, tmpDir)
+	assert.NoError(err)
 }

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -37,7 +37,7 @@ func TestDescribeBadArgs(t *testing.T) {
 	args = []string{"describe", util.RandString(16)}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "Unable to find any active project")
+	assert.Contains(string(out), "could not find project")
 
 	// Ensure we get a failure if using too many arguments.
 	args = []string{"describe", util.RandString(16), util.RandString(16)}

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -229,6 +229,7 @@ func TestDdevDescribeMissingProjectDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
 	assert.NoError(err)
 

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -72,10 +72,10 @@ func TestDevList(t *testing.T) {
 
 }
 
-// TestDdevListContinuous tests the --continuous flag for ddev list.
-func TestDdevListContinuous(t *testing.T) {
+// TestCmdListContinuous tests the --continuous flag for ddev list.
+func TestCmdListContinuous(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Skipping TestDdevListContinuous because Windows stdout capture doesn't work.")
+		t.Skip("Skipping TestCmdListContinuous because Windows stdout capture doesn't work.")
 	}
 
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -62,6 +62,7 @@ func TestCmdRemoveMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
 	assert := asrt.New(t)
+	projDir, _ := os.Getwd()
 
 	projectName := util.RandString(6)
 
@@ -75,13 +76,17 @@ func TestCmdRemoveMissingProjectDirectory(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
 	assert.NoError(err)
 
+	err = os.Chdir(projDir)
+	assert.NoError(err)
+
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
-	defer testcommon.CleanupDir(copyDir)
-	defer testcommon.Chdir(copyDir)()
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"remove", projectName})
 	assert.NoError(err)
 	assert.Contains(out, "has been removed")
+
+	err = os.Rename(copyDir, tmpDir)
+	assert.NoError(err)
 }

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -56,9 +56,9 @@ func TestDevRemove(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestDdevRemoveMissingProjectDirectory ensures the `ddev remove` command can operate on a project when the
+// TestCmdRemoveMissingProjectDirectory ensures the `ddev remove` command can operate on a project when the
 // project's directory has been removed.
-func TestDdevRemoveMissingProjectDirectory(t *testing.T) {
+func TestCmdRemoveMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -16,8 +16,8 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDevRemove runs `ddev rm` on the test apps
-func TestDevRemove(t *testing.T) {
+// TestCmdRemove runs `ddev rm` on the test apps
+func TestCmdRemove(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Make sure we have running sites.

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -77,6 +77,8 @@ func TestDdevRemoveMissingProjectDirectory(t *testing.T) {
 
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
+	defer testcommon.CleanupDir(copyDir)
+	defer testcommon.Chdir(copyDir)()
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"remove", projectName})

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -7,6 +7,8 @@ import (
 
 	"os"
 
+	"path/filepath"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
@@ -64,6 +66,7 @@ func TestDdevRemoveMissingProjectDirectory(t *testing.T) {
 	projectName := util.RandString(6)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
+	defer testcommon.CleanupDir(tmpDir)
 	defer testcommon.Chdir(tmpDir)()
 
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
@@ -72,7 +75,8 @@ func TestDdevRemoveMissingProjectDirectory(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
 	assert.NoError(err)
 
-	err = os.RemoveAll(tmpDir)
+	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
+	err = os.Rename(tmpDir, copyDir)
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"remove", projectName})

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -40,15 +40,9 @@ func TestDevRemove(t *testing.T) {
 	// Re-create running sites.
 	err = addSites()
 	require.NoError(t, err)
-	// Ensure a user can't accidentally wipe out everything.
-	appsBefore := len(ddevapp.GetApps())
-	out, err := exec.RunCommand(DdevBin, []string{"remove", "--remove-data", "--all"})
-	assert.Error(err, "ddev remove --all --remove-data should error, but succeeded")
-	assert.Contains(out, "Illegal option")
-	assert.EqualValues(appsBefore, len(ddevapp.GetApps()), "No apps should be removed or added after ddev remove --all --remove-data")
 
 	// Ensure the --all option can remove all active apps
-	out, err = exec.RunCommand(DdevBin, []string{"remove", "--all"})
+	out, err := exec.RunCommand(DdevBin, []string{"remove", "--all"})
 	assert.NoError(err, "ddev remove --all should succeed but failed, err: %v, output: %s", err, out)
 	out, err = exec.RunCommand(DdevBin, []string{"list"})
 	assert.NoError(err)

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -14,7 +14,7 @@ var DdevSnapshotCommand = &cobra.Command{
 	Short: "Create a database snapshot for one or more projects.",
 	Long:  `Uses mariabackup command to create a database snapshot in the .ddev/db_snapshots folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		apps, err := getRequestedApps(args, snapshotAll)
+		apps, err := getRequestedProjects(args, snapshotAll)
 		if err != nil {
 			util.Failed("Unable to get project(s) %v: %v", args, err)
 		}

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/ddevapp"
 	"strings"
 
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -36,7 +37,7 @@ any directory by running 'ddev start projectname [projectname ...]'`,
 		}
 
 		for _, project := range projects {
-			if err := checkForMissingProjectFiles(project); err != nil {
+			if err := ddevapp.CheckForMissingProjectFiles(project); err != nil {
 				util.Failed("Failed to start %s: %v", project.GetName(), err)
 			}
 

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -64,6 +64,8 @@ func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	var out string
 	assert := asrt.New(t)
 
+	projDir, _ := os.Getwd()
+
 	projectName := util.RandString(6)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
@@ -79,10 +81,11 @@ func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
 	assert.NoError(err)
 
+	err = os.Chdir(projDir)
+	assert.NoError(err)
+
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
-	defer testcommon.CleanupDir(copyDir)
-	defer testcommon.Chdir(copyDir)()
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"start", projectName})

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -81,6 +81,8 @@ func TestDdevStartMissingProjectDirectory(t *testing.T) {
 
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
+	defer testcommon.CleanupDir(copyDir)
+	defer testcommon.Chdir(copyDir)()
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"start", projectName})

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,7 @@ func TestDdevStartMissingProjectDirectory(t *testing.T) {
 	projectName := util.RandString(6)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
+	defer testcommon.CleanupDir(tmpDir)
 	defer testcommon.Chdir(tmpDir)()
 
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
@@ -77,7 +79,8 @@ func TestDdevStartMissingProjectDirectory(t *testing.T) {
 	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
 	assert.NoError(err)
 
-	err = os.RemoveAll(tmpDir)
+	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
+	err = os.Rename(tmpDir, copyDir)
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"start", projectName})

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -15,8 +15,8 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDdevStart runs `ddev start` on the test apps
-func TestDdevStart(t *testing.T) {
+// TestCmdStart runs `ddev start` on the test apps
+func TestCmdStart(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Make sure we have running sites.
@@ -57,9 +57,9 @@ func TestDdevStart(t *testing.T) {
 	}
 }
 
-// TestDdevStartMissingProjectDirectory ensures the `ddev start` command returns the expected help text when
+// TestCmdStartMissingProjectDirectory ensures the `ddev start` command returns the expected help text when
 // a project's directory no longer exists.
-func TestDdevStartMissingProjectDirectory(t *testing.T) {
+func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -72,6 +72,8 @@ func TestDdevStartMissingProjectDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
+
+	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
 	assert.NoError(err)
 

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +22,7 @@ in any directory by running 'ddev stop projectname [projectname ...]'`,
 		}
 
 		for _, project := range projects {
-			if err := checkForMissingProjectFiles(project); err != nil {
+			if err := ddevapp.CheckForMissingProjectFiles(project); err != nil {
 				util.Failed("Failed to stop %s: %v", project.GetName(), err)
 			}
 

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -15,17 +15,21 @@ var DdevStopCmd = &cobra.Command{
 from a project directory to stop that project, or you can stop running projects
 in any directory by running 'ddev stop projectname [projectname ...]'`,
 	Run: func(cmd *cobra.Command, args []string) {
-		apps, err := getRequestedApps(args, stopAll)
+		projects, err := getRequestedProjects(args, stopAll)
 		if err != nil {
 			util.Failed("Unable to get project(s): %v", err)
 		}
 
-		for _, app := range apps {
-			if err := app.Stop(); err != nil {
-				util.Failed("Failed to stop %s: %v", app.GetName(), err)
+		for _, project := range projects {
+			if err := checkForMissingProjectFiles(project); err != nil {
+				util.Failed("Failed to stop %s: %v", project.GetName(), err)
 			}
 
-			util.Success("Project %s has been stopped.", app.GetName())
+			if err := project.Stop(); err != nil {
+				util.Failed("Failed to stop %s: %v", project.GetName(), err)
+			}
+
+			util.Success("Project %s has been stopped.", project.GetName())
 		}
 	},
 }

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -16,8 +16,8 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDdevStop runs `ddev stop` on the test apps
-func TestDdevStop(t *testing.T) {
+// TestCmdStop runs `ddev stop` on the test apps
+func TestCmdStop(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Make sure we have running sites.
@@ -60,9 +60,9 @@ func TestDdevStop(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestDdevStopMissingProjectDirectory ensures the `ddev stop` command returns the expected help text when
+// TestCmdStopMissingProjectDirectory ensures the `ddev stop` command returns the expected help text when
 // a project's directory no longer exists.
-func TestDdevStopMissingProjectDirectory(t *testing.T) {
+func TestCmdStopMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -67,6 +67,8 @@ func TestCmdStopMissingProjectDirectory(t *testing.T) {
 	var out string
 	assert := asrt.New(t)
 
+	projDir, _ := os.Getwd()
+
 	projectName := util.RandString(6)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
@@ -81,10 +83,11 @@ func TestCmdStopMissingProjectDirectory(t *testing.T) {
 	defer exec.RunCommand(DdevBin, []string{"remove", projectName})
 	assert.NoError(err)
 
+	err = os.Chdir(projDir)
+	assert.NoError(err)
+
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
-	defer testcommon.CleanupDir(copyDir)
-	defer testcommon.Chdir(copyDir)()
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"stop", projectName})

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -74,6 +74,7 @@ func TestDdevStopMissingProjectDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"remove", projectName})
 	assert.NoError(err)
 

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -7,6 +7,8 @@ import (
 
 	"os"
 
+	"path/filepath"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
@@ -68,6 +70,7 @@ func TestDdevStopMissingProjectDirectory(t *testing.T) {
 	projectName := util.RandString(6)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
+	defer testcommon.CleanupDir(tmpDir)
 	defer testcommon.Chdir(tmpDir)()
 
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
@@ -78,7 +81,8 @@ func TestDdevStopMissingProjectDirectory(t *testing.T) {
 	defer exec.RunCommand(DdevBin, []string{"remove", projectName})
 	assert.NoError(err)
 
-	err = os.RemoveAll(tmpDir)
+	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
+	err = os.Rename(tmpDir, copyDir)
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"stop", projectName})

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -83,6 +83,8 @@ func TestDdevStopMissingProjectDirectory(t *testing.T) {
 
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
+	defer testcommon.CleanupDir(copyDir)
+	defer testcommon.Chdir(copyDir)()
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"stop", projectName})

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"strings"
-
 	"github.com/drud/ddev/pkg/ddevapp"
 )
 
@@ -50,13 +48,4 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 	}
 
 	return requestedProjects, nil
-}
-
-// checkForMissingProjectFiles returns an error if the project's configuration or project root cannot be found
-func checkForMissingProjectFiles(project *ddevapp.DdevApp) error {
-	if strings.Contains(project.SiteStatus(), ddevapp.SiteConfigMissing) || strings.Contains(project.SiteStatus(), ddevapp.SiteDirMissing) {
-		return fmt.Errorf("ddev can no longer find your project files at %s. If you would like to continue using ddev to manage this project please restore your files to that directory. If you would like to remove this site from ddev, you may run 'ddev remove %s'", project.GetAppRoot(), project.GetName())
-	}
-
-	return nil
 }

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -3,37 +3,60 @@ package cmd
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 )
 
-// getRequestedApps will collect and return the requested apps from command line arguments and flags.
-func getRequestedApps(args []string, all bool) ([]*ddevapp.DdevApp, error) {
-	// If all is true, all active apps will be returned.
-	if all {
-		return ddevapp.GetApps(), nil
-	}
+// getRequestedProjects will collect and return the requested projects from command line arguments and flags.
+func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) {
+	requestedProjects := make([]*ddevapp.DdevApp, 0)
 
-	// If multiple apps are requested by their site name, collect and return them.
-	if len(args) > 0 {
-		var apps []*ddevapp.DdevApp
-
-		for _, siteName := range args {
-			app, err := ddevapp.GetActiveApp(siteName)
-			if err != nil {
-				return []*ddevapp.DdevApp{}, fmt.Errorf("failed to get %s: %v", siteName, err)
-			}
-
-			apps = append(apps, app)
+	// If no project is specified, return the current project
+	if len(names) == 0 && !all {
+		project, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			return nil, err
 		}
 
-		return apps, nil
+		return append(requestedProjects, project), nil
 	}
 
-	// If all is false and no specific apps are requested, return the current app.
-	app, err := ddevapp.GetActiveApp("")
-	if err != nil {
-		return []*ddevapp.DdevApp{}, err
+	allProjects := ddevapp.GetApps()
+
+	// If all projects are requested, return here
+	if all {
+		return allProjects, nil
 	}
 
-	return []*ddevapp.DdevApp{app}, nil
+	// Convert all projects slice into map indexed by project name to prevent duplication
+	allProjectsMap := map[string]*ddevapp.DdevApp{}
+	for _, project := range allProjects {
+		allProjectsMap[project.Name] = project
+	}
+
+	// Select requested projects
+	requestedProjectsMap := map[string]*ddevapp.DdevApp{}
+	for _, name := range names {
+		var exists bool
+		if requestedProjectsMap[name], exists = allProjectsMap[name]; !exists {
+			return nil, fmt.Errorf("could not find project %s", name)
+		}
+	}
+
+	// Convert map back to slice
+	for _, project := range requestedProjectsMap {
+		requestedProjects = append(requestedProjects, project)
+	}
+
+	return requestedProjects, nil
+}
+
+// checkForMissingProjectFiles returns an error if the project's configuration or project root cannot be found
+func checkForMissingProjectFiles(project *ddevapp.DdevApp) error {
+	if strings.Contains(project.SiteStatus(), ddevapp.SiteConfigMissing) || strings.Contains(project.SiteStatus(), ddevapp.SiteDirMissing) {
+		return fmt.Errorf("ddev can no longer find your project files at %s. If you would like to continue using ddev to manage this project please restore your files to that directory. If you would like to remove this site from ddev, you may run 'ddev remove %s'", project.GetAppRoot(), project.GetName())
+	}
+
+	return nil
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2,10 +2,11 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/drud/ddev/pkg/globalconfig"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/drud/ddev/pkg/globalconfig"
 
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -981,10 +982,6 @@ func (app *DdevApp) Stop() error {
 		return fmt.Errorf("no project to stop")
 	}
 
-	if strings.Contains(app.SiteStatus(), SiteDirMissing) || strings.Contains(app.SiteStatus(), SiteConfigMissing) {
-		return fmt.Errorf("ddev can no longer find your project files at %s. If you would like to continue using ddev to manage this project please restore your files to that directory. If you would like to remove this site from ddev, you may run 'ddev remove %s'", app.GetAppRoot(), app.GetName())
-	}
-
 	files, err := app.ComposeFiles()
 	if err != nil {
 		return err
@@ -1432,8 +1429,7 @@ func GetActiveAppRoot(siteName string) (string, error) {
 	}
 	appRoot, err := CheckForConf(siteDir)
 	if err != nil {
-		// In the case of a missing .ddev/config.yml just return the site directory.
-		return siteDir, nil
+		return siteDir, err
 	}
 
 	return appRoot, nil

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3,8 +3,6 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
-	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net"
 	"os"
@@ -16,6 +14,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/stretchr/testify/require"
 
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/ddevapp"

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1513,18 +1513,23 @@ func TestDdevStopMissingDirectory(t *testing.T) {
 		t.Fatalf("app.StartAndWaitForSync failed err=%v logs from broken container: \n=======\n%s\n========\n", startErr, logs)
 	}
 
-	tempPath := testcommon.CreateTmpDir("site-copy")
+	tempPath := testcommon.CreateTmpDir(t.Name() + "site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
 	defer removeAllErrCheck(tempPath, assert)
 
 	// Move the site directory to a temp location to mimic a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
+	err = os.Remove(site.Dir)
+	assert.NoError(err)
 
 	err = app.Stop()
 	assert.Error(err)
 	assert.Contains(err.Error(), "If you would like to continue using ddev to manage this project please restore your files to that directory.")
+
 	// Move the site directory back to its original location.
+	err = os.MkdirAll(site.Dir, 0755)
+	assert.NoError(err)
 	err = os.Rename(siteCopyDest, site.Dir)
 	assert.NoError(err)
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1513,23 +1513,20 @@ func TestDdevStopMissingDirectory(t *testing.T) {
 		t.Fatalf("app.StartAndWaitForSync failed err=%v logs from broken container: \n=======\n%s\n========\n", startErr, logs)
 	}
 
-	tempPath := testcommon.CreateTmpDir(t.Name() + "site-copy")
+	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")
 	defer removeAllErrCheck(tempPath, assert)
 
 	// Move the site directory to a temp location to mimic a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
-	err = os.Remove(site.Dir)
-	assert.NoError(err)
 
-	err = app.Stop()
+	// ddev stop (in cmd) actually does the check for missing project files,
+	// so we imitate that here.
+	err = ddevapp.CheckForMissingProjectFiles(app)
 	assert.Error(err)
 	assert.Contains(err.Error(), "If you would like to continue using ddev to manage this project please restore your files to that directory.")
-
 	// Move the site directory back to its original location.
-	err = os.MkdirAll(site.Dir, 0755)
-	assert.NoError(err)
 	err = os.Rename(siteCopyDest, site.Dir)
 	assert.NoError(err)
 }

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -309,3 +309,12 @@ func WaitForSync(app *DdevApp, seconds int) {
 		time.Sleep(time.Duration(seconds) * time.Second)
 	}
 }
+
+// CheckForMissingProjectFiles returns an error if the project's configuration or project root cannot be found
+func CheckForMissingProjectFiles(project *DdevApp) error {
+	if strings.Contains(project.SiteStatus(), SiteConfigMissing) || strings.Contains(project.SiteStatus(), SiteDirMissing) {
+		return fmt.Errorf("ddev can no longer find your project files at %s. If you would like to continue using ddev to manage this project please restore your files to that directory. If you would like to remove this site from ddev, you may run 'ddev remove %s'", project.GetAppRoot(), project.GetName())
+	}
+
+	return nil
+}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -176,15 +176,13 @@ func Chdir(path string) func() {
 	curDir, _ := os.Getwd()
 	err := os.Chdir(path)
 	if err != nil {
-		// TODO: This should never Fatalf, as it terminates the process without test running finishing cleanup.
-		log.Fatalf("Could not change to directory %s: %v\n", path, err)
+		log.Errorf("Could not change to directory %s: %v\n", path, err)
 	}
 
 	return func() {
 		err := os.Chdir(curDir)
 		if err != nil {
-			// TODO: This should never Fatalf, as it terminates the process without test running finishing cleanup.
-			log.Fatalf("Failed to change directory to original dir=%s, err=%v", curDir, err)
+			log.Errorf("Failed to change directory to original dir=%s, err=%v", curDir, err)
 		}
 	}
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1338 describes how a project can't be deleted by name (`ddev remove <name>`) after the project's directory has been removed. 

## How this PR Solves The Problem:
This updates the `remove` command to no longer use a convenience method that returns full-fledged apps because that method tried to read the config to fully initialize the app. This isn't necessary when removing an app, so now we're just pulling existing containers by names found in the container tags.

## Manual Testing Instructions:
`mkdir ~/project`
`cd ~/project`
`ddev config --project-type php`
`ddev start`
`cd ~`
`rm -r ~/project`
`ddev remove project`

## Automated Testing Overview:
A test case has been added to ensure a project can be removed by name after deleting the project directory. Other test cases have been added to ensure that `start`, `stop`, and `describe` return consistent help text when the project directory is missing.

## Related Issue Link(s):
#1338 


