### PR TITLE
Generate homebrew bottles for Linux and macOS for #1516

### DIFF
--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -55,6 +55,19 @@ tar -czf $ARTIFACTS/ddev_chocolatey.$VERSION.tar.gz chocolatey
 
 cp ddev_windows_installer*.exe $ARTIFACTS
 
+# Create macOS and Linux homebrew bottles
+for os in sierra x86_64_linux ; do
+    NO_V_VERSION=${VERSION#v}
+    rm -rf /tmp/bottle
+    BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
+    mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d}
+    cp $BASE_DIR/.gotmp/bin/ddev_bash_completion.sh $BOTTLE_BASE/etc/bash_completion.d/ddev
+    if [ "${os}" = "sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin ; fi
+    if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/ddev $BOTTLE_BASE/bin ; fi
+    cp $BASE_DIR/{README.md,LICENSE} $BOTTLE_BASE
+    tar -czf $ARTIFACTS/ddev-$NO_V_VERSION.$os.bottle.tar.gz -C /tmp/bottle .
+done
+
 # Create the sha256 files
 cd $ARTIFACTS
 for item in *.*; do

--- a/docs/developers/release-checklist.md
+++ b/docs/developers/release-checklist.md
@@ -5,7 +5,7 @@
 - [ ] Create a tag for the new version according to the instructions below, initiating a tag build
 - [ ] Build and push artifacts with the .circleci/trigger_release.sh tool: `.circleci/trigger_release.sh --release-tag=v1.7.1 --circleci-token=circleToken900908b3443ea58316baf928b --github-token=githubPersonalToken853ae6f72c40525cd21036f742904a   --windows-signing-password=windowscodepassword | jq -r 'del(.circle_yml)'  | jq -r 'del(.circle_yml)'`
 - [ ] Add the commit list (`git log vXXX..vYYY --oneline --decorate=no`) to the release page
-- [ ] Update the `ddev` [Homebrew formula](https://github.com/drud/homebrew-ddev) with the source .tar.gz and SHA checksum of the tarball and the bottle builds and tarballs. The bottle builds for macOS (sierra) and x86_64_linux are built automatically by the CircleCI release build process.
+- [ ] Update the `ddev` [Homebrew formula](https://github.com/drud/homebrew-ddev) with the source .tar.gz and SHA checksum of the tarball and the bottle builds and tarballs. The bottles for macOS (sierra) and x86_64_linux are built and pushed to the release page automatically by the CircleCI release build process.
 - [ ] Test `brew upgrade ddev` and make sure ddev is the right version and behaves well
 - [ ] Test the Windows installer and confirm it's signed correctly
 - [ ] Update the release page with specifics about the current release


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1516 - Homebrew bottle creation has been a big pain. With this PR, the bottle is just created via a script, instead of building it using `brew bottle` during artifact creation.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

