### PR TITLE
apache-cgi should respect php overrides, fixes #1556

### DIFF
--- a/containers/ddev-webserver/scripts/start.sh
+++ b/containers/ddev-webserver/scripts/start.sh
@@ -37,6 +37,7 @@ if [ -d /mnt/ddev_config/php ] ; then
     if [ -n "$(ls -A /mnt/ddev_config/php/*.ini 2>/dev/null)" ]; then
         cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/cli/conf.d/
         cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/fpm/conf.d/
+        cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/apache2/conf.d/
     fi
 fi
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
@@ -648,6 +649,14 @@ func TestPHPOverrides(t *testing.T) {
 			t.Logf("failed app.StartAndWait(): %v", startErr)
 			t.Fatalf("============== logs from app.StartAndWait() ==============\n%s\n", logs)
 		}
+
+		// On Docker Toolbox, it appearas that the change notification gets to the router
+		// slower than on other platforms. Give it time to come through.
+		// Otherwise the SSL cert may not yet have been created
+		if nodeps.IsDockerToolbox() {
+			time.Sleep(time.Duration(5) * time.Second)
+		}
+
 		_, _ = testcommon.EnsureLocalHTTPContent(t, "http://"+app.GetHostname()+"/phpinfo.php", `max_input_time</td><td class="v">999`)
 		err = app.Stop(true, false)
 		assert.NoError(err)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -610,6 +610,52 @@ func TestConfigOverrideDetection(t *testing.T) {
 	runTime()
 }
 
+// TestPHPOverrides tests to make sure that PHP overrides work in all webservers.
+func TestPHPOverrides(t *testing.T) {
+	assert := asrt.New(t)
+	app := &DdevApp{}
+	testDir, _ := os.Getwd()
+
+	site := TestSites[0]
+	switchDir := site.Chdir()
+	defer switchDir()
+
+	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s PHPOverrides", site.Name))
+
+	// Copy test overrides into the project .ddev directory
+	err := fileutil.CopyDir(filepath.Join(testDir, "testdata/TestPHPOverrides/.ddev/php"), filepath.Join(site.Dir, ".ddev/php"))
+	assert.NoError(err)
+	err = fileutil.CopyFile(filepath.Join(testDir, "testdata/TestPHPOverrides/phpinfo.php"), filepath.Join(site.Dir, site.Docroot, "phpinfo.php"))
+	assert.NoError(err)
+
+	// And when we're done, we have to clean those out again.
+	defer func() {
+		_ = os.RemoveAll(filepath.Join(site.Dir, ".ddev/php"))
+		_ = os.RemoveAll(filepath.Join(site.Dir, "phpinfo.php"))
+	}()
+
+	for _, webserverType := range []string{WebserverNginxFPM, WebserverApacheFPM, WebserverApacheCGI} {
+		testcommon.ClearDockerEnv()
+		app.WebserverType = webserverType
+		err = app.Init(site.Dir)
+		assert.NoError(err)
+		_ = app.Stop(true, false)
+		// nolint: errcheck
+		defer app.Stop(true, false)
+		startErr := app.StartAndWaitForSync(2)
+		if startErr != nil {
+			logs, _ := GetErrLogsFromApp(app, startErr)
+			t.Logf("failed app.StartAndWait(): %v", startErr)
+			t.Fatalf("============== logs from app.StartAndWait() ==============\n%s\n", logs)
+		}
+		_, _ = testcommon.EnsureLocalHTTPContent(t, "http://"+app.GetHostname()+"/phpinfo.php", `max_input_time</td><td class="v">999`)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+	}
+
+	runTime()
+}
+
 // TestConfigLoadingOrder verifies that configs load in lexicographical order
 // AFTER config.yaml
 func TestConfigLoadingOrder(t *testing.T) {

--- a/pkg/ddevapp/testdata/TestPHPOverrides/.ddev/php/my-php.ini
+++ b/pkg/ddevapp/testdata/TestPHPOverrides/.ddev/php/my-php.ini
@@ -1,0 +1,2 @@
+[PHP]
+max_input_time = 999

--- a/pkg/ddevapp/testdata/TestPHPOverrides/phpinfo.php
+++ b/pkg/ddevapp/testdata/TestPHPOverrides/phpinfo.php
@@ -1,0 +1,2 @@
+<?php
+phpinfo();

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190422_blackfire_io" // Note that this can be overridden by make
+var WebTag = "20190420_fix_apache_cgi" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1556 - apache-cgi doesn't respect PHP overrides. 

## How this PR Solves The Problem:

Copy the overrides into /etc/php/*/apache2/conf.d in addition to copying into fpm and cli directories.

## Automated tests

Added TestPHPOverrides, which tests for the PHP override on all webserver types