### PR TITLE
Use CircleCI's new Ubuntu 16.04 machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       DRUD_NONINTERACTIVE: "true"
@@ -31,7 +31,7 @@ jobs:
 
   lx_nginx_fpm_test:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
@@ -183,7 +183,7 @@ jobs:
 
   lx_apache_fpm_test:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
@@ -216,7 +216,7 @@ jobs:
 
   lx_apache_cgi_test:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: apache-cgi
@@ -246,7 +246,7 @@ jobs:
 
   lx_nfsmount_test:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_USE_NFSMOUNT: true
@@ -278,7 +278,7 @@ jobs:
 
   staticrequired:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       ARTIFACTS: /artifacts
@@ -301,7 +301,7 @@ jobs:
 
   lx_container_test:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     steps:
     - checkout
@@ -358,7 +358,7 @@ jobs:
 
   artifacts:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       ARTIFACTS: /artifacts
@@ -384,7 +384,7 @@ jobs:
   # 'tag_build' automatically builds a tag .
   tag_build:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       DRUD_DEBUG: "true"
@@ -426,7 +426,7 @@ jobs:
   # 'release_build' is used to push a full release.
   release_build:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
       DRUD_DEBUG: "true"

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -15,27 +15,12 @@ if [ ! -d /home/linuxbrew/.linuxbrew/bin ] ; then
 fi
 export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
 /home/linuxbrew/.linuxbrew/bin/brew update
-for item in osslsigncode golang docker-compose; do
+for item in osslsigncode golang; do
     /home/linuxbrew/.linuxbrew/bin/brew install $item || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item
 done
 
 sudo bash -c "printf '/home 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)\n/tmp 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)' >>/etc/exports"
 sudo service nfs-kernel-server restart
-
-# Remove existing docker and install from their apt package
-sudo apt-get remove docker docker-engine docker.io
-sudo apt-get install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-sudo apt-get update -qq
-sudo apt-get install -qq docker-ce
 
 # gotestsum
 GOTESTSUM_VERSION=0.3.2


### PR DESCRIPTION
## The Problem/Issue/Bug:

CircleCI announced (finally) (and only 16.04?) a supported Ubuntu image, which comes with Docker set up properly on it. This is  a first try with it.

See https://discuss.circleci.com/t/default-machine-executor-image-update/29308

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

