### PR TITLE
Notify when the project type does not support import-files, fixes #1416

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -226,7 +226,7 @@ func (app *DdevApp) ImportFilesAction(importPath, extPath string) error {
 		return appFuncs.importFilesAction(app, importPath, extPath)
 	}
 
-	return nil
+	return fmt.Errorf("this project type (%s) does not support import-files", app.Type)
 }
 
 // DefaultWorkingDirMap returns the app type's default working directory map.


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1416: We were saying "Oh everything is fine" even on a project that doesn't support import-files

## How this PR Solves The Problem:

Error when import-files is used on a project that doesn't support it.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

