### PR TITLE
Prevent running as root except for ddev hostname, fixes #1379

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -135,6 +135,12 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&output.JSONOutput, "json-output", "j", false, "If true, user-oriented output will be in JSON format.")
 
+	// Prevent running as root for most cases
+	// We really don't want ~/.ddev to have root ownership, breaks things.
+	if os.Geteuid() == 0 && len(os.Args) > 1 && os.Args[1] != "hostname" {
+		output.UserOut.Fatal("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
+	}
+
 	err := globalconfig.ReadGlobalConfig()
 	if err != nil {
 		util.Failed("Failed to read global config file %s: %v", globalconfig.GetGlobalConfigPath(), err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

We get periodic problems with people running as root, the biggest thing is they get their ~/.ddev root-ownership, which breaks everything later. It mostly happens on linux, but there are sudo-addicts out there in the mac world too. OP #1379

`ddev hostname` though usually requires sudo

## How this PR Solves The Problem:

* For all commands but hostname, refuse.
* Check for the situation of them creating the ~/.ddev to make global config with `sudo ddev hostname` being the first command ever run, a very unusual situation.

## Manual Testing Instructions:

* Try all commands
* try `sudo ddev start` and other things. Try `sudo ddev hostname junker99.ddev.local 127.0.0.1`, it should be allowed.
* Try removing or renaming ~/.ddev and then use `sudo ddev start` - should not create that directory. `sudo ddev hostname junker99.ddev.local 127.0.0.1` should succeed, but should not create the directory.

## Automated Testing Overview:

I didn't figure out how to do general testing that would require a sudo password. sudo is passwordless on CIrcleci, so it might be possible to add a test that was only Circleci.

## Related Issue Link(s):

OP #1379


