### PR TITLE
Add the cached attribute back into docker-compose mount of project dir for #1352

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -50,6 +50,8 @@ services:
         {{ if eq .MountType "volume" }}
         volume:
           nocopy: true
+        {{ else }}
+        consistency: cached
         {{ end }}
       - ".:/mnt/ddev_config:ro"
       - ddev-composer-cache:/mnt/composer_cache


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1352 complains about performance on v1.5.0... We lost the ":Cached" attribute on the project mount. It's a significant difference.

In https://github.com/drud/ddev/commit/a403452284fc5564c610886f6487569abc6beb12 (#1277) there was a reorganization of the bind-mount syntax and the ":cached" attribute was lost. This is one of our most important weapons in the war against docker bind-mount slowness... and we lost it.

We were so focused on the webcache improvement that we lost track of the ordinary setup

## How this PR Solves The Problem:

Add cached back in.

## Manual Testing Instructions:

On a D8 project
* `ddev start`
* `ddev ssh`
* `time drush si -y`

Without this I get about 100s to completion. With it I get about 50-60s to completion. So the regression was 40-50%


## Related Issue Link(s):

#1352 has people complaining about performance, especially on older MBPs. I'm not sure whether this PR is a complete answer, but #1352 spurred the investigation (git bisect, using `time drush si -y`, and out popped this problem.)

## Release/Deployment notes:

I think we'll want to do a point release.
