### PR TITLE
.gitattributes, again. Fix problem with png files showing up modified in index on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,11 @@
 # text=false here essentially is the same as core.autocrlf=false
 * text=false eol=lf
 
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.JPG binary
+*.JPEG binary
+*.tar binary
+*gz binary
+*MY? binary


### PR DESCRIPTION
## The Problem/Issue/Bug:

I'm obviously demonstrating my novice mastery of .gitattributes, but I have learned a whole lot. 

I don't seem to quite have it yet, but here's another pass to prevent the problem with all the png files in the repo showing as modified on checkout on macOS.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

