### PR TITLE
 SetSiteSettingsPaths() has to be set after we've read the config, fixes #1553

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -85,7 +85,6 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	// Provide a default app name based on directory name
 	app.Name = filepath.Base(app.AppRoot)
 	app.OmitContainers = globalconfig.DdevGlobalConfig.OmitContainers
-	app.SetApptypeSettingsPaths()
 
 	// These should always default to the latest image/tag names from the Version package.
 	app.WebImage = version.GetWebImage()
@@ -101,6 +100,7 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 			return app, fmt.Errorf("%v exists but cannot be read. It may be invalid due to a syntax error.: %v", app.ConfigPath, err)
 		}
 	}
+	app.SetApptypeSettingsPaths()
 
 	// If the dbimage has not been overridden (because it takes precedence
 	// and the mariadb_version *has* been changed by config,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -902,6 +902,12 @@ func TestDdevFullSiteSetup(t *testing.T) {
 
 		err = app.Start()
 		assert.NoError(err)
+		settingsLocation, err := app.DetermineSettingsPathLocation()
+		assert.NoError(err)
+		assert.Equal(settingsLocation, app.SiteSettingsPath)
+		if app.Type == "drupal6" || app.Type == "drupal7" || app.Type == "drupal8" || app.Type == "backdrop" {
+			assert.FileExists(filepath.Join(filepath.Dir(app.SiteSettingsPath), "ddev_drush_settings.php"))
+		}
 
 		if site.DBTarURL != "" {
 			_, cachedArchive, err := testcommon.GetCachedArchive(site.Name, site.Name+"_siteTarArchive", "", site.DBTarURL)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
+	"github.com/drud/ddev/pkg/nodeps"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -904,8 +905,8 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		assert.NoError(err)
 		settingsLocation, err := app.DetermineSettingsPathLocation()
 		assert.NoError(err)
-		assert.Equal(settingsLocation, app.SiteSettingsPath)
-		if app.Type == "drupal6" || app.Type == "drupal7" || app.Type == "drupal8" || app.Type == "backdrop" {
+		assert.Equal(filepath.Dir(settingsLocation), filepath.Dir(app.SiteSettingsPath))
+		if nodeps.ArrayContainsString([]string{"drupal6", "drupal7", "drupal8", "backdrop"}, app.Type) {
 			assert.FileExists(filepath.Join(filepath.Dir(app.SiteSettingsPath), "ddev_drush_settings.php"))
 		}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1553 points out that the ddev_drush_settings.php is getting created in the projectroot instead of in the settings directory.

This turns out to be a side-effect of default project creation, the project type was being set *after* the site settings file was derived.

## How this PR Solves The Problem:

* Move the settings file setup to after the reading of the project config.yaml
* Add test coverage

## Manual Testing Instructions:

`ddev start` 
You should be able to `drush sql-cli` successfully if you have a drush8 on the host.

Or just verify that ddev_drush_settings.php got created in the (Drupal) sites/default

## Automated Testing Overview:

Added simplistic test coverage for the settings location and the ddev_drush_settings.php in TestDdevFullSiteSetup

## Related Issue Link(s):

OP #1553 


