### PR TITLE
Add quickstart for PHP project [skip ci][ci skip]

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -5,9 +5,24 @@ Type `ddev` or `ddev -h`in a terminal windows to see the available ddev commands
 
 ## Quickstart Guides
 
-These are quickstart instructions for WordPress, Drupal 6, Drupal 7, Drupal 8, TYPO3, and Backdrop.
+These are quickstart instructions for plain PHP, WordPress, Drupal 6, Drupal 7, Drupal 8, TYPO3, and Backdrop.
 
 **Prerequisites:** Before you start, follow the [installation instructions](../index.md#installation). Make sure to [check the system requirements](../index.md#system-requirements), you will need *docker* and *docker-compose* to use ddev.
+
+### PHP Project Quickstart
+
+DDEV is happy to work with most any PHP or HTML project, although it has special additional support for several CMSs. But you don't need special support if you already know how to configure your project.
+
+1. Create a directory (`mkdir my-new-project`)
+2. cd into the directory
+3. `ddev config`
+4. Get initial code:
+    * Clone your project into the current directory
+    * Or build it with `ddev composer create <package_name>`
+5. `ddev start`
+6. Configure any database settings; host='db', user='db', password='db', database='db'
+7. If needed, import a database with `ddev import-db`
+7. Visit the project and continue on.
 
 ### WordPress Quickstart
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -5,13 +5,13 @@ Type `ddev` or `ddev -h`in a terminal windows to see the available ddev commands
 
 ## Quickstart Guides
 
-These are quickstart instructions for plain PHP, WordPress, Drupal 6, Drupal 7, Drupal 8, TYPO3, and Backdrop.
+These are quickstart instructions for generic PHP, WordPress, Drupal 6, Drupal 7, Drupal 8, TYPO3, and Backdrop.
 
 **Prerequisites:** Before you start, follow the [installation instructions](../index.md#installation). Make sure to [check the system requirements](../index.md#system-requirements), you will need *docker* and *docker-compose* to use ddev.
 
 ### PHP Project Quickstart
 
-DDEV is happy to work with most any PHP or HTML project, although it has special additional support for several CMSs. But you don't need special support if you already know how to configure your project.
+DDEV works happily with most any PHP or static HTML project, although it has special additional support for several CMSs. But you don't need special support if you already know how to configure your project.
 
 1. Create a directory (`mkdir my-new-project`)
 2. cd into the directory


### PR DESCRIPTION
## The Problem/Issue/Bug:

People often don't "get" that ddev works fine with basic PHP projects. 

## How this PR Solves The Problem:

Add a "PHP quickstart" to the docs.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

