### PR TITLE
Fix CaptureLogs to not use CaptureStdOut

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2246,15 +2246,12 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 
 // TestCaptureLogs checks that app.CaptureLogs() works
 func TestCaptureLogs(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping TestCaptureLogs on windows, it sometimes hangs")
-	}
 	assert := asrt.New(t)
 
 	site := TestSites[0]
 	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s CaptureLogs", site.Name))
 
-	app := new(ddevapp.DdevApp)
+	app := ddevapp.DdevApp{}
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

app.CaptureLogs() has long been problematic in not working on Windows and using CaptureStdout, which is awkward. But there's a fairly easy workaround.

## How this PR Solves The Problem:

Change it.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

