### PR TITLE
We no longer have to cleanup the temp dir as it's cleaned up in the body, fixes #1457

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -100,11 +100,6 @@ project root will be deleted when creating a project.`,
 		containerInstallPath := path.Join("/var/www/html", tmpDir)
 		hostInstallPath := filepath.Join(app.AppRoot, tmpDir)
 
-		// If WebcacheEnabled, the cleanup is done inline and doesn't have to be done here.
-		if !app.WebcacheEnabled {
-			defer cleanupTmpDir(hostInstallPath)
-		}
-
 		// Build container composer command
 		composerCmd := []string{
 			"composer",
@@ -219,17 +214,4 @@ func init() {
 	ComposerCreateCmd.Flags().StringVar(&stabilityArg, "stability", "", "Pass the --stability <arg> option to composer create-project")
 	ComposerCreateCmd.Flags().BoolVar(&noInteractionArg, "no-interaction", false, "Pass the --no-interaction flag to composer create-project")
 	ComposerCreateCmd.Flags().BoolVar(&preferDistArg, "prefer-dist", false, "Pass the --prefer-dist flag to composer create-project")
-}
-
-func cleanupTmpDir(hostTmpDir string) {
-	output.UserOut.Println("Removing temporary install directory")
-	if err := fileutil.PurgeDirectory(hostTmpDir); err != nil {
-		util.Warning("Failed to purge the temporary install directory %s: %v", hostTmpDir, err)
-		return
-	}
-
-	if err := os.RemoveAll(hostTmpDir); err != nil {
-		util.Warning("Failed to remove temporary install directory %v: %v", hostTmpDir, err)
-		return
-	}
 }

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -40,7 +40,7 @@ func TestComposerCmd(t *testing.T) {
 	assert.NoError(err)
 
 	// Test create-project
-	// ddev composer create cweagans/composer-patches --prefer-dist --no-interaction
+	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0
 	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log", "1.1.0"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, out)


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1457 reported a warning (it turned out to be only a warning) that the temp directory on `ddev composer create` was not being deleted. It turns out that we had actually improved the code that moves everything, so it was no longer necessary to do the cleanup at all.

## How this PR Solves The Problem:

Remove the obsolete code, and the defer that called it.

## Manual Testing Instructions:

```
mkdir junk && cd junk
ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0
```

* You should not see a warning about failing to remove
* `ls -a` should show no leftover .tmp directory


## Automated Testing Overview:

## Related Issue Link(s):

OP #1457

