### PR TITLE
Add webcache_excludes option to config.yaml

### DIFF
--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -69,3 +69,12 @@ Tools to debug and solve permission problems:
 A separate webcache container is also provided as a separate experimental performance technique. It does not rely on any host configuration, but in some cases when large changes are made in the filesystem it can stop syncing and be unstable.
 
 To enable, edit .ddev/config.yaml to set `webcache_enabled:true` and `ddev start` to get a caching container going so that actual webserving happens on a much faster filesystem. This is experimental and has some risks, we want to know your experience. It takes longer to do a ddev start because your entire project has to be pushed into the container, but after that hitting a page is way, way more satisfying. Note that .git directories are not copied into the webcache, git won't work inside the web container. It just seemed too risky to combine 2-way file synchronization with your precious git repository, so do git operations on the host. Note that if you have a lot of files or big files in your repo, they have to be pushed into the container, and that can take time. For example, cleaning up the .ddev/db_snapshots directory rather than waiting for the docker cp is a good idea.
+
+### Exclude an OS from webcache
+
+To disable the webcache feature for an specific OS you can add one or multiple os entries to `webcache_excludes` in your `ddev/config.yaml`.  
+```
+webcache_excludes:
+  - linux
+  - darwin
+```

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -72,6 +72,7 @@ func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	app.PHPVersion = PHPDefault
 	app.WebserverType = WebserverDefault
 	app.WebcacheEnabled = WebcacheEnabledDefault
+	app.WebcacheExcludes = WebcacheExcludesDefault
 	app.RouterHTTPPort = DdevDefaultRouterHTTPPort
 	app.RouterHTTPSPort = DdevDefaultRouterHTTPSPort
 	app.MariaDBVersion = version.MariaDBDefaultVersion
@@ -94,6 +95,12 @@ func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	if runtime.GOOS != "darwin" && app.WebcacheEnabled && !globalconfig.DdevGlobalConfig.DeveloperMode {
 		app.WebcacheEnabled = false
 		util.Warning("webcache_enabled is not yet supported on %s, disabling it", runtime.GOOS)
+	}
+
+	// Turn off webcache_enabled if the current OS is specifically excluded
+	if stringInList(runtime.GOOS, app.WebcacheExcludes) {
+		app.WebcacheEnabled = false
+		util.Warning("Your OS '%s' is excluded from the webcache feature", runtime.GOOS)
 	}
 
 	// Allow override with provider.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -98,7 +98,7 @@ func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	}
 
 	// Turn off webcache_enabled if the current OS is specifically excluded
-	if stringInList(runtime.GOOS, app.WebcacheExcludes) {
+	if stringInSlice(runtime.GOOS, app.WebcacheExcludes) {
 		app.WebcacheEnabled = false
 		util.Warning("Your OS '%s' is excluded from the webcache feature", runtime.GOOS)
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -84,6 +84,7 @@ type DdevApp struct {
 	AdditionalFQDNs       []string             `yaml:"additional_fqdns"`
 	MariaDBVersion        string               `yaml:"mariadb_version"`
 	WebcacheEnabled       bool                 `yaml:"webcache_enabled"`
+	WebcacheExcludes      []string             `yaml:"webcache_excludes"`
 	NFSMountEnabled       bool                 `yaml:"nfs_mount_enabled"`
 	ConfigPath            string               `yaml:"-"`
 	AppRoot               string               `yaml:"-"`

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -318,7 +318,7 @@ func CheckForMissingProjectFiles(project *DdevApp) error {
 }
 
 // Check for string in array
-func stringInList(a string, list []string) bool {
+func stringInSlice(a string, list []string) bool {
 	for _, b := range list {
 		if b == a {
 			return true

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -316,3 +316,13 @@ func CheckForMissingProjectFiles(project *DdevApp) error {
 
 	return nil
 }
+
+// Check for string in array
+func stringInList(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -78,7 +78,7 @@ var WebserverDefault = WebserverNginxFPM
 // WebcacheEnabledDefault is the default value for app.WebCacheEnabled
 var WebcacheEnabledDefault = false
 
-// WebcacheExcludedDefault is the default value for app.WebcacheExcluded
+// WebcacheExcludesDefault is the default value for app.WebcacheExcludesDefault
 var WebcacheExcludesDefault = []string{}
 
 // NFSMountEnabledDefault is default value for app.NFSMountEnabled

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -78,6 +78,9 @@ var WebserverDefault = WebserverNginxFPM
 // WebcacheEnabledDefault is the default value for app.WebCacheEnabled
 var WebcacheEnabledDefault = false
 
+// WebcacheExcludedDefault is the default value for app.WebcacheExcluded
+var WebcacheExcludesDefault = false
+
 // NFSMountEnabledDefault is default value for app.NFSMountEnabled
 var NFSMountEnabledDefault = false
 

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -79,7 +79,7 @@ var WebserverDefault = WebserverNginxFPM
 var WebcacheEnabledDefault = false
 
 // WebcacheExcludedDefault is the default value for app.WebcacheExcluded
-var WebcacheExcludesDefault = false
+var WebcacheExcludesDefault = []string{}
 
 // NFSMountEnabledDefault is default value for app.NFSMountEnabled
 var NFSMountEnabledDefault = false


### PR DESCRIPTION
## The Problem/Issue/Bug:
As mentioned in issue #1410 there is no feature to to override the config.yaml webcache_enabled property.

## How this PR Solves The Problem:
It adds the opportunity to exclude specific operation systems from webcache enabled even if the option is enabled in general

## Manual Testing Instructions:
Add webcache_excludes options as mentioned in the updated docs/users/performance.md 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
[#1410 ](https://github.com/drud/ddev/issues/1410)
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

