### PR TITLE
Minor: Better volume cleanup before running tests and full remove

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1201,7 +1201,7 @@ func (app *DdevApp) Down(removeData bool, createSnapshot bool) error {
 			return fmt.Errorf("failed to remove hosts entries: %v", err)
 		}
 
-		for _, volName := range []string{app.Name + "-mariadb", "ddev-" + app.GetUnisonCatalogVolName(), app.GetWebcacheVolName()} {
+		for _, volName := range []string{app.Name + "-mariadb", app.GetUnisonCatalogVolName(), app.GetWebcacheVolName()} {
 			err = dockerutil.RemoveVolume(volName)
 			if err != nil {
 				util.Warning("could not remove volume %s: %v", volName, err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -191,10 +191,9 @@ func TestMain(m *testing.M) {
 			log.Errorf("TestMain startup: app.WriteConfig() failed on site %s in dir %s, err=%v", TestSites[i].Name, TestSites[i].Dir, err)
 			continue
 		}
-		// TODO: webcache PR will add other volumes that should be removed here.
-		for _, volume := range []string{app.Name + "-mariadb"} {
+		for _, volume := range []string{app.Name + "-mariadb", app.GetUnisonCatalogVolName(), app.GetWebcacheVolName()} {
 			err = dockerutil.RemoveVolume(volume)
-			if err != nil && err.Error() != "no such volume" {
+			if err != nil {
 				log.Errorf("TestMain startup: Failed to delete volume %s: %v", volume, err)
 			}
 		}


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noticed a comment in the TestMain for ddevapp about deleting more volumes when webcache PR landed. This just addresses that.

Oops, also in the process discovered a bug where we don't properly remove the unisoncatalogvol in ddev rm -RO

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

