### PR TITLE
Specify how project names work with Pantheon

### DIFF
--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -24,7 +24,7 @@ If you have ddev installed, and have an active Pantheon account with an active W
 
     a. Navigate in your terminal to your checkout of the project codebase.
 
-    b. Run `ddev config pantheon`. When asked for the project name you must use the exact name of the Pantheon project.
+    b. Run `ddev config pantheon`. When asked for the project name you must use the exact name of the Pantheon project. The name is found in the URL of your Pantheon dev site. For example, if your site is viewed at http://dev-foo-bar.pantheonsite.io/ enter 'foo-bar' as the name (not 'Foo Bar').
 
     c. Configuration prompts will allow you to choose a Pantheon environment, suggesting "dev" as the default.
 


### PR DESCRIPTION
I had a hard time entering a project name as I did not understand that it is not the human readable name of my project in the Pantheon dashboard but rather the machine name used in the Pantheon URL. This is probably an issue for sites with spaces in human name, not sure about capitalization. Let's better explain what is meant by 'name' here.

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

