### PR TITLE
Regression: mariadb_version should work correctly, but be overridden by DBImage, fixes #1455

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -80,6 +80,7 @@ func NewApp(AppRoot string, provider string) (*DdevApp, error) {
 	app.WebImage = version.GetWebImage()
 	app.DBImage = version.GetDBImage(app.MariaDBVersion)
 	app.DBAImage = version.GetDBAImage()
+	app.BgsyncImage = version.GetBgsyncImage()
 
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -205,6 +205,8 @@ func (app *DdevApp) ReadConfig() error {
 		return fmt.Errorf("invalid configuration in %s: %v", app.ConfigPath, err)
 	}
 
+	app.DBImage = "" // DBImage will be set below
+
 	// ReadConfig config values from file.
 	err = yaml.Unmarshal(source, app)
 	if err != nil {
@@ -215,12 +217,11 @@ func (app *DdevApp) ReadConfig() error {
 	if app.Name == "" {
 		app.Name = filepath.Base(app.AppRoot)
 	}
-	if app.PHPVersion == "" {
-		app.PHPVersion = PHPDefault
-	}
 
-	if app.WebserverType == "" {
-		app.WebserverType = WebserverDefault
+	// If app.DBImage has not has been overridden, use it,
+	// Otherwise just use GetDBImage to get the correct image.
+	if app.DBImage == "" {
+		app.DBImage = version.GetDBImage(app.MariaDBVersion)
 	}
 
 	if WebcacheEnabledDefault == true {
@@ -231,28 +232,6 @@ func (app *DdevApp) ReadConfig() error {
 		app.NFSMountEnabled = NFSMountEnabledDefault
 	}
 
-	if app.RouterHTTPPort == "" {
-		app.RouterHTTPPort = DdevDefaultRouterHTTPPort
-	}
-
-	if app.RouterHTTPSPort == "" {
-		app.RouterHTTPSPort = DdevDefaultRouterHTTPSPort
-	}
-
-	if app.WebImage == "" {
-		app.WebImage = version.GetWebImage()
-	}
-
-	if app.DBImage == "" {
-		app.DBImage = version.GetDBImage(app.MariaDBVersion)
-	}
-
-	if app.DBAImage == "" {
-		app.DBAImage = version.GetDBAImage()
-	}
-	if app.BgsyncImage == "" {
-		app.BgsyncImage = version.GetBgsyncImage()
-	}
 	if app.OmitContainers == nil {
 		app.OmitContainers = globalconfig.DdevGlobalConfig.OmitContainers
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1455:` mariadb_version: 10.1` no longer had any effect in ddev v1.6.0

This was caused by a regression introduced in #1402, which was supposed to solve the *other* problem of not being able to override mariadb_version with a custom DBImage. 

## How this PR Solves The Problem:

This fixes the direct problem by setting DBImage to "" before processing the config.yaml, then only overriding it if it hasn't been changed on import of the config.yaml.

I'd love to see a very generic approach to this, and we may need one as we introduce other specialty images like the 10.1 dbimage. 

## Manual Testing Instructions:

* `ddev start` with `mariadb_version: 10.1` and with `mariadb_version: 10.2`. Both should result in containers that are what you asked for (see `docker ps -a | grep "ddev-.*-db$"` Note that the one that doesn't match your db (normally 10.1) will fail to come up because of the mismatch, but that's OK.
* `ddev start` with each of those and an override in the config.yaml, for example `dbimage: drud/ddev-dbserver:20190227_mariadb_on_debian-10.1` and `dbimage: drud/ddev-dbserver:20190227_mariadb_on_debian-10.2`. The dbimage should win, regardless of mariadb_version.

## Automated Testing Overview:

So far this is too tweaky for a test, but it deserves on now that there have been two regressions around it. 


## Related Issue Link(s):

OP #1455 and previous regression introducer #1402 


