### PR TITLE
Fix Windows NFS script when username has spaces, fixes #1452

### DIFF
--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -30,7 +30,7 @@ if ! command -v winnfsd.exe >/dev/null; then
     echo "winnfsd.exe does not seem to be installed or is not in the PATH"
     exit 101
 fi
-winnfsd=$(command -v winnfsd.exe)
+winnfsd=$(where winnfsd.exe)
 
 if [ -f "$HOME/.ddev/nfs_exports.txt" ]; then
     printf "$HOME/.ddev/nfs_exports.txt already exists, not overwriting it, you will be responsible for its exports.\n"
@@ -42,7 +42,7 @@ else
 # Additional lines can be added for additional directories or drives.
 C:\ > /C" >"$HOME/.ddev/nfs_exports.txt"
 fi
-sudo nssm install nfsd "${winnfsd}" -id ${DDEV_WINDOWS_UID} ${DDEV_WINDOWS_GID} -log off -pathFile "$HOME/.ddev/nfs_exports.txt"
+sudo nssm install nfsd "${winnfsd}" -id ${DDEV_WINDOWS_UID} ${DDEV_WINDOWS_GID} -log off -pathFile "\"$HOMEDRIVE$HOMEPATH\.ddev\nfs_exports.txt\""
 sudo nssm start nfsd || true
 sleep 2
 nssm status nfsd

--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -32,15 +32,15 @@ if ! command -v winnfsd.exe >/dev/null; then
 fi
 winnfsd=$(command -v winnfsd.exe)
 
-if [ -f ~/.ddev/nfs_exports.txt ]; then
-    echo "~/.ddev/nfs_exports.txt already exists, not overwriting it"
+if [ -f "$HOME/.ddev/nfs_exports.txt" ]; then
+    printf "$HOME/.ddev/nfs_exports.txt already exists, not overwriting it, you will be responsible for its exports.\n"
 else
     echo "
 # Exports for winnfsd for ddev
 # You can edit these yourself to match your workflow
 # But nfs must share your project directory
 # Additional lines can be added for additional directories or drives.
-C:\ > /C" >~/.ddev/nfs_exports.txt
+C:\ > /C" >"$HOME/.ddev/nfs_exports.txt"
 fi
 sudo nssm install nfsd "${winnfsd}" -id ${DDEV_WINDOWS_UID} ${DDEV_WINDOWS_GID} -log off -pathFile "$HOME/.ddev/nfs_exports.txt"
 sudo nssm start nfsd || true


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1452 reports that the Windows NFS installation script fails when there are spaces in the user's names.

## How this PR Solves The Problem:

Use $HOME instead of ~, and put path in quotes.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

