### PR TITLE
Try docker command twice in sanetestbot.sh, minor improvements to sanetestbot

### DIFF
--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -23,7 +23,7 @@ docker ps >/dev/null
 docker pull busybox:latest >/dev/null
 # Try the docker run command twice because of the really annoying mkdir /c: file exists bug
 # Apparently https://github.com/docker/for-win/issues/1560
-sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null )
+(sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null ))
 
 # Check that required commands are available.
 for command in mysql git go make; do

--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -19,7 +19,9 @@ fi
 docker ps >/dev/null
 # Test that docker can allocate 80 and 443, get get busybox
 docker pull busybox:latest >/dev/null
-docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null
+# Try the docker run command twice because of the really annoying mkdir /c: file exists bug
+# Apparently https://github.com/docker/for-win/issues/1560
+sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null )
 
 # Check that required commands are available.
 for command in mysql git go make; do

--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -3,6 +3,8 @@
 # Check a testbot or test environment to make sure it's likely to be sane.
 # We should add to this script whenever a testbot fails and we can figure out why.
 
+MIN_DDEV_VERSION=v1.5
+
 set -o errexit
 set -o pipefail
 set -o nounset
@@ -33,4 +35,8 @@ if [ "$(go env GOOS)" = "windows"  -a "$(git config core.autocrlf)" != "false" ]
  exit 3
 fi
 
+if command -v ddev >/dev/null && [ "$(ddev version -j | jq -r .raw.cli)" \< "${MIN_DDEV_VERSION}" ] ; then
+  echo "ddev version in $(command -v ddev) is inadequate: $(ddev version -j | jq -r .raw.cli)"
+  exit 4
+fi
 echo "=== testbot $HOSTNAME seems to be set up OK ==="

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -2,7 +2,9 @@
 
 # This script is used to build drud/ddev using buildkite
 
-echo "--- buildkite building ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) for OS=$(go env GOOS) in $PWD with golang=$(go version) docker=$(docker version --format '{{.Server.Version}}') and docker-compose $(docker-compose version --short)"
+
+
+echo "--- buildkite building ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) for OS=$(go env GOOS) in $PWD with golang=$(go version) docker=$(docker version --format '{{.Server.Version}}') and docker-compose $(docker-compose version --short) ddev info=$(ddev version)"
 
 export GOTEST_SHORT=1
 export DRUD_NONINTERACTIVE=true

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -4,7 +4,7 @@
 
 
 
-echo "--- buildkite building ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) for OS=$(go env GOOS) in $PWD with golang=$(go version) docker=$(docker version --format '{{.Server.Version}}') and docker-compose $(docker-compose version --short) ddev info=$(ddev version)"
+echo "--- buildkite building ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) for OS=$(go env GOOS) in $PWD with golang=$(go version) docker=$(docker version --format '{{.Server.Version}}') and docker-compose $(docker-compose version --short) ddev version=$(ddev version -j | jq -r .raw.cli)"
 
 export GOTEST_SHORT=1
 export DRUD_NONINTERACTIVE=true


### PR DESCRIPTION
## The Problem/Issue/Bug:

* We've had a perpetual problem with  `mkdir /c: file exists` bug, apparently https://github.com/docker/for-win/issues/1560
* Try executing the `docker run` command twice in sanetestbot.sh to maybe work around it.
* Improve reporting of ddev version in test.sh (buildkite)
* Improve checking of existing ddev version in sanetestbot.sh


## How this PR Solves The Problem:

## Manual Testing Instructions:

Just read the code and a buildkite build.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

