### PR TITLE
Interpret ddev exec and hooks with bash, fixes #1023

### DIFF
--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -54,7 +54,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	// identity
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=false", "root@" + internalIPAddr, "pwd"},
+		Cmd:     "ssh -o BatchMode=yes -o StrictHostKeyChecking=false root@" + internalIPAddr + " pwd",
 	})
 	assert.Error(err)
 
@@ -70,7 +70,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	// And at this point we should be able to ssh into the test-cmd-ssh-server
 	out, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=false", "root@" + internalIPAddr, "pwd"},
+		Cmd:     "ssh -o BatchMode=yes -o StrictHostKeyChecking=false root@" + internalIPAddr + " pwd",
 	})
 	assert.NoError(err)
 	assert.Contains(out, "/root")

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -137,7 +137,7 @@ project root will be deleted when creating a project.`,
 		output.UserOut.Printf("Executing composer command: %s\n", composerCmdString)
 		stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
-			Cmd:     composerCmd,
+			Cmd:     composerCmdString,
 		})
 		if err != nil {
 			util.Failed("Failed to create project")
@@ -184,7 +184,7 @@ project root will be deleted when creating a project.`,
 			// If webcacheEnabled, we can move the contents easily and quickly inside the container.
 			_, _, err = app.Exec(&ddevapp.ExecOpts{
 				Service: "web",
-				Cmd:     []string{"bash", "-c", fmt.Sprintf("shopt -s dotglob && mv %s/* /var/www/html && rmdir %s", containerInstallPath, containerInstallPath)},
+				Cmd:     fmt.Sprintf("shopt -s dotglob && mv %s/* /var/www/html && rmdir %s", containerInstallPath, containerInstallPath),
 			})
 		}
 		// This err check picks up either of the above: The filepath.Walk and the mv

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/output"
-
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -35,11 +33,10 @@ ddev composer outdated --minor-only`,
 			}
 		}
 
-		output.UserOut.Printf("Executing [composer %s] at the project root (/var/www/html in the container, %s on the host)", strings.Join(args, " "), app.AppRoot)
 		stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
 			Dir:     "/var/www/html",
-			Cmd:     append([]string{"composer"}, args...),
+			Cmd:     fmt.Sprintf("composer %s", strings.Join(args, " ")),
 		})
 		if err != nil {
 			util.Failed("composer command failed: %v", err)

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -43,7 +43,7 @@ func TestComposerCmd(t *testing.T) {
 	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0
 	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log", "1.1.0"}
 	out, err = exec.RunCommand(DdevBin, args)
-	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, out)
+	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 	assert.Contains(out, "Created project in ")
 	ddevapp.WaitForSync(app, 2)
 	assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
@@ -51,7 +51,7 @@ func TestComposerCmd(t *testing.T) {
 	// Test a composer require, with passthrough args
 	args = []string{"composer", "require", "sebastian/version", "--no-plugins", "--ansi"}
 	out, err = exec.RunCommand(DdevBin, args)
-	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, out)
+	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 	assert.Contains(out, "Generating autoload files")
 	ddevapp.WaitForSync(app, 2)
 	assert.FileExists(filepath.Join(tmpDir, "vendor/sebastian/version/composer.json"))
@@ -59,12 +59,12 @@ func TestComposerCmd(t *testing.T) {
 	// Test a composer remove
 	if nodeps.IsDockerToolbox() {
 		// On docker toolbox, git objects are read-only, causing the composer remove to fail.
-		_, err = exec.RunCommand(DdevBin, []string{"exec", "bash", "-c", "chmod -R u+w /var/www/html/"})
+		_, err = exec.RunCommand(DdevBin, []string{"exec", "chmod -R u+w /var/www/html/"})
 		assert.NoError(err)
 	}
 	args = []string{"composer", "remove", "sebastian/version"}
 	out, err = exec.RunCommand(DdevBin, args)
-	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, out)
+	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 	assert.Contains(out, "Generating autoload files")
 	ddevapp.WaitForSync(app, 2)
 	assert.False(fileutil.FileExists(filepath.Join(tmpDir, "vendor/sebastian")))

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -38,6 +38,8 @@ func TestComposerCmd(t *testing.T) {
 	// Get an app just so we can do waits and check webcacheenabled etc.
 	app, err := ddevapp.NewApp(tmpDir, true, "")
 	assert.NoError(err)
+	//nolint: errcheck
+	defer app.Stop(true, false)
 
 	// Test create-project
 	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0
@@ -59,7 +61,7 @@ func TestComposerCmd(t *testing.T) {
 	// Test a composer remove
 	if nodeps.IsDockerToolbox() {
 		// On docker toolbox, git objects are read-only, causing the composer remove to fail.
-		_, err = exec.RunCommand(DdevBin, []string{"exec", "chmod -R u+w /var/www/html/"})
+		_, err = exec.RunCommand(DdevBin, []string{"exec", "chmod", "-R", "u+w", "//var/www/html/"})
 		assert.NoError(err)
 	}
 	args = []string{"composer", "remove", "sebastian/version"}

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -37,7 +37,7 @@ var DdevExecCmd = &cobra.Command{
 		}
 
 		if strings.Contains(app.SiteStatus(), ddevapp.SitePaused) {
-			util.Failed("Project is stopped. Run 'ddev start' to start the environment.")
+			util.Failed("Project is paused. Run 'ddev start' to start it.")
 		}
 
 		app.DockerEnv()
@@ -45,12 +45,12 @@ var DdevExecCmd = &cobra.Command{
 		out, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: serviceType,
 			Dir:     execDirArg,
-			Cmd:     args,
-			Tty:     true,
+			Cmd:     strings.Join(args, " "),
+			Tty:	true,
 		})
 
 		if err != nil {
-			util.Failed("Failed to execute command %s: %v", args, err)
+			util.Failed("Failed to execute command %s: %v", strings.Join(args, " "), err)
 		}
 		output.UserOut.Print(out)
 	},

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -46,7 +46,7 @@ var DdevExecCmd = &cobra.Command{
 			Service: serviceType,
 			Dir:     execDirArg,
 			Cmd:     strings.Join(args, " "),
-			Tty:	true,
+			Tty:     true,
 		})
 
 		if err != nil {

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -64,17 +64,17 @@ func TestCmdExec(t *testing.T) {
 		assert.Contains(out, "no such file or directory")
 
 		args = []string{"exec", "ls >/var/www/html/TestCmdExec-${OSTYPE}.txt"}
-		out, err = exec.RunCommand(DdevBin, args)
+		_, err = exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
 		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-linux-gnu.txt"))
 
 		args = []string{"exec", "ls >/dev/null && touch /var/www/html/TestCmdExec-touch-all-in-one.txt"}
-		out, err = exec.RunCommand(DdevBin, args)
+		_, err = exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
 		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-touch-all-in-one.txt"))
 
 		args = []string{"exec", "true", "&&", "touch", "/var/www/html/TestCmdExec-touch-separate-args.txt"}
-		out, err = exec.RunCommand(DdevBin, args)
+		_, err = exec.RunCommand(DdevBin, args)
 		assert.NoError(err)
 		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-touch-separate-args.txt"))
 

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/drud/ddev/pkg/exec"
@@ -19,7 +20,7 @@ func TestCmdExecBadArgs(t *testing.T) {
 	assert.Contains(string(out), "Usage:")
 }
 
-// TestCmdExec runs `ddev exec pwd` with proper args
+// TestCmdExec runs a number of exec commands to verify behavior
 func TestCmdExec(t *testing.T) {
 
 	assert := asrt.New(t)
@@ -61,6 +62,21 @@ func TestCmdExec(t *testing.T) {
 		out, err = exec.RunCommand(DdevBin, args)
 		assert.Error(err)
 		assert.Contains(out, "no such file or directory")
+
+		args = []string{"exec", "ls >/var/www/html/TestCmdExec-${OSTYPE}.txt"}
+		out, err = exec.RunCommand(DdevBin, args)
+		assert.NoError(err)
+		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-linux-gnu.txt"))
+
+		args = []string{"exec", "ls >/dev/null && touch /var/www/html/TestCmdExec-touch-all-in-one.txt"}
+		out, err = exec.RunCommand(DdevBin, args)
+		assert.NoError(err)
+		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-touch-all-in-one.txt"))
+
+		args = []string{"exec", "true", "&&", "touch", "/var/www/html/TestCmdExec-touch-separate-args.txt"}
+		out, err = exec.RunCommand(DdevBin, args)
+		assert.NoError(err)
+		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-touch-separate-args.txt"))
 
 		cleanup()
 	}

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 
 	// Attempt to stop/remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
-	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent"}); err != nil {
+	if _, err = exec.RunCommand(DdevBin, []string{"remove", "--all", "--stop-ssh-agent"}); err != nil {
 		log.Warnf("Failed to stop/remove all running projects: %v", err)
 	}
 
@@ -167,10 +167,10 @@ func removeSites() {
 	for _, site := range DevTestSites {
 		_ = site.Chdir()
 
-		args := []string{"stop", "-RO"}
+		args := []string{"remove", "-RO"}
 		out, err := exec.RunCommand(DdevBin, args)
 		if err != nil {
-			log.Errorf("Failed to run ddev stop -RO command, err: %v, output: %s\n", err, out)
+			log.Errorf("Failed to run ddev remove -RO command, err: %v, output: %s\n", err, out)
 		}
 	}
 }

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -34,7 +34,7 @@ var DdevSSHCmd = &cobra.Command{
 
 		err = app.ExecWithTty(&ddevapp.ExecOpts{
 			Service: serviceType,
-			Cmd:     []string{"bash"},
+			Cmd:     "bash",
 			Dir:     sshDirArg,
 		})
 

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -4,17 +4,16 @@ Certain ddev commands provide hooks to run tasks before or after the main comman
 
 To define command tasks in your configuration, specify the desired command hook as a subfield to `hooks`, then provide a list of tasks to run.
 
-_Note: Only simple commands are currently supported, so if you need to handle multiple commands, put them in as separate tasks. Shell pipes, &&, ||, and related bash/shell expressions are not yet supported._
-
 Example:
 
 ```
 hooks:
   post-start:
     - exec: "simple command expression"
+    - exec: "ls >/dev/null && touch /var/www/html/somefile.txt"
     - exec-host: "simple command expression"
   post-import-db:
-    - exec-host: "drush uli"
+    - exec: "drush uli"
 ```
 
 ## Supported Command Hooks

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -39,10 +39,10 @@ _Use drush to clear the Drupal cache and get a user login link after database im
 ```
 hooks:
   post-import-db:
-    - exec: "drush cc all"
-    - exec: "drush uli"
+    - exec: drush cr
+    - exec: drush uli
   post-start:
-    - exec: bash -c "sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ghostscript sqlite3 php7.2-sqlite3 && sudo killall -HUP php-fpm"```
+    - exec: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ghostscript sqlite3 php7.2-sqlite3 && sudo killall -HUP php-fpm
 ```
 
 Example:
@@ -52,7 +52,7 @@ _Use wp-cli to replace the production URL with development URL in the database o
 ```
 hooks:
   post-import-db:
-    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
+    - exec: wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local
 ```
 
 ### `exec-host`: Execute a shell command on the host system.
@@ -126,7 +126,7 @@ hooks:
 ```
 hooks:
     post-start:
-      - exec: "composer install -d /var/www/html/"
+      - exec: composer install -d /var/www/html/
 ```
 
 ## Adding Additional PHP Modules Example
@@ -135,5 +135,5 @@ hooks:
 hooks:
     post-start:
       # Install php modules and then tell php-fpm to reload
-      - exec: bash -c "sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y php7.1-ldap php7.1-tidy && killall -HUP php-fpm"
+      - exec: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y php7.1-ldap php7.1-tidy && killall -HUP php-fpm
 ```

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -689,14 +689,14 @@ func TestExtraPackages(t *testing.T) {
 
 	_, _, err = app.Exec(&ExecOpts{
 		Service: "web",
-		Cmd:     []string{"bash", "-c", "command -v zsh"},
+		Cmd:     "command -v zsh",
 	})
 	assert.Error(err)
 	assert.Contains(err.Error(), "exit status 1")
 
 	_, _, err = app.Exec(&ExecOpts{
 		Service: "db",
-		Cmd:     []string{"bash", "-c", "command -v ncdu"},
+		Cmd:     "command -v ncdu",
 	})
 	assert.Error(err)
 	assert.Contains(err.Error(), "exit status 1")
@@ -709,14 +709,14 @@ func TestExtraPackages(t *testing.T) {
 
 	stdout, _, err := app.Exec(&ExecOpts{
 		Service: "web",
-		Cmd:     []string{"bash", "-c", "command -v zsh"},
+		Cmd:     "command -v zsh",
 	})
 	assert.NoError(err)
 	assert.Equal("/usr/bin/zsh", strings.Trim(stdout, "\n"))
 
 	stdout, _, err = app.Exec(&ExecOpts{
 		Service: "db",
-		Cmd:     []string{"bash", "-c", "command -v ncdu"},
+		Cmd:     "command -v ncdu",
 	})
 	assert.NoError(err)
 	assert.Equal("/usr/bin/ncdu", strings.Trim(stdout, "\n"))
@@ -730,7 +730,7 @@ func TestExtraPackages(t *testing.T) {
 
 	_, _, err = app.Exec(&ExecOpts{
 		Service: "web",
-		Cmd:     []string{"bash", "-c", "command -v zsh"},
+		Cmd:     "command -v zsh",
 	})
 	assert.Error(err)
 	assert.Contains(err.Error(), "exit status 1")
@@ -780,7 +780,7 @@ RUN touch /var/tmp/`+"added-by-"+item+".txt"))
 	for _, item := range []string{"web", "db"} {
 		_, _, err = app.Exec(&ExecOpts{
 			Service: item,
-			Cmd:     []string{"ls", "/var/tmp/added-by-" + item + ".txt"},
+			Cmd:     "ls /var/tmp/added-by-" + item + ".txt",
 		})
 		assert.NoError(err)
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/mattn/go-isatty"
+	"github.com/mattn/go-shellwords"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -33,7 +34,6 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/fsouza/go-dockerclient"
-	"github.com/mattn/go-shellwords"
 )
 
 // containerWaitTimeout is the max time we wait for all containers to become ready.
@@ -352,7 +352,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool) error
 	insideContainerImportPath := path.Join("/mnt/ddev_config", filepath.Base(dbPath))
 	_, _, err = app.Exec(&ExecOpts{
 		Service: "db",
-		Cmd:     []string{"bash", "-c", "mysql --database=mysql -e 'DROP DATABASE IF EXISTS db; CREATE DATABASE db;' && pv " + insideContainerImportPath + "/*.*sql | mysql db"},
+		Cmd:     "mysql --database=mysql -e 'DROP DATABASE IF EXISTS db; CREATE DATABASE db;' && pv " + insideContainerImportPath + "/*.*sql | mysql db",
 		Tty:     progress && isatty.IsTerminal(os.Stderr.Fd()),
 	})
 
@@ -390,11 +390,11 @@ func (app *DdevApp) ExportDB(outFile string, gzip bool) error {
 
 	opts := &ExecOpts{
 		Service:   "db",
-		Cmd:       []string{"bash", "-c", "mysqldump db"},
+		Cmd:       "mysqldump db",
 		NoCapture: true,
 	}
 	if gzip {
-		opts.Cmd = []string{"bash", "-c", "mysqldump db | gzip"}
+		opts.Cmd = "mysqldump db | gzip"
 	}
 	if outFile != "" {
 		f, err := os.OpenFile(outFile, os.O_RDWR|os.O_CREATE, 0644)
@@ -623,14 +623,17 @@ func (app *DdevApp) ProcessHooks(hookName string) error {
 		if c.Exec != "" {
 			output.UserOut.Printf("--- Running exec command: %s ---", c.Exec)
 
-			args, err := shellwords.Parse(c.Exec)
+			testargs, err := shellwords.Parse(c.Exec)
 			if err != nil {
 				return fmt.Errorf("%s exec failed: %v", hookName, err)
 			}
+			_ = testargs
+			args := strings.Split(c.Exec, " ")
+			_ = args
 
 			stdout, stderr, err := app.Exec(&ExecOpts{
 				Service: "web",
-				Cmd:     args,
+				Cmd:     c.Exec,
 			})
 
 			if err != nil {
@@ -768,7 +771,7 @@ func (app *DdevApp) Start() error {
 	if postStartCmds := app.Commands["post-start"]; len(postStartCmds) > 0 {
 		stdout, _, _ := app.Exec(&ExecOpts{
 			Service: "web",
-			Cmd:     []string{"bash", "-c", "if [ -f /var/tmp/ddev_started.txt ]; then echo -n 'already started'; else touch /var/tmp/ddev_started.txt && echo -n 'starting'; fi"},
+			Cmd:     "if [ -f /var/tmp/ddev_started.txt ]; then echo -n 'already started'; else touch /var/tmp/ddev_started.txt && echo -n 'starting'; fi",
 		})
 		if stdout != "already started" {
 			err = app.ProcessHooks("post-start")
@@ -787,8 +790,8 @@ type ExecOpts struct {
 	Service string
 	// Dir is the working directory inside the container
 	Dir string
-	// Cmd is the array of string to execute
-	Cmd []string
+	// Cmd is the string to execute
+	Cmd string
 	// Nocapture if true causes use of ComposeNoCapture, so the stdout and stderr go right to stdout/stderr
 	NoCapture bool
 	// Tty if true causes a tty to be allocated
@@ -820,11 +823,19 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 
 	exec = append(exec, opts.Service)
 
-	if opts.Cmd == nil {
+	if opts.Cmd == "" {
 		return "", "", fmt.Errorf("no command provided")
 	}
 
-	exec = append(exec, opts.Cmd...)
+	// Cases to handle
+	// - Free form, all unquoted. Like `ls -l -a`
+	// - Quoted to delay pipes and other features to container, like `"ls -l -a | grep junk"`
+	// - Already with bash -c, like `bash -c "ls -la | grep junk"`
+	// Note that a set quoted on the host in ddev exec will come through as a single arg
+
+	//cmdString := strings.ReplaceAll(opts.Cmd, `"`, `\"`)
+
+	exec = append(exec, "bash", "-c", opts.Cmd)
 
 	files, err := app.ComposeFiles()
 	if err != nil {
@@ -866,11 +877,11 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 
 	exec = append(exec, opts.Service)
 
-	if opts.Cmd == nil {
+	if opts.Cmd == "" {
 		return fmt.Errorf("no command provided")
 	}
 
-	exec = append(exec, opts.Cmd...)
+	exec = append(exec, opts.Cmd)
 
 	files, err := app.ComposeFiles()
 	if err != nil {
@@ -1170,7 +1181,7 @@ func (app *DdevApp) SnapshotDatabase(snapshotName string) (string, error) {
 	util.Warning("Creating database snapshot %s", snapshotName)
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "db",
-		Cmd:     []string{"bash", "-c", fmt.Sprintf("mariabackup --backup --target-dir=%s --user root --password root --socket=/var/tmp/mysql.sock 2>/var/log/mariadbackup_backup_%s.log && cp /var/lib/mysql/db_mariadb_version.txt %s", containerSnapshotDir, snapshotName, containerSnapshotDir)},
+		Cmd:     fmt.Sprintf("mariabackup --backup --target-dir=%s --user root --password root --socket=/var/tmp/mysql.sock 2>/var/log/mariadbackup_backup_%s.log && cp /var/lib/mysql/db_mariadb_version.txt %s", containerSnapshotDir, snapshotName, containerSnapshotDir),
 	})
 
 	if err != nil {
@@ -1622,7 +1633,7 @@ func (app *DdevApp) precacheWebdir() error {
 	// Set the flag to tell unison it can start syncing
 	_, _, err = app.Exec(&ExecOpts{
 		Service: BGSYNCContainer,
-		Cmd:     []string{"touch", "/var/tmp/unison_start_authorized"},
+		Cmd:     "touch /var/tmp/unison_start_authorized",
 	})
 	if err != nil {
 		return fmt.Errorf("could not start bgsync container syncing: %v", err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -830,10 +830,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	// Cases to handle
 	// - Free form, all unquoted. Like `ls -l -a`
 	// - Quoted to delay pipes and other features to container, like `"ls -l -a | grep junk"`
-	// - Already with bash -c, like `bash -c "ls -la | grep junk"`
 	// Note that a set quoted on the host in ddev exec will come through as a single arg
-
-	//cmdString := strings.ReplaceAll(opts.Cmd, `"`, `\"`)
 
 	exec = append(exec, "bash", "-c", opts.Cmd)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1474,12 +1474,10 @@ func TestProcessHooks(t *testing.T) {
 	// echo and pwd are things that work pretty much the same in both places.
 	app.Commands = map[string][]ddevapp.Command{
 		"hook-test": {
-			{
-				Exec: "ls /usr/local/bin/composer",
-			},
-			{
-				ExecHost: "echo something",
-			},
+			{Exec: "ls /usr/local/bin/composer"},
+			{ExecHost: "echo something"},
+			{Exec: "echo TestProcessHooks > /var/www/html/TestProcessHooks${DDEV_ROUTER_HTTPS_PORT}.txt"},
+			{Exec: "touch /var/tmp/TestProcessHooks && touch /var/www/html/touch_works_after_and.txt"},
 		},
 	}
 
@@ -1492,6 +1490,8 @@ func TestProcessHooks(t *testing.T) {
 
 	assert.Contains(out, "hook-test exec command succeeded, output below ---\n/usr/local/bin/composer")
 	assert.Contains(out, "--- Running host command: echo something ---\nRunning Command Command=echo something\nsomething")
+	assert.FileExists(filepath.Join(app.AppRoot, fmt.Sprintf("TestProcessHooks%s.txt", app.RouterHTTPSPort)))
+	assert.FileExists(filepath.Join(app.AppRoot, "touch_works_after_and.txt"))
 
 	err = app.Stop(true, false)
 	assert.NoError(err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -302,7 +302,7 @@ func TestDdevStart(t *testing.T) {
 	err = os.Chdir(site.Dir)
 	assert.NoError(err)
 	err = app.Init(site.Dir)
-	app.Commands = map[string][]ddevapp.Command{"post-start": {{Exec: "bash -c 'echo hello'"}}}
+	app.Commands = map[string][]ddevapp.Command{"post-start": {{Exec: "echo hello"}}}
 
 	assert.NoError(err)
 	stdout := util.CaptureUserOut()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -669,7 +669,7 @@ func TestDdevImportDB(t *testing.T) {
 
 			out, _, err := app.Exec(&ddevapp.ExecOpts{
 				Service: "db",
-				Cmd:     "mysql -e SHOW TABLES;",
+				Cmd:     "mysql -e 'SHOW TABLES;'",
 			})
 			assert.NoError(err)
 
@@ -688,7 +688,7 @@ func TestDdevImportDB(t *testing.T) {
 
 			out, _, err := app.Exec(&ddevapp.ExecOpts{
 				Service: "db",
-				Cmd:     "mysql -e SHOW TABLES;",
+				Cmd:     "mysql -e 'SHOW TABLES;'",
 			})
 			assert.NoError(err)
 
@@ -1364,12 +1364,12 @@ func TestDdevExec(t *testing.T) {
 
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "db",
-			Cmd:     "mysql -e DROP DATABASE db;",
+			Cmd:     "mysql -e 'DROP DATABASE db;'",
 		})
 		assert.NoError(err)
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "db",
-			Cmd:     "mysql information_schema -e \"CREATE DATABASE db;\"",
+			Cmd:     "mysql information_schema -e 'CREATE DATABASE db;'",
 		})
 		assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -465,7 +465,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 	opts := &ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"php", "--ri", "xdebug"},
+		Cmd:     "php --ri xdebug",
 	}
 	stdout, _, err := app.Exec(opts)
 	assert.Error(err)
@@ -524,24 +524,24 @@ func TestDdevMysqlWorks(t *testing.T) {
 	// Test that mysql + .my.cnf works on web container
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"bash", "-c", "mysql -e 'SELECT USER();' | grep 'db@'"},
+		Cmd:     "mysql -e 'SELECT USER();' | grep 'db@'",
 	})
 	assert.NoError(err)
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"bash", "-c", "mysql -e 'SELECT DATABASE();' | grep 'db'"},
+		Cmd:     "mysql -e 'SELECT DATABASE();' | grep 'db'",
 	})
 	assert.NoError(err)
 
 	// Test that mysql + .my.cnf works on db container
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
-		Cmd:     []string{"bash", "-c", "mysql -e 'SELECT USER();' | grep 'root@localhost'"},
+		Cmd:     "mysql -e 'SELECT USER();' | grep 'root@localhost'",
 	})
 	assert.NoError(err)
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
-		Cmd:     []string{"bash", "-c", "mysql -e 'SELECT DATABASE();' | grep 'db'"},
+		Cmd:     "mysql -e 'SELECT DATABASE();' | grep 'db'",
 	})
 	assert.NoError(err)
 
@@ -669,7 +669,7 @@ func TestDdevImportDB(t *testing.T) {
 
 			out, _, err := app.Exec(&ddevapp.ExecOpts{
 				Service: "db",
-				Cmd:     []string{"mysql", "-e", "SHOW TABLES;"},
+				Cmd:     "mysql -e SHOW TABLES;",
 			})
 			assert.NoError(err)
 
@@ -688,7 +688,7 @@ func TestDdevImportDB(t *testing.T) {
 
 			out, _, err := app.Exec(&ddevapp.ExecOpts{
 				Service: "db",
-				Cmd:     []string{"mysql", "-e", "SHOW TABLES;"},
+				Cmd:     "mysql -e SHOW TABLES;",
 			})
 			assert.NoError(err)
 
@@ -1106,7 +1106,7 @@ func TestWriteableFilesDirectory(t *testing.T) {
 
 	_, _, createFileErr := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"sh", "-c", "echo 'content created inside container\n' >" + inContainerRelativePath},
+		Cmd:     "echo 'content created inside container\n' >" + inContainerRelativePath,
 	})
 	assert.NoError(createFileErr)
 	if app.WebcacheEnabled && createFileErr != nil {
@@ -1120,7 +1120,7 @@ func TestWriteableFilesDirectory(t *testing.T) {
 		// ls -lR in container
 		inContainerList, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
-			Cmd:     []string{"ls", "-lR", filepath.Dir(uploadDir)},
+			Cmd:     "ls -lR " + filepath.Dir(uploadDir),
 		})
 		assert.NoError(err)
 		t.Fatalf("Unable to create file %s inside container; onHost ls=\n====\n%s\n====\ninContainer ls=\n======\n%s\n=====\nContainer Sync logs=\n=======\n%s\n===========\n", inContainerRelativePath, onHostList, inContainerList, syncLogs)
@@ -1164,13 +1164,13 @@ func TestWriteableFilesDirectory(t *testing.T) {
 	// if the file exists, add to it. We don't want to add if it's not already there.
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"sh", "-c", "if [ -f " + inContainerRelativePath + " ]; then echo 'content added inside container\n' >>" + inContainerRelativePath + "; fi"},
+		Cmd:     "if [ -f " + inContainerRelativePath + " ]; then echo 'content added inside container\n' >>" + inContainerRelativePath + "; fi",
 	})
 	assert.NoError(err)
 	// grep the file for both the content added on host and that added in container.
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"sh", "-c", "grep 'base content was inserted on the host' " + inContainerRelativePath + "&& grep 'content added inside container' " + inContainerRelativePath},
+		Cmd:     "grep 'base content was inserted on the host' " + inContainerRelativePath + "&& grep 'content added inside container' " + inContainerRelativePath,
 	})
 	assert.NoError(err)
 
@@ -1349,7 +1349,7 @@ func TestDdevExec(t *testing.T) {
 
 		out, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
-			Cmd:     []string{"pwd"},
+			Cmd:     "pwd",
 		})
 		assert.NoError(err)
 		assert.Contains(out, "/var/www/html")
@@ -1357,19 +1357,19 @@ func TestDdevExec(t *testing.T) {
 		out, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
 			Dir:     "/usr/local",
-			Cmd:     []string{"pwd"},
+			Cmd:     "pwd",
 		})
 		assert.NoError(err)
 		assert.Contains(out, "/usr/local")
 
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "db",
-			Cmd:     []string{"mysql", "-e", "DROP DATABASE db;"},
+			Cmd:     "mysql -e DROP DATABASE db;",
 		})
 		assert.NoError(err)
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "db",
-			Cmd:     []string{"mysql", "information_schema", "-e", "CREATE DATABASE db;"},
+			Cmd:     "mysql information_schema -e \"CREATE DATABASE db;\"",
 		})
 		assert.NoError(err)
 
@@ -1381,14 +1381,14 @@ func TestDdevExec(t *testing.T) {
 		case ddevapp.AppTypeDrupal8:
 			out, _, err = app.Exec(&ddevapp.ExecOpts{
 				Service: "web",
-				Cmd:     []string{"drush", "status"},
+				Cmd:     "drush status",
 			})
 			assert.NoError(err)
 			assert.Regexp("PHP configuration[ :]*/etc/php/[0-9].[0-9]/fpm/php.ini", out)
 		case ddevapp.AppTypeWordPress:
 			out, _, err = app.Exec(&ddevapp.ExecOpts{
 				Service: "web",
-				Cmd:     []string{"wp", "--info"},
+				Cmd:     "wp --info",
 			})
 			assert.NoError(err)
 			assert.Regexp("/etc/php.*/php.ini", out)
@@ -2244,7 +2244,7 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 			if _, err := strconv.ParseInt(hostParts[0], 10, 64); err != nil {
 				out, _, err := app.Exec(&ddevapp.ExecOpts{
 					Service: "web",
-					Cmd:     []string{"bash", "-c", "curl -sS --fail " + item + site.Safe200URIWithExpectation.URI},
+					Cmd:     "curl -sS --fail " + item + site.Safe200URIWithExpectation.URI,
 				})
 				assert.NoError(err, "failed curl to %s: %v", item+site.Safe200URIWithExpectation.URI, err)
 				assert.Contains(out, site.Safe200URIWithExpectation.Expect)
@@ -2325,7 +2325,7 @@ func TestNFSMount(t *testing.T) {
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     []string{"bash", "-c", "findmnt -T ."},
+		Cmd:     "findmnt -T .",
 	})
 	assert.NoError(err)
 	assert.Contains(stdout, ":"+dockerutil.MassageWIndowsNFSMount(app.AppRoot))
@@ -2337,7 +2337,7 @@ func TestNFSMount(t *testing.T) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     []string{"bash", "-c", "ls nfslinked_.ddev/config.yaml"},
+		Cmd:     "ls nfslinked_.ddev/config.yaml",
 	})
 	assert.NoError(err)
 
@@ -2348,7 +2348,7 @@ func TestNFSMount(t *testing.T) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     []string{"bash", "-c", "ls nfslinked_config.yaml"},
+		Cmd:     "ls nfslinked_config.yaml",
 	})
 	assert.NoError(err)
 
@@ -2356,7 +2356,7 @@ func TestNFSMount(t *testing.T) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     []string{"bash", "-c", "ln -s  .ddev nfscontainerlinked_ddev"},
+		Cmd:     "ln -s  .ddev nfscontainerlinked_ddev",
 	})
 	assert.NoError(err)
 	time.Sleep(2 * time.Second)
@@ -2366,7 +2366,7 @@ func TestNFSMount(t *testing.T) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     []string{"bash", "-c", "ln -s  .ddev/config.yaml nfscontainerlinked_config.yaml"},
+		Cmd:     "ln -s  .ddev/config.yaml nfscontainerlinked_config.yaml",
 	})
 	assert.NoError(err)
 	time.Sleep(2 * time.Second)
@@ -2409,7 +2409,7 @@ func TestWebcache(t *testing.T) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     []string{"bash", "-c", "ls webcachelinked_.ddev/config.yaml"},
+		Cmd:     "ls webcachelinked_.ddev/config.yaml",
 	})
 	assert.NoError(err)
 
@@ -2417,7 +2417,7 @@ func TestWebcache(t *testing.T) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     []string{"bash", "-c", "ln -s  .ddev webcachecontainerlinked_ddev"},
+		Cmd:     "ln -s  .ddev webcachecontainerlinked_ddev",
 	})
 	assert.NoError(err)
 	time.Sleep(2 * time.Second)
@@ -2427,7 +2427,7 @@ func TestWebcache(t *testing.T) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     []string{"bash", "-c", "ln -s  .ddev/config.yaml webcachecontainerlinked_config.yaml"},
+		Cmd:     "ln -s  .ddev/config.yaml webcachecontainerlinked_config.yaml",
 	})
 	assert.NoError(err)
 	time.Sleep(2 * time.Second)

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -85,7 +85,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try a simple ssh (with no auth set up), it should fail with "Permission denied"
 	_, stderr, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"bash", "-c", "ssh -o BatchMode=yes -o StrictHostKeyChecking=false root@test-ssh-server pwd"},
+		Cmd:     "ssh -o BatchMode=yes -o StrictHostKeyChecking=false root@test-ssh-server pwd",
 	})
 
 	assert.Error(err)
@@ -103,7 +103,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try ssh, should succeed
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"bash", "-c", "ssh -o StrictHostKeyChecking=false root@test-ssh-server pwd"},
+		Cmd:     "ssh -o StrictHostKeyChecking=false root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\n")
 	assert.Equal(stdout, "/root")
@@ -119,7 +119,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try ssh, should succeed
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"bash", "-c", "ssh -o StrictHostKeyChecking=false root@test-ssh-server pwd"},
+		Cmd:     "ssh -o StrictHostKeyChecking=false root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\n")
 	assert.Equal(stdout, "/root")

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -131,7 +131,7 @@ func checkSolrService(t *testing.T, app *ddevapp.DdevApp) {
 	checkCommand := fmt.Sprintf("curl -sL -w '%%{http_code}' '%s' -o /dev/null", path)
 	out, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"sh", "-c", checkCommand},
+		Cmd:     checkCommand,
 	})
 	assert.NoError(err, "Unable to make request to http://%s:%s/solr/", service, port)
 	assert.Equal("200", out)
@@ -165,7 +165,7 @@ func checkMemcachedService(t *testing.T, app *ddevapp.DdevApp) {
 
 	out, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     []string{"sh", "-c", checkCommand},
+		Cmd:     checkCommand,
 	})
 	assert.NoError(err)
 	assert.Contains(out, "STAT pid")


### PR DESCRIPTION
## The Problem/Issue/Bug:

People always expect a shell interpreter for `ddev exec` and exec hooks. We have used none.

## How this PR Solves The Problem:

Add bash in.

## Manual Testing Instructions:

* `ddev exec ls`
* `ddev exec "ls -l | grep apache"`
* post-start hook `exec: "set | grep DDEV"

Everything else you can think of.

## Automated Testing Overview:

- [x] `ddev exec "ls >/tmp/junk"`
- [x] `ddev exec "ls | grep apache"`
- [x] `ddev exec echo \$HOSTNAME`
- [x] Any other thing you normally use ddev exec for
- [x] Hooks
```
hooks:
  post-start:
    - exec: set | grep DDEV
    - exec: "set | grep DDEV"
    - exec: ls >/tmp/junk
    - exec: ls *.php
```

## Related Issue Link(s):

OP #1023 

## Release/Deployment notes:

* I couldn't figure out how to handle existing `bash -c "..."` with this, and it seemed less complex to just ask people to remove the "bash -c" from existing hooks. So... ask them to update hooks that might include `bash -c`.
* There is an existing [stack overflow article](https://stackoverflow.com/questions/50971602/how-can-i-use-bash-constructs-like-cd-or-or-redirection-with-ddev-exe) that needs to be updated or deleted (it's now obsolete)
