### PR TITLE
Remove drush --yes behavior when in ddev exec behavior, fixes #1584

### DIFF
--- a/containers/ddev-webserver/files/etc/drush/drushrc.php
+++ b/containers/ddev-webserver/files/etc/drush/drushrc.php
@@ -2,7 +2,3 @@
 if (!empty($_ENV['DDEV_URL'])) {
     $options['uri'] = $_ENV['DDEV_URL'];
 }
-# Skip confirmations since `ddev exec` cannot support interactive prompts
-if (!empty($_ENV['DDEV_EXEC'])) {
-    $options['yes'] = 1;
-}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -812,7 +812,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		return "", "", fmt.Errorf("no service provided")
 	}
 
-	exec := []string{"exec", "-e", "DDEV_EXEC=true"}
+	exec := []string{"exec"}
 	if workingDir := app.getWorkingDir(opts.Service, opts.Dir); workingDir != "" {
 		exec = append(exec, "-w", workingDir)
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.8.0" // Note that this can be overridden by make
+var WebTag = "20190511_remove_drush_yes" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

From long ago, long, long ago, `drush` defaulted to --yes when in `ddev exec` context. It wasn't probably ever reasonable behavior, but it was there to avoid the interactive prompt mostly in exec hooks.

## How this PR Solves The Problem:

Remove that special behavior.

## Manual Testing Instructions:

`ddev exec upc --security-only` on a Drupal site that needs update, it should stop to confirm.
`ddev exec drush sql-drop` - it should stop to confirm.

## Automated Testing Overview:

## Related Issue Link(s):

OP #1584, thanks @damienmckenna 

## Release/Deployment notes:

There may be people that have counted on this in exec hooks. So release notes have to tell them to add -y to their exec hooks.
