### PR TITLE
Improve "ddev version" and add --version flag, fixes #960

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ddev is an open source tool that makes it simple to get local PHP development en
 
 ## Getting Started
 
-1. **Check System Requirements:** We support recent versions of macOS, Windows 10, and Linux distributions that will run docker-ce (ddev requires Docker and docker-compose). ([more info here](https://ddev.readthedocs.io/en/stable/#system-requirements)). 
+1. **Check System Requirements:** We support recent versions of macOS, Windows 10, and Linux distributions that will run Docker (ddev requires Docker and docker-compose). ([more info here](https://ddev.readthedocs.io/en/stable/#system-requirements)). 
 2. **Install ddev:** [Options include](https://ddev.readthedocs.io/en/stable/#installation) macOS homebrew (recommended), an install script, or manual installation.
 3. **Choose a CMS Quick Start Guide:** 
   - [WordPress](https://ddev.readthedocs.io/en/stable/users/cli-usage#wordpress-quickstart)

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -79,7 +79,7 @@ On windows the building is somewhat more difficult due to the build being bash/l
 * [chocolatey](https://chocolatey.org/install) installed
 * make for Windows 3.81 (Recommended package [choco install make](https://chocolatey.org/packages/make) on chocolatey.org)
 * git for windows (Recommended package [choco install git](https://chocolatey.org/packages/git.install))
-* docker for windows.
+* Docker Desktop for Windows.
 
 (You can certainly install the base gnu make package, and the traditional git for windows package should work fine. Chocolatey installs are recommended here because there are many, many ways to get mixes of unix-style components that absolutely don't work. Microsoft's lovely bash-for-windows is a great tool, but it's an actual Ubuntu environment so isn't a good place for testing Windows builds.)
 

--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -34,7 +34,7 @@ var versionCmd = &cobra.Command{
 		sort.Strings(keys)
 
 		for _, label := range keys {
-			if label != "build info" {
+			if label != "build info" && label != "bgsync" {
 				versionOutput.AddRow(label, v[label])
 			}
 		}

--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -24,7 +24,7 @@ func TestCmdVersion(t *testing.T) {
 	raw, ok := versionData["raw"].(map[string]interface{})
 	require.True(t, ok, "raw section wasn't found in versioninfo %v", out)
 
-	assert.Equal(version.DdevVersion, raw["cli"])
+	assert.Equal(version.DdevVersion, raw["DDEV-Local version"])
 	assert.Equal(version.WebImg+":"+version.WebTag, raw["web"])
 	assert.Equal(version.GetDBImage(), raw["db"])
 	assert.Equal(version.GetDBAImage(), raw["dba"])

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/nodeps"
 	"os"
 	"path"
 	"path/filepath"
@@ -190,7 +191,7 @@ project root will be deleted when creating a project.`,
 		if err != nil {
 			util.Failed("Failed to create project: %v", err)
 		}
-		if runtime.GOOS == "windows" && !util.IsDockerToolbox() {
+		if runtime.GOOS == "windows" && !nodeps.IsDockerToolbox() {
 			replaceSimulatedLinks(app.AppRoot)
 		}
 

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/nodeps"
 	"runtime"
 	"strings"
 
@@ -43,7 +44,7 @@ ddev composer outdated --minor-only`,
 		if err != nil {
 			util.Failed("composer command failed: %v", err)
 		}
-		if runtime.GOOS == "windows" && !util.IsDockerToolbox() {
+		if runtime.GOOS == "windows" && !nodeps.IsDockerToolbox() {
 			replaceSimulatedLinks(app.AppRoot)
 		}
 

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -4,8 +4,8 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
-	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
@@ -57,7 +57,7 @@ func TestComposerCmd(t *testing.T) {
 	assert.FileExists(filepath.Join(tmpDir, "vendor/sebastian/version/composer.json"))
 
 	// Test a composer remove
-	if util.IsDockerToolbox() {
+	if nodeps.IsDockerToolbox() {
 		// On docker toolbox, git objects are read-only, causing the composer remove to fail.
 		_, err = exec.RunCommand(DdevBin, []string{"exec", "bash", "-c", "chmod -R u+w /var/www/html/"})
 		assert.NoError(err)

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -25,9 +25,10 @@ var (
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "ddev",
-	Short: "A CLI for interacting with ddev.",
-	Long:  "This Command Line Interface (CLI) gives you the ability to interact with the ddev to create a development environment.",
+	Use:     "ddev",
+	Short:   "DDEV-Local local development environment",
+	Long:    "Create and maintain a local web development environment.",
+	Version: version.DdevVersion,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		ignores := []string{"version", "config", "hostname", "help", "auth-pantheon", "import-files"}
 		command := strings.Join(os.Args[1:], " ")

--- a/containers/ddev-bgsync/README.md
+++ b/containers/ddev-bgsync/README.md
@@ -1,4 +1,4 @@
-# bg-sync
+# bg-sync (deprecated)
 
 Forked from https://github.com/cweagans/docker-bg-sync at
 https://github.com/cweagans/docker-bg-sync/commit/4e39642ab414f2ba0b55eb3933203115e6ed2c0b
@@ -8,7 +8,7 @@ Thanks!
 ====================
 
 This container continuously syncs files between two directories. This is useful
-for avoiding the filesystem slowness on Docker for Mac, for instance. It's also
+for avoiding the filesystem slowness on Docker Desktop for Mac, for instance. It's also
 generally useful for any other time where you have a slow filesystem as a source
 of files that need to be read inside of a container.
 

--- a/docs/developers/buildkite-testmachine-setup.md
+++ b/docs/developers/buildkite-testmachine-setup.md
@@ -20,8 +20,8 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
     - __on the "Log On" tab in the services widget it must be set up to log in as the primary user of the machine, so it inherits environment variables and home directory.__
 8. Set up the machine to [automatically log in on boot](https://www.cnet.com/how-to/automatically-log-in-to-your-windows-10-pc/).  Run netplwiz, provide the password for the main user, uncheck the "require a password to log in".
 9. On Docker Toolbox systems, add a link to "Docker Quickstart Terminal" in C:\ProgramData\Microsoft\Windows\Start Menu\Programs\StartUp (see [link](http://www.thewindowsclub.com/make-programs-run-on-startup-windows)).
-10. On Docker-for-windows systems, launch Docker. It will offer to reconfigure Hyper-V and do a restart.
-11. On Docker-for-windows, configured the C: and other drives as shared to docker.
+10. On Docker Desktop for Windows systems, launch Docker. It will offer to reconfigure Hyper-V and do a restart.
+11. On Docker Desktop for Windows, configured the C: and other drives as shared to docker.
 12. On Docker Toolbox systems, make sure that nested virtualization is enabled however you need to enable it.
 13. Edit /c/ProgramData/git/config "core" section to `autocrlf: false` and `eol: lf` verify that `git config --list` shows only autocrlf: false. 
 14. Run `winpty docker run -it -p 80 busybox ls` to trigger the Windows Defender warning, and "allow access".

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,11 +7,11 @@
 ## System Requirements
 
 - [Docker](https://www.docker.com/community-edition) version 18.06 or higher. Linux users make sure you upgrade docker-compose and do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
-- docker-compose 1.21.0 and higher (bundled with Docker in Docker for Mac and Docker for Windows)
+- docker-compose 1.21.0 and higher (bundled with Docker in Docker Desktop for Mac and Docker Desktop for Windows)
 - OS Support
-  - macOS Sierra and higher (macOS 10.12 and higher; it should run anywhere docker-for-mac runs.
+  - macOS Sierra and higher (macOS 10.12 and higher; it should run anywhere Docker Desktop for Mac runs.
   - Linux: Most Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 14.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
-  - Windows 10 Pro or Enterprise with [Docker-for-windows](https://docs.docker.com/docker-for-windows/install/)
+  - Windows 10 Pro or Enterprise with [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/install/)
   - Windows 10 Home (or other Windows version) with [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/)
 
 

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -31,11 +31,11 @@ To execute a fully-featured `composer create-project` command, you can execute t
 <a name="windows-os-and-ddev-composer"></a>
 #### Windows OS and `ddev composer`
 
-Both composer and Docker for Windows introduce quite complex filesystem workarounds. DDEV attempts to help you with each of them.
+Both composer and Docker Desktop for Windows introduce quite complex filesystem workarounds. DDEV attempts to help you with each of them.
 
 You generally don't have to worry about any of this, but it does keep things cleaner. Mostly just a few of the more complex TYPO3 projects have been affected.
 
-* On Docker for Windows, symlinks are created in the container as "simulated symlinks", or XSym files. These are special text files that behave as symlinks inside the container (on CIFS filesystem), but appear as simple text files on the Windows host. (on the CIFS filesystem used by Docker for Windows inside the container there is no capability to create real symlinks, even though Windows now has this capability.)
+* On Docker Desktop for Windows, symlinks are created in the container as "simulated symlinks", or XSym files. These are special text files that behave as symlinks inside the container (on CIFS filesystem), but appear as simple text files on the Windows host. (on the CIFS filesystem used by Docker for Windows inside the container there is no capability to create real symlinks, even though Windows now has this capability.)
 * DDEV-Local attempts to clean up for this situation. Since Windows 10 (in developer mode) can now create real symlinks, DDEV-Local scans your repository after a `ddev composer` command and attempts to convert XSym files into real symlinks. It can only do this if your Windows 10 host is set to Developer Mode.
 * On Windows 10, to set your computer to developer mode, search for "developer" in settings. Screenshots are below.
 * Docker Toolbox (Windows 10 Home) does not have any capability to create symlinks inside the web container on a mount. But composer detects this and uses copies instead of symlinks.

--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -1,12 +1,12 @@
 <h1>Docker Installation</h1>
 
-## macOS Installation: Docker-ce For Mac
+## macOS Installation: Docker Desktop for Mac
 
-Most MacOS versions and computers will run Docker for Mac. Homebrew users can `brew cask install docker` or you can download from [download.docker.com](https://download.docker.com/mac/stable/Docker.dmg). 
+Most MacOS versions and computers will run Docker Desktop for Mac. Homebrew users can `brew cask install docker` or you can download from [download.docker.com](https://download.docker.com/mac/stable/Docker.dmg). 
 
-## Windows Installation: Docker-ce For Windows
+## Windows Installation: Docker Desktop for Windows
 
-Docker For Windows is the preferred docker environment for Windows 10 Pro and Windows 10 Enterprise. 
+Docker Desktop for Windows is the preferred docker environment for Windows 10 Pro and Windows 10 Enterprise. 
 
 [Download Docker-ce for Windows](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
 
@@ -17,7 +17,7 @@ __Please note that you *must* share your local drives in the "settings" after in
 
 ## Windows Installation: Docker Toolbox
 
-Docker Toolbox is only recommended for systems that absolutely won't run Docker-ce for Windows (Windows 10 Home, etc.)
+Docker Toolbox is only recommended for systems that absolutely won't run Docker Desktop for Windows (Windows 10 Home, etc.)
 
 [Download and install docker toolbox](https://download.docker.com/win/stable/DockerToolbox.exe). 
 
@@ -78,7 +78,7 @@ If that fails (if you get an error, or you don't see the contents of your projec
 * "Error response from daemon: Get https://registry-1.docker.io/v2/" - Docker may not be running (restart it) or you may not have any access to the internet.
 * "403 authentication required" when trying to `ddev start`: Try `docker logout` and do it again. Docker authentication is *not* required for any normal ddev action.
  
-If you are on Docker for Windows or Docker for Mac and you are seeing shared directories not show up in the web container (nothing there when you `ddev ssh`) then:
+If you are on Docker Desktop for Windows or Docker Desktop for Mac and you are seeing shared directories not show up in the web container (nothing there when you `ddev ssh`) then:
 
 * Unshare and then reshare the drive
 * Consider resetting Docker to factory defaults. This often helps in this situation because Docker goes through the whole authentication process again.

--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -1,6 +1,6 @@
 <h1>Performance</h1>
 
-Every developer wants both quick starts of the environment and quick response to web page requests. DDEV-Local is always focused on improving this. However, both Docker for Windows and Docker for Mac have significant performance problems with mounted filesystems (like the mounted project where code can be edited either inside the container or on the host). There are currently two ways to work around this Docker performance issue.
+Every developer wants both quick starts of the environment and quick response to web page requests. DDEV-Local is always focused on improving this. However, both Docker Desktop for Windows and Docker Desktop for Mac have significant performance problems with mounted filesystems (like the mounted project where code can be edited either inside the container or on the host). There are currently two ways to work around this Docker performance issue.
 
 ## Using NFS to Mount the Project into the Container
 

--- a/pkg/ddevapp/raven.go
+++ b/pkg/ddevapp/raven.go
@@ -2,8 +2,8 @@ package ddevapp
 
 import (
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/ravenutils"
-	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/getsentry/raven-go"
 	"os"
@@ -17,7 +17,7 @@ func SetRavenBaseTags() {
 	if globalconfig.DdevGlobalConfig.InstrumentationOptIn {
 		dockerVersion, _ := version.GetDockerVersion()
 		composeVersion, _ := version.GetDockerComposeVersion()
-		isToolbox := util.IsDockerToolbox()
+		isToolbox := nodeps.IsDockerToolbox()
 
 		raven.SetRelease("ddev@" + version.COMMIT)
 

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -22,7 +23,7 @@ import (
 // TestSSHAuth tests basic ssh authentication
 func TestSSHAuth(t *testing.T) {
 	assert := asrt.New(t)
-	if util.IsDockerToolbox() {
+	if nodeps.IsDockerToolbox() {
 		t.Skip("Skpping TestSSHAuth because running on Docker toolbox")
 	}
 	testDir, _ := os.Getwd()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	exec2 "github.com/drud/ddev/pkg/exec"
-	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/version"
 	"io"
 	"log"
@@ -694,7 +694,7 @@ func GetHostDockerInternalIP() (string, error) {
 				hostDockerInternal = components[1]
 			}
 		}
-	} else if util.IsDockerToolbox() {
+	} else if nodeps.IsDockerToolbox() {
 		dockerIP, err := GetDockerIP()
 		if err != nil {
 			return "", err

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -1,6 +1,7 @@
 package dockerutil_test
 
 import (
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
@@ -152,7 +153,7 @@ func TestContainerWait(t *testing.T) {
 	healthDetail, err := ContainerWait(15, labels)
 	assert.NoError(err)
 
-	if !util.IsDockerToolbox() {
+	if !nodeps.IsDockerToolbox() {
 		assert.Contains(healthDetail, "phpstatus: OK")
 	}
 

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -1,5 +1,7 @@
 package nodeps
 
+import "os"
+
 // ArrayContainsString returns true if slice contains element
 func ArrayContainsString(slice []string, element string) bool {
 	return !(posString(slice, element) == -1)
@@ -14,4 +16,16 @@ func posString(slice []string, element string) int {
 		}
 	}
 	return -1
+}
+
+// IsDockerToolbox detects if the running docker is docker toolbox
+// It shouldn't be run much as it requires actually running the executable.
+// This lives here instead of in dockerutils to avoid unecessary import cycles.
+// Inspired by https://stackoverflow.com/questions/43242218/how-can-a-script-distinguish-docker-toolbox-and-docker-for-windows
+func IsDockerToolbox() bool {
+	dockerToolboxPath := os.Getenv("DOCKER_TOOLBOX_INSTALL_PATH")
+	if dockerToolboxPath != "" {
+		return true
+	}
+	return false
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -3,7 +3,6 @@ package util
 import (
 	"github.com/drud/ddev/pkg/nodeps"
 	"math/rand"
-	"os"
 	osexec "os/exec"
 	"os/user"
 	"strconv"
@@ -130,18 +129,6 @@ func GetContainerUIDGid() (uid int, gid int, uidStr string, gidStr string) {
 	}
 	return uidInt, gidInt, uidStr, gidStr
 
-}
-
-// IsDockerToolbox detects if the running docker is docker toolbox
-// It shouldn't be run much as it requires actually running the executable.
-// This lives here instead of in dockerutils to avoid unecessary import cycles.
-// Inspired by https://stackoverflow.com/questions/43242218/how-can-a-script-distinguish-docker-toolbox-and-docker-for-windows
-func IsDockerToolbox() bool {
-	dockerToolboxPath := os.Getenv("DOCKER_TOOLBOX_INSTALL_PATH")
-	if dockerToolboxPath != "" {
-		return true
-	}
-	return false
 }
 
 // IsCommandAvailable uses shell's "command" to find out if a command is available

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,8 +2,10 @@ package version
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/fsouza/go-dockerclient"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -176,5 +178,13 @@ func GetDockerVersion() (string, error) {
 		return "", err
 	}
 	DockerVersion = v.Get("Version")
+
+	if runtime.GOOS == "windows" {
+		if !nodeps.IsDockerToolbox() {
+			DockerVersion = DockerVersion + " (Docker for Windows)"
+		} else {
+			DockerVersion = DockerVersion + " (Docker Toolbox)"
+		}
+	}
 	return DockerVersion, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -116,7 +116,7 @@ func GetVersionInfo() map[string]string {
 		if nodeps.IsDockerToolbox() {
 			versionInfo["docker type"] = "Docker Toolbox"
 		} else {
-			versionInfo["docker type"] = "Docker For Windows"
+			versionInfo["docker type"] = "Docker Desktop For Windows"
 		}
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -112,6 +112,13 @@ func GetVersionInfo() map[string]string {
 	if versionInfo["docker-compose"], err = GetDockerComposeVersion(); err != nil {
 		versionInfo["docker-compose"] = fmt.Sprintf("failed to GetDockerComposeVersion(): %v", err)
 	}
+	if runtime.GOOS == "windows" {
+		if nodeps.IsDockerToolbox() {
+			versionInfo["docker type"] = "Docker Toolbox"
+		} else {
+			versionInfo["docker type"] = "Docker For Windows"
+		}
+	}
 
 	return versionInfo
 }
@@ -180,12 +187,5 @@ func GetDockerVersion() (string, error) {
 	}
 	DockerVersion = v.Get("Version")
 
-	if runtime.GOOS == "windows" {
-		if !nodeps.IsDockerToolbox() {
-			DockerVersion = DockerVersion + " (Docker for Windows)"
-		} else {
-			DockerVersion = DockerVersion + " (Docker Toolbox)"
-		}
-	}
 	return DockerVersion, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -95,7 +95,7 @@ func GetVersionInfo() map[string]string {
 	var err error
 	versionInfo := make(map[string]string)
 
-	versionInfo["cli"] = DdevVersion
+	versionInfo["DDEV-Local version"] = DdevVersion
 	versionInfo["web"] = GetWebImage()
 	versionInfo["db"] = GetDBImage()
 	versionInfo["dba"] = GetDBAImage()
@@ -105,6 +105,7 @@ func GetVersionInfo() map[string]string {
 	versionInfo["commit"] = COMMIT
 	versionInfo["domain"] = DDevTLD
 	versionInfo["build info"] = BUILDINFO
+	versionInfo["os"] = runtime.GOOS
 	if versionInfo["docker"], err = GetDockerVersion(); err != nil {
 		versionInfo["docker"] = fmt.Sprintf("failed to GetDockerVersion(): %v", err)
 	}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"runtime"
 	"testing"
 
 	asrt "github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ func TestGetVersionInfo(t *testing.T) {
 	assert := asrt.New(t)
 	v := GetVersionInfo()
 
-	assert.Equal(DdevVersion, v["cli"])
+	assert.Equal(DdevVersion, v["DDEV-Local version"])
 	assert.Contains(v["web"], WebImg)
 	assert.Contains(v["web"], WebTag)
 	assert.Contains(v["db"], DBImg)
@@ -18,6 +19,7 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Contains(v["dba"], DBAImg)
 	assert.Contains(v["dba"], DBATag)
 	assert.Equal(COMMIT, v["commit"])
+	assert.Equal(runtime.GOOS, v["os"])
 	assert.Equal(DDevTLD, v["domain"])
 	assert.Equal(BUILDINFO, v["build info"])
 	assert.NotEmpty(v["docker-compose"])


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #960 : `ddev version` still needs to show the OS information

## How this PR Solves The Problem:

* Add OS info
* Add docker-toolbox/docker-for-windows info
* Add --version flag

## Manual Testing Instructions:

Use
`ddev --version`
`ddev version`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #960 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

