### PR TITLE
More robust handling of ddev stop -RO, remove from global list, fixes #1523

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -39,7 +39,7 @@ func TestDescribeBadArgs(t *testing.T) {
 	args = []string{"describe", util.RandString(16)}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.Error(err)
-	assert.Contains(string(out), "could not find project")
+	assert.Contains(string(out), "could not find requested project")
 
 	// Ensure we get a failure if using too many arguments.
 	args = []string{"describe", util.RandString(16), util.RandString(16)}

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -164,7 +164,7 @@ func removeInactiveHostnames(hosts goodhosts.Hosts) {
 
 	// Get the list active hosts names to preserve
 	activeHostNames := make(map[string]bool)
-	for _, app := range ddevapp.GetApps() {
+	for _, app := range ddevapp.GetDockerProjects() {
 		for _, h := range app.GetHostnames() {
 			activeHostNames[h] = true
 		}

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -18,7 +18,7 @@ var DdevListCmd = &cobra.Command{
 	Long:  `List projects.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for {
-			apps := ddevapp.GetApps()
+			apps := ddevapp.GetDockerProjects()
 			appDescs := make([]map[string]interface{}, 0)
 
 			if len(apps) < 1 {

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -31,7 +31,7 @@ func TestCmdPauseContainers(t *testing.T) {
 		assert.NoError(err, "ddev pause should succeed but failed, err: %v, output: %s", err, out)
 		assert.Contains(out, "has been paused")
 
-		apps := ddevapp.GetApps()
+		apps := ddevapp.GetDockerProjects()
 		for _, app := range apps {
 			if app.GetName() != site.Name {
 				continue

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -32,6 +32,7 @@ func TestCmdPauseContainers(t *testing.T) {
 		assert.Contains(out, "has been paused")
 
 		apps := ddevapp.GetDockerProjects()
+
 		for _, app := range apps {
 			if app.GetName() != site.Name {
 				continue
@@ -50,7 +51,7 @@ func TestCmdPauseContainers(t *testing.T) {
 	assert.NoError(err, "ddev pause --all should succeed but failed, err: %v, output: %s", err, out)
 
 	// Confirm all sites are stopped.
-	apps := ddevapp.GetApps()
+	apps := ddevapp.GetDockerProjects()
 	for _, app := range apps {
 		assert.True(app.SiteStatus() == ddevapp.SitePaused, "All sites should be stopped, but %s status: %s", app.GetName(), app.SiteStatus())
 	}
@@ -60,9 +61,9 @@ func TestCmdPauseContainers(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestCmdStopContainersMissingProjectDirectory ensures the `ddev stop` command returns the expected help text when
+// TestCmdPauseContainersMissingProjectDirectory ensures the `ddev pause` command returns the expected help text when
 // a project's directory no longer exists.
-func TestCmdStopContainersMissingProjectDirectory(t *testing.T) {
+func TestCmdPauseContainersMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
 	assert := asrt.New(t)
@@ -82,7 +83,7 @@ func TestCmdStopContainersMissingProjectDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	//nolint: errcheck
-	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
+	defer exec.RunCommand(DdevBin, []string{"stop", "-RO", projectName})
 
 	err = os.Chdir(projDir)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -56,10 +56,10 @@ func TestMain(m *testing.M) {
 	// We don't want the tests reporting to Sentry.
 	_ = os.Setenv("DDEV_NO_SENTRY", "true")
 
-	// Attempt to remove all running containers before starting a test.
+	// Attempt to stop/remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
-	if _, err = exec.RunCommand(DdevBin, []string{"remove", "--all"}); err != nil {
-		log.Warnf("Failed to remove all running projects: %v", err)
+	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent"}); err != nil {
+		log.Warnf("Failed to stop/remove all running projects: %v", err)
 	}
 
 	for i := range DevTestSites {

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -32,7 +32,7 @@ func TestCmdStart(t *testing.T) {
 	assert.NoError(err, "ddev start --all should succeed but failed, err: %v, output: %s", err, out)
 
 	// Confirm all sites are running.
-	apps := ddevapp.GetApps()
+	apps := ddevapp.GetDockerProjects()
 	for _, app := range apps {
 		assert.True(app.SiteStatus() == ddevapp.SiteRunning, "All sites should be running, but %s status: %s", app.GetName(), app.SiteStatus())
 	}

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -38,7 +38,7 @@ func TestCmdStart(t *testing.T) {
 	}
 
 	// Stop-containers all sites.
-	_, err = exec.RunCommand(DdevBin, []string{"stop-containers", "--all"})
+	_, err = exec.RunCommand(DdevBin, []string{"stop-containers", "--all", "-RO"})
 	assert.NoError(err)
 
 	// Build start command startMultipleArgs

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -24,7 +24,7 @@ func TestCmdStart(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stop-Containers all sites.
-	_, err = exec.RunCommand(DdevBin, []string{"stop-containers", "--all"})
+	_, err = exec.RunCommand(DdevBin, []string{"pause", "--all"})
 	assert.NoError(err)
 
 	// Ensure all sites are started after ddev start --all.
@@ -37,8 +37,7 @@ func TestCmdStart(t *testing.T) {
 		assert.True(app.SiteStatus() == ddevapp.SiteRunning, "All sites should be running, but %s status: %s", app.GetName(), app.SiteStatus())
 	}
 
-	// Stop-containers all sites.
-	_, err = exec.RunCommand(DdevBin, []string{"stop-containers", "--all", "-RO"})
+	_, err = exec.RunCommand(DdevBin, []string{"pause", "--all"})
 	assert.NoError(err)
 
 	// Build start command startMultipleArgs

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1190,8 +1190,13 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		return err
 	}
 
-	// Remove data/database/hostname if we need to.
+	// Remove data/database/projectInfo/hostname if we need to.
 	if removeData {
+		err := globalconfig.RemoveProjectInfo(app.Name)
+		if err != nil {
+			util.Warning("failed to RemoveProjectInfo(%s): %v", app.Name, err)
+		}
+
 		if err = app.RemoveHostsEntries(); err != nil {
 			return fmt.Errorf("failed to remove hosts entries: %v", err)
 		}
@@ -1214,9 +1219,9 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	return err
 }
 
-// RemoveReservedHostPorts() deletes the app from the UsedHostPorts
+// RemoveGlobalProjectInfo() deletes the project from ProjectList
 func (app *DdevApp) RemoveGlobalProjectInfo() {
-	delete(globalconfig.DdevGlobalConfig.ProjectList, app.Name)
+	_ = globalconfig.RemoveProjectInfo(app.Name)
 }
 
 // GetHTTPURL returns the HTTP URL for an app.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -151,7 +151,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	count := len(ddevapp.GetApps())
+	count := len(ddevapp.GetDockerProjects())
 	if count > 0 {
 		log.Fatalf("ddevapp tests require no projects running. You have %v project(s) running.", count)
 	}
@@ -554,7 +554,7 @@ func TestStartWithoutDdevConfig(t *testing.T) {
 	}
 }
 
-// TestGetApps tests the GetApps function to ensure it accurately returns a list of running applications.
+// TestGetApps tests the GetDockerProjects function to ensure it accurately returns a list of running applications.
 func TestGetApps(t *testing.T) {
 	assert := asrt.New(t)
 
@@ -570,7 +570,7 @@ func TestGetApps(t *testing.T) {
 		assert.NoError(err)
 	}
 
-	apps := ddevapp.GetApps()
+	apps := ddevapp.GetDockerProjects()
 	assert.Equal(len(TestSites), len(apps))
 
 	for _, testSite := range TestSites {
@@ -1771,7 +1771,7 @@ func TestCleanupWithoutCompose(t *testing.T) {
 
 }
 
-// TestGetappsEmpty ensures that GetApps returns an empty list when no applications are running.
+// TestGetappsEmpty ensures that GetDockerProjects returns an empty list when no applications are running.
 func TestGetAppsEmpty(t *testing.T) {
 	assert := asrt.New(t)
 
@@ -1792,7 +1792,7 @@ func TestGetAppsEmpty(t *testing.T) {
 		switchDir()
 	}
 
-	apps := ddevapp.GetApps()
+	apps := ddevapp.GetDockerProjects()
 	assert.Equal(0, len(apps), "Expected to find no apps but found %d apps=%v", len(apps), apps)
 }
 
@@ -1817,7 +1817,7 @@ func TestListWithoutDir(t *testing.T) {
 	packageDir, _ := os.Getwd()
 
 	// startCount is the count of apps at the start of this adventure
-	apps := ddevapp.GetApps()
+	apps := ddevapp.GetDockerProjects()
 	startCount := len(apps)
 
 	testDir := testcommon.CreateTmpDir("TestStartWithoutDdevConfig")
@@ -1850,7 +1850,7 @@ func TestListWithoutDir(t *testing.T) {
 
 	testcommon.CleanupDir(testDir)
 
-	apps = ddevapp.GetApps()
+	apps = ddevapp.GetDockerProjects()
 
 	assert.EqualValues(len(apps), startCount+1)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -140,11 +140,11 @@ func TestMain(m *testing.M) {
 	// Attempt to remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
 	// If a system doesn't have `ddev` in its $PATH, this will emit a warning but will not fail the test.
-	if _, err := exec.RunCommand("ddev", []string{"remove", "--all", "--stop-ssh-agent"}); err != nil {
+	if _, err := exec.RunCommand("ddev", []string{"stop", "--all", "--stop-ssh-agent"}); err != nil {
 		log.Warnf("Failed to remove all running projects: %v", err)
 	}
 
-	for _, volume := range []string{"ddev-composer-cache", "ddev-router-cert-cache", "ddev-ssh-agent_dot_ssh", "ddev-ssh-agent_socket_dir"} {
+	for _, volume := range []string{"ddev-router-cert-cache", "ddev-ssh-agent_dot_ssh", "ddev-ssh-agent_socket_dir"} {
 		err := dockerutil.RemoveVolume(volume)
 		if err != nil && err.Error() != "no such volume" {
 			log.Errorf("TestMain startup: Failed to delete volume %s: %v", volume, err)

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -23,8 +23,8 @@ import (
 	gohomedir "github.com/mitchellh/go-homedir"
 )
 
-// GetApps returns an array of ddev applications.
-func GetApps() []*DdevApp {
+// GetDockerProjects returns an array of ddev applications.
+func GetDockerProjects() []*DdevApp {
 	apps := make([]*DdevApp, 0)
 	labels := map[string]string{
 		"com.ddev.platform":          "ddev",

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -237,3 +237,16 @@ func ReservePorts(projectName string, ports []string) error {
 	err := WriteGlobalConfig(DdevGlobalConfig)
 	return err
 }
+
+// RemoveProjectInfo() removes the ProjectInfo line for a project
+func RemoveProjectInfo(projectName string) error {
+	_, ok := DdevGlobalConfig.ProjectList[projectName]
+	if ok {
+		delete(DdevGlobalConfig.ProjectList, projectName)
+		err := WriteGlobalConfig(DdevGlobalConfig)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1523: `ddev stop -RO <projectname>` doesn't remove project from global config.

## How this PR Solves The Problem:

Accept a project name for deletion even if no containers are associated with it.

## Manual Testing Instructions:

* `ddev config` to create a project in global list. `ddev rm -RO <name>` to get rid of it.
* `ddev config` and `ddev start` and `ddev rm` to create project and start it and stop it. Then `ddev rm -RO <project>` to verify complete cleanup (look in ~/.ddev/global_config.yaml)

## Automated Testing Overview:

I think it's probably best to cover this with some extensive testing in #642

## Related Issue Link(s):
OP #1523 
But #642 (manage global list more completely) will again touch this. 

