### PR TITLE
Test improvements for Win 10 Docker Toolbox

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -395,7 +395,6 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		assert.NoError(err)
 
 		err = app.Start()
-
 		assert.NoError(err)
 		if err != nil && strings.Contains(err.Error(), "db container failed") {
 			container, err := app.FindContainerByType("db")
@@ -403,6 +402,12 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 			out, err := exec.RunCommand("docker", []string{"logs", container.Names[0]})
 			assert.NoError(err)
 			t.Logf("DB Logs after app.Start: \n%s\n=== END DB LOGS ===", out)
+		}
+		// On Docker Toolbox, it appearas that the change notification gets to the router
+		// slower than on other platforms. Give it time to come through.
+		// Otherwise the SSL cert may not yet have been created
+		if nodeps.IsDockerToolbox() {
+			time.Sleep(time.Duration(5) * time.Second)
 		}
 
 		// ensure docker-compose.yaml exists inside .ddev site folder
@@ -2221,6 +2226,13 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 
 		err = app.StartAndWaitForSync(0)
 		assert.NoError(err)
+
+		// On Docker Toolbox, it appearas that the change notification gets to the router
+		// slower than on other platforms. Give it time to come through.
+		// Otherwise the SSL cert may not yet have been created
+		if nodeps.IsDockerToolbox() {
+			time.Sleep(time.Duration(5) * time.Second)
+		}
 
 		urls := app.GetAllURLs()
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/fileutil"
@@ -176,6 +178,11 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 			logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
 			assert.NoError(err)
 			t.Fatalf("logs from broken container:\n=======\n%s\n========\n", logs)
+		}
+		// On Docker Toolbox, it appearas that the notification gets to the router
+		// slower than on other platforms. Give it time to come through.
+		if nodeps.IsDockerToolbox() {
+			time.Sleep(time.Duration(5) * time.Second)
 		}
 
 		safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -179,8 +179,9 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 			assert.NoError(err)
 			t.Fatalf("logs from broken container:\n=======\n%s\n========\n", logs)
 		}
-		// On Docker Toolbox, it appearas that the notification gets to the router
+		// On Docker Toolbox, it appearas that the change notification gets to the router
 		// slower than on other platforms. Give it time to come through.
+		// Otherwise the SSL cert may not yet have been created
 		if nodeps.IsDockerToolbox() {
 			time.Sleep(time.Duration(5) * time.Second)
 		}


### PR DESCRIPTION
## The Problem/Issue/Bug:

There are remaining problems with intermittent test failures on Win 10 Home/Docker toolbox. 

Sometimes the TLS certificate is not respected in a few tests.

My only theory is that the notification to the ddev-router doesn't come through in time before tests are already accessing https.

## How this PR Solves The Problem:

Slow things down on Docker toolbox. In test situation, wait a few seconds after app.Start() before hitting it with web traffic.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

