### PR TITLE
 Add blackfire.io to web container, fixes #653

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get -qq update && \
         locales-all && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list && \
+    wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add - && \
+    echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list && \
     wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
     apt-key add /tmp/nginx_signing.key && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
@@ -83,6 +85,7 @@ RUN apt-get -qq update && \
         php-uploadprogress && \
     for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-pgsql $v-mbstring $v-memcached $v-opcache $v-redis $v-soap $v-sqlite3 $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
+    apt-get install blackfire-php -y --allow-unauthenticated && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2207,10 +2207,10 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		err = app.WriteConfig()
 		assert.NoError(err)
 
-		if app.SiteStatus() == ddevapp.SitePaused || app.SiteStatus() == ddevapp.SiteRunning {
-			err = app.Stop(true, false)
-			assert.NoError(err)
-		}
+		// Make sure that project is absolutely not running
+		err = app.Stop(true, false)
+		assert.NoError(err)
+
 		err = app.StartAndWaitForSync(0)
 		assert.NoError(err)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190417_trust_ssl_certs" // Note that this can be overridden by make
+var WebTag = "20190422_blackfire_io" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#653 requests blackfire.io. This adds it to the web container.

We'll have to evaluate if the size difference is acceptable, https://hub.docker.com/r/drud/ddev-webserver/tags/
