### PR TITLE
ddev exec command should allow tty interactions

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -46,6 +46,7 @@ var DdevExecCmd = &cobra.Command{
 			Service: serviceType,
 			Dir:     execDirArg,
 			Cmd:     args,
+			Tty:     true,
 		})
 
 		if err != nil {

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -7,8 +7,8 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDevExecBadArgs run `ddev exec` without the proper args
-func TestDevExecBadArgs(t *testing.T) {
+// TestCmdExecBadArgs run `ddev exec` without the proper args
+func TestCmdExecBadArgs(t *testing.T) {
 	// Change to the first DevTestSite for the duration of this test.
 	defer DevTestSites[0].Chdir()()
 	assert := asrt.New(t)
@@ -19,8 +19,8 @@ func TestDevExecBadArgs(t *testing.T) {
 	assert.Contains(string(out), "Usage:")
 }
 
-// TestDevExec run `ddev exec pwd` with proper args
-func TestDevExec(t *testing.T) {
+// TestCmdExec runs `ddev exec pwd` with proper args
+func TestCmdExec(t *testing.T) {
 
 	assert := asrt.New(t)
 	for _, v := range DevTestSites {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -812,7 +812,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		exec = append(exec, "-w", workingDir)
 	}
 
-	if !opts.Tty {
+	if !isatty.IsTerminal(os.Stdout.Fd()) || !opts.Tty {
 		exec = append(exec, "-T")
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

People have long been frustrated by the inability to interact with the console using `ddev exec`. But we long since have been able to do that, but didn't add it to the `ddev exec` command.

## How this PR Solves The Problem:

Allow interaction when doing ddev exec. Kind of makes it identical to `ddev ssh`, but no direct interaction with the container.

## Manual Testing Instructions:

`ddev exec mysql`
`ddev exec vi index.php`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

https://github.com/drud/ddev/issues/1023 will be adding bash interpretation to ddev exec
https://github.com/drud/ddev/issues/1162 will eventually make ddev exec handle stdout/stderr and exit values correctly

## Release/Deployment notes:

This will be an important announcement, and could conceivably affect some people's workflow.
