### PR TITLE
Bump mariadb to 10.1.38-r1 and 10.2.22-r0

### DIFF
--- a/containers/ddev-dbserver/10.1/Dockerfile
+++ b/containers/ddev-dbserver/10.1/Dockerfile
@@ -5,7 +5,7 @@ ENV MYSQL_USER db
 ENV MYSQL_PASSWORD db
 ENV MYSQL_ROOT_PASSWORD root
 ENV MARIADB_VERSION 10.1
-ENV MARIADB_FULL_VERSION 10.1.37-r0
+ENV MARIADB_FULL_VERSION 10.1.38-r1
 
 # Install mariadb and other packages
 RUN apk add --no-cache mariadb=$MARIADB_FULL_VERSION mariadb-client=$MARIADB_FULL_VERSION bash tzdata shadow sudo pv

--- a/containers/ddev-dbserver/10.2/Dockerfile
+++ b/containers/ddev-dbserver/10.2/Dockerfile
@@ -5,7 +5,7 @@ ENV MYSQL_USER db
 ENV MYSQL_PASSWORD db
 ENV MYSQL_ROOT_PASSWORD root
 ENV MARIADB_VERSION 10.2
-ENV MARIADB_FULL_VERSION 10.2.19-r1
+ENV MARIADB_FULL_VERSION 10.2.22-r0
 
 # Install mariadb and other packages
 RUN apk add --no-cache mariadb=$MARIADB_FULL_VERSION mariadb-client=$MARIADB_FULL_VERSION mariadb-backup=$MARIADB_FULL_VERSION mariadb-server-utils=$MARIADB_FULL_VERSION bash tzdata shadow sudo pv

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var WebTag = "v1.6.0" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.6.0"
+var BaseDBTag = "20190226_bump_mariadb"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

I don't know why we can't use plain pinned mariadb versions in alpine/apk, but until we learn how, we have to bump when the upstream changes.

Bump mariadb to 10.1.38-r1 and 10.2.22-r0
