### PR TITLE
Update PHP_DEFAULT_VERSION in web container

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/minideb:stretch
 
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3"
-ENV PHP_DEFAULT_VERSION="7.1"
+ENV PHP_DEFAULT_VERSION="7.2"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 
 ENV DRUSH_VERSION=8.1.18

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.8.0" // Note that this can be overridden by make
+var WebTag = "20190514_default_php_in_container" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

We changed the default PHP version to 7.2 a while ago, but when the container is run by itself it still defaults to 7.2

## How this PR Solves The Problem:

Change it to 7.2 in the container (when run without ddev)

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

