### PR TITLE
Bump pinned mariaDB pinned version to solve container build problems

### DIFF
--- a/containers/ddev-dbserver/10.1/Dockerfile
+++ b/containers/ddev-dbserver/10.1/Dockerfile
@@ -5,7 +5,7 @@ ENV MYSQL_USER db
 ENV MYSQL_PASSWORD db
 ENV MYSQL_ROOT_PASSWORD root
 ENV MARIADB_VERSION 10.1
-ENV MARIADB_FULL_VERSION 10.1.32-r0
+ENV MARIADB_FULL_VERSION 10.1.37-r0
 
 # Install mariadb and other packages
 RUN apk add --no-cache mariadb=$MARIADB_FULL_VERSION mariadb-client=$MARIADB_FULL_VERSION bash tzdata shadow sudo pv

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -47,20 +47,24 @@ build: container
 
 container:
 	for item in $(DIRS); do \
+		set -euo pipefail \
 		echo $$item && $(MAKE) -C $$item container; \
 	done
 
 push:
 	for item in $(DIRS); do \
+		set -euo pipefail \
 		echo $$item && $(MAKE) -C $$item push; \
 	done
 
 clean:
 	for item in $(DIRS); do \
+		set -euo pipefail \
 		echo $$item && $(MAKE) -C $$item clean; \
 	done
 
 test: container
 	for item in $(DIRS); do \
+		set -euo pipefail \
 		echo $$item && $(MAKE) -C $$item test; \
 	done

--- a/containers/ddev-dbserver/test/testserver.sh
+++ b/containers/ddev-dbserver/test/testserver.sh
@@ -17,6 +17,7 @@ if [[ "$MOUNTUID" -gt "60000" || "$MOUNTGID" -gt "60000" ]] ; then
 	MOUNTGID=1000
 fi
 
+mkdir -p /usr/local/etc/my.cnf.d || sudo mkdir -p /usr/local/etc/my.cnf.d
 
 # Always clean up the container on exit.
 function cleanup {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var WebTag = "20190116_update_web_versions_drush" // Note that this can be overr
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20190124_sql_triggers"
+var BaseDBTag = "20190205_bump_maria_10_1_version"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

I note that recent container builds are all failing on ddev-dbserver 10.1, because they issued a new one. It wasn't clear to me why our pin wasn't able to resolve the issues, but this bumps. 
Also debugged a problem that the Makefile had not been stopping on build failure as it should have. 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

