### PR TITLE
Don't ask about sentry if DDEV_NO_SENTRY

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -151,7 +151,7 @@ func sentryNotSetupWarning() {
 // from the last saved version. If it is, prompt to request anon ddev usage stats
 // and update the info.
 func checkDdevVersionAndOptInSentry() error {
-	if !output.JSONOutput && version.COMMIT != globalconfig.DdevGlobalConfig.LastUsedVersion && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && os.Getenv("DDEV_NO_SENTRY") == "" {
+	if !output.JSONOutput && version.COMMIT != globalconfig.DdevGlobalConfig.LastUsedVersion && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoSentry {
 		allowStats := util.Confirm("It looks like you have a new ddev release.\nMay we send anonymous ddev usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/latest/users/cli-usage/#opt-in-usage-information\nPermission to beam up?")
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -151,7 +151,7 @@ func sentryNotSetupWarning() {
 // from the last saved version. If it is, prompt to request anon ddev usage stats
 // and update the info.
 func checkDdevVersionAndOptInSentry() error {
-	if !output.JSONOutput && version.COMMIT != globalconfig.DdevGlobalConfig.LastUsedVersion && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false {
+	if !output.JSONOutput && version.COMMIT != globalconfig.DdevGlobalConfig.LastUsedVersion && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && os.Getenv("DDEV_NO_SENTRY") == "" {
 		allowStats := util.Confirm("It looks like you have a new ddev release.\nMay we send anonymous ddev usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/latest/users/cli-usage/#opt-in-usage-information\nPermission to beam up?")
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"github.com/drud/ddev/cmd/ddev/cmd"
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/getsentry/raven-go"
-	"os"
 )
 
 func main() {
@@ -13,8 +13,7 @@ func main() {
 }
 
 func init() {
-	noSentry := os.Getenv("DDEV_NO_SENTRY")
-	if noSentry == "" {
+	if !globalconfig.DdevNoSentry {
 		_ = raven.SetDSN(version.SentryDSN)
 		ddevapp.SetRavenBaseTags()
 	}

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -1,5 +1,7 @@
 package globalconfig
 
+import "os"
+
 // Container types used with ddev (duplicated from ddevapp, avoiding cross-package cycles)
 const (
 	DdevSSHAgentContainer = "ddev-ssh-agent"
@@ -10,3 +12,5 @@ var ValidOmitContainers = map[string]bool{
 	DdevSSHAgentContainer: true,
 	DBAContainer:          true,
 }
+
+var DdevNoSentry = os.Getenv("DDEV_NO_SENTRY") == "true"

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/ravenutils"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/evalphobia/logrus_sentry"
@@ -32,7 +33,7 @@ func LogSetUp() {
 	}
 
 	// Report errors and panics to Sentry
-	if version.SentryDSN != "" && os.Getenv("DDEV_NO_SENTRY") == "" {
+	if version.SentryDSN != "" && !globalconfig.DdevNoSentry {
 		hook, err := logrus_sentry.NewAsyncWithTagsSentryHook(version.SentryDSN, ravenutils.RavenTags, levels)
 		if err == nil {
 			UserOut.Hooks.Add(hook)


### PR DESCRIPTION
## The Problem/Issue/Bug:

It's just annoying to be asked about sentry when you're developing and you do a new build. No reason to ask if DDEV_NO_SENTRY.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

