### PR TITLE
Warn windows users when hosts file has too many entries on a line, fixes #948

### DIFF
--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -111,6 +111,18 @@ Database snapshots from MariaDB 10.1 (normally from before ddev v1.3) cannot be 
   * `ddev restart`
  
 
+## Windows-Specific Issues
+<a name="windows-hosts-file-limited">
+### Windows Hosts File limited to 10 hosts per IP address line
+
+On Windows only, there is a limit to the number of hosts that can be placed in one line. But since all ddev hosts are typically on the same IP address (typically 127.0.0.1, localhost), they can really add up. As soon as you have more than 10 entries there, your browser won't be able to resolve the addresses beyond the 10th entry.
+
+There are two workarounds for this problem:
+
+1. Use `ddev stop --all` and `sudo ddev hostname --remove-inactive` to prune the number of hosts on that hosts-file line. When you start a project, the hostname(s) associated with that project will be added back again.
+2. Manually edit the hosts file (typically `C:\Windows\System32\drivers\etc\hosts`) and put some of your hosts on a separate line in the file. 
+
+
 ## More Support
 
 [Support options](https://ddev.readthedocs.io/en/stable/#support) has a variety of options.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1401,9 +1401,9 @@ func (app *DdevApp) AddHostsEntries() error {
 	if ipPosition != -1 && runtime.GOOS == "windows" {
 		hostsLine := hosts.Lines[ipPosition]
 		if len(hostsLine.Hosts) >= 10 {
-			util.Warning("You have more than 9 entries in your (windows) hostsfile entry for %s", dockerIP)
-			util.Warning("Please use `ddev hostname --remove-inactive` or edit the hosts file manually")
-			util.Warning("Please see %s for more information", "https://ddev.readthedocs.io/en/stable/users/troubleshooting/#windows-hosts-file-limited")
+			util.Error("You have more than 9 entries in your (windows) hostsfile entry for %s", dockerIP)
+			util.Error("Please use `ddev hostname --remove-inactive` or edit the hosts file manually")
+			util.Error("Please see %s for more information", "https://ddev.readthedocs.io/en/stable/users/troubleshooting/#windows-hosts-file-limited")
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/lextoumbourou/goodhosts"
 	"github.com/mattn/go-isatty"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 
 	"golang.org/x/crypto/ssh/terminal"
@@ -23,6 +25,7 @@ import (
 	"github.com/drud/ddev/pkg/appimport"
 	"github.com/drud/ddev/pkg/appports"
 	"github.com/drud/ddev/pkg/archive"
+	"github.com/drud/ddev/pkg/ddevhosts"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
@@ -30,7 +33,6 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/fsouza/go-dockerclient"
-	"github.com/lextoumbourou/goodhosts"
 	"github.com/mattn/go-shellwords"
 )
 
@@ -1391,9 +1393,18 @@ func (app *DdevApp) AddHostsEntries() error {
 		return fmt.Errorf("could not get Docker IP: %v", err)
 	}
 
-	hosts, err := goodhosts.NewHosts()
+	hosts, err := ddevhosts.New()
 	if err != nil {
 		util.Failed("could not open hostfile: %v", err)
+	}
+	ipPosition := hosts.GetIPPosition(dockerIP)
+	if ipPosition != -1 && runtime.GOOS == "windows" {
+		hostsLine := hosts.Lines[ipPosition]
+		if len(hostsLine.Hosts) >= 10 {
+			util.Warning("You have more than 9 entries in your (windows) hostsfile entry for %s", dockerIP)
+			util.Warning("Please use `ddev hostname --remove-inactive` or edit the hosts file manually")
+			util.Warning("Please see %s for more information", "https://ddev.readthedocs.io/en/stable/users/troubleshooting/#windows-hosts-file-limited")
+		}
 	}
 
 	for _, name := range app.GetHostnames() {

--- a/pkg/ddevhosts/ddevhosts.go
+++ b/pkg/ddevhosts/ddevhosts.go
@@ -1,0 +1,41 @@
+package ddevhosts
+
+// This package is a simple wrapper on goodhosts.
+// Its only current purpose is to provide GetIPPosition as an
+// exported function.
+
+import (
+	"github.com/lextoumbourou/goodhosts"
+)
+
+// DdevHosts uses composition to absorb all exported functions of goodhosts
+type DdevHosts struct {
+	goodhosts.Hosts // provides all exported functions from goodhosts
+}
+
+// GetIPPosition is the same as the unexported getIpPosition,
+// providing the position of the line in the hosts file that
+// supports the IP address we're looking for.
+// Or it returns -1 if none is found yet.
+func (h DdevHosts) GetIPPosition(ip string) int {
+	for i := range h.Lines {
+		line := h.Lines[i]
+		if !line.IsComment() && line.Raw != "" {
+			if line.IP == ip {
+				return i
+			}
+		}
+	}
+
+	return -1
+}
+
+// New() is a simple wrapper on goodhosts.NewHosts()
+func New() (*DdevHosts, error) {
+	h, err := goodhosts.NewHosts()
+	if err != nil {
+		return nil, err
+	}
+
+	return &DdevHosts{h}, nil
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #948 explains the bug in Windows where /etc/hosts entries cease to be recognized when you hit 10 entries. 

It would be nice to completely re-do goodhosts to think in terms of a map[ip]hostname that could be written in any fashion, but goodhosts is so fundamentally line-oriented that it would be very risky.

## How this PR Solves The Problem:

* Detect if there are more than 9 entries on the ip address line in the hosts file on WIndows.
* Warn in that case (windows only)
* Add docs

## Manual Testing Instructions:

On Windows, create multiple entries against the dockerIP (usually 127.0.0.1 on Docker Desktop)
See the warning.
Read the docs.

## Automated Testing Overview:

I don't think this is very easy to test because of the need for escalated privileges to edit the hosts file.

## Related Issue Link(s):

OP #948 


## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

