### PR TITLE
Improve curl commands so they fail when they should on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,7 +466,7 @@ jobs:
             version=$(make version)
             version="${version#*:}"  # Remove the VERSION: in front of make version
             echo "GITHUB_TOKEN provided, pushing release $RELEASE_TAG"
-            /home/circleci/ghr \
+            ghr \
             -prerelease \
             -r $CIRCLE_PROJECT_REPONAME \
             -u $CIRCLE_PROJECT_USERNAME \

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -41,7 +41,6 @@ curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTES
 
 # Install ghr
 GHR_RELEASE="v0.12.0"
-curl -fsL -o ~/${GHR_RELEASE}.tar.gz https://github.com/tcnksm/ghr/releases/download/${GHR_RELEASE}/ghr_${GHR_RELEASE}_linux_amd64.tar.gz
-tar -xzf ~/${GHR_RELEASE}.tar.gz -C ~/
-ln -s ~/${GHR_RELEASE}/ghr ~/ghr
-~/ghr -v
+curl -fsL -o /tmp/ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/${GHR_RELEASE}/ghr_${GHR_RELEASE}_linux_amd64.tar.gz
+sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/ghr.tar.gz ghr_${GHR_RELEASE}_linux_amd64/ghr
+ghr -v

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -15,15 +15,10 @@ if [ ! -d /home/linuxbrew/.linuxbrew/bin ] ; then
 fi
 export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
 /home/linuxbrew/.linuxbrew/bin/brew update
-/home/linuxbrew/.linuxbrew/bin/brew install osslsigncode golang
+/home/linuxbrew/.linuxbrew/bin/brew install osslsigncode golang docker-compose
 
 sudo bash -c "printf '/home 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)\n/tmp 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)' >>/etc/exports"
 sudo service nfs-kernel-server restart
-
-# docker-compose
-sudo rm -f /usr/local/bin/docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
 
 # Remove existing docker and install from their apt package
 sudo apt-get remove docker docker-engine docker.io
@@ -45,8 +40,8 @@ GOTESTSUM_VERSION=0.3.2
 curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTESTSUM_VERSION/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum && sudo chmod +x /usr/local/bin/gotestsum
 
 # Install ghr
-GHR_RELEASE="ghr_v0.12.0_linux_amd64"
-curl -sL https://github.com/tcnksm/ghr/releases/download/v0.12.0/${GHR_RELEASE}.tar.gz > /home/circleci/${GHR_RELEASE}.tar.gz
-tar -xzf /home/circleci/${GHR_RELEASE}.tar.gz -C /home/circleci
-ln -s /home/circleci/${GHR_RELEASE}/ghr /home/circleci/ghr
-/home/circleci/ghr -v 
+GHR_RELEASE="v0.12.0"
+curl -fsL -o ~/${GHR_RELEASE}.tar.gz https://github.com/tcnksm/ghr/releases/download/${GHR_RELEASE}/ghr_${GHR_RELEASE}_linux_amd64.tar.gz
+tar -xzf ~/${GHR_RELEASE}.tar.gz -C ~/
+ln -s ~/${GHR_RELEASE}/ghr ~/ghr
+~/ghr -v

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -16,11 +16,11 @@ brew tap drud/ddev
 brew install mysql-client zip nsis jq expect coreutils golang ddev
 brew link --force mysql-client
 
-curl -sSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v0.3.2/gotestsum_0.3.2_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
+curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v0.3.2/gotestsum_0.3.2_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
 
 # gotestsum
 GOTESTSUM_VERSION=0.3.2
-curl -sSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
+curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
 
 sudo bash -c "cat <<EOF >/etc/exports
 /Users -alldirs -mapall=$(id -u):$(id -g) localhost

--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,12 @@ chocolatey: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe
 
 
 $(GOTMP)/bin/windows_amd64/sudo.exe $(GOTMP)/bin/windows_amd64/sudo_license.txt:
-	curl -sSL -o /tmp/sudo.zip -O  https://github.com/mattn/sudo/releases/download/$(WINDOWS_SUDO_VERSION)/sudo-x86_64.zip
+	curl --fail -sSL -o /tmp/sudo.zip -O  https://github.com/mattn/sudo/releases/download/$(WINDOWS_SUDO_VERSION)/sudo-x86_64.zip
 	unzip -o -d $(GOTMP)/bin/windows_amd64 /tmp/sudo.zip
-	curl -sSL -o $(GOTMP)/bin/windows_amd64/sudo_license.txt https://raw.githubusercontent.com/mattn/sudo/master/LICENSE
+	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/sudo_license.txt https://raw.githubusercontent.com/mattn/sudo/master/LICENSE
 
 $(GOTMP)/bin/windows_amd64/nssm.exe $(GOTMP)/bin/windows_amd64/winnfsd_license.txt $(GOTMP)/bin/windows_amd64/winnfsd.exe :
-	curl -sSL -o $(GOTMP)/bin/windows_amd64/winnfsd.exe  https://github.com/winnfsd/winnfsd/releases/download/$(WINNFSD_VERSION)/WinNFSd.exe
-	curl -sSL -o /tmp/nssm.zip https://nssm.cc/ci/nssm-$(NSSM_VERSION).zip
+	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/winnfsd.exe  https://github.com/winnfsd/winnfsd/releases/download/$(WINNFSD_VERSION)/WinNFSd.exe
+	curl --fail -sSL -o /tmp/nssm.zip https://nssm.cc/ci/nssm-$(NSSM_VERSION).zip
 	unzip -oj /tmp/nssm.zip  nssm-$(NSSM_VERSION)/win64/nssm.exe -d $(GOTMP)/bin/windows_amd64
-	curl -sSL -o $(GOTMP)/bin/windows_amd64/winnfsd_license.txt https://www.gnu.org/licenses/gpl.txt
+	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/winnfsd_license.txt https://www.gnu.org/licenses/gpl.txt


### PR DESCRIPTION
## The Problem/Issue/Bug:

On the nightly build last night we had an issue where nssm was not downloading properly. But the failure was in the unzip, and it should have been on the download. This adds -f or --fail to the various curls used in the build process.

In passing, also:
* Moves docker-compose to brew install
* Minor change to ghr download technique

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

