### PR TITLE
Use docker volume in sample apachesolr config

### DIFF
--- a/pkg/servicetest/testdata/services/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.solr.yaml
@@ -25,7 +25,7 @@ services:
       - HTTP_EXPOSE=8983 # This defines the port the service should be accessible from at sitename.ddev.local
     volumes:
       - "./solr:/solr-conf" # This exposes a mount to the host system `.ddev/solr-conf` directory.
-      - data:/opt/solr/server/solr/mycores # This uses the 'data' volume defined below
+      - solrdata:/opt/solr/server/solr/mycores # This uses the 'data' volume defined below
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate
@@ -36,4 +36,4 @@ services:
     links:
       - solr:$DDEV_HOSTNAME
 volumes:
-  data: # This creates a Docker volume that sticks around even if you remove or rebuild the container
+  solrdata: # This creates a Docker volume that sticks around even if you remove or rebuild the container

--- a/pkg/servicetest/testdata/services/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.solr.yaml
@@ -25,6 +25,7 @@ services:
       - HTTP_EXPOSE=8983 # This defines the port the service should be accessible from at sitename.ddev.local
     volumes:
       - "./solr:/solr-conf" # This exposes a mount to the host system `.ddev/solr-conf` directory.
+      - data:/opt/solr/server/solr/mycores # This uses the 'data' volume defined below
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate
@@ -34,3 +35,5 @@ services:
   web:
     links:
       - solr:$DDEV_HOSTNAME
+  volumes:
+    data: # This creates a Docker volume that sticks around even if you remove or rebuild the container

--- a/pkg/servicetest/testdata/services/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.solr.yaml
@@ -35,5 +35,5 @@ services:
   web:
     links:
       - solr:$DDEV_HOSTNAME
-  volumes:
-    data: # This creates a Docker volume that sticks around even if you remove or rebuild the container
+volumes:
+  data: # This creates a Docker volume that sticks around even if you remove or rebuild the container


### PR DESCRIPTION
## The Problem/Issue/Bug:
The suggested DDEV Solr configuration at https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#apache-solr does not include a persistent Docker volume.

## How this PR Solves The Problem:
It adds one.

## Manual Testing Instructions:
1. Copy the Compose file, then run `ddev start`. DDEV will tell you that it created a volume.
1. Run `docker volume ls` and ensure that the volume is there. It will be named `ddev-PROJECTNAME-data`.

## Automated Testing Overview:
This is something the user would add. It won't break DDEV even if it's broken.

## Related Issue Link(s):
- https://github.com/drud/ddev/pull/1526

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

