### PR TITLE
Use sudo to copy mysql config files, fixes #1541

### DIFF
--- a/containers/ddev-dbserver/10.1/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/10.1/files/docker-entrypoint.sh
@@ -55,8 +55,8 @@ sudo chown -R "$UID:$(id -g)" /var/lib/mysql
 
 # If we have extra mariadb cnf files,, copy them to where they go.
 if [ -d /mnt/ddev_config/mysql -a "$(echo /mnt/ddev_config/mysql/*.cnf)" != "/mnt/ddev_config/mysql/*.cnf" ] ; then
-  cp /mnt/ddev_config/mysql/*.cnf /etc/mysql/conf.d
-  chmod ugo-w /etc/mysql/conf.d/*
+  sudo cp /mnt/ddev_config/mysql/*.cnf /etc/mysql/conf.d
+  sudo chmod -R ugo-w /etc/mysql/conf.d
 fi
 
 # If mariadb has not been initialized, copy in the base image from either the default starter image (/var/tmp/mysqlbase)

--- a/containers/ddev-dbserver/10.2/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/10.2/files/docker-entrypoint.sh
@@ -41,8 +41,8 @@ sudo chown -R "$UID:$(id -g)" /var/lib/mysql
 
 # If we have extra mariadb cnf files,, copy them to where they go.
 if [ -d /mnt/ddev_config/mysql -a "$(echo /mnt/ddev_config/mysql/*.cnf)" != "/mnt/ddev_config/mysql/*.cnf" ] ; then
-  cp /mnt/ddev_config/mysql/*.cnf /etc/mysql/conf.d
-  chmod ugo-w /etc/mysql/conf.d/*
+  sudo cp /mnt/ddev_config/mysql/*.cnf /etc/mysql/conf.d
+  sudo chmod -R ugo-w /etc/mysql/conf.d
 fi
 
 # If mariadb has not been initialized, copy in the base image from either the default starter image (/var/tmp/mysqlbase)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ var WebTag = "20190422_blackfire_io" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20190329_maria_logs_config"
+var BaseDBTag = "20190501_fix_mariadb_override_restart_problem"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1541 points out that if mysql overrides are done, you can't do a `ddev start` after doing a `ddev pause` because of permissions problems inside the container. 

## How this PR Solves The Problem:

Use sudo to copy those files.

## Manual Testing Instructions:

Configure mysql overrides for a project. Start the project. `ddev pause`, `ddev start`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

