### PR TITLE
Add .mysql* to list of accepted import-db filetypes, fixes #1483

### DIFF
--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -18,9 +18,10 @@ var ImportDBCmd = &cobra.Command{
 	Use:   "import-db",
 	Short: "Pull the database of an existing project to the dev environment.",
 	Long: `Pull the database of an existing project to the development environment.
-The database can be provided as a SQL dump in a .sql, .sql.gz, .zip, .tgz, or .tar.gz
+The database can be provided as a SQL dump in a .sql, .sql.gz, .mysql, .mysql.gz, .zip, .tgz, or .tar.gz
 format. For the zip and tar formats, the path to a .sql file within the archive
 can be provided if it is not located at the top level of the archive.`,
+	Example: `"ddev import-db" or "ddev import-db --src=.tarballs/junk.sql" or "ddev import-db --src=.tarballs/junk.sql.gz"`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			err := cmd.Usage()

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -199,7 +199,7 @@ Your application can be reached at: http://example-backdrop-site.ddev.local
 
 ### Database Imports
 
-Import a database with just one command; We offer support for several file formats, including: **.sql, sql.gz, tar, tar.gz, and zip**.
+Import a database with just one command; We offer support for several file formats, including: **.sql, sql.gz, mysql, mysql.gz, tar, tar.gz, and zip**.
 
 Here's an example of a database import using ddev:
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1483: The usage of .mysql and .mysql.gz was not documented.

## How this PR Solves The Problem:

* Document both
* Add both to `ddev help import-db`

