### PR TITLE
Use pv to show progress bar during import-db

### DIFF
--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -11,6 +11,7 @@ import (
 
 var dbSource string
 var dbExtPath string
+var progressOption bool
 
 // ImportDBCmd represents the `ddev import-db` command.
 var ImportDBCmd = &cobra.Command{
@@ -41,7 +42,7 @@ can be provided if it is not located at the top level of the archive.`,
 			}
 		}
 
-		err = app.ImportDB(dbSource, dbExtPath)
+		err = app.ImportDB(dbSource, dbExtPath, progressOption)
 		if err != nil {
 			util.Failed("Failed to import database for %s: %v", app.GetName(), err)
 		}
@@ -52,5 +53,6 @@ can be provided if it is not located at the top level of the archive.`,
 func init() {
 	ImportDBCmd.Flags().StringVarP(&dbSource, "src", "", "", "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format")
 	ImportDBCmd.Flags().StringVarP(&dbExtPath, "extract-path", "", "", "If provided asset is an archive, provide the path to extract within the archive.")
+	ImportDBCmd.Flags().BoolVarP(&progressOption, "progress", "p", true, "Display a progress bar during import")
 	RootCmd.AddCommand(ImportDBCmd)
 }

--- a/containers/ddev-dbserver/10.1/Dockerfile
+++ b/containers/ddev-dbserver/10.1/Dockerfile
@@ -7,7 +7,7 @@ ENV MYSQL_ROOT_PASSWORD root
 ENV MARIADB_VERSION 10.1
 
 # Install mariadb and other packages
-RUN apk add --no-cache mariadb mariadb-client bash tzdata shadow sudo
+RUN apk add --no-cache mariadb mariadb-client bash tzdata shadow sudo pv
 # Remove the installed version as we need to set up our own from scratch
 
 RUN rm -rf /var/lib/mysql/* /etc/mysql

--- a/containers/ddev-dbserver/10.2/Dockerfile
+++ b/containers/ddev-dbserver/10.2/Dockerfile
@@ -7,7 +7,7 @@ ENV MYSQL_ROOT_PASSWORD root
 ENV MARIADB_VERSION 10.2
 
 # Install mariadb and other packages
-RUN apk add --no-cache mariadb mariadb-client mariadb-backup mariadb-server-utils bash tzdata shadow sudo
+RUN apk add --no-cache mariadb mariadb-client mariadb-backup mariadb-server-utils bash tzdata shadow sudo pv
 # Remove the installed version as we need to set up our own from scratch
 
 RUN rm -rf /var/lib/mysql/* /etc/mysql

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -337,9 +337,9 @@ func (app *DdevApp) ImportDB(imPath string, extPath string) error {
 		return fmt.Errorf("no .sql or .mysql files found to import")
 	}
 
-	_, _, err = app.Exec(&ExecOpts{
+	err = app.ExecWithTty(&ExecOpts{
 		Service: "db",
-		Cmd:     []string{"bash", "-c", "mysql --database=mysql -e 'DROP DATABASE IF EXISTS db; CREATE DATABASE db;' && cat /db/*.*sql | mysql db"},
+		Cmd:     []string{"bash", "-c", "mysql --database=mysql -e 'DROP DATABASE IF EXISTS db; CREATE DATABASE db;' && pv /db/*.*sql | mysql db"},
 	})
 
 	if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -27,8 +27,8 @@ import (
 	"github.com/drud/ddev/pkg/version"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/lextoumbourou/goodhosts"
-	"github.com/mattn/go-shellwords"
 	"github.com/mattn/go-isatty"
+	"github.com/mattn/go-shellwords"
 )
 
 // containerWaitTimeout is the max time we wait for all containers to become ready.
@@ -794,7 +794,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 
 	if !opts.Tty {
 		exec = append(exec, "-T")
-        }
+	}
 
 	exec = append(exec, opts.Service)
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -767,6 +767,8 @@ type ExecOpts struct {
 	Cmd []string
 	// Nocapture if true causes use of ComposeNoCapture, so the stdout and stderr go right to stdout/stderr
 	NoCapture bool
+	// Tty if true causes a tty to be allocated
+	Tty bool
 	// Stdout can be overridden with a File
 	Stdout *os.File
 	// Stderr can be overridden with a File
@@ -788,7 +790,11 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		exec = append(exec, "-w", workingDir)
 	}
 
-	exec = append(exec, "-T", opts.Service)
+	if !opts.Tty {
+		exec = append(exec, "-T")
+        }
+
+	exec = append(exec, opts.Service)
 
 	if opts.Cmd == nil {
 		return "", "", fmt.Errorf("no command provided")
@@ -811,7 +817,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	}
 
 	var stdoutResult, stderrResult string
-	if opts.NoCapture {
+	if opts.NoCapture || opts.Tty {
 		err = dockerutil.ComposeWithStreams(files, os.Stdin, stdout, stderr, exec...)
 	} else {
 		stdoutResult, stderrResult, err = dockerutil.ComposeCmd(files, exec...)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -582,7 +582,7 @@ func TestDdevImportDB(t *testing.T) {
 		// Test simple db loads.
 		for _, file := range []string{"users.sql", "users.mysql", "users.sql.gz", "users.mysql.gz", "users.sql.tar", "users.mysql.tar", "users.sql.tar.gz", "users.mysql.tar.gz", "users.sql.tgz", "users.mysql.tgz", "users.sql.zip", "users.mysql.zip"} {
 			path := filepath.Join(testDir, "testdata", file)
-			err = app.ImportDB(path, "")
+			err = app.ImportDB(path, "", false)
 			assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", path, err)
 			if err != nil {
 				continue
@@ -608,7 +608,7 @@ func TestDdevImportDB(t *testing.T) {
 		if site.DBTarURL != "" {
 			_, cachedArchive, err := testcommon.GetCachedArchive(site.Name, site.Name+"_siteTarArchive", "", site.DBTarURL)
 			assert.NoError(err)
-			err = app.ImportDB(cachedArchive, "")
+			err = app.ImportDB(cachedArchive, "", false)
 			assert.NoError(err)
 
 			out, _, err := app.Exec(&ddevapp.ExecOpts{
@@ -627,7 +627,7 @@ func TestDdevImportDB(t *testing.T) {
 			_, cachedArchive, err := testcommon.GetCachedArchive(site.Name, site.Name+"_siteZipArchive", "", site.DBZipURL)
 
 			assert.NoError(err)
-			err = app.ImportDB(cachedArchive, "")
+			err = app.ImportDB(cachedArchive, "", false)
 			assert.NoError(err)
 
 			out, _, err := app.Exec(&ddevapp.ExecOpts{
@@ -644,7 +644,7 @@ func TestDdevImportDB(t *testing.T) {
 			_, cachedArchive, err := testcommon.GetCachedArchive(site.Name, site.Name+"_FullSiteTarballURL", "", site.FullSiteTarballURL)
 			assert.NoError(err)
 
-			err = app.ImportDB(cachedArchive, "data.sql")
+			err = app.ImportDB(cachedArchive, "data.sql", false)
 			assert.NoError(err, "Failed to find data.sql at root of tarball %s", cachedArchive)
 		}
 		// We don't want all the projects running at once.
@@ -689,7 +689,7 @@ func TestDdevOldMariaDB(t *testing.T) {
 	defer app.Down(true, false)
 
 	importPath := filepath.Join(testDir, "testdata", "users.sql")
-	err = app.ImportDB(importPath, "")
+	err = app.ImportDB(importPath, "", false)
 	require.NoError(t, err)
 
 	err = os.Mkdir("tmp", 0777)
@@ -771,7 +771,7 @@ func TestDdevExportDB(t *testing.T) {
 	//nolint: errcheck
 	defer app.Down(true, false)
 	importPath := filepath.Join(testDir, "testdata", "users.sql")
-	err = app.ImportDB(importPath, "")
+	err = app.ImportDB(importPath, "", false)
 	require.NoError(t, err)
 
 	_ = os.Mkdir("tmp", 0777)
@@ -849,7 +849,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		if site.DBTarURL != "" {
 			_, cachedArchive, err := testcommon.GetCachedArchive(site.Name, site.Name+"_siteTarArchive", "", site.DBTarURL)
 			assert.NoError(err)
-			err = app.ImportDB(cachedArchive, "")
+			err = app.ImportDB(cachedArchive, "", false)
 			assert.NoError(err)
 		}
 
@@ -924,7 +924,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	err = app.Start()
 	require.NoError(t, err)
 
-	err = app.ImportDB(d7testerTest1Dump, "")
+	err = app.ImportDB(d7testerTest1Dump, "", false)
 	require.NoError(t, err, "Failed to app.ImportDB path: %s err: %v", d7testerTest1Dump, err)
 
 	err = app.StartAndWaitForSync(2)
@@ -949,7 +949,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	assert.EqualValues(snapshotName, "d7testerTest1")
 	assert.True(fileutil.FileExists(filepath.Join(backupsDir, snapshotName, "xtrabackup_info")))
 
-	err = app.ImportDB(d7testerTest2Dump, "")
+	err = app.ImportDB(d7testerTest2Dump, "", false)
 	assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", d7testerTest2Dump, err)
 	_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 2 has 2 nodes", 45)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var WebTag = "v1.5.1" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.5.0"
+var BaseDBTag = "20190103_import-db-progress"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:
There is no feedback during long running database imports.

## How this PR Solves The Problem:
This PR uses `pv` instead of `cat` to read the database dump which provides a progress bar on stderr.

## Manual Testing Instructions:
- Import a (preferably large) database dump file with `ddev import-db` and check that a progress bar is displayed.
- Import a database dump with `ddev import-db -p=false` and check the progress bar is hidden.

## Automated Testing Overview:
Changes are visual only, and require a tty, so automated testing is quite tricky.

## Related Issue Link(s):
Fixes #1348

## Release/Deployment notes:
Automated processes that use `ddev import-db` should not be affected as we detect presence of a tty and disable the progress bar in these environments. There is also the `-p=false` switch to disable the progress bar if needed.