### PR TITLE
Change PHP typo when it should be MySQL

### DIFF
--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -78,7 +78,7 @@ max_execution_time = 240;
 
 ## Providing custom mysql/MariaDB configuration (my.cnf)
 
-You can provide additional PHP configuration for a project by creating a directory called `.ddev/mysql/` and adding any number of MySQL configuration files (these must have the suffix ".cnf"). These files will be automatically included when MySQL is started. Make sure that the section header is included in the file 
+You can provide additional MySQL configuration for a project by creating a directory called `.ddev/mysql/` and adding any number of MySQL configuration files (these must have the suffix ".cnf"). These files will be automatically included when MySQL is started. Make sure that the section header is included in the file 
 
 An example file in .ddev/mysql/no_utf8mb4.cnf might be:
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
The phrase says PHP when is a MySQL phrase

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

