### PR TITLE
Fix version constraint to have a pre, fixes #1431

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,11 +26,11 @@ var SentryDSN = ""
 // See https://godoc.org/github.com/Masterminds/semver#hdr-Checking_Version_Constraints
 // for examples defining version constraints.
 // REMEMBER TO CHANGE docs/index.md if you touch this!
-var DockerVersionConstraint = ">= 18.06.0-ce"
+var DockerVersionConstraint = ">= 18.06.1-alpha1"
 
 // DockerComposeVersionConstraint is the current minimum version of docker-compose required for ddev.
 // REMEMBER TO CHANGE docs/index.md if you touch this!
-var DockerComposeVersionConstraint = ">= 1.21.0"
+var DockerComposeVersionConstraint = ">= 1.21.0-alpha1"
 
 // DockerComposeFileFormatVersion is the compose version to be used
 var DockerComposeFileFormatVersion = "3.6"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,10 +26,14 @@ var SentryDSN = ""
 // See https://godoc.org/github.com/Masterminds/semver#hdr-Checking_Version_Constraints
 // for examples defining version constraints.
 // REMEMBER TO CHANGE docs/index.md if you touch this!
+// The constraint MUST HAVE a -pre of some kind on it for successful comparison.
+// See https://github.com/drud/ddev/pull/738.. and regression https://github.com/drud/ddev/issues/1431
 var DockerVersionConstraint = ">= 18.06.1-alpha1"
 
 // DockerComposeVersionConstraint is the current minimum version of docker-compose required for ddev.
 // REMEMBER TO CHANGE docs/index.md if you touch this!
+// The constraint MUST HAVE a -pre of some kind on it for successful comparison.
+// See https://github.com/drud/ddev/pull/738.. and regression https://github.com/drud/ddev/issues/1431
 var DockerComposeVersionConstraint = ">= 1.21.0-alpha1"
 
 // DockerComposeFileFormatVersion is the compose version to be used


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1431, but original PR (we regressed :) ) was https://github.com/drud/ddev/pull/738
If docker comes out with a release number with a "pre" after it ( [semver does not support versions with a pre unless the check has a pre](https://github.com/Masterminds/semver/issues/21).), like the current edge docker-compose: `1.24.0-rc1`. 

## How this PR Solves The Problem:

Add a "pre" back into the docker constraints. It needs a comment saying "DON'T LOSE THE -pre!"

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

