### PR TITLE
Use StartAndWaitForSync to accomodate docker toolbox slowness

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -3,7 +3,6 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
-	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
@@ -643,18 +642,11 @@ func TestPHPOverrides(t *testing.T) {
 		_ = app.Stop(true, false)
 		// nolint: errcheck
 		defer app.Stop(true, false)
-		startErr := app.StartAndWaitForSync(2)
+		startErr := app.StartAndWaitForSync(5)
 		if startErr != nil {
 			logs, _ := GetErrLogsFromApp(app, startErr)
 			t.Logf("failed app.StartAndWait(): %v", startErr)
 			t.Fatalf("============== logs from app.StartAndWait() ==============\n%s\n", logs)
-		}
-
-		// On Docker Toolbox, it appearas that the change notification gets to the router
-		// slower than on other platforms. Give it time to come through.
-		// Otherwise the SSL cert may not yet have been created
-		if nodeps.IsDockerToolbox() {
-			time.Sleep(time.Duration(5) * time.Second)
 		}
 
 		_, _ = testcommon.EnsureLocalHTTPContent(t, "http://"+app.GetHostname()+"/phpinfo.php", `max_input_time</td><td class="v">999`)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1107,6 +1107,12 @@ func (app *DdevApp) StartAndWaitForSync(extraSleep int) error {
 		if extraSleep > 0 {
 			time.Sleep(time.Duration(extraSleep) * time.Second)
 		}
+	} else if nodeps.IsDockerToolbox() {
+		// Docker Toolbox seems not to get the router properly
+		// updated with certs as fast as we expect, use the extraSleep for that.
+		if extraSleep > 0 {
+			time.Sleep(time.Duration(extraSleep) * time.Second)
+		}
 	}
 	return nil
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -394,7 +394,7 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		err = app.WriteConfig()
 		assert.NoError(err)
 
-		err = app.Start()
+		err = app.StartAndWaitForSync(5)
 		assert.NoError(err)
 		if err != nil && strings.Contains(err.Error(), "db container failed") {
 			container, err := app.FindContainerByType("db")
@@ -402,12 +402,6 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 			out, err := exec.RunCommand("docker", []string{"logs", container.Names[0]})
 			assert.NoError(err)
 			t.Logf("DB Logs after app.Start: \n%s\n=== END DB LOGS ===", out)
-		}
-		// On Docker Toolbox, it appearas that the change notification gets to the router
-		// slower than on other platforms. Give it time to come through.
-		// Otherwise the SSL cert may not yet have been created
-		if nodeps.IsDockerToolbox() {
-			time.Sleep(time.Duration(5) * time.Second)
 		}
 
 		// ensure docker-compose.yaml exists inside .ddev site folder
@@ -1966,12 +1960,6 @@ func TestHttpsRedirection(t *testing.T) {
 
 			t.Fatalf("app.StartAndWaitForSync failure; err=%v \n===== container logs ===\n%s\n===== bgsync health info ===\n%s\n========\n", startErr, appLogs, healthcheck)
 		}
-		// On Docker Toolbox, it appearas that the change notification gets to the router
-		// slower than on other platforms. Give it time to come through.
-		// Otherwise the SSL cert may not yet have been created
-		if nodeps.IsDockerToolbox() {
-			time.Sleep(time.Duration(5) * time.Second)
-		}
 		// Test for directory redirects under https and http
 		for _, parts := range expectations {
 
@@ -2224,15 +2212,8 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		err = app.Stop(true, false)
 		assert.NoError(err)
 
-		err = app.StartAndWaitForSync(0)
+		err = app.StartAndWaitForSync(5)
 		assert.NoError(err)
-
-		// On Docker Toolbox, it appearas that the change notification gets to the router
-		// slower than on other platforms. Give it time to come through.
-		// Otherwise the SSL cert may not yet have been created
-		if nodeps.IsDockerToolbox() {
-			time.Sleep(time.Duration(5) * time.Second)
-		}
 
 		urls := app.GetAllURLs()
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -2,19 +2,16 @@ package testcommon
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
-	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/fileutil"
+	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
-	"time"
-
-	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/fileutil"
-	asrt "github.com/stretchr/testify/assert"
 )
 
 var DdevBin = "ddev"
@@ -178,12 +175,6 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 			logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
 			assert.NoError(err)
 			t.Fatalf("logs from broken container:\n=======\n%s\n========\n", logs)
-		}
-		// On Docker Toolbox, it appearas that the change notification gets to the router
-		// slower than on other platforms. Give it time to come through.
-		// Otherwise the SSL cert may not yet have been created
-		if nodeps.IsDockerToolbox() {
-			time.Sleep(time.Duration(5) * time.Second)
 		}
 
 		safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI


### PR DESCRIPTION
## The Problem/Issue/Bug:

I had second thoughts about the hacky way I accommodated slow Docker Toolbox ddev-router updating. 

## How this PR Solves The Problem:

Do it with app.StartAndWaitForSync() instead.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

