### PR TITLE
Kill containers before sanetestbot

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -22,6 +22,8 @@ rm -rf ~/.ddev/Test*
 # go clean -modcache  (Doesn't work due to current bug in golang)
 chmod -R u+w ~/go/pkg && rm -rf ~/go/pkg/*
 
+# Kill off any running containers before sanetestbot.
+docker rm -f $(docker ps -aq) || true
 # Our testbot should be sane, run the testbot checker to make sure.
 echo "--- running sanetestbot.sh"
 ./.buildkite/sanetestbot.sh
@@ -32,6 +34,7 @@ if [ "$(docker ps -aq | wc -l)" -gt 0 ] ; then
 	docker rm -f $(docker ps -aq) || true
 fi
 docker system prune --volumes --force || true
+docker rm -f $(docker ps -aq) || true
 
 # Update all images that could have changed
 ( docker images | awk '/drud/ {print $1":"$2 }' | xargs -L1 docker pull ) || true


### PR DESCRIPTION
## The Problem/Issue/Bug:

* We moved sanetestbot.sh check to earlier in the script
* But docker containers might still be running, preventing sanetestbot from binding to ports

## How this PR Solves The Problem:

* Kill docker containers both before and after sanetestbot. That way we ought to get them most of the time.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

