### PR TITLE
Use docker-compose build for dynamic containers, allow easier container config

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -114,6 +114,11 @@ var (
 
 	// hostHTTPSPortArg sets host_https_port
 	hostHTTPSPortArg string
+
+	// webImageExtraPackages and dbImageExtraPackages are comma-delimited
+	// lists of Debian packages to be added to related containers on build
+	webimageExtraPackages string
+	dbimageExtraPackages  string
 )
 
 var providerName = ddevapp.ProviderDefault
@@ -243,6 +248,10 @@ func init() {
 	ConfigCommand.Flags().StringVar(&projectNameArg, "sitename", "", projectNameUsage+" This is the same as project-name and is included only for backwards compatibility")
 	err = ConfigCommand.Flags().MarkDeprecated("sitename", "The sitename flag is deprecated in favor of --project-name")
 	util.CheckErr(err)
+
+	ConfigCommand.Flags().StringVar(&webimageExtraPackages, "webimage-extra-packages", "", "A comma-delimited list of Debian packages that should be added to web container when the project is started")
+
+	ConfigCommand.Flags().StringVar(&dbimageExtraPackages, "dbimage-extra-packages", "", "A comma-delimited list of Debian packages that should be added to db container when the project is started")
 
 	RootCmd.AddCommand(ConfigCommand)
 }
@@ -415,6 +424,26 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if omitContainersArg != "" {
 		app.OmitContainers = strings.Split(omitContainersArg, ",")
+	}
+
+	if cmd.Flag("webimage-extra-packages").Changed {
+		if webimageExtraPackages == "" {
+			app.WebImageExtraPackages = nil
+		} else {
+			app.WebImageExtraPackages = strings.Split(webimageExtraPackages, ",")
+		}
+	}
+
+	if cmd.Flag("dbimage-extra-packages").Changed {
+		if dbimageExtraPackages == "" {
+			app.DBImageExtraPackages = nil
+		} else {
+			app.DBImageExtraPackages = strings.Split(dbimageExtraPackages, ",")
+		}
+	}
+
+	if cmd.Flag("dbimage-extra-packages").Changed {
+		app.WebImageExtraPackages = strings.Split(webimageExtraPackages, ",")
 	}
 
 	if uploadDirArg != "" {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -123,6 +123,10 @@ func TestConfigSetValues(t *testing.T) {
 	additionalFQDNs := strings.Join(additionalFQDNsSlice, ",")
 	omitContainersSlice := []string{"dba", "ddev-ssh-agent"}
 	omitContainers := strings.Join(omitContainersSlice, ",")
+	webimageExtraPackagesSlice := []string{"php-ldap", "php7.3-tidy"}
+	webimageExtraPackages := strings.Join(webimageExtraPackagesSlice, ",")
+	dbimageExtraPackagesSlice := []string{"netcat", "ncdu"}
+	dbimageExtraPackages := strings.Join(dbimageExtraPackagesSlice, ",")
 
 	uploadDir := filepath.Join("custom", "config", "path")
 	webserverType := ddevapp.WebserverApacheFPM
@@ -156,6 +160,8 @@ func TestConfigSetValues(t *testing.T) {
 		"--host-db-port", hostDBPort,
 		"--host-webserver-port", hostWebserverPort,
 		"--host-https-port", hostHTTPSPort,
+		"--webimage-extra-packages", webimageExtraPackages,
+		"--dbimage-extra-packages", dbimageExtraPackages,
 	}
 
 	_, err = exec.RunCommand(DdevBin, args)
@@ -191,6 +197,8 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(webWorkingDir, app.WorkingDir["web"])
 	assert.Equal(dbWorkingDir, app.WorkingDir["db"])
 	assert.Equal(dbaWorkingDir, app.WorkingDir["dba"])
+	assert.Equal(webimageExtraPackagesSlice, app.WebImageExtraPackages)
+	assert.Equal(dbimageExtraPackagesSlice, app.DBImageExtraPackages)
 
 	// Test that container images and working dirs can be unset with default flags
 	args = []string{

--- a/containers/ddev-dbserver/10.1/files/etc/passwd
+++ b/containers/ddev-dbserver/10.1/files/etc/passwd
@@ -100,6 +100,7 @@ uid_97:x:97:97:gid_97:/home:/bin/bash
 uid_98:x:98:98:gid_98:/home:/bin/bash
 uid_99:x:99:99:gid_99:/home:/bin/bash
 uid_100:x:100:100:gid_100:/home:/bin/bash
+_apt:x:100:65534:gid_100:/home:/bin/bash
 uid_101:x:101:101:gid_101:/home:/bin/bash
 uid_102:x:102:102:gid_102:/home:/bin/bash
 uid_103:x:103:103:gid_103:/home:/bin/bash

--- a/containers/ddev-dbserver/10.2/files/etc/passwd
+++ b/containers/ddev-dbserver/10.2/files/etc/passwd
@@ -100,6 +100,7 @@ uid_97:x:97:97:gid_97:/home:/bin/bash
 uid_98:x:98:98:gid_98:/home:/bin/bash
 uid_99:x:99:99:gid_99:/home:/bin/bash
 uid_100:x:100:100:gid_100:/home:/bin/bash
+_apt:x:100:65534:gid_100:/home:/bin/bash
 uid_101:x:101:101:gid_101:/home:/bin/bash
 uid_102:x:102:102:gid_102:/home:/bin/bash
 uid_103:x:103:103:gid_103:/home:/bin/bash

--- a/docs/users/extend/customizing-images.md
+++ b/docs/users/extend/customizing-images.md
@@ -1,0 +1,36 @@
+<h1> Customizing Docker Images</h1>
+
+It's common to have a requirement for the web or db images which is not bundled in them by default. Thre are two easy ways to extend these docker images:
+
+* `webimage_extra_packages` and `dbimage_extra_packages` in .ddev/config.yaml
+* An add-on Dockerfile in `.ddev/web-build` or `.ddev/db-build`
+
+## Adding extra Debian packages with webimage_extra_packages and dbimage_extra_packages
+
+You can add extra Debian packages if that's all that is needed with lines like this in `.ddev/config.yaml`:
+
+```
+webimage_extra_packages: [php-yaml, php7.3-ldap]
+dbimage_extra_packages: [telnet, netcat]
+
+```
+
+Then the additional packages will be built into the containers during `ddev start`
+
+## Adding extra Dockerfiles for webimage and dbimage
+
+For more complex requirements, you can add .ddev/web-build/Dockerfile or .ddev/db-build/Dockerfile. 
+
+Examples of possible Dockerfiles are given in `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example`
+
+An example web image `.ddev/web-build/Dockerfile` might be:
+
+```
+ARG BASE_IMAGE=drud/ddev-webserver:20190422_blackfire_io
+FROM $BASE_IMAGE
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y php-yaml
+RUN npm install --global gulp-cli
+RUN ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime && dpkg-reconfigure --frontend noninteractive tzdata
+```
+
+Note that if a Dockerfile is provided, any config.yaml `webimage_extra_packages` or `dbimage_extra_packages` will be ignored.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ pages:
       - 'Extending and Customizing Environments': 'users/extend/customization-extendibility.md'
       - 'Additional Services': 'users/extend/additional-services.md'
       - 'Defining Custom Services': 'users/extend/custom-compose-files.md'
+      - 'Customizing Docker Images': users/extend/customizing-images.md
     - 'Integration with Hosting Providers':
       - 'Pantheon': 'users/providers/pantheon.md'
       - 'DDEV-Live': 'users/providers/drud-s3.md'

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -224,7 +224,7 @@ RUN npm install --global gulp-cli
 RUN ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime && dpkg-reconfigure --frontend noninteractive tzdata
 `)
 
-	err = writeImageDockerfile(app.GetConfigPath("web-build")+"/Dockerfile.example", contents)
+	err = WriteImageDockerfile(app.GetConfigPath("web-build")+"/Dockerfile.example", contents)
 	if err != nil {
 		return err
 	}
@@ -237,7 +237,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y telnet n
 RUN echo "Built from ` + app.DBImage + `" >/var/tmp/built-from.txt
 `)
 
-	err = writeImageDockerfile(app.GetConfigPath("db-build")+"/Dockerfile.example", contents)
+	err = WriteImageDockerfile(app.GetConfigPath("db-build")+"/Dockerfile.example", contents)
 	if err != nil {
 		return err
 	}
@@ -666,11 +666,11 @@ func WriteImagePackagesDockerfile(fullpath string, extraPackages []string) error
 FROM $BASE_IMAGE
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ` + strings.Join(extraPackages, " ") + "\n")
 
-	return writeImageDockerfile(fullpath, contents)
+	return WriteImageDockerfile(fullpath, contents)
 }
 
 // WriteImageDockerfile writes a dockerfile at the fullpath (including the filename)
-func writeImageDockerfile(fullpath string, contents []byte) error {
+func WriteImageDockerfile(fullpath string, contents []byte) error {
 	err := os.MkdirAll(filepath.Dir(fullpath), 0755)
 	if err != nil {
 		return err

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -522,6 +522,7 @@ type composeYAMLVars struct {
 	MountType            string
 	WebMount             string
 	WebBuildContext      string
+	DBBuildContext       string
 	OmitDBA              bool
 	OmitSSHAgent         bool
 	WebcacheEnabled      bool
@@ -591,6 +592,11 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	if fileutil.FileExists(webBuildContext) {
 		templateVars.WebBuildContext = app.GetConfigPath("web-build")
 	}
+	dbBuildContext := app.GetConfigPath("db-build/Dockerfile")
+	if fileutil.FileExists(dbBuildContext) {
+		templateVars.DBBuildContext = app.GetConfigPath("db-build")
+	}
+
 	templateVars.DockerIP, err = dockerutil.GetDockerIP()
 	if err != nil {
 		return "", err

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -626,6 +626,9 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		}
 	} else if len(app.WebImageExtraPackages) > 0 {
 		err = writeImagePackagesDockerfile(app.GetConfigPath(".webimageExtra/Dockerfile"), app.WebImageExtraPackages)
+		if err != nil {
+			return "", err
+		}
 		templateVars.WebBuildContext = app.GetConfigPath(".webimageExtra")
 	}
 
@@ -637,6 +640,9 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		}
 	} else if len(app.DBImageExtraPackages) > 0 {
 		err = writeImagePackagesDockerfile(app.GetConfigPath(".dbimageExtra/Dockerfile"), app.DBImageExtraPackages)
+		if err != nil {
+			return "", err
+		}
 		templateVars.DBBuildContext = app.GetConfigPath(".dbimageExtra")
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -636,8 +636,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 			util.Warning(".ddev/db-build/Dockerfile is provided, ignoring dbimage_extra_packages")
 		}
 	} else if len(app.DBImageExtraPackages) > 0 {
-		err = writeImagePackagesDockerfile(app.GetConfigPath(".dbimageExtra/Dockerfile"), app.WebImageExtraPackages)
-		templateVars.WebBuildContext = app.GetConfigPath(".dbimageExtra")
+		err = writeImagePackagesDockerfile(app.GetConfigPath(".dbimageExtra/Dockerfile"), app.DBImageExtraPackages)
+		templateVars.DBBuildContext = app.GetConfigPath(".dbimageExtra")
 	}
 
 	templateVars.DockerIP, err = dockerutil.GetDockerIP()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -625,7 +625,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 			util.Warning(".ddev/web-build/Dockerfile is provided, ignoring webimage_extra_packages")
 		}
 	} else if len(app.WebImageExtraPackages) > 0 {
-		err = writeImagePackagesDockerfile(app.GetConfigPath(".webimageExtra/Dockerfile"), app.WebImageExtraPackages)
+		err = WriteImagePackagesDockerfile(app.GetConfigPath(".webimageExtra/Dockerfile"), app.WebImageExtraPackages)
 		if err != nil {
 			return "", err
 		}
@@ -639,7 +639,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 			util.Warning(".ddev/db-build/Dockerfile is provided, ignoring dbimage_extra_packages")
 		}
 	} else if len(app.DBImageExtraPackages) > 0 {
-		err = writeImagePackagesDockerfile(app.GetConfigPath(".dbimageExtra/Dockerfile"), app.DBImageExtraPackages)
+		err = WriteImagePackagesDockerfile(app.GetConfigPath(".dbimageExtra/Dockerfile"), app.DBImageExtraPackages)
 		if err != nil {
 			return "", err
 		}
@@ -657,7 +657,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 
 // WriteImagePackagesDockerfile writes a simple Dockerfile with extraPackages at given location
 // fullpath is the path to the Dockerfile including the filename
-func writeImagePackagesDockerfile(fullpath string, extraPackages []string) error {
+func WriteImagePackagesDockerfile(fullpath string, extraPackages []string) error {
 	err := os.MkdirAll(filepath.Dir(fullpath), 0755)
 	if err != nil {
 		return err

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -832,7 +832,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db", ".bgsync*", "config.*.y*ml", ".webImageExtra", ".dbImageExtra")
+	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db", ".bgsync*", "config.*.y*ml", ".webImageExtra", ".dbImageExtra", "*-build/Dockerfile.example")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -521,6 +521,7 @@ type composeYAMLVars struct {
 	ComposeVersion       string
 	MountType            string
 	WebMount             string
+	WebBuildContext      string
 	OmitDBA              bool
 	OmitSSHAgent         bool
 	WebcacheEnabled      bool
@@ -585,6 +586,10 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 			// and completely chokes in C:\Users\rfay...
 			templateVars.NFSSource = dockerutil.MassageWIndowsNFSMount(app.AppRoot)
 		}
+	}
+	webBuildContext := app.GetConfigPath("web-build/Dockerfile")
+	if fileutil.FileExists(webBuildContext) {
+		templateVars.WebBuildContext = app.GetConfigPath("web-build")
 	}
 	templateVars.DockerIP, err = dockerutil.GetDockerIP()
 	if err != nil {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -715,21 +715,19 @@ func TestExtraPackages(t *testing.T) {
 	err = app.Start()
 	assert.NoError(err)
 
-	stdout, stderr, err := app.Exec(&ExecOpts{
+	stdout, _, err := app.Exec(&ExecOpts{
 		Service: "web",
 		Cmd:     []string{"bash", "-c", "command -v zsh"},
 	})
 	assert.NoError(err)
 	assert.Equal("/usr/bin/zsh", strings.Trim(stdout, "\n"))
 
-	stdout, stderr, err = app.Exec(&ExecOpts{
+	stdout, _, err = app.Exec(&ExecOpts{
 		Service: "db",
 		Cmd:     []string{"bash", "-c", "command -v ncdu"},
 	})
 	assert.NoError(err)
 	assert.Equal("/usr/bin/ncdu", strings.Trim(stdout, "\n"))
-
-	assert.NoError(err, "err was %v: %s %s", err, stdout, stderr)
 
 	// Now write a web-build Dockerfile and make sure the packages don't get in there any more.
 	err = WriteImagePackagesDockerfile(app.GetConfigPath("web-build/Dockerfile"), []string{"netcat"})

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -731,7 +731,7 @@ func (app *DdevApp) Start() error {
 	_ = dockerutil.RemoveVolume(app.GetWebcacheVolName())
 	_ = dockerutil.RemoveVolume(app.GetNFSMountVolName())
 
-	_, _, err = dockerutil.ComposeCmd(files, "up", "-d")
+	_, _, err = dockerutil.ComposeCmd(files, "up", "--build", "-d")
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -102,6 +102,8 @@ type DdevApp struct {
 	HostDBPort            string               `yaml:"host_db_port,omitempty"`
 	HostWebserverPort     string               `yaml:"host_webserver_port,omitempty"`
 	HostHTTPSPort         string               `yaml:"host_https_port,omitempty"`
+	WebImageExtraPackages []string             `yaml:"webimage_extra_packages,omitempty,flow"`
+	DBImageExtraPackages  []string             `yaml:"dbimage_extra_packages,omitempty,flow"`
 }
 
 // GetType returns the application type as a (lowercase) string

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -7,7 +7,14 @@ const DDevComposeTemplate = `version: '{{ .ComposeVersion }}'
 services:
   db:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-db
-    image: $DDEV_DBIMAGE
+    {{ if .DBBuildContext }}
+    build: 
+      context: "{{ .DBBuildContext }}"
+      args: 
+        BASE_IMAGE: $DDEV_DBIMAGE
+    {{ else }}
+    image: "$DDEV_DBIMAGE"
+    {{ end }}
     stop_grace_period: 60s
     volumes:
       - type: "volume"

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -284,6 +284,13 @@ const ConfigInstructions = `
 # The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
 # unless explicitly specified.
 
+# webimage_extra_packages: [php-yaml, php7.3-ldap]
+# Extra Debian packages that are needed in the webimage can be added here
+# This is ignored if a free-form .ddev/web-build/Dockerfile is provided
+
+# dbimage_extra_packages: [telnet,netcat]
+# Extra Debian packages that are needed in the dbimage can be added here
+# This is ignored if a free-form .ddev/db-build/Dockerfile is provided
 
 # provider: default # Currently either "default" or "pantheon"
 #

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -38,7 +38,14 @@ services:
       start_period: 60s
   web:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
+    {{ if .WebBuildContext }}
+    build: 
+      context: "{{ .WebBuildContext }}"
+      args: 
+        BASE_IMAGE: $DDEV_WEBIMAGE
+    {{ else }}
     image: $DDEV_WEBIMAGE
+    {{ end }}
     cap_add:
       - SYS_PTRACE
     volumes:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -9,7 +9,7 @@ services:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-db
     {{ if .DBBuildContext }}
     build: 
-      context: "{{ .DBBuildContext }}"
+      context: '{{ .DBBuildContext }}'
       args: 
         BASE_IMAGE: $DDEV_DBIMAGE
     {{ else }}
@@ -47,7 +47,7 @@ services:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
     {{ if .WebBuildContext }}
     build: 
-      context: "{{ .WebBuildContext }}"
+      context: '{{ .WebBuildContext }}'
       args: 
         BASE_IMAGE: $DDEV_WEBIMAGE
     {{ else }}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ var WebTag = "nginx-dont-hide-upstream-errors" // Note that this can be overridd
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20190501_fix_mariadb_override_restart_problem"
+var BaseDBTag = "20190430_use_build_for_dynamic_containers"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Our web container gets bigger and bigger
* Users will always have new requests for containers, or for extra config

## How this PR Solves The Problem:

* Uses docker-compose up --build, so that a build context can be added for dynamic containers
* If .ddev/db-build/Dockerfile or .ddev/web-build/Dockerfile exists, the Dockerfile there will be used to build the web or db image. 
* config.yaml `webimage_extra_packages` and `dbimage_extra_packages` allow just adding debian packages without writing a Dockerfile.
* See the [docs](https://github.com/drud/ddev/blob/a04396fee1dc0090a8529c1c89c7c3b02cd0d95b/docs/users/extend/customizing-images.md)

TODO:
- [x] Allow a simple list of packages to add in config.yaml
- [x] docs
- [x] .ddev/*-build/Dockerfile.example should be gitignored
- [x] Add config commands for *_extra_packages

## Manual Testing Instructions:

* Create a .ddev/web-build/Dockerfile with these contents:
```
ARG BASE_IMAGE=drud/ddev-webserver:latest
FROM $BASE_IMAGE
RUN touch /var/tmp/this-was-from
RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y php7.3-yaml
```
* `ddev start`
* You should find on `ddev ssh` that php7.3-yaml is installed

* Do the same thing for db-build (with a different package or action)

## Automated Testing Overview:

- [x] Test webimage_extra_packages and dbimage_extra_packages
- [x] Test to make sure Dockerfile overrides webimage_extra_packages
- [x] Test behavior of Dockerfile

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

