### PR TITLE
Don't complain if can't kill nfs volume

### DIFF
--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -136,11 +136,9 @@ func Cleanup(app *DdevApp) error {
 			return fmt.Errorf("could not remove container %s: %v", containerName, err)
 		}
 	}
+	// Always kill the nfs volume on ddev remove
 	for _, volName := range []string{app.GetNFSMountVolName()} {
-		err = client.RemoveVolumeWithOptions(docker.RemoveVolumeOptions{Name: volName})
-		if err != nil {
-			util.Warning("could not remove volume %s: %v", volName, err)
-		}
+		_ = dockerutil.RemoveVolume(volName)
 	}
 
 	err = StopRouterIfNoContainers()


### PR DESCRIPTION
## The Problem/Issue/Bug:

In testing I found a place where it complains about the NFS volume not existing on `ddev rm` with non-NFS.

## How this PR Solves The Problem:

Use dockerutil.RemoveVolume()

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

