### PR TITLE
Fix nightly build broken by #1425

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,7 +454,8 @@ workflows:
                 - "pull/[0-9]+"
     jobs:
     - build
-    - lx_tst_nginx_fpm:
+    - lx_container_test
+    - lx_nginx_fpm_test:
         requires:
         - build
     - artifacts:


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1425 had a failed rename that didn't come into play until the nightly build happened.

## How this PR Solves The Problem:

* Fix the rename
* Add container build to nightly

## Manual Testing Instructions:

Review this.
Pull it
Hope it works.

We don't have an easy way to hit the nightly build with the api at this point.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

