### PR TITLE
Package php5.6 and php7.0 so we can still provide them after sury stops providing, fixes #1448

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get -qq update && \
         php-imagick \
         php-uploadprogress && \
     for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-sqlite3 $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
-    cd /tmp && apt-get -qq install -y libmcrypt4 libzip5; for item in php5.6_final php7.0_final unversionedphp5.6_7.0_final; do curl --fail -sSL -O ${OLD_PHP_TARBALL_BASE_URL}${item}.${OLD_PHP_TARBALL_VERSION}.tgz;  tar -zxf ${item}.${OLD_PHP_TARBALL_VERSION}.tgz; done && dpkg -i *.deb && \
+    cd /tmp && apt-get -qq install -y libmcrypt4 libzip5; for item in php5.6_final php7.0_final ; do curl --fail -sSL -O ${OLD_PHP_TARBALL_BASE_URL}${item}.${OLD_PHP_TARBALL_VERSION}.tgz;  tar -zxf ${item}.${OLD_PHP_TARBALL_VERSION}.tgz; done && dpkg -i *.deb && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -1,6 +1,8 @@
 FROM bitnami/minideb:stretch
 
-ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3"
+ENV PHP_VERSIONS="php7.1 php7.2 php7.3"
+ENV OLD_PHP_TARBALL_VERSION=v1.0
+ENV OLD_PHP_TARBALL_BASE_URL=https://dl.bintray.com/drud/oldphptarballs/
 ENV PHP_DEFAULT_VERSION="7.1"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 
@@ -41,7 +43,7 @@ RUN apt-get -qq update && \
         bzip2 \
         ghostscript \
         gnupg \
-        locales-all && \
+        locales-all  && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list && \
     wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
@@ -81,10 +83,11 @@ RUN apt-get -qq update && \
         php-imagick \
         php-uploadprogress && \
     for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-sqlite3 $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
-    for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
+    cd /tmp && apt-get -qq install -y libmcrypt4 libzip5; for item in php5.6_final php7.0_final unversionedphp5.6_7.0_final; do curl --fail -sSL -O ${OLD_PHP_TARBALL_BASE_URL}${item}.${OLD_PHP_TARBALL_VERSION}.tgz;  tar -zxf ${item}.${OLD_PHP_TARBALL_VERSION}.tgz; done && dpkg -i *.deb && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
     rm -rf /var/lib/apt/lists/*
+
 
 # Arbitrary user needs to be able to bind to privileged ports (for nginx and apache2)
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/nginx

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,7 +43,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.6.0" // Note that this can be overridden by make
+var WebTag = "20190305_old_php" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1448: deb.sury.org will no longer be providing php5.6 and php7.0, but our users will still want those. 

## How this PR Solves The Problem:

* Put the php5.6 and php7.0 .deb packages on bintray as tarballs
* Download them during the docker build and install as files.

## Manual Testing Instructions:

All this really requires is checking to make sure that php5.6 and php7.0 can still be used.

It would be good to check on xdebug on all versions

## Automated Testing Overview:

Existing tests should catch regressions.

## Related Issue Link(s):

OP #1448

## Release/Deployment notes:

This requires having the old package tarballs in a safe location so we can repeat this build in the future. I put it at bintray (https://dl.bintray.com/drud/oldphptarballs) but I'm not totally sold that that's the best place. Suggestions are welcome.
