### PR TITLE
Minor docs fix to remind people to composer install when using git checkout

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -81,6 +81,7 @@ Get started with Drupal 8 projects on ddev either by cloning a git repository or
 ```
 git clone https://github.com/example-user/my-drupal8-site
 cd my-drupal8-site
+ddev composer install
 ```
 
 **Composer Setup Example**
@@ -124,9 +125,8 @@ To get started using ddev with a TYPO3 project, clone the project's repository a
 ```
 git clone https://github.com/example-user/example-typo3-site
 cd example-typo3-site
+ddev composer install
 ```
-
-If necessary, run build steps that you may require, like `composer install` in the correct directory.
 
 **Composer Setup Example**
 


### PR DESCRIPTION

## The Problem/Issue/Bug:

People often are baffled with a drupal 8 checkout that does not have the vendor directory; we might as well add the `ddev composer install` to the suggested work.

This PR also will be the first to run on testbots with docker 18.09.1

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

