### PR TITLE
Increase version requirement for ddev to macOS Sierra 10.12 since docker increased theirs, fixes #1466

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 - [Docker](https://www.docker.com/community-edition) version 18.06 or higher. Linux users make sure you upgrade docker-compose and do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
 - docker-compose 1.21.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
 - OS Support
-  - macOS El Capitan and higher (macOS 10.11 and higher but it should run anywhere docker-ce runs)
+  - macOS Sierra and higher (macOS 10.12 and higher; it should run anywhere docker-for-mac runs.
   - Linux: Most Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
   - Windows 10 Pro or Enterprise with [Docker-for-windows](https://docs.docker.com/docker-for-windows/install/)
   - Windows 10 Home (or other Windows version) with [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Docker for Mac now supports only macOS Sierra (10.12) and higher. That means we have the same constraint. So fix docs to say that.
