### PR TITLE
Make very long server names possible

### DIFF
--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -38,6 +38,9 @@ map $http_upgrade $proxy_connection {
   '' close;
 }
 
+# Apply fix for very long server names
+server_names_hash_bucket_size 128;
+
 # Default dhparam
 # ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -67,7 +67,7 @@ var BgsyncTag = "v1.6.0" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.6.0" // Note that this can be overridden by make
+var RouterTag = "20190309_longer_server_names" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,7 +43,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190305_longer_nginx_server_names" // Note that this can be overridden by make
+var WebTag = "v1.6.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,7 +43,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.6.0" // Note that this can be overridden by make
+var WebTag = "20190305_longer_nginx_server_names" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Having long server names causes the ddev-router to cease working.
Error message during start:
```nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size: 64```

## How this PR Solves The Problem:

This patch increases server_names_hash_bucket_size to the maximum possible size (128).

## Manual Testing Instructions:

Create a server name longer than 32 characters and you should see, that none of your projects will start again.
