### PR TITLE
Use restart: no on additional service examples

### DIFF
--- a/pkg/servicetest/testdata/services/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.beanstalkd.yaml
@@ -8,7 +8,7 @@ services:
   beanstalk: # This is the service name used when running ddev commands accepting the --service flag
     container_name: ddev-${DDEV_SITENAME}-beanstalk # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
     image: schickling/beanstalkd:latest
-    restart: always
+    restart: "no"
     ports:
     - 11300 # beanstalk is available at this port inside the container (default port for beanstalkd)
     labels:

--- a/pkg/servicetest/testdata/services/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.memcached.yaml
@@ -10,7 +10,7 @@ services:
   memcached: # This is the service name used when running ddev commands accepting the --service flag
     container_name: ddev-${DDEV_SITENAME}-memcached # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
     image: memcached:1.5
-    restart: always
+    restart: "no"
     ports:
       - 11211 # memcached is available at this port inside the container
     labels:

--- a/pkg/servicetest/testdata/services/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.solr.yaml
@@ -21,7 +21,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-solr
     # Controls the version of Solr which is installed.
     image: solr:6.6
-    restart: always
+    restart: "no"
     # Solr is served from this port inside the container.
     ports:
       - 8983


### PR DESCRIPTION
## The Problem/Issue/Bug:

@damienmckenna and @mglaman point out in #1549 that we have `restart: always` in the additional service examples, but `restart: "no"` is what is actually always used in docker-compose.yaml (for a really long time). 

Changing it here.

