### PR TITLE
Support xdebug on Docker Toolbox, fixes #1297

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -4,10 +4,9 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/version"
+	"os"
 	"path/filepath"
 	"testing"
-
-	"os"
 
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
@@ -46,7 +45,7 @@ func TestLogs(t *testing.T) {
 		ddevapp.WaitForSync(app, 2)
 
 		url := "http://" + v.Name + "." + version.DDevTLD + "/logtest.php"
-		_, _, err = testcommon.GetLocalHTTPResponse(t, url)
+		_, err = testcommon.EnsureLocalHTTPContent(t, url, "Notice to demonstrate logging", 5)
 		assert.NoError(err)
 
 		args := []string{"logs"}

--- a/docs/developers/buildkite-testmachine-setup.md
+++ b/docs/developers/buildkite-testmachine-setup.md
@@ -6,7 +6,7 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 
 0. Create the user "testbot" on the machine. The password should be the password of testbot@drud.com.
 1. Install [chocolatey](https://chocolatey.org/)
-2. Install golang/mysql-cli/make/git/docker-ce/nssm with `choco install -y git mysql-cli golang make docker-desktop nssm GoogleChrome zip jq composer cmder` (If docker-toolbox, use that instead; you may have to download the release separately to get correct version.)
+2. Install golang/mysql-cli/make/git/docker-ce/nssm with `choco install -y git mysql-cli golang make docker-desktop nssm GoogleChrome zip jq composer cmder netcat` (If docker-toolbox, use that instead; you may have to download the release separately to get correct version.)
 3. Enable gd and curl extensions in /c/tools/php73/php.ini
 3. Install bats: `git clone git://github.com/bats-core/bats-core; cd bats-core; git checkout v1.1.0; ./install.sh`
 3. If a laptop, set the "lid closing" setting in settings to do nothing.
@@ -36,13 +36,14 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 
 1. `docker-machine rm default`
 2. `docker-machine create -d virtualbox --virtualbox-cpu-count=2 --virtualbox-memory=4096 --virtualbox-disk-size=50000 default`
+3. Disable "Windows Defender Firewall", as it always blocks our Xdebug test.
 
 ### macOS Test Agent Setup
 
 0. Create the user "testbot" on the machine. The password should be the password of testbot@drud.com.
 1. Change the name of the machine to something in keeping with current style. Maybe `testbot-macstadium-macos-3`.
 1. Install [homebrew](https://brew.sh/) `xcode select --install` and `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-2. Install golang/git/docker with `brew cask install item2 google-chrome  docker nosleep && brew tap buildkite/buildkite && brew tap drud/ddev && brew install golang git buildkite-agent mariadb jq p7zip bats-core composer ddev`
+2. Install golang/git/docker with `brew cask install item2 google-chrome  docker nosleep && brew tap buildkite/buildkite && brew tap drud/ddev && brew install golang git buildkite-agent mariadb jq p7zip bats-core composer ddev netcat`
 4. If the xcode command line tools are not yet installed, install them with `xcode select --install`
 5. Edit the buildkite-agent.cfg in /usr/local/etc/buildkite-agent.cfg to add 
     * the agent token 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -460,21 +460,22 @@ func (app *DdevApp) CheckCustomConfig() {
 }
 
 type composeYAMLVars struct {
-	Name            string
-	Plugin          string
-	AppType         string
-	MailhogPort     string
-	DBAPort         string
-	DBPort          string
-	DdevGenerated   string
-	ExtraHost       string
-	ComposeVersion  string
-	MountType       string
-	WebMount        string
-	OmitDBA         bool
-	OmitSSHAgent    bool
-	WebcacheEnabled bool
-	IsWindowsFS     bool
+	Name                       string
+	Plugin                     string
+	AppType                    string
+	MailhogPort                string
+	DBAPort                    string
+	DBPort                     string
+	DdevGenerated              string
+	HostDockerInternalHostname string
+	HostDockerInternalIP       string
+	ComposeVersion             string
+	MountType                  string
+	WebMount                   string
+	OmitDBA                    bool
+	OmitSSHAgent               bool
+	WebcacheEnabled            bool
+	IsWindowsFS                bool
 }
 
 // RenderComposeYAML renders the contents of docker-compose.yaml.
@@ -516,21 +517,22 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	}
 
 	templateVars := composeYAMLVars{
-		Name:            app.Name,
-		Plugin:          "ddev",
-		AppType:         app.Type,
-		MailhogPort:     appports.GetPort("mailhog"),
-		DBAPort:         appports.GetPort("dba"),
-		DBPort:          appports.GetPort("db"),
-		DdevGenerated:   DdevFileSignature,
-		ExtraHost:       hostDockerInternalHostname + `:` + hostDockerInternalIP,
-		ComposeVersion:  version.DockerComposeFileFormatVersion,
-		OmitDBA:         util.ArrayContainsString(app.OmitContainers, "dba"),
-		OmitSSHAgent:    util.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent"),
-		WebcacheEnabled: app.WebcacheEnabled,
-		IsWindowsFS:     runtime.GOOS == "windows",
-		MountType:       "bind",
-		WebMount:        "../",
+		Name:                       app.Name,
+		Plugin:                     "ddev",
+		AppType:                    app.Type,
+		MailhogPort:                appports.GetPort("mailhog"),
+		DBAPort:                    appports.GetPort("dba"),
+		DBPort:                     appports.GetPort("db"),
+		DdevGenerated:              DdevFileSignature,
+		HostDockerInternalHostname: hostDockerInternalHostname,
+		HostDockerInternalIP:       hostDockerInternalIP,
+		ComposeVersion:             version.DockerComposeFileFormatVersion,
+		OmitDBA:                    util.ArrayContainsString(app.OmitContainers, "dba"),
+		OmitSSHAgent:               util.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent"),
+		WebcacheEnabled:            app.WebcacheEnabled,
+		IsWindowsFS:                runtime.GOOS == "windows",
+		MountType:                  "bind",
+		WebMount:                   "../",
 	}
 	if templateVars.WebcacheEnabled {
 		templateVars.MountType = "volume"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -3,6 +3,7 @@ package ddevapp
 import (
 	"bytes"
 	"fmt"
+	"github.com/drud/ddev/pkg/dockerutil"
 	"html/template"
 	"io/ioutil"
 	"os"
@@ -480,15 +481,15 @@ type composeYAMLVars struct {
 func (app *DdevApp) RenderComposeYAML() (string, error) {
 	var doc bytes.Buffer
 	var err error
-	var docker0Addr = "127.0.0.1"
-	var docker0Hostname = "unneeded"
+	var hostDockerInternalIP = ""
+	var hostDockerInternalHostname = "unneeded"
 	templ := template.New("compose template")
 	templ, err = templ.Parse(DDevComposeTemplate)
 	if err != nil {
 		return "", err
 	}
 
-	// Docker 18.03 on linux doesn't define host.docker.internal
+	// Docker 18.09 on linux and docker-toolbox don't define host.docker.internal
 	// so we need to go get the ip address of docker0
 	// We would hope to be able to remove this when
 	// https://github.com/docker/for-linux/issues/264 gets resolved.
@@ -499,10 +500,19 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 			addr := regexp.MustCompile(`inet *[0-9\.]+`).FindString(out)
 			components := strings.Split(addr, " ")
 			if len(components) == 2 {
-				docker0Addr = components[1]
-				docker0Hostname = "host.docker.internal"
+				hostDockerInternalIP = components[1]
 			}
 		}
+	} else if util.IsDockerToolbox() {
+		hostDockerInternalIP, err = dockerutil.GetDockerIP()
+		if err != nil {
+			return "", err
+		}
+	}
+	// If we've come up with a host.docker.internal IP, set the hostname explicitly in
+	// docker-compose.yaml
+	if hostDockerInternalIP != "" {
+		hostDockerInternalHostname = "host.docker.internal"
 	}
 
 	templateVars := composeYAMLVars{
@@ -513,7 +523,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		DBAPort:         appports.GetPort("dba"),
 		DBPort:          appports.GetPort("db"),
 		DdevGenerated:   DdevFileSignature,
-		ExtraHost:       docker0Hostname + `:` + docker0Addr,
+		ExtraHost:       hostDockerInternalHostname + `:` + hostDockerInternalIP,
 		ComposeVersion:  version.DockerComposeFileFormatVersion,
 		OmitDBA:         util.ArrayContainsString(app.OmitContainers, "dba"),
 		OmitSSHAgent:    util.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent"),

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -505,10 +505,17 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 			}
 		}
 	} else if util.IsDockerToolbox() {
-		hostDockerInternalIP, err = dockerutil.GetDockerIP()
+		dockerIP, err := dockerutil.GetDockerIP()
 		if err != nil {
 			return "", err
 		}
+		octets := strings.Split(dockerIP, ".")
+		if len(octets) != 4 {
+			return "", fmt.Errorf("dockerIP %s does not have 4 octets", dockerIP)
+		}
+		// If the docker IP is 192.168.99.100, the *router* ip is 192.168.99.1
+		// So replace the final octet with 1.
+		hostDockerInternalIP = fmt.Sprintf("%s.%s.%s.1", octets[0], octets[1], octets[2])
 	}
 	// If we've come up with a host.docker.internal IP, set the hostname explicitly in
 	// docker-compose.yaml

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -685,7 +685,7 @@ func TestDdevOldMariaDB(t *testing.T) {
 	if startErr != nil {
 		appLogs, err := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(err)
-		require.NoError(t, err, "app start failure %v; logs:\n=====\n%s\n=====\n", startErr, appLogs)
+		t.Fatalf("app.StartAndWaitForSync() failure %v; logs:\n=====\n%s\n=====\n", startErr, appLogs)
 	}
 
 	importPath := filepath.Join(testDir, "testdata", "users.sql")
@@ -853,12 +853,11 @@ func TestDdevFullSiteSetup(t *testing.T) {
 			assert.NoError(err)
 		}
 
-		err = app.StartAndWaitForSync(2)
-		assert.NoError(err)
-		if err != nil {
-			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, err)
+		startErr := app.StartAndWaitForSync(2)
+		if startErr != nil {
+			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 			assert.NoError(getLogsErr)
-			t.Logf("app start failure; logs:\n=====\n%s\n=====\n", appLogs)
+			t.Fatalf("app.StartAndWaitForSync() failure err=%v; logs:\n=====\n%s\n=====\n", startErr, appLogs)
 		}
 
 		// Test static content.
@@ -867,9 +866,10 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		rawurl := app.GetHTTPURL() + site.DynamicURI.URI
 		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, 60)
 		assert.NoError(err, "GetLocalHTTPResponse returned err on project=%s rawurl %s, resp=%v: %v", site.Name, rawurl, resp, err)
-		if err != nil && strings.Contains(err.Error(), "container ") {
-			logs, _ := ddevapp.GetErrLogsFromApp(app, err)
-			t.Logf("Logs after GetLocalHTTPResponse for err=%v: %s", err, logs)
+		if err != nil  && strings.Contains(err.Error(), "container ") {
+			logs, err := ddevapp.GetErrLogsFromApp(app, err)
+			assert.NoError(err)
+			t.Fatalf("Logs after GetLocalHTTPResponse: %s", logs)
 		}
 		assert.Contains(body, site.DynamicURI.Expect, "expected %s on project %s", site.DynamicURI.Expect, site.Name)
 
@@ -930,15 +930,16 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	require.NoError(t, err, "app.Start() failed on site %s, err=%v", site.Name, err)
 
 	resp, ensureErr := testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), "d7 tester test 1 has 1 node", 45)
+	assert.NoError(ensureErr)
 	if ensureErr != nil && strings.Contains(ensureErr.Error(), "container failed") {
-		logs, err := ddevapp.GetErrLogsFromApp(app, err)
+		logs, err := ddevapp.GetErrLogsFromApp(app, ensureErr)
 		assert.NoError(err)
 		t.Fatalf("container failed: logs:\n=======\n%s\n========\n", logs)
 	}
 	if ensureErr != nil && resp.StatusCode != 200 {
 		logs, err := app.CaptureLogs("web", false, "")
 		assert.NoError(err)
-		t.Logf("EnsureLocalHTTPContent received %d. Resp=%v, web logs=\n========\n%s\n=========\n", resp.StatusCode, resp, logs)
+		t.Fatalf("EnsureLocalHTTPContent received %d. Resp=%v, web logs=\n========\n%s\n=========\n", resp.StatusCode, resp, logs)
 	}
 
 	// Make a snapshot of d7 tester test 1
@@ -1276,8 +1277,9 @@ func TestDdevExec(t *testing.T) {
 		assert.NoError(err)
 		startErr := app.StartAndWaitForSync(0)
 		if startErr != nil {
-			logs, _ := ddevapp.GetErrLogsFromApp(app, startErr)
-			require.NoError(t, startErr, "Start() failed: %v, logs from broken container:\n=======\n%s\n========\n", startErr, logs)
+			logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+			assert.NoError(err)
+			t.Fatalf("app.StartAndWaitForSync() failed err=%v, logs from broken container:\n=======\n%s\n========\n", startErr, logs)
 		}
 
 		out, _, err := app.Exec(&ddevapp.ExecOpts{
@@ -1356,8 +1358,9 @@ func TestDdevLogs(t *testing.T) {
 	assert.NoError(err)
 
 	startErr := app.StartAndWaitForSync(0)
-	if err != nil {
-		logs, _ := ddevapp.GetErrLogsFromApp(app, startErr)
+	if startErr != nil {
+		logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		assert.NoError(err)
 		t.Fatalf("app.Start failed, err=%v, logs=\n========\n%s\n===========\n", startErr, logs)
 	}
 
@@ -1562,13 +1565,11 @@ func TestDdevDescribeMissingDirectory(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 	err := app.Init(site.Dir)
 	assert.NoError(err)
-	err = app.StartAndWaitForSync(0)
-	assert.NoError(err)
-	if err != nil {
-		logs, err := ddevapp.GetErrLogsFromApp(app, err)
-		if err != nil {
-			t.Logf("logs from broken container:\n=======\n%s\n========\n", logs)
-		}
+	startErr := app.StartAndWaitForSync(0)
+	if startErr != nil {
+		logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		assert.NoError(err)
+		t.Fatalf("app.StartAndWaitForSync failed err=%v logs from broken container: \n=======\n%s\n========\n", startErr, logs)
 	}
 	// Move the site directory to a temp location to mimick a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
@@ -1613,22 +1614,22 @@ func TestRouterPortsCheck(t *testing.T) {
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
-	err = app.StartAndWaitForSync(0)
-	if err != nil {
-		appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, err)
+	startErr := app.StartAndWaitForSync(5)
+	if startErr != nil {
+		appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(getLogsErr)
-		t.Logf("app.StartAndWaitForSync() failure; logs:\n=====\n%s\n=====\n", appLogs)
+		t.Fatalf("app.StartAndWaitForSync() failure; err=%v logs:\n=====\n%s\n=====\n", startErr, appLogs)
 	}
 
 	app, err = ddevapp.GetActiveApp(site.Name)
 	if err != nil {
 		t.Fatalf("Failed to GetActiveApp(%s), err:%v", site.Name, err)
 	}
-	err = app.Start()
-	if err != nil {
-		appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, err)
+	startErr = app.StartAndWaitForSync(5)
+	if startErr != nil {
+		appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(getLogsErr)
-		t.Logf("app start failure; logs:\n=====\n%s\n=====\n", appLogs)
+		t.Fatalf("app.StartAndWaitForSync() failure err=%v logs:\n=====\n%s\n=====\n", startErr, appLogs)
 	}
 
 	// Stop the router using code from StopRouterIfNoContainers().
@@ -1870,16 +1871,15 @@ func TestHttpsRedirection(t *testing.T) {
 		// Do a start on the configured site.
 		app, err = ddevapp.GetActiveApp("")
 		assert.NoError(err)
-		err = app.StartAndWaitForSync(30)
-		assert.NoError(err, "failed to StartAndWaitForSync on project %s webserverType=%s: %v", app.Name, webserverType, err)
-		if err != nil {
-			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, err)
+		startErr := app.StartAndWaitForSync(30)
+		if startErr != nil {
+			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 			assert.NoError(getLogsErr)
 			// Get healthcheck status on bgsync container
 			healthcheck, inspectErr := exec.RunCommandPipe("bash", []string{"-c", fmt.Sprintf("docker inspect ddev-%s-bgsync|jq -r '.[0].State.Health.Log[-1]'", app.Name)})
 			assert.NoError(inspectErr)
 
-			t.Logf("app.StartAndWaitForSync start failure; logs:\n==== container logs ======\n%s\n==== bgsync healthchecks ===\n%s\n=======", appLogs, healthcheck)
+			t.Fatalf("app.StartAndWaitForSync failure; err=%v \n===== container logs ===\n%s\n===== bgsync health info ===\n%s\n========\n", startErr, appLogs, healthcheck)
 		}
 
 		// Test for directory redirects under https and http
@@ -2074,12 +2074,11 @@ func TestWebserverType(t *testing.T) {
 
 			testcommon.ClearDockerEnv()
 
-			err = app.Start()
-			assert.NoError(err)
-			if err != nil {
-				appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, err)
+			startErr := app.StartAndWaitForSync(5)
+			if startErr != nil {
+				appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 				assert.NoError(getLogsErr)
-				t.Logf("app start failure; logs:\n=====\n%s\n=====\n", appLogs)
+				t.Fatalf("app.StartAndWaitForSync failure; err=%v, logs:\n=====\n%s\n=====\n", startErr, appLogs)
 			}
 			out, resp, err := testcommon.GetLocalHTTPResponse(t, app.GetWebContainerDirectURL()+"/servertype.php")
 			assert.NoError(err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -885,7 +885,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		rawurl := app.GetHTTPURL() + site.DynamicURI.URI
 		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, 60)
 		assert.NoError(err, "GetLocalHTTPResponse returned err on project=%s rawurl %s, resp=%v: %v", site.Name, rawurl, resp, err)
-		if err != nil  && strings.Contains(err.Error(), "container ") {
+		if err != nil && strings.Contains(err.Error(), "container ") {
 			logs, err := ddevapp.GetErrLogsFromApp(app, err)
 			assert.NoError(err)
 			t.Fatalf("Logs after GetLocalHTTPResponse: %s", logs)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2110,6 +2110,8 @@ func TestWebserverType(t *testing.T) {
 			}
 			assert.Contains(resp.Header["Server"][0], expectedServerType, "Server header for project=%s, app.WebserverType=%s should be %s", app.Name, app.WebserverType, expectedServerType)
 			assert.Contains(out, expectedServerType, "For app.WebserverType=%s phpinfo expected servertype.php to show %s", app.WebserverType, expectedServerType)
+			err = app.Down(true, false)
+			assert.NoError(err)
 		}
 
 		// Set the apptype back to whatever the default was so we don't break any following tests.
@@ -2119,8 +2121,6 @@ func TestWebserverType(t *testing.T) {
 			err = app.WriteConfig()
 			assert.NoError(err)
 		}
-		err = app.Down(true, false)
-		assert.NoError(err)
 
 		runTime()
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1504,8 +1504,12 @@ func TestDdevStopMissingDirectory(t *testing.T) {
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 
-	err = app.StartAndWaitForSync(0)
-	assert.NoError(err)
+	startErr := app.StartAndWaitForSync(0)
+	if startErr != nil {
+		logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		assert.NoError(err)
+		t.Fatalf("app.StartAndWaitForSync failed err=%v logs from broken container: \n=======\n%s\n========\n", startErr, logs)
+	}
 
 	tempPath := testcommon.CreateTmpDir("site-copy")
 	siteCopyDest := filepath.Join(tempPath, "site")

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2095,7 +2095,7 @@ func TestWebserverType(t *testing.T) {
 
 			testcommon.ClearDockerEnv()
 
-			startErr := app.StartAndWaitForSync(5)
+			startErr := app.StartAndWaitForSync(30)
 			if startErr != nil {
 				appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 				assert.NoError(getLogsErr)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1890,6 +1890,8 @@ func TestHttpsRedirection(t *testing.T) {
 		// Do a start on the configured site.
 		app, err = ddevapp.GetActiveApp("")
 		assert.NoError(err)
+		//nolint: errcheck
+		defer app.Down(true, false)
 		startErr := app.StartAndWaitForSync(30)
 		if startErr != nil {
 			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
@@ -1924,10 +1926,9 @@ func TestHttpsRedirection(t *testing.T) {
 				assert.EqualValues(locHeader, expectedRedirect, "For webserver_type %s url %s expected redirect %s != actual %s", webserverType, reqURL, expectedRedirect, locHeader)
 			}
 		}
+		err = app.Down(true, false)
+		assert.NoError(err)
 	}
-
-	err = app.Down(true, false)
-	assert.NoError(err)
 
 	// Change back to package dir. Lots of things will have to be cleaned up
 	// in defers, and for windows we have to not be sitting in them.
@@ -1948,6 +1949,7 @@ func TestMultipleComposeFiles(t *testing.T) {
 
 	files, err := app.ComposeFiles()
 	assert.NoError(err)
+	require.NotEmpty(t, files)
 	require.Equal(t, files[0], filepath.Join(app.AppConfDir(), "docker-compose.yaml"))
 	require.Equal(t, files[len(files)-1], filepath.Join(app.AppConfDir(), "docker-compose.override.yaml"))
 

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -2,7 +2,6 @@ package ddevapp_test
 
 import (
 	"github.com/drud/ddev/pkg/netutil"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 
@@ -58,7 +57,7 @@ func TestPortOverride(t *testing.T) {
 			assert.False(netutil.IsPortActive(app.RouterHTTPSPort))
 		}
 
-		err = app.Start()
+		startErr := app.StartAndWaitForSync(5)
 		// defer the app.Down so we have a more diverse set of tests. If we brought
 		// each down before testing the next that would be a more trivial test.
 		// Don't worry about the possible error case as this is just a test cleanup
@@ -66,10 +65,11 @@ func TestPortOverride(t *testing.T) {
 		defer app.Down(true, false)
 
 		var logs string
-		if err != nil {
-			logs, _ = ddevapp.GetErrLogsFromApp(app, err)
+		if startErr != nil {
+			logs, err = ddevapp.GetErrLogsFromApp(app, err)
+			assert.NoError(err)
+			t.Fatalf("failed to app.StartAndWaitForSync(), err=%v logs=\n=========\n%s\n===========\n", startErr, logs)
 		}
-		require.NoError(t, err, "failed to app.Start(), logs=\n=========\n%s\n===========\n", logs)
 		err = app.Wait([]string{"web"})
 		assert.NoError(err)
 		assert.True(netutil.IsPortActive(app.RouterHTTPPort))

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -73,7 +73,7 @@ func TestSSHAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	startErr := app.StartAndWaitForSync(0)
-	if err != nil {
+	if startErr != nil {
 		logs, _ := ddevapp.GetErrLogsFromApp(app, startErr)
 		t.Fatalf("app.StartAndWaitForSync failed, err=%v, logs=\n========\n%s\n===========\n", startErr, logs)
 	}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -37,7 +37,8 @@ services:
     command: "$DDEV_MARIADB_LOCAL_COMMAND"
     healthcheck:
       interval: 5s
-      retries: 3
+      retries: 4
+      start_period: 20s
   web:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -93,7 +93,9 @@ services:
       com.ddev.app-type: {{ .AppType }}
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
-    extra_hosts: ["{{ .ExtraHost }}"]
+{{ if .HostDockerInternalIP }}
+	extra_hosts: ["{{ .HostDockerInternalHostname }}":{{ .HostDockerInternalIP }}, ]
+{{ end }}
     external_links:
       - ddev-router:$DDEV_HOSTNAME
     healthcheck:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -94,7 +94,7 @@ services:
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
 {{ if .HostDockerInternalIP }}
-    extra_hosts: ["{{ .HostDockerInternalHostname }}":{{ .HostDockerInternalIP }}, ]
+    extra_hosts: [ "{{ .HostDockerInternalHostname }}:{{ .HostDockerInternalIP }}" ]
 {{ end }}
     external_links:
       - ddev-router:$DDEV_HOSTNAME

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -94,7 +94,7 @@ services:
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
 {{ if .HostDockerInternalIP }}
-	extra_hosts: ["{{ .HostDockerInternalHostname }}":{{ .HostDockerInternalIP }}, ]
+    extra_hosts: ["{{ .HostDockerInternalHostname }}":{{ .HostDockerInternalIP }}, ]
 {{ end }}
     external_links:
       - ddev-router:$DDEV_HOSTNAME

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -152,13 +152,11 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 		err = app.WriteConfig()
 		assert.NoError(err)
 
-		err = app.Start()
-		assert.NoError(err)
-		if err != nil {
-			logs, err := ddevapp.GetErrLogsFromApp(app, err)
-			if err != nil {
-				t.Logf("logs from broken container:\n=======\n%s\n========\n", logs)
-			}
+		startErr := app.StartAndWaitForSync(5)
+		if startErr != nil {
+			logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+			assert.NoError(err)
+			t.Fatalf("logs from broken container:\n=======\n%s\n========\n", logs)
 		}
 
 		safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1297 points out that docker toolbox can't be used with xdebug; the hostname docker.host.internal is missing on docker toolbox (and Linux).

## How this PR Solves The Problem:

Add the correct IP (derived from DOCKER_HOST) explicitly to docker-composer.yaml in extra_hosts if we're on docker toolbox.

## Manual Testing Instructions:

It's ok with me if reviewers just try XDebug on one platform; I can try it on all 4. 

Manually use xdebug and PHPStorm to demonstrate its correct behavior on 
* Docker Toolbox
* Docker for Windows
* Linux
* macOS

## Automated Testing Overview:

This finally adds coverage in TestDdevXdebugEnabled for xdebug attempting to make the connection back to the host. Yay!  And it should work on all 4 platforms.

## Related Issue Link(s):

OP #1297 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

