### PR TITLE
Fix typo in description, change completion to 'has been stopped'

### DIFF
--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -26,7 +26,7 @@ var DdevStopCmd = &cobra.Command{
 	Use:     "stop [projectname ...]",
 	Aliases: []string{"rm", "remove"},
 	Short:   "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data.",
-	Long: `Stop and remove the containers of a project. You can run 'ddev stp['
+	Long: `Stop and remove the containers of a project. You can run 'ddev stop'
 from a project directory to stop/remove that project, or you can stop/remove projects in
 any directory by running 'ddev stop projectname [projectname ...]' or 'ddev stop -a'.
 
@@ -60,7 +60,7 @@ To snapshot the database on stop, use "ddev stop --snapshot"; A snapshot is auto
 				util.Failed("Failed to remove project %s: \n%v", project.GetName(), err)
 			}
 
-			util.Success("Project %s has been stopped and removed.", project.GetName())
+			util.Success("Project %s has been stopped.", project.GetName())
 		}
 
 		if stopSSHAgent {

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -29,7 +29,7 @@ func TestCmdStop(t *testing.T) {
 
 		out, err := exec.RunCommand(DdevBin, []string{"stop"})
 		assert.NoError(err, "ddev stop should succeed but failed, err: %v, output: %s", err, out)
-		assert.Contains(out, "has been stopped and removed")
+		assert.Contains(out, "has been stopped")
 
 		// Ensure the site that was just stopped does not appear in the list of sites
 		apps := ddevapp.GetDockerProjects()
@@ -94,7 +94,7 @@ func TestCmdStopMissingProjectDirectory(t *testing.T) {
 
 	out, err = exec.RunCommand(DdevBin, []string{"stop", projectName})
 	assert.NoError(err)
-	assert.Contains(out, "has been stopped and removed")
+	assert.Contains(out, "has been stopped")
 
 	err = os.Rename(copyDir, tmpDir)
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* A small typo in the description of ddev stop was discovered in testing.
* The completion message said the project had been "stopped and removed", which might alarm people.

## How this PR Solves The Problem:

* Fix the typo
* Change wording to "has been stopped"

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

