### PR TITLE
Increase timeout for db startup, fixes #1477

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -37,8 +37,8 @@ services:
     command: "$DDEV_MARIADB_LOCAL_COMMAND"
     healthcheck:
       interval: 5s
-      retries: 4
-      start_period: 20s
+      retries: 12
+      start_period: 60s
   web:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
     image: $DDEV_WEBIMAGE


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1477 reported that (apparently) on import of a large db it takes longer to start up than our db healthcheck allows. This increases that time. The OP reported it solved their problem.


