### PR TITLE
Change default PHP version from 7.1 to 7.2

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -68,7 +68,7 @@ func init() {
 			settingsCreator: createDrupal6SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal6Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal6App, postImportDBAction: nil, configOverrideAction: drupal6ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal6PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		AppTypeDrupal7: {
-			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: drupal7ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
+			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		AppTypeDrupal8: {
 			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -56,7 +56,7 @@ func TestPostConfigAction(t *testing.T) {
 
 	appTypes := map[string]string{
 		ddevapp.AppTypeDrupal6:   ddevapp.PHP56,
-		ddevapp.AppTypeDrupal7:   ddevapp.PHP71,
+		ddevapp.AppTypeDrupal7:   ddevapp.PHPDefault,
 		ddevapp.AppTypeDrupal8:   ddevapp.PHPDefault,
 		ddevapp.AppTypeWordPress: ddevapp.PHPDefault,
 		ddevapp.AppTypeBackdrop:  ddevapp.PHPDefault,

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -143,8 +143,8 @@ func TestConfigCommand(t *testing.T) {
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {AppTypeDrupal6, PHP56},
-		"drupal7phpversion": {AppTypeDrupal7, PHP71},
-		"drupal8phpversion": {AppTypeDrupal8, PHP71},
+		"drupal7phpversion": {AppTypeDrupal7, PHP72},
+		"drupal8phpversion": {AppTypeDrupal8, PHP72},
 	}
 
 	for testName, testValues := range testMatrix {
@@ -205,7 +205,7 @@ func TestConfigCommand(t *testing.T) {
 		assert.Equal(name, app.Name)
 		assert.Equal(testValues[apptypePos], app.Type)
 		assert.Equal("docroot", app.Docroot)
-		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion)
+		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion, "PHP value incorrect for app %v", app)
 		err = PrepDdevDirectory(testDir)
 		assert.NoError(err)
 	}
@@ -224,8 +224,8 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {AppTypeDrupal6, PHP56},
-		"drupal7phpversion": {AppTypeDrupal7, PHP71},
-		"drupal8phpversion": {AppTypeDrupal8, PHP71},
+		"drupal7phpversion": {AppTypeDrupal7, PHP72},
+		"drupal8phpversion": {AppTypeDrupal8, PHP72},
 	}
 
 	for testName := range testMatrix {
@@ -270,8 +270,8 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {AppTypeDrupal6, PHP56},
-		"drupal7phpversion": {AppTypeDrupal7, PHP71},
-		"drupal8phpversion": {AppTypeDrupal8, PHP71},
+		"drupal7phpversion": {AppTypeDrupal7, PHP72},
+		"drupal8phpversion": {AppTypeDrupal8, PHP72},
 	}
 
 	for testName, testValues := range testMatrix {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -615,12 +615,6 @@ func isDrupal6App(app *DdevApp) bool {
 	return false
 }
 
-// drupal7ConfigOverrideAction sets a safe php_version for D7
-func drupal7ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = PHP71
-	return nil
-}
-
 // drupal6ConfigOverrideAction overrides php_version for D6, since it is incompatible
 // with php7+
 func drupal6ConfigOverrideAction(app *DdevApp) error {

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -43,7 +43,7 @@ const (
 )
 
 // PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
-const PHPDefault = PHP71
+const PHPDefault = PHP72
 
 // ValidPHPVersions should be updated whenever PHP versions are added or removed, and should
 // be used to ensure user-supplied values are valid.


### PR DESCRIPTION
## The Problem/Issue/Bug:

PHP7.1 is outside its window of support, is in security-only, see http://php.net/supported-versions.php

So we should make our default PHP 7.2.

