### PR TITLE
Minor improvements to mariadb binlog management

### DIFF
--- a/containers/ddev-dbserver/10.1/files/etc/my.cnf
+++ b/containers/ddev-dbserver/10.1/files/etc/my.cnf
@@ -26,10 +26,12 @@ skip-name-resolve
 datadir=/var/lib/mysql
 secure-file-priv=/var/lib/mysql-files
 # Windows 10 home fix: must not use native_aio, since there is none.
-# log-bin=on fixes a bug with Virtualbox (used by docker toolbox)
+# log-bin fixes a bug with Virtualbox (used by docker toolbox)
 # see https://dba.stackexchange.com/a/185006/149238
 innodb_use_native_aio=0
-log-bin=on
+log-bin
+expire-logs-days = 1
+
 # log_bin_trust_function_creators is required when log_bin is on for creating triggers
 log_bin_trust_function_creators=on
 

--- a/containers/ddev-dbserver/10.2/files/etc/my.cnf
+++ b/containers/ddev-dbserver/10.2/files/etc/my.cnf
@@ -29,7 +29,9 @@ secure-file-priv=/var/lib/mysql-files
 # log-bin=on fixes a bug with Virtualbox (used by docker toolbox)
 # see https://dba.stackexchange.com/a/185006/149238
 innodb_use_native_aio=0
-log-bin=on
+log-bin
+expire-logs-days = 1
+
 # log_bin_trust_function_creators is required when log_bin is on for creating triggers
 log_bin_trust_function_creators=on
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var WebTag = "v1.7.0" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.7.0"
+var BaseDBTag = "20190329_maria_logs_config"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* We were using log-bin=on, which actually doesn't just turn on log-bin but also sets the name of the logs to "on.*". Might as well use the default.
* binlogs were never being purged because `expire-logs-days` was set to the default 0, never purge.

## How this PR Solves The Problem:

Minor config change.

## Manual Testing Instructions:

* `ddev ssh -s db`
* `mysql` and inspect values with `SHOW VARIABLES LIKE 'expire%'` and `show variables like 'log_bin%';`
* Maybe verify that no extra files are around when you start up a day later.

Additional ideas:
* Purge logs on start with `PURGE BINARY LOGS BEFORE NOW();`
* Set `log_bin_basename = /tmp/mariadb-bin` - (credit @freelock) - that would make it so that when a new container was created the binlogs would be left behind.

