### PR TITLE
Fix markdown format for hook examples.

### DIFF
--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -43,6 +43,7 @@ hooks:
     - exec: "drush uli"
   post-start:
     - exec: bash -c "sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ghostscript sqlite3 php7.2-sqlite3 && sudo killall -HUP php-fpm"```
+```
 
 Example:
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

There was a missing markdown close tag on the extending-commands.md which resulted in text rendering as code and code rendering as text.

## How this PR Solves The Problem:

Adds the close tag.

## Manual Testing Instructions:

Look at the page in gitlab's markdown. It obviously renders broken.

https://github.com/drud/ddev/blob/master/docs/users/extending-commands.md

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

