### PR TITLE
ddev composer should fail if composer fails, fixes #1373

### DIFF
--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -35,11 +35,14 @@ ddev composer outdated --minor-only`,
 		}
 
 		output.UserOut.Printf("Executing [composer %s] at the project root (/var/www/html in the container, %s on the host)", strings.Join(args, " "), app.AppRoot)
-		stdout, _, _ := app.Exec(&ddevapp.ExecOpts{
+		stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
 			Dir:     "/var/www/html",
 			Cmd:     append([]string{"composer"}, args...),
 		})
+		if err != nil {
+			util.Failed("composer command failed: %v", err)
+		}
 		if runtime.GOOS == "windows" && !util.IsDockerToolbox() {
 			replaceSimulatedLinks(app.AppRoot)
 		}


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1373 points out that even though composer may fail in `ddev composer`, ddev still returns success. Shouldn't be that way. Could also hide test failures.

## How this PR Solves The Problem:

## Manual Testing Instructions:

Break the composer.json in a project; maybe just introduce an extra brace.
`ddev composer install`
You should get an error return.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

