### PR TITLE
Add separate lines for each external_links, fixes #1235

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -3,6 +3,7 @@ package ddevapp
 import (
 	"bytes"
 	"fmt"
+	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/nodeps"
 	"html/template"
@@ -513,13 +514,17 @@ type composeYAMLVars struct {
 	NFSSource            string
 	DockerIP             string
 	IsWindowsFS          bool
+	Hostnames            []string
 }
 
 // RenderComposeYAML renders the contents of docker-compose.yaml.
 func (app *DdevApp) RenderComposeYAML() (string, error) {
 	var doc bytes.Buffer
 	var err error
-	templ := template.New("compose template")
+	templ, err := template.New("compose template").Funcs(sprig.HtmlFuncMap()).Parse(DDevComposeTemplate)
+	if err != nil {
+		return "", err
+	}
 	templ, err = templ.Parse(DDevComposeTemplate)
 	if err != nil {
 		return "", err
@@ -551,6 +556,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		IsWindowsFS:          runtime.GOOS == "windows",
 		MountType:            "bind",
 		WebMount:             "../",
+		Hostnames:            app.GetHostnames(),
 	}
 	if app.WebcacheEnabled {
 		templateVars.MountType = "volume"

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2137,7 +2137,8 @@ func TestAllURLsInsideContainer(t *testing.T) {
 	expectedNumUrls := (2 * len(app.GetHostnames())) + 1
 	assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d", len(urlMap))
 
-	URLList := append(app.GetAllURLs(), "http://localhost/"+site.Safe200URIWithExpectation.URI, "https://localhost/"+site.Safe200URIWithExpectation.URI)
+	// TODO: Add https://localhost to this list when trusted SSL goes in.
+	URLList := append(app.GetAllURLs(), "http://localhost")
 	for _, item := range URLList {
 		parts, err := url.Parse(item)
 		assert.NoError(err)
@@ -2145,10 +2146,12 @@ func TestAllURLsInsideContainer(t *testing.T) {
 		hostParts := strings.Split(parts.Host, ".")
 		if _, err := strconv.ParseInt(hostParts[0], 10, 64); err != nil {
 			_, _, err = app.Exec(&ddevapp.ExecOpts{
-				Service:   "web",
-				Cmd:       []string{"bash", "-c", "curl -sS --fail " + item + "/" + site.Safe200URIWithExpectation.URI + ">/dev/null"},
+				Service: "web",
+				// TODO: Remove the 'k' from curl when trusted SSL goes in.
+				Cmd:       []string{"bash", "-c", "curl -sSk --fail " + item + site.Safe200URIWithExpectation.URI + ">/dev/null"},
 				NoCapture: true,
 			})
+			assert.NoError(err, "failed curl to %s: %v", item+site.Safe200URIWithExpectation.URI, err)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2101,73 +2101,6 @@ func TestGetAllURLs(t *testing.T) {
 	runTime()
 }
 
-// TestAllURLsInsideContainer makes sure that we can use URLs
-// with proper name resolution inside the container.
-func TestAllURLsInsideContainer(t *testing.T) {
-	assert := asrt.New(t)
-
-	site := TestSites[0]
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s AllURLsInsideContainer", site.Name))
-
-	testcommon.ClearDockerEnv()
-	app := new(ddevapp.DdevApp)
-
-	err := app.Init(site.Dir)
-	assert.NoError(err)
-
-	// Add some additional hostnames
-	app.AdditionalHostnames = []string{"sub1", "sub2", "sub3"}
-	app.AdditionalFQDNs = []string{"junker99.example.com"}
-
-	err = app.WriteConfig()
-	assert.NoError(err)
-
-	err = app.StartAndWaitForSync(0)
-	require.NoError(t, err)
-
-	urls := app.GetAllURLs()
-
-	// Convert URLs to map[string]bool
-	urlMap := make(map[string]bool)
-	for _, u := range urls {
-		urlMap[u] = true
-	}
-
-	// We expect two URLs for each hostname (http/https) and one direct web container address.
-	expectedNumUrls := (2 * len(app.GetHostnames())) + 1
-	assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d", len(urlMap))
-
-	// TODO: Add https://localhost to this list when trusted SSL goes in.
-	URLList := append(app.GetAllURLs(), "http://localhost")
-	for _, item := range URLList {
-		parts, err := url.Parse(item)
-		assert.NoError(err)
-		// Only try it if not an IP address URL; those won't be right
-		hostParts := strings.Split(parts.Host, ".")
-		if _, err := strconv.ParseInt(hostParts[0], 10, 64); err != nil {
-			_, _, err = app.Exec(&ddevapp.ExecOpts{
-				Service: "web",
-				// TODO: Remove the 'k' from curl when trusted SSL goes in.
-				Cmd:       []string{"bash", "-c", "curl -sSk --fail " + item + site.Safe200URIWithExpectation.URI + ">/dev/null"},
-				NoCapture: true,
-			})
-			assert.NoError(err, "failed curl to %s: %v", item+site.Safe200URIWithExpectation.URI, err)
-		}
-	}
-
-	// Multiple projects can't run at the same time with the fqdns, so we need to clean
-	// up these for tests that run later.
-	app.AdditionalFQDNs = []string{}
-	app.AdditionalHostnames = []string{}
-	err = app.WriteConfig()
-	assert.NoError(err)
-
-	err = app.Stop(true, false)
-	assert.NoError(err)
-
-	runTime()
-}
-
 // TestWebserverType checks that webserver_type:apache-cgi or apache-fpm does the right thing
 func TestWebserverType(t *testing.T) {
 	assert := asrt.New(t)
@@ -2227,63 +2160,88 @@ func TestWebserverType(t *testing.T) {
 	}
 }
 
-// TestInternalAndExternalAccessToURL checks we can access content from host and from inside container by URL (with port)
+// TestInternalAndExternalAccessToURL checks we can access content
+// from host and from inside container by URL (with port)
 func TestInternalAndExternalAccessToURL(t *testing.T) {
 	assert := asrt.New(t)
 
-	for _, site := range TestSites {
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s TestInternalAndExternalAccessToURL", site.Name))
+	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("TestInternalAndExternalAccessToURL"))
 
-		app := new(ddevapp.DdevApp)
+	site := TestSites[0]
+	app := new(ddevapp.DdevApp)
 
-		err := app.Init(site.Dir)
-		assert.NoError(err)
+	err := app.Init(site.Dir)
+	assert.NoError(err)
 
-		for _, pair := range []testcommon.PortPair{{"80", "443"}, {"8080", "8443"}} {
-			testcommon.ClearDockerEnv()
-			app.RouterHTTPPort = pair.HTTPPort
-			app.RouterHTTPSPort = pair.HTTPSPort
-			err = app.WriteConfig()
-			assert.NoError(err)
+	// Add some additional hostnames
+	app.AdditionalHostnames = []string{"sub1", "sub2", "sub3"}
+	app.AdditionalFQDNs = []string{"junker99.example.com"}
 
-			if app.SiteStatus() == ddevapp.SitePaused || app.SiteStatus() == ddevapp.SiteRunning {
-				err = app.Stop(true, false)
-				assert.NoError(err)
-			}
-			err = app.Start()
-			assert.NoError(err)
-
-			// Ensure that we can access from the host even with extra port specifications.
-			_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
-			_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
-
-			// Ensure that we can access the same URL from within the web container (via router)
-			var out string
-			out, _, err = app.Exec(&ddevapp.ExecOpts{
-				Service: "web",
-				Cmd:     []string{"curl", "-sk", app.GetHTTPURL() + site.Safe200URIWithExpectation.URI},
-			})
-			assert.NoError(err)
-			assert.Contains(out, site.Safe200URIWithExpectation.Expect)
-
-			out, _, err = app.Exec(&ddevapp.ExecOpts{
-				Service: "web",
-				Cmd:     []string{"curl", "-sk", app.GetHTTPSURL() + site.Safe200URIWithExpectation.URI},
-			})
-			assert.NoError(err)
-			assert.Contains(out, site.Safe200URIWithExpectation.Expect)
-		}
-
-		// Set the ports back to the default was so we don't break any following tests.
-		app.RouterHTTPSPort = "443"
-		app.RouterHTTPPort = "80"
+	for _, pair := range []testcommon.PortPair{{"80", "443"}, {"8080", "8443"}} {
+		testcommon.ClearDockerEnv()
+		app.RouterHTTPPort = pair.HTTPPort
+		app.RouterHTTPSPort = pair.HTTPSPort
 		err = app.WriteConfig()
 		assert.NoError(err)
-		err = app.Stop(true, false)
+
+		if app.SiteStatus() == ddevapp.SitePaused || app.SiteStatus() == ddevapp.SiteRunning {
+			err = app.Stop(true, false)
+			assert.NoError(err)
+		}
+		err = app.StartAndWaitForSync(0)
 		assert.NoError(err)
 
-		runTime()
+		urls := app.GetAllURLs()
+
+		// Convert URLs to map[string]bool
+		urlMap := make(map[string]bool)
+		for _, u := range urls {
+			urlMap[u] = true
+		}
+
+		// We expect two URLs for each hostname (http/https) and one direct web container address.
+		expectedNumUrls := (2 * len(app.GetHostnames())) + 1
+		assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d", len(urlMap))
+
+		// TODO: Add https://localhost to this list when trusted SSL goes in.
+		URLList := append(app.GetAllURLs(), "http://localhost")
+		for _, item := range URLList {
+			// Make sure internal (web container) access is successful
+			parts, err := url.Parse(item)
+			assert.NoError(err)
+			// Only try it if not an IP address URL; those won't be right
+			hostParts := strings.Split(parts.Host, ".")
+
+			// Make sure access from host is successful
+			// But "localhost" is only for inside container.
+			if parts.Host != "localhost" {
+				_, _ = testcommon.EnsureLocalHTTPContent(t, item+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+			}
+
+			if _, err := strconv.ParseInt(hostParts[0], 10, 64); err != nil {
+				out, _, err := app.Exec(&ddevapp.ExecOpts{
+					Service: "web",
+					// TODO: Remove the 'k' from curl when trusted SSL goes in.
+					Cmd: []string{"bash", "-c", "curl -sSk --fail " + item + site.Safe200URIWithExpectation.URI},
+				})
+				assert.NoError(err, "failed curl to %s: %v", item+site.Safe200URIWithExpectation.URI, err)
+				assert.Contains(out, site.Safe200URIWithExpectation.Expect)
+			}
+		}
 	}
+
+	// Set the ports back to the default was so we don't break any following tests.
+	app.RouterHTTPSPort = "443"
+	app.RouterHTTPPort = "80"
+	app.AdditionalFQDNs = []string{}
+	app.AdditionalHostnames = []string{}
+
+	err = app.WriteConfig()
+	assert.NoError(err)
+	err = app.Stop(true, false)
+	assert.NoError(err)
+
+	runTime()
 }
 
 // TestCaptureLogs checks that app.CaptureLogs() works

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -95,7 +95,8 @@ services:
     extra_hosts: [ "host.docker.internal:{{ .HostDockerInternalIP }}" ]
 {{ end }}
     external_links:
-      - ddev-router:$DDEV_HOSTNAME
+    {{ range $hostname := .Hostnames }}- "ddev-router:{{ $hostname }}" 
+    {{ end }}
     healthcheck:
       interval: 4s
       retries: 6

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -286,8 +286,8 @@ func ComposeWithStreams(composeFiles []string, stdin io.Reader, stdout io.Writer
 	proc.Stdin = stdin
 	proc.Stderr = stderr
 
-	_ = proc.Run()
-	return nil
+	err := proc.Run()
+	return err
 }
 
 // ComposeCmd executes docker-compose commands via shell.

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -226,16 +226,16 @@ func TestComposeWithStreams(t *testing.T) {
 	// Reverse stdout and stderr and create an error and normal stdout. We should see only the error captured in stdout
 	stdout = util.CaptureStdOut()
 	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stderr, os.Stdout, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
-	assert.NoError(err)
+	assert.Error(err)
 	output = stdout()
-	assert.Equal(output, "ls: cannot access 'xx': No such file or directory\n")
+	assert.Equal("ls: cannot access 'xx': No such file or directory\n", output)
 
 	// Flip stdout and stderr and create an error and normal stdout. We should see only the success captured in stdout
 	stdout = util.CaptureStdOut()
 	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stdout, os.Stderr, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
-	assert.NoError(err)
+	assert.Error(err)
 	output = stdout()
-	assert.Equal(output, "/var/run/apache2\n")
+	assert.Equal("/var/run/apache2\n", output)
 }
 
 // TestCheckCompose tests detection of docker-compose.


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1235: With a single hostname (the default situation, like "somesite.ddev.local", the name was resolved from within the web container as being the ddev-router.

However, as soon as you added additional_hostnames or additional_fqdns, this feature disappeared

## How this PR Solves The Problem:

The docker-compose.yaml was being incorrectly generated. A separate entry in external_links: was required for each of those entries.

## Manual Testing Instructions:

* Create a project with additional_hostnames and additional_fqdns.
* `ddev ssh`
* You should be able to `curl http://hostname1.ddev.local` successfully (it should be going to ddev-router)
* Verify that `ping hostname1.ddev.local` actually resolves to ddev-router's IP address.

## Automated Testing Overview:

TestInternalAndExternalAccessToURL() was updated to do *lots* of hits both inside and outside.

## Related Issue Link(s):

OP #1235 

## Release/Deployment notes:

https://github.com/drud/ddev/pull/1546/commits/03d065bbcd3f177e49d300dd37b9105ef0ecae22 fixes a bug where ComposeWithStreams() did not return the error it encountered, which caused app.Exec() to misbehave. It's possible this will affect some other behavior.
