### PR TITLE
Make dbimage work again in config.yaml, fixes #1374

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -237,7 +237,9 @@ func (app *DdevApp) ReadConfig() error {
 		app.WebImage = version.GetWebImage()
 	}
 
-	app.DBImage = version.GetDBImage(app.MariaDBVersion)
+	if app.DBImage == "" {
+		app.DBImage = version.GetDBImage(app.MariaDBVersion)
+	}
 
 	if app.DBAImage == "" {
 		app.DBAImage = version.GetDBAImage()


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1374: dbimage statement in config.yaml stopped working when we added mariadb version support. Seems it was just one missing if statement.

## How this PR Solves The Problem:

Add the if statement

## Manual Testing Instructions:

You should be able to set dbimage: in config.yaml (try using `dbimage: drud/ddev-dbserver:v1.5.2-10.2` to get 1.5.2). Or if you leave it out/comment it out, you should get `drud/ddev-dbserver:20190124_sql_triggers-10.2` with current code.

## Automated Testing Overview:

I didn't add anything.

## Related Issue Link(s):

OP #1374

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

