### PR TITLE
[BUGFIX] Removes warning from empty DB Connections array (#1380)

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -19,8 +19,9 @@ const typo3AdditionalConfigTemplate = `<?php
  */
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
+$ORIGINAL_CONFIG = isset($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']) ? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] : [];
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'], [
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($ORIGINAL_CONFIG, [
                     'dbname' => 'db',
                     'host' => 'db',
                     'password' => 'db',


### PR DESCRIPTION
## The Problem/Issue/Bug: 
Removes the warning when the DB Connection array is empty

## How this PR Solves The Problem:
Checking is the array is set if not set, an empty array is assigned to allow the `merge_array()`

## Manual Testing Instructions:
Run through the Steps to reproduce, and one shouldn't see the warning anymore. 

## Related Issue Link(s):
#1380 
