### PR TITLE
Improvements to bgsync/webcache debugging, testing, and behavior

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -867,10 +867,9 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		rawurl := app.GetHTTPURL() + site.DynamicURI.URI
 		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, 60)
 		assert.NoError(err, "GetLocalHTTPResponse returned err on project=%s rawurl %s, resp=%v: %v", site.Name, rawurl, resp, err)
-		if err != nil {
-			logs, err := ddevapp.GetErrLogsFromApp(app, err)
-			assert.NoError(err)
-			t.Logf("Logs after GetLocalHTTPResponse: %s", logs)
+		if err != nil && strings.Contains(err.Error(), "container ") {
+			logs, _ := ddevapp.GetErrLogsFromApp(app, err)
+			t.Logf("Logs after GetLocalHTTPResponse for err=%v: %s", err, logs)
 		}
 		assert.Contains(body, site.DynamicURI.Expect, "expected %s on project %s", site.DynamicURI.Expect, site.Name)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1871,12 +1871,16 @@ func TestHttpsRedirection(t *testing.T) {
 		// Do a start on the configured site.
 		app, err = ddevapp.GetActiveApp("")
 		assert.NoError(err)
-		err = app.StartAndWaitForSync(5)
+		err = app.StartAndWaitForSync(30)
 		assert.NoError(err, "failed to StartAndWaitForSync on project %s webserverType=%s: %v", app.Name, webserverType, err)
 		if err != nil {
 			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, err)
 			assert.NoError(getLogsErr)
-			t.Logf("app start failure; logs:\n=====\n%s\n=====\n", appLogs)
+			// Get healthcheck status on bgsync container
+			healthcheck, inspectErr := exec.RunCommandPipe("bash", []string{"-c", fmt.Sprintf("docker inspect ddev-%s-bgsync|jq -r '.[0].State.Health.Log[-1]'", app.Name)})
+			assert.NoError(inspectErr)
+
+			t.Logf("app.StartAndWaitForSync start failure; logs:\n==== container logs ======\n%s\n==== bgsync healthchecks ===\n%s\n=======", appLogs, healthcheck)
 		}
 
 		// Test for directory redirects under https and http

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -125,8 +125,8 @@ services:
       com.ddev.app-url: $DDEV_URL
     healthcheck:
       interval: 10s
-      retries: 5
-      start_period: 180s
+      retries: 24
+      start_period: 240s
 
 {{end}}
 

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -291,7 +291,7 @@ func GetErrLogsFromApp(app *DdevApp, errorReceived error) (string, error) {
 			return logs, nil
 		}
 	}
-	return "", fmt.Errorf("no logs found for service %s", serviceName)
+	return "", fmt.Errorf("no logs found for service %s (Inspected err=%v)", serviceName, errorReceived)
 }
 
 // WaitForSync is a test helper; it's hard to know exactly when the bgsync


### PR DESCRIPTION
## The Problem/Issue/Bug:

We don't know enough about why webcache tests fail and need to get some more information

## How this PR Solves The Problem:

* Increase the amount of time allotted for bgcache to become available.
* Gather more information (healthcheck data) when TestHttpsRedirection fails with bgsync timeout

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

