### PR TITLE
Ensure that our containers only have files with LFs in them, not CRLF

### DIFF
--- a/.buildkite/test_containers.sh
+++ b/.buildkite/test_containers.sh
@@ -39,11 +39,13 @@ cleanup
 
 set -x
 
-for dir in containers/*
-    do pushd $dir
-    echo "--- Build container $dir"
-    time make container DOCKER_ARGS=--no-cache
-    echo "--- Test container $dir"
-    time make test
-    popd
+for dir in containers/*; do
+    if [ -d "$dir" ] ; then
+        pushd $dir
+        echo "--- Build container $dir"
+        time make container DOCKER_ARGS=--no-cache
+        echo "--- Test container $dir"
+        time make test
+        popd
+    fi
 done

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,5 @@
 # Article: https://help.github.com/articles/dealing-with-line-endings/
 text=auto
 
-containers/* binary
+/containers/* text eol=lf
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# On Windows the wrong line endings break docker containers
+# Article: https://help.github.com/articles/dealing-with-line-endings/
+text=auto
+
+containers/* binary
+

--- a/added_on_windows.txt
+++ b/added_on_windows.txt
@@ -1,0 +1,3 @@
+This file was added on
+windows
+and started with CRLFs

--- a/containers/added_on_windows.txt
+++ b/containers/added_on_windows.txt
@@ -1,0 +1,3 @@
+This file was added on
+windows
+and started with CRLFs

--- a/containers/ddev-webserver/added_on_windows.txt
+++ b/containers/ddev-webserver/added_on_windows.txt
@@ -1,0 +1,3 @@
+This file was added on
+windows
+and started with CRLFs


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've always had the problem that if Windows CRLFs get into scripts on the containers then those scripts are broken. 

## How this PR Solves The Problem:

Add a .gitattributes that ensures that checkouts of all text files in the containers directory will be treated as Linux-style files. 

Now a user can `git config --global core.autocrlf true` and things will work out OK. This also means we should be able to remove the requirement for special configuration of the testbots.

## Manual Testing Instructions:

* Check out the repo on Windows. You should see only LFs inside text files in containers/ (And there's a commit there with files to look at). You can use `od -xc <file>` to see the actual linefeeds. Also vim will typically show the file as "dos" if it has CRLF. I'm sure there are other ways.
* Check out the repo on mac or Linux. You should see only LFs 
* Adding files with CRLF (on windows) in directories other than containers should be handled with autocrlf true. Adding files in the containers area should end up with commits that convert them to LFs.

## Automated Testing Overview:

No testing change, but this *should* mean that we can remove the requirement for special git setup on windows testbots.

## Related Issue Link(s):

## Release/Deployment notes:

Before pull, get rid of the test commit.
