### PR TITLE
Invalidate homebrew cache with new version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
 
@@ -42,13 +42,13 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
 
@@ -73,14 +73,14 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v2
+        - homebrew-macos-v3
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - save_cache:
-        key: homebrew-macos-v2
+        key: homebrew-macos-v3
         paths:
         - /usr/local/Homebrew
     - run:
@@ -103,7 +103,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v2
+        - homebrew-macos-v3
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -116,7 +116,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macos-v2
+        key: homebrew-macos-v3
         paths:
         - /usr/local/Homebrew
 
@@ -134,7 +134,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v2
+        - homebrew-macos-v3
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -147,7 +147,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macos-v2
+        key: homebrew-macos-v3
         paths:
         - /usr/local/Homebrew
 
@@ -164,13 +164,13 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v2
+        - homebrew-macos-v3
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v2
+        key: homebrew-macos-v3
         paths:
         - /usr/local/Homebrew
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
@@ -194,14 +194,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
 
@@ -227,14 +227,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
     - run:
@@ -257,14 +257,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
@@ -287,12 +287,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
     - run:
@@ -308,12 +308,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
     - run:
@@ -336,12 +336,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v2
+        - homebrew-macos-v3
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v2
+        key: homebrew-macos-v3
         paths:
         - /usr/local/Homebrew
     - run:
@@ -366,7 +366,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     - attach_workspace:
         at: ~/
     - run:
@@ -374,7 +374,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
     - store_artifacts:
@@ -394,12 +394,12 @@ jobs:
       - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
       - restore_cache:
           keys:
-          - homebrew-linux-v2
+          - homebrew-linux-v3
       - run:
           command: ./.circleci/linux_circle_vm_setup.sh
           name: TAG BUILD Circle VM setup - tools, docker, golang
       - save_cache:
-          key: homebrew-linux-v2
+          key: homebrew-linux-v3
           paths:
           - /home/linuxbrew
 
@@ -436,12 +436,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v2
+        - homebrew-linux-v3
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: RELEASE BUILD Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v2
+        key: homebrew-linux-v3
         paths:
         - /home/linuxbrew
 

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -15,7 +15,9 @@ if [ ! -d /home/linuxbrew/.linuxbrew/bin ] ; then
 fi
 export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
 /home/linuxbrew/.linuxbrew/bin/brew update
-/home/linuxbrew/.linuxbrew/bin/brew install osslsigncode golang docker-compose
+for item in osslsigncode golang docker-compose; do
+    /home/linuxbrew/.linuxbrew/bin/brew install $item || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item
+done
 
 sudo bash -c "printf '/home 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)\n/tmp 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)' >>/etc/exports"
 sudo service nfs-kernel-server restart

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -13,7 +13,11 @@ sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unatt
 nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 
 brew tap drud/ddev
-brew install mysql-client zip nsis jq expect coreutils golang ddev
+
+for item in mysql-client zip nsis jq expect coreutils golang ddev; do
+    brew install $item || brew upgrade $item
+done
+
 brew link --force mysql-client
 
 curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v0.3.2/gotestsum_0.3.2_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum


### PR DESCRIPTION
## The Problem/Issue/Bug:

Golang bumped to v1.12; homebrew won't upgrade unless we ask it to upgrade. We'll want to do something more robust in the future, but for now, just invalidate the homebrew cache.

