### PR TITLE
Remove 3/4 of macOS CircleCI tests, fixes #1487

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,7 +498,7 @@ workflows:
   normal_build_and_test:
     jobs:
     - build
-    - mac_container_test
+#    - mac_container_test
     - lx_container_test
     - staticrequired
     - artifacts:
@@ -510,15 +510,15 @@ workflows:
     - mac_nginx_fpm_test:
         requires:
         - build
-    - mac_apache_fpm_test:
-        requires:
-        - build
-    - mac_webcache_test:
-        requires:
-        - build
-    - mac_nfsmount_test:
-        requires:
-        - build
+#    - mac_apache_fpm_test:
+#        requires:
+#        - build
+#    - mac_webcache_test:
+#        requires:
+#        - build
+#    - mac_nfsmount_test:
+#        requires:
+#        - build
     - lx_apache_fpm_test:
         requires:
         - build


### PR DESCRIPTION
## The Problem/Issue/Bug:

CircleCI was costing way too much for macOS builds.

## How this PR Solves The Problem:

Disable 3 of the 4 macOS builds, just keep the main nginx-fpm one.
