### PR TITLE
Skip prerelease versions in update check

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -95,10 +95,10 @@ func TestCmdDescribe(t *testing.T) {
 			}
 		}
 		require.True(t, rawFound, "did not find 'raw' in item in logItems\n===\n%s\n===\n", out)
-		assert.EqualValues(raw["status"], "running")
-		assert.EqualValues(raw["name"], v.Name)
-		assert.EqualValues(raw["shortroot"].(string), ddevapp.RenderHomeRootedDir(v.Dir))
-		assert.EqualValues(raw["approot"].(string), v.Dir)
+		assert.EqualValues("running", raw["status"])
+		assert.EqualValues(v.Name, raw["name"])
+		assert.Equal(ddevapp.RenderHomeRootedDir(v.Dir), raw["shortroot"].(string))
+		assert.EqualValues(v.Dir, raw["approot"].(string))
 
 		assert.NotEmpty(item["msg"])
 	}

--- a/pkg/updatecheck/updatecheck.go
+++ b/pkg/updatecheck/updatecheck.go
@@ -28,6 +28,9 @@ func AvailableUpdates(repoOrg string, repoName string, currentVersion string) (b
 			return false, "", err
 		}
 		for _, release := range releases {
+			if *release.Prerelease {
+				continue
+			}
 			releaseVersion, err := semver.NewVersion(*release.TagName)
 			if err != nil {
 				return false, "", err


### PR DESCRIPTION
## The Problem/Issue/Bug:

It would be nice if we had the capability of creating prerelease versions for community testing, etc. But we don't want ddev's update check to notice them.

## How this PR Solves The Problem:

When traversing releases in updatecheck.AvailableUpdates(), skip versions marked as prerelease. 

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

