### PR TITLE
ddev auth ssh should show key it's working on (docker toolbox), fixes #1394

### DIFF
--- a/containers/ddev-ssh-agent/files/entry.sh
+++ b/containers/ddev-ssh-agent/files/entry.sh
@@ -61,6 +61,7 @@ case "$1" in
       for key in $keyfiles; do
         perm=$(stat -c %a "$key")
         if [ $perm = "777" ] ; then
+            echo "Please add password for ${key}..."
             cat $key | ssh-add -k -
         else
             ssh-add $key

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -67,7 +67,7 @@ var RouterTag = "v1.5.2" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.5.2"
+var SSHAuthTag = "20190125_ddev_auth_ssh_show_key"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug

#1394 points out that on Docker Toolbox, `ddev auth ssh` emits a very unsatisfying description of the key for which a passphrase is required. This is due to the fact that on Docker Toolbox, mounts make everything 777, and ssh-add is completely unwilling to operate on 777 keys. So we cat them into it. 

## How this PR Solves The Problem:

Announce the key name when this situation is encountered:

<img width="456" alt="windows_10_home" src="https://user-images.githubusercontent.com/112444/51780362-0cff0400-20cb-11e9-9d18-37a19f8a8823.png">


## Manual Testing Instructions:

On Docker Toolbox (Windows), do a `ddev ssh auth`. You should see the key name announced.


