### PR TITLE
Improved Solr install docs, update to 6.6, fixes #1547

### DIFF
--- a/pkg/servicetest/testdata/services/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.solr.yaml
@@ -1,39 +1,58 @@
-# ddev apache solr recipe file
+# DDev Apache Solr recipe file.
 #
-# To use this in your own project: Copy this file to your project's .ddev folder,
-# and create the folder path .ddev/solr/conf. Then, copy the solr configuration
-# files for your project to .ddev/solr/conf. E.g., using Drupal Search API Solr, 
-# you would copy the solr-conf/5.x/ contents into .ddev/solr/conf. The configuration
-# files must be present before running `ddev start`.
+# To use this in your own project:
+# 1. Copy this file to your project's ".ddev" directory.
+# 2. Create the folder path ".ddev/solr/conf".
+# 3. Copy the Solr configuration files for the appropriate plugin/module to
+#    ".ddev/solr/conf". For example, using Drupal 7's Search API Solr module,
+#    copy the files from its "solr-conf/6.x" directory into ".ddev/solr/conf"
+#    so that a file exists with the path ".ddev/solr/conf/solrconfig.xml".
+#
+# Note: The configuration files must be present before running `ddev start`.
 
 version: '3.6'
 
 services:
-  solr: # This is the service name used when running ddev commands accepting the --service flag
-    container_name: ddev-${DDEV_SITENAME}-solr # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
-    image: solr:5.4
+  # This is the service name used when running ddev commands accepting the
+  # --service flag.
+  solr:
+    # This is the name of the container. It is recommended to follow the same
+    # name convention used in the main docker-compose.yml file.
+    container_name: ddev-${DDEV_SITENAME}-solr
+    # Controls the version of Solr which is installed.
+    image: solr:6.6
     restart: always
+    # Solr is served from this port inside the container.
     ports:
-      - 8983 # Solr is served from this port inside the container
+      - 8983
+    # These labels ensure this service is discoverable by ddev.
     labels:
-    # These labels ensure this service is discoverable by ddev
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
       com.ddev.app-url: $DDEV_URL
     environment:
-      - VIRTUAL_HOST=$DDEV_HOSTNAME # This defines the host name the service should be accessible from. This will be sitename.ddev.local
-      - HTTP_EXPOSE=8983 # This defines the port the service should be accessible from at sitename.ddev.local
+      # This defines the host name the service should be accessible from. This
+      # will be sitename.ddev.local.
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      # This defines the port the service should be accessible from at
+      # sitename.ddev.local.
+      - HTTP_EXPOSE=8983
     volumes:
-      - "./solr:/solr-conf" # This exposes a mount to the host system `.ddev/solr-conf` directory.
-      - solrdata:/opt/solr/server/solr/mycores # This uses the 'data' volume defined below
+      # This exposes a mount to the host system `.ddev/solr-conf` directory.
+      - "./solr:/solr-conf" 
+      # solr cores are stored on the 'solrdata' volume
+      - solrdata:/opt/solr/server/solr/mycores 
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate
       - dev
       - /solr-conf
-# This links the solr service to the web service defined in the main docker-compose.yml, allowing applications running in the web service to access the solr service at sitename.ddev.local:8983
+# This links the Solr service to the web service defined in the main
+# docker-compose.yml, allowing applications running in the web service to
+# access the Solr service at sitename.ddev.local:8983.
   web:
     links:
       - solr:$DDEV_HOSTNAME
 volumes:
-  solrdata: # This creates a Docker volume that sticks around even if you remove or rebuild the container
+  # This creates a Docker volume that sticks around even if you remove or rebuild the container
+  solrdata: 


### PR DESCRIPTION
Updated the Apache Solr installation instructions to default to v6.6.
It also makes it more clear what the expected directory structure
should be.

## The Problem/Issue/Bug:
Per issue #1547, the included config file for Solr installed v5.4, which is no longer supported.

## How this PR Solves The Problem:
This PR updates it the Solr install to v6.6 and improves the documentation.

## Manual Testing Instructions:
Use the config file to install Solr. Expected results: it installs Apache Solr 6.6 instead of the previous 5.4.

## Automated Testing Overview:
None.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/1547

## Release/Deployment notes:
Don't know (-: