### PR TITLE
Revert parent config search, prevent directory destruction, hopefully fixes #1574

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -71,11 +71,9 @@ project root will be deleted when creating a project.`,
 		}
 
 		// Make the user confirm that existing contents will be deleted
-		util.Warning("Warning: Any existing contents of the project root (%s) will be removed", app.AppRoot)
-		if !noInteractionArg {
-			if !util.Confirm("Would you like to continue?") {
-				util.Failed("create-project cancelled")
-			}
+		util.Warning("Warning: ALL EXISTING CONTENT of the project root (%s) will be deleted", app.AppRoot)
+		if !util.Confirm("Would you like to continue?") {
+			util.Failed("create-project cancelled")
 		}
 
 		// Remove any contents of project root

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -258,24 +258,16 @@ func init() {
 
 // getConfigApp() does the basic setup of the app (with provider) and returns it.
 func getConfigApp(providerName string) (*ddevapp.DdevApp, error) {
-	// Find app root
-	cd, err := os.Getwd()
+	appRoot, err := os.Getwd()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not determine current working directory: %v", err)
 	}
-
-	// Check for an existing config in this or a parent dir
-	appRoot, err := ddevapp.CheckForConf(cd)
-	if err != nil {
-		// An error indicates no config file was found, use current directory
-		appRoot = cd
-	}
+	// TODO: Handle case where config may be in parent directories.
 
 	app, err := ddevapp.NewApp(appRoot, false, providerName)
 	if err != nil {
 		return nil, fmt.Errorf("could not create new config: %v", err)
 	}
-
 	return app, nil
 }
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -270,6 +270,14 @@ func getConfigApp(providerName string) (*ddevapp.DdevApp, error) {
 		return nil, fmt.Errorf("could not determine current working directory: %v", err)
 	}
 
+	// Check for an existing config in a parent dir
+	otherRoot, err := ddevapp.CheckForConf(appRoot)
+	if err != nil {
+		return nil, err
+	}
+	if otherRoot != appRoot {
+		util.Error("Is it possible you wanted to `ddev config` in parent directory %s?", otherRoot)
+	}
 	app, err := ddevapp.NewApp(appRoot, false, providerName)
 	if err != nil {
 		return nil, fmt.Errorf("could not create new config: %v", err)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/version"
+	"github.com/mitchellh/go-homedir"
 	"os"
 	"strings"
 
@@ -140,6 +142,11 @@ func handleConfigRun(cmd *cobra.Command, args []string) {
 	app, err := getConfigApp(providerName)
 	if err != nil {
 		util.Failed(err.Error())
+	}
+
+	homeDir, _ := homedir.Dir()
+	if app.AppRoot == filepath.Dir(globalconfig.GetGlobalDdevDir()) || app.AppRoot == homeDir {
+		util.Failed("Please do not use `ddev config` in your home directory")
 	}
 
 	if cmd.Flags().NFlag() == 0 {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -262,7 +262,6 @@ func getConfigApp(providerName string) (*ddevapp.DdevApp, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not determine current working directory: %v", err)
 	}
-	// TODO: Handle case where config may be in parent directories.
 
 	app, err := ddevapp.NewApp(appRoot, false, providerName)
 	if err != nil {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -271,10 +271,7 @@ func getConfigApp(providerName string) (*ddevapp.DdevApp, error) {
 	}
 
 	// Check for an existing config in a parent dir
-	otherRoot, err := ddevapp.CheckForConf(appRoot)
-	if err != nil {
-		return nil, err
-	}
+	otherRoot, _ := ddevapp.CheckForConf(appRoot)
 	if otherRoot != appRoot {
 		util.Error("Is it possible you wanted to `ddev config` in parent directory %s?", otherRoot)
 	}

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -272,7 +272,7 @@ func getConfigApp(providerName string) (*ddevapp.DdevApp, error) {
 
 	// Check for an existing config in a parent dir
 	otherRoot, _ := ddevapp.CheckForConf(appRoot)
-	if otherRoot != appRoot {
+	if otherRoot != "" && otherRoot != appRoot {
 		util.Error("Is it possible you wanted to `ddev config` in parent directory %s?", otherRoot)
 	}
 	app, err := ddevapp.NewApp(appRoot, false, providerName)

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -306,45 +306,7 @@ func TestConfigInvalidProjectname(t *testing.T) {
 		assert.NotContains(out, "You may now run 'ddev start'")
 		_ = os.Remove(filepath.Join(tmpdir, ".ddev", "config.yaml"))
 	}
-}
 
-// TestConfigSubdir ensures an existing config can be found from subdirectories
-func TestConfigSubdir(t *testing.T) {
-	var err error
-	assert := asrt.New(t)
-
-	// Create a temporary directory and switch to it.
-	tmpdir := testcommon.CreateTmpDir(t.Name())
-	defer testcommon.CleanupDir(tmpdir)
-	defer testcommon.Chdir(tmpdir)()
-
-	// Create a simple config.
-	args := []string{
-		"config",
-		"--project-type",
-		"php",
-	}
-
-	out, err := exec.RunCommand(DdevBin, args)
-	assert.NoError(err)
-	assert.Contains(out, "You may now run 'ddev start'")
-
-	// Create a subdirectory and switch to it.
-	subdir := filepath.Join(tmpdir, "some", "sub", "dir")
-	err = os.MkdirAll(subdir, 0755)
-	assert.NoError(err)
-	defer testcommon.Chdir(subdir)()
-
-	// Confirm that the detected config location is in the original dir.
-	args = []string{
-		"config",
-		"--show-config-location",
-	}
-
-	// Ensure the existing config can be found
-	out, err = exec.RunCommand(DdevBin, args)
-	assert.NoError(err)
-	assert.Contains(out, filepath.Join(tmpdir, ".ddev", "config.yaml"))
 }
 
 /**

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -333,13 +333,14 @@ func TestCmdDisasterConfig(t *testing.T) {
 	defer testcommon.CleanupDir(tmpdir)
 	defer testcommon.Chdir(tmpdir)()
 
-	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
+	out, err = exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
 	assert.NoError(err)
 	subdir := filepath.Join(tmpdir, "junk")
 	err = os.Mkdir(subdir, 0777)
 	assert.NoError(err)
 	err = os.Chdir(subdir)
 	assert.NoError(err)
+	assert.NotContains(out, "possible you wanted to")
 
 	// Make sure that ddev config in subdir gives a warning
 	out, err = exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -333,7 +333,7 @@ func TestCmdDisasterConfig(t *testing.T) {
 	defer testcommon.CleanupDir(tmpdir)
 	defer testcommon.Chdir(tmpdir)()
 
-	out, err = exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
+	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
 	assert.NoError(err)
 	subdir := filepath.Join(tmpdir, "junk")
 	err = os.Mkdir(subdir, 0777)

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/version"
+	"github.com/mitchellh/go-homedir"
 	"testing"
 
 	"os"
@@ -307,6 +308,45 @@ func TestConfigInvalidProjectname(t *testing.T) {
 		_ = os.Remove(filepath.Join(tmpdir, ".ddev", "config.yaml"))
 	}
 
+}
+
+// TestCmdDisasterConfig tests to make sure we can't accidentally
+// config in homedir, and that config in a subdir is handled correctly
+func TestCmdDisasterConfig(t *testing.T) {
+	var err error
+	assert := asrt.New(t)
+
+	testDir, _ := os.Getwd()
+	// Make sure we're not allowed to config in home directory.
+	home, _ := homedir.Dir()
+	err = os.Chdir(home)
+	assert.NoError(err)
+	out, err := exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
+	assert.Error(err)
+	_ = out
+
+	err = os.Chdir(testDir)
+	assert.NoError(err)
+
+	// Create a temporary directory and switch to it.
+	tmpdir := testcommon.CreateTmpDir(t.Name())
+	defer testcommon.CleanupDir(tmpdir)
+	defer testcommon.Chdir(tmpdir)()
+
+	out, err = exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
+	assert.NoError(err)
+	subdir := filepath.Join(tmpdir, "junk")
+	err = os.Mkdir(subdir, 0777)
+	assert.NoError(err)
+	err = os.Chdir(subdir)
+	assert.NoError(err)
+
+	// Make sure that ddev config in subdir gives a warning
+	out, err = exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
+	assert.NoError(err)
+	assert.Contains(out, "possible you wanted to")
+	assert.Contains(out, fmt.Sprintf("parent directory %s?", tmpdir))
+	assert.FileExists(filepath.Join(subdir, ".ddev/config.yaml"))
 }
 
 /**

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -720,10 +720,11 @@ func DiscoverDefaultDocroot(app *DdevApp) string {
 	var defaultDocroot = app.Docroot
 	if defaultDocroot == "" {
 		for _, docroot := range AvailableDocrootLocations() {
-			if _, err := os.Stat(docroot); err != nil {
+			if _, err := os.Stat(filepath.Join(app.AppRoot, docroot)); err != nil {
 				continue
 			}
-			if fileutil.FileExists(filepath.Join(docroot, "index.php")) {
+
+			if fileutil.FileExists(filepath.Join(app.AppRoot, docroot, "index.php")) {
 				defaultDocroot = docroot
 				break
 			}
@@ -740,15 +741,19 @@ func (app *DdevApp) docrootPrompt() error {
 	}
 
 	// Determine the document root.
-	output.UserOut.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your project root (%s)", app.AppRoot)
+	util.Warning("\nThe docroot is the directory from which your site is served.\nThis is a relative path from your project root at %s", app.AppRoot)
 	output.UserOut.Println("You may leave this value blank if your site files are in the project root")
 	var docrootPrompt = "Docroot Location"
 	var defaultDocroot = DiscoverDefaultDocroot(app)
 	// If there is a default docroot, display it in the prompt.
 	if defaultDocroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
-	} else {
+	} else if cd, _ := os.Getwd(); cd == filepath.Join(app.AppRoot, defaultDocroot) {
+		// Preserve the case where the docroot is the current directory
 		docrootPrompt = fmt.Sprintf("%s (current directory)", docrootPrompt)
+	} else {
+		// Explicitly state 'project root' when in a subdirectory
+		docrootPrompt = fmt.Sprintf("%s (project root)", docrootPrompt)
 	}
 
 	fmt.Print(docrootPrompt + ": ")

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/mitchellh/go-homedir"
 	"html/template"
 	"io/ioutil"
 	"os"
@@ -67,6 +68,11 @@ func init() {
 func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, error) {
 	// Set defaults.
 	app := &DdevApp{}
+
+	homeDir, _ := homedir.Dir()
+	if AppRoot == filepath.Dir(globalconfig.GetGlobalDdevDir()) || app.AppRoot == homeDir {
+		return nil, fmt.Errorf("ddev config is not useful in home directory (%s)", homeDir)
+	}
 
 	if !fileutil.FileExists(AppRoot) {
 		return app, fmt.Errorf("project root %s does not exist", AppRoot)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -720,11 +720,10 @@ func DiscoverDefaultDocroot(app *DdevApp) string {
 	var defaultDocroot = app.Docroot
 	if defaultDocroot == "" {
 		for _, docroot := range AvailableDocrootLocations() {
-			if _, err := os.Stat(filepath.Join(app.AppRoot, docroot)); err != nil {
+			if _, err := os.Stat(docroot); err != nil {
 				continue
 			}
-
-			if fileutil.FileExists(filepath.Join(app.AppRoot, docroot, "index.php")) {
+			if fileutil.FileExists(filepath.Join(docroot, "index.php")) {
 				defaultDocroot = docroot
 				break
 			}
@@ -741,19 +740,15 @@ func (app *DdevApp) docrootPrompt() error {
 	}
 
 	// Determine the document root.
-	util.Warning("\nThe docroot is the directory from which your site is served.\nThis is a relative path from your project root at %s", app.AppRoot)
+	output.UserOut.Printf("\nThe docroot is the directory from which your site is served. This is a relative path from your project root (%s)", app.AppRoot)
 	output.UserOut.Println("You may leave this value blank if your site files are in the project root")
 	var docrootPrompt = "Docroot Location"
 	var defaultDocroot = DiscoverDefaultDocroot(app)
 	// If there is a default docroot, display it in the prompt.
 	if defaultDocroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
-	} else if cd, _ := os.Getwd(); cd == filepath.Join(app.AppRoot, defaultDocroot) {
-		// Preserve the case where the docroot is the current directory
-		docrootPrompt = fmt.Sprintf("%s (current directory)", docrootPrompt)
 	} else {
-		// Explicitly state 'project root' when in a subdirectory
-		docrootPrompt = fmt.Sprintf("%s (project root)", docrootPrompt)
+		docrootPrompt = fmt.Sprintf("%s (current directory)", docrootPrompt)
 	}
 
 	fmt.Print(docrootPrompt + ": ")

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -60,19 +60,23 @@ func TestNewConfig(t *testing.T) {
 func TestDisasterConfig(t *testing.T) {
 	assert := asrt.New(t)
 
+	testDir, _ := os.Getwd()
+
 	// Make sure we're not allowed to config in home directory.
-	testDir, _ := homedir.Dir()
-	app, err := NewApp(testDir, false, ProviderDefault)
+	tmpDir, _ := homedir.Dir()
+	_, err := NewApp(tmpDir, false, ProviderDefault)
 	assert.Error(err)
+	assert.Contains(err.Error(), "ddev config is not useful in home directory")
+	_ = os.Chdir(testDir)
 
 	// Create a temporary directory and change to it for the duration of this test.
-	testDir = testcommon.CreateTmpDir("TestDisasterConfig")
+	tmpDir = testcommon.CreateTmpDir("TestDisasterConfig")
 
-	defer testcommon.CleanupDir(testDir)
-	defer testcommon.Chdir(testDir)()
+	defer testcommon.CleanupDir(tmpDir)
+	defer testcommon.Chdir(tmpDir)()
 
 	// Load a new Config
-	app, err = NewApp(testDir, false, ProviderDefault)
+	app, err := NewApp(tmpDir, false, ProviderDefault)
 	assert.NoError(err)
 
 	// WriteConfig the app.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
+	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
@@ -52,6 +53,42 @@ func TestNewConfig(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(app.Name, loadedConfig.Name)
 	assert.Equal(app.Type, loadedConfig.Type)
+
+}
+
+// TestDisasterConfig tests for disaster opportunities (configing wrong directory, home dir, etc).
+func TestDisasterConfig(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Make sure we're not allowed to config in home directory.
+	testDir, _ := homedir.Dir()
+	app, err := NewApp(testDir, false, ProviderDefault)
+	assert.Error(err)
+
+	// Create a temporary directory and change to it for the duration of this test.
+	testDir = testcommon.CreateTmpDir("TestDisasterConfig")
+
+	defer testcommon.CleanupDir(testDir)
+	defer testcommon.Chdir(testDir)()
+
+	// Load a new Config
+	app, err = NewApp(testDir, false, ProviderDefault)
+	assert.NoError(err)
+
+	// WriteConfig the app.
+	err = app.WriteConfig()
+	assert.NoError(err)
+	_, err = os.Stat(app.ConfigPath)
+	assert.NoError(err)
+
+	subdir := filepath.Join(app.AppRoot, "subdir")
+	err = os.Mkdir(subdir, 0777)
+	assert.NoError(err)
+	err = os.Chdir(subdir)
+	assert.NoError(err)
+	subdirApp, err := NewApp(subdir, false, ProviderDefault)
+	assert.NoError(err)
+	_ = subdirApp
 
 }
 

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -12,6 +12,8 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gosuri/uitable"
 
+	"errors"
+
 	"os"
 	"text/template"
 
@@ -148,19 +150,19 @@ func Cleanup(app *DdevApp) error {
 
 // CheckForConf checks for a config.yaml at the cwd or parent dirs.
 func CheckForConf(confPath string) (string, error) {
-	if fileutil.FileExists(filepath.Join(confPath, ".ddev", "config.yaml")) {
+	if fileutil.FileExists(confPath + "/.ddev/config.yaml") {
 		return confPath, nil
 	}
+	pathList := strings.Split(confPath, "/")
 
-	// Keep going until we can't go any higher
-	for filepath.Dir(confPath) != confPath {
+	for range pathList {
 		confPath = filepath.Dir(confPath)
-		if fileutil.FileExists(filepath.Join(confPath, ".ddev", "config.yaml")) {
+		if fileutil.FileExists(confPath + "/.ddev/config.yaml") {
 			return confPath, nil
 		}
 	}
 
-	return "", fmt.Errorf("no %s file was found in this directory or any parent", filepath.Join(".ddev", "config.yaml"))
+	return "", errors.New("no .ddev/config.yaml file was found in this directory or any parent")
 }
 
 // ddevContainersRunning determines if any ddev-controlled containers are currently running.

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -12,8 +12,6 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gosuri/uitable"
 
-	"errors"
-
 	"os"
 	"text/template"
 
@@ -150,19 +148,19 @@ func Cleanup(app *DdevApp) error {
 
 // CheckForConf checks for a config.yaml at the cwd or parent dirs.
 func CheckForConf(confPath string) (string, error) {
-	if fileutil.FileExists(confPath + "/.ddev/config.yaml") {
+	if fileutil.FileExists(filepath.Join(confPath, ".ddev", "config.yaml")) {
 		return confPath, nil
 	}
-	pathList := strings.Split(confPath, "/")
 
-	for range pathList {
+	// Keep going until we can't go any higher
+	for filepath.Dir(confPath) != confPath {
 		confPath = filepath.Dir(confPath)
-		if fileutil.FileExists(confPath + "/.ddev/config.yaml") {
+		if fileutil.FileExists(filepath.Join(confPath, ".ddev", "config.yaml")) {
 			return confPath, nil
 		}
 	}
 
-	return "", errors.New("no .ddev/config.yaml file was found in this directory or any parent")
+	return "", fmt.Errorf("no %s file was found in this directory or any parent", filepath.Join(".ddev", "config.yaml"))
 }
 
 // ddevContainersRunning determines if any ddev-controlled containers are currently running.

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -143,6 +143,11 @@ func GetGlobalDdevDir() string {
 			logrus.Fatalf("Failed to create required directory %s, err: %v", ddevDir, err)
 		}
 	}
+	// config.yaml is not allowed in ~/.ddev, can only result in disaster
+	globalConfigYaml := filepath.Join(ddevDir, "config.yaml")
+	if _, err := os.Stat(globalConfigYaml); err == nil {
+		_ = os.Remove(filepath.Join(globalConfigYaml))
+	}
 	return ddevDir
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

In #1574 a user reported destruction of their entire home directory by a `ddev composer create` command that mistakenly operated on the home directory.

## How this PR Solves The Problem:

* Revert #1275, which allowed automatic searching of parent directories for a project.
* Instead, do the search and note the results during `ddev config`
* Prevent users from using `ddev config` in their home directory.
* Remove the --no-interaction behavior from `ddev composer create` that allows wholesale destruction without the user saying "ok".

## Manual Testing Instructions:

* Try `ddev config` in home directory.
* Create a ~/junk folder and `ddev config` in it. Then create ~/junk/sub1 and `ddev config` in it. It should be willing to config, but warn about the existing parent.
* Run `ddev composer create --no-interaction`. The composer portion should run without interaction, but when it comes to delete time, it needs to require your OK. 

## Automated Testing Overview:

This definitely needs some tests:
- [x] Try ddev config in home directory
- [x] Try ddev config in a subdirectory of a project
- [ ] Make sure `ddev composer create --no-interaction` requires interaction before deletion.

## Related Issue Link(s):

OP #1574 "Ddev deleted everything in my home directory"

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

