### PR TITLE
Fix regression with mariadb-version arg, fixes #1517

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -20,8 +20,7 @@ var configGlobalCommand *cobra.Command = &cobra.Command{
 	Use:     "global [flags]",
 	Short:   "Change global configuration",
 	Example: "ddev config global --instrumentation-opt-in=false\nddev config global --omit-containers=dba,ddev-ssh-agent",
-	//Args:    cobra.NoArgs,
-	Run: handleGlobalConfig,
+	Run:     handleGlobalConfig,
 }
 
 // handleGlobalConfig handles all the flag processing for global config

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -43,4 +43,10 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Contains(globalconfig.DdevGlobalConfig.OmitContainers, "ddev-ssh-agent")
 	assert.Contains(globalconfig.DdevGlobalConfig.OmitContainers, "dba")
 	assert.Len(globalconfig.DdevGlobalConfig.OmitContainers, 2)
+
+	// Even though the global config is going to be deleted, make sure it's sane before leaving
+	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=\"\""}
+	_, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+
 }

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -23,6 +23,11 @@ func TestCmdGlobalConfig(t *testing.T) {
 		err := os.Remove(configFile)
 		require.NoError(t, err)
 	}
+	// We need to make sure that the (corrupted, bogus) global config file is removed
+	// and then read (empty)
+	// nolint: errcheck
+	defer globalconfig.ReadGlobalConfig()
+	// nolint: errcheck
 	defer os.Remove(configFile)
 
 	// Look at initial config
@@ -45,8 +50,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Len(globalconfig.DdevGlobalConfig.OmitContainers, 2)
 
 	// Even though the global config is going to be deleted, make sure it's sane before leaving
-	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=\"\""}
+	args = []string{"config", "global", "--omit-containers", ""}
 	_, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -357,6 +357,12 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		util.Failed("failed to run ConfigFileOverrideAction: %v", err)
 	}
 
+	// We don't want to write out dbimage if it's just the one that goes with
+	// the mariadb_version.
+	if app.DBImage == version.GetDBImage(app.MariaDBVersion) {
+		app.DBImage = ""
+	}
+
 	if phpVersionArg != "" {
 		app.PHPVersion = phpVersionArg
 	}
@@ -378,13 +384,8 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	}
 
 	// If the mariaDBVersionArg is set, use it
-	// and set the appropriate app.DBImage... but only if there is not
-	// also a dbImageArg
 	if mariaDBVersionArg != "" {
 		app.MariaDBVersion = mariaDBVersionArg
-		if dbImageArg == "" {
-			app.DBImage = version.GetDBImage(app.MariaDBVersion)
-		}
 	}
 
 	if cmd.Flag("nfs-mount-enabled").Changed {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/version"
 	"os"
 	"strings"
 
@@ -376,8 +377,14 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		app.HostDBPort = hostDBPortArg
 	}
 
+	// If the mariaDBVersionArg is set, use it
+	// and set the appropriate app.DBImage... but only if there is not
+	// also a dbImageArg
 	if mariaDBVersionArg != "" {
 		app.MariaDBVersion = mariaDBVersionArg
+		if dbImageArg == "" {
+			app.DBImage = version.GetDBImage(app.MariaDBVersion)
+		}
 	}
 
 	if cmd.Flag("nfs-mount-enabled").Changed {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -104,6 +104,9 @@ func TestConfigSetValues(t *testing.T) {
 		t.Errorf("Could not create docroot %s in %s", docroot, tmpdir)
 	}
 
+	err = os.Chdir(tmpdir)
+	assert.NoError(err)
+
 	// Build config args
 	projectName := "my-project-name"
 	projectType := ddevapp.AppTypeTYPO3

--- a/cmd/ddev/cmd/debug-compose-config_test.go
+++ b/cmd/ddev/cmd/debug-compose-config_test.go
@@ -38,6 +38,9 @@ func TestComposeConfigCmd(t *testing.T) {
 	_, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(t, err)
 
+	//nolint: errcheck
+	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", "compose-config"})
+
 	// Ensure ddev debug compose-config works as expected
 	args = []string{"debug", "compose-config"}
 	out, err := exec.RunCommand(DdevBin, args)

--- a/cmd/ddev/cmd/debug-nfsmount_test.go
+++ b/cmd/ddev/cmd/debug-nfsmount_test.go
@@ -30,6 +30,10 @@ func TestDebugNFSMount(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 
+	// Running config creates a line in global config
+	//nolint: errcheck
+	defer exec.RunCommand("remove", []string{"--remove-data"})
+
 	// Test basic `ddev debug nfsmount`
 	args = []string{"debug", "nfsmount"}
 	out, err := exec.RunCommand(DdevBin, args)

--- a/cmd/ddev/cmd/remove_test.go
+++ b/cmd/ddev/cmd/remove_test.go
@@ -73,6 +73,9 @@ func TestCmdRemoveMissingProjectDirectory(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
 	assert.NoError(err)
 
+	//nolint: errcheck
+	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
+
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
 	assert.NoError(err)
 

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -89,6 +89,7 @@ func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	out, err = exec.RunCommand(DdevBin, []string{"start", projectName})
+
 	assert.Error(err, "Expected an error when starting project with no project directory")
 	assert.Contains(out, "ddev can no longer find your project files")
 }

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -82,7 +82,7 @@ func TestCmdStopMissingProjectDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	//nolint: errcheck
-	defer exec.RunCommand(DdevBin, []string{"remove", projectName})
+	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
 
 	err = os.Chdir(projDir)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -79,9 +79,10 @@ func TestCmdStopMissingProjectDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	assert.NoError(err)
+
 	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"remove", projectName})
-	assert.NoError(err)
 
 	err = os.Chdir(projDir)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.10.1
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.10.1
@@ -1,0 +1,4 @@
+name: callme10.1
+type: php
+docroot: ""
+mariadb_version: "10.1"

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.10.2
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.10.2
@@ -1,0 +1,4 @@
+name: callme10.2
+type: php
+docroot: ""
+mariadb_version: "10.2"

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.1
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.1
@@ -1,0 +1,4 @@
+name: imagespec10.1
+type: php
+docroot: ""
+dbimage: drud/ddev-dbserver:v1.6.0-10.1

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.1
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.1
@@ -1,4 +1,4 @@
 name: imagespec10.1
 type: php
 docroot: ""
-dbimage: drud/ddev-dbserver:v1.6.0-10.1
+dbimage: somerandomdbimg:v0.9999-10.1

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.2
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.2
@@ -1,0 +1,4 @@
+name: imagespec10.2
+type: php
+docroot: ""
+dbimage: drud/ddev-dbserver:v1.6.0-10.2

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.2
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.2
@@ -1,4 +1,4 @@
 name: imagespec10.2
 type: php
 docroot: ""
-dbimage: drud/ddev-dbserver:v1.6.0-10.2
+dbimage: somerandomdbimg:v0.9999-10.2

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -67,6 +67,9 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	// Set defaults.
 	app := &DdevApp{}
 
+	if !fileutil.FileExists(AppRoot) {
+		return app, fmt.Errorf("project root %s does not exist", AppRoot)
+	}
 	app.AppRoot = AppRoot
 	app.ConfigPath = app.GetConfigPath("config.yaml")
 	app.APIVersion = version.DdevVersion
@@ -78,6 +81,7 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	app.RouterHTTPPort = DdevDefaultRouterHTTPPort
 	app.RouterHTTPSPort = DdevDefaultRouterHTTPSPort
 	app.MariaDBVersion = version.MariaDBDefaultVersion
+	// Provide a default app name based on directory name
 	app.Name = filepath.Base(app.AppRoot)
 	app.OmitContainers = globalconfig.DdevGlobalConfig.OmitContainers
 	app.SetApptypeSettingsPaths()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -70,16 +70,21 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	app.AppRoot = AppRoot
 	app.ConfigPath = app.GetConfigPath("config.yaml")
 	app.APIVersion = version.DdevVersion
+	app.Type = AppTypePHP
 	app.PHPVersion = PHPDefault
 	app.WebserverType = WebserverDefault
 	app.WebcacheEnabled = WebcacheEnabledDefault
+	app.NFSMountEnabled = NFSMountEnabledDefault
 	app.RouterHTTPPort = DdevDefaultRouterHTTPPort
 	app.RouterHTTPSPort = DdevDefaultRouterHTTPSPort
 	app.MariaDBVersion = version.MariaDBDefaultVersion
+	app.Name = filepath.Base(app.AppRoot)
+	app.OmitContainers = globalconfig.DdevGlobalConfig.OmitContainers
+	app.SetApptypeSettingsPaths()
 
 	// These should always default to the latest image/tag names from the Version package.
 	app.WebImage = version.GetWebImage()
-	app.DBImage = version.GetDBImage(app.MariaDBVersion)
+	app.DBImage = version.GetDBImage(version.MariaDBDefaultVersion)
 	app.DBAImage = version.GetDBAImage()
 	app.BgsyncImage = version.GetBgsyncImage()
 
@@ -90,6 +95,13 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 		if err != nil {
 			return app, fmt.Errorf("%v exists but cannot be read. It may be invalid due to a syntax error.: %v", app.ConfigPath, err)
 		}
+	}
+
+	// If the dbimage has not been overridden (because it takes precedence
+	// and the mariadb_version *has* been changed by config,
+	// use the related dbimage.
+	if app.DBImage == version.GetDBImage(version.MariaDBDefaultVersion) && app.MariaDBVersion != version.MariaDBDefaultVersion {
+		app.DBImage = version.GetDBImage(app.MariaDBVersion)
 	}
 
 	// Turn off webcache_enabled except if macOS/darwin or global `developer_mode: true`
@@ -220,8 +232,8 @@ func (app *DdevApp) CheckAndReserveHostPorts() error {
 	return err
 }
 
-// ReadConfig reads project configuration, falling
-// back to defaults for config values not defined in the read config file.
+// ReadConfig reads project configuration from the config.yaml file
+// It does not attempt to set default values; that's NewApp's job.
 func (app *DdevApp) ReadConfig(includeOverrides bool) ([]string, error) {
 
 	// Load config.yaml
@@ -229,7 +241,6 @@ func (app *DdevApp) ReadConfig(includeOverrides bool) ([]string, error) {
 	if err != nil {
 		return []string{}, fmt.Errorf("unable to load config file %s: %v", app.ConfigPath, err)
 	}
-	app.DBImage = "" // DBImage will be set below
 
 	configOverrides := []string{}
 	// Load config.*.y*ml after in glob order
@@ -247,31 +258,6 @@ func (app *DdevApp) ReadConfig(includeOverrides bool) ([]string, error) {
 			}
 		}
 	}
-
-	// If any of these values aren't defined in the config file, set them to defaults.
-	if app.Name == "" {
-		app.Name = filepath.Base(app.AppRoot)
-	}
-
-	// If app.DBImage has not has been overridden, use it,
-	// Otherwise just use GetDBImage to get the correct image.
-	if app.DBImage == "" {
-		app.DBImage = version.GetDBImage(app.MariaDBVersion)
-	}
-
-	if WebcacheEnabledDefault == true {
-		app.WebcacheEnabled = WebcacheEnabledDefault
-	}
-
-	if NFSMountEnabledDefault == true {
-		app.NFSMountEnabled = NFSMountEnabledDefault
-	}
-
-	if app.OmitContainers == nil {
-		app.OmitContainers = globalconfig.DdevGlobalConfig.OmitContainers
-	}
-
-	app.SetApptypeSettingsPaths()
 
 	return append([]string{app.ConfigPath}, configOverrides...), nil
 }

--- a/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/dbimage-10.1/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/dbimage-10.1/.ddev/config.yaml
@@ -1,0 +1,1 @@
+dbimage: somedbimage:10.1

--- a/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/dbimage-10.2/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/dbimage-10.2/.ddev/config.yaml
@@ -1,0 +1,1 @@
+dbimage: somedbimage:10.2

--- a/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/mariadb-version-10.1/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/mariadb-version-10.1/.ddev/config.yaml
@@ -1,0 +1,1 @@
+mariadb_version: 10.1

--- a/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/mariadb-version-10.2/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/mariadb-version-10.2/.ddev/config.yaml
@@ -1,0 +1,1 @@
+mariadb_version: 10.2

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -71,7 +71,7 @@ func ReadGlobalConfig() error {
 			return nil
 		}
 		if os.IsNotExist(err) {
-			err := WriteGlobalConfig(DdevGlobalConfig)
+			err := WriteGlobalConfig(GlobalConfig{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1517: Sadly, `ddev config --mariadb-version 10.1` creates a config.yaml with the `dbimage...10.2`... and it shouldn't even have a dbimage at all. 

## How this PR Solves The Problem:

In the midst of config spaghetti, this makes sure the default dbimage in config handling gets set right.

## Manual Testing Instructions:

Oh, this has to be tested against every regression in its sad history.

But 
* `ddev config --mariadb-version 10.1` should work with the .ddev/config.yaml showing the right stuff (and not having a dbimage spec)
* `ddev config --mariadb-version 10.2` should do the same
* Manually changing to 10.1 or 10.2 in the config.yaml should work
* Manually setting the dbimage for 10.1 or 10.2 should work


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

I'm not sure if it's worth getting this into v1.7.0 or just telling people not to use `ddev config --mariadb-version` for this release. I'm not entirely sure that anybody uses it.

It's clear that interacting specifications give us enormous pain and we'll have to figure out a coherent approach to them.
