### PR TITLE
Create settings.ddev.php on ddev start, fixes #1423

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -93,7 +93,7 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	// If neither settings file options are set, then don't continue. Return
 	// a nil error because this should not halt execution if the apptype
 	// does not have a settings definition.
-	if app.SiteLocalSettingsPath == "" && app.SiteSettingsPath == "" {
+	if app.SiteDdevSettingsFile == "" && app.SiteSettingsPath == "" {
 		util.Warning("Project type has no settings paths configured, so not creating settings file.")
 		return "", nil
 	}
@@ -101,7 +101,7 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	// Drupal and WordPress love to change settings files to be unwriteable.
 	// Chmod them to something we can work with in the event that they already
 	// exist.
-	chmodTargets := []string{filepath.Dir(app.SiteSettingsPath), app.SiteLocalSettingsPath}
+	chmodTargets := []string{filepath.Dir(app.SiteSettingsPath), app.SiteDdevSettingsFile}
 	for _, fp := range chmodTargets {
 		fileInfo, err := os.Stat(fp)
 		if err != nil {
@@ -132,8 +132,8 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 		if err != nil {
 			util.Warning("Unable to create settings file: %v", err)
 		}
-		if err := CreateGitIgnore(filepath.Dir(app.SiteSettingsPath), filepath.Base(app.SiteLocalSettingsPath), "ddev_drush_settings.php"); err != nil {
-			util.Warning("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteLocalSettingsPath), err)
+		if err := CreateGitIgnore(filepath.Dir(app.SiteSettingsPath), filepath.Base(app.SiteDdevSettingsFile), "ddev_drush_settings.php"); err != nil {
+			util.Warning("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteDdevSettingsFile), err)
 		}
 
 		return settingsPath, nil

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -74,10 +74,10 @@ func init() {
 			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		AppTypeWordPress: {
-			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: wordpressImportFilesAction,
+			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: wordpressPostStartAction, importFilesAction: wordpressImportFilesAction,
 		},
 		AppTypeTYPO3: {
-			settingsCreator: createTypo3SettingsFile, uploadDir: getTypo3UploadDir, hookDefaultComments: getTypo3Hooks, apptypeSettingsPaths: setTypo3SiteSettingsPaths, appTypeDetect: isTypo3App, postImportDBAction: nil, configOverrideAction: typo3ConfigOverrideAction, postConfigAction: nil, postStartAction: nil, importFilesAction: typo3ImportFilesAction,
+			settingsCreator: createTypo3SettingsFile, uploadDir: getTypo3UploadDir, hookDefaultComments: getTypo3Hooks, apptypeSettingsPaths: setTypo3SiteSettingsPaths, appTypeDetect: isTypo3App, postImportDBAction: nil, configOverrideAction: typo3ConfigOverrideAction, postConfigAction: nil, postStartAction: typo3PostStartAction, importFilesAction: typo3ImportFilesAction,
 		},
 		AppTypeBackdrop: {
 			settingsCreator: createBackdropSettingsFile, uploadDir: getBackdropUploadDir, hookDefaultComments: getBackdropHooks, apptypeSettingsPaths: setBackdropSiteSettingsPaths, appTypeDetect: isBackdropApp, postImportDBAction: backdropPostImportDBAction, configOverrideAction: nil, postConfigAction: nil, postStartAction: backdropPostStartAction, importFilesAction: backdropImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -128,11 +128,11 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 		}
 	}
 
-	if err = writeBackdropDdevSettingsFile(settings, app.SiteLocalSettingsPath); err != nil {
-		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
+	if err = writeBackdropDdevSettingsFile(settings, app.SiteDdevSettingsFile); err != nil {
+		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 
-	return app.SiteLocalSettingsPath, nil
+	return app.SiteDdevSettingsFile, nil
 }
 
 // writeBackdropMainSettingsFile dynamically produces a valid settings.php file by
@@ -232,7 +232,7 @@ func setBackdropSiteSettingsPaths(app *DdevApp) {
 	settings := NewBackdropSettings()
 	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
 	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, settings.SiteSettings)
-	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, settings.SiteSettingsDdev)
+	app.SiteDdevSettingsFile = filepath.Join(settingsFileBasePath, settings.SiteSettingsDdev)
 }
 
 // isBackdropApp returns true if the app is of type "backdrop".
@@ -340,7 +340,7 @@ func backdropPostStartAction(app *DdevApp) error {
 	}
 
 	if _, err = app.CreateSettingsFile(); err != nil {
-		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 	return nil
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -86,23 +86,23 @@ type DdevApp struct {
 	XdebugEnabled         bool                 `yaml:"xdebug_enabled"`
 	AdditionalHostnames   []string             `yaml:"additional_hostnames"`
 	AdditionalFQDNs       []string             `yaml:"additional_fqdns"`
-	MariaDBVersion       string               `yaml:"mariadb_version"`
-	WebcacheEnabled      bool                 `yaml:"webcache_enabled,omitempty"`
-	NFSMountEnabled      bool                 `yaml:"nfs_mount_enabled"`
-	ConfigPath           string               `yaml:"-"`
-	AppRoot              string               `yaml:"-"`
-	Platform             string               `yaml:"-"`
-	Provider             string               `yaml:"provider,omitempty"`
-	DataDir              string               `yaml:"-"`
-	SiteSettingsPath     string               `yaml:"-"`
-	SiteDdevSettingsFile string               `yaml:"-"`
-	providerInstance     Provider             `yaml:"-"`
-	Commands             map[string][]Command `yaml:"hooks,omitempty"`
-	UploadDir            string               `yaml:"upload_dir,omitempty"`
-	WorkingDir           map[string]string    `yaml:"working_dir,omitempty"`
-	OmitContainers       []string             `yaml:"omit_containers,omitempty,flow"`
-	HostDBPort           string               `yaml:"host_db_port,omitempty"`
-	HostWebserverPort    string               `yaml:"host_webserver_port,omitempty"`
+	MariaDBVersion        string               `yaml:"mariadb_version"`
+	WebcacheEnabled       bool                 `yaml:"webcache_enabled,omitempty"`
+	NFSMountEnabled       bool                 `yaml:"nfs_mount_enabled"`
+	ConfigPath            string               `yaml:"-"`
+	AppRoot               string               `yaml:"-"`
+	Platform              string               `yaml:"-"`
+	Provider              string               `yaml:"provider,omitempty"`
+	DataDir               string               `yaml:"-"`
+	SiteSettingsPath      string               `yaml:"-"`
+	SiteDdevSettingsFile  string               `yaml:"-"`
+	providerInstance      Provider             `yaml:"-"`
+	Commands              map[string][]Command `yaml:"hooks,omitempty"`
+	UploadDir             string               `yaml:"upload_dir,omitempty"`
+	WorkingDir            map[string]string    `yaml:"working_dir,omitempty"`
+	OmitContainers        []string             `yaml:"omit_containers,omitempty,flow"`
+	HostDBPort            string               `yaml:"host_db_port,omitempty"`
+	HostWebserverPort     string               `yaml:"host_webserver_port,omitempty"`
 	HostHTTPSPort         string               `yaml:"host_https_port,omitempty"`
 	WebImageExtraPackages []string             `yaml:"webimage_extra_packages,omitempty,flow"`
 	DBImageExtraPackages  []string             `yaml:"dbimage_extra_packages,omitempty,flow"`

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -86,23 +86,23 @@ type DdevApp struct {
 	XdebugEnabled         bool                 `yaml:"xdebug_enabled"`
 	AdditionalHostnames   []string             `yaml:"additional_hostnames"`
 	AdditionalFQDNs       []string             `yaml:"additional_fqdns"`
-	MariaDBVersion        string               `yaml:"mariadb_version"`
-	WebcacheEnabled       bool                 `yaml:"webcache_enabled,omitempty"`
-	NFSMountEnabled       bool                 `yaml:"nfs_mount_enabled"`
-	ConfigPath            string               `yaml:"-"`
-	AppRoot               string               `yaml:"-"`
-	Platform              string               `yaml:"-"`
-	Provider              string               `yaml:"provider,omitempty"`
-	DataDir               string               `yaml:"-"`
-	SiteSettingsPath      string               `yaml:"-"`
-	SiteLocalSettingsPath string               `yaml:"-"`
-	providerInstance      Provider             `yaml:"-"`
-	Commands              map[string][]Command `yaml:"hooks,omitempty"`
-	UploadDir             string               `yaml:"upload_dir,omitempty"`
-	WorkingDir            map[string]string    `yaml:"working_dir,omitempty"`
-	OmitContainers        []string             `yaml:"omit_containers,omitempty,flow"`
-	HostDBPort            string               `yaml:"host_db_port,omitempty"`
-	HostWebserverPort     string               `yaml:"host_webserver_port,omitempty"`
+	MariaDBVersion       string               `yaml:"mariadb_version"`
+	WebcacheEnabled      bool                 `yaml:"webcache_enabled,omitempty"`
+	NFSMountEnabled      bool                 `yaml:"nfs_mount_enabled"`
+	ConfigPath           string               `yaml:"-"`
+	AppRoot              string               `yaml:"-"`
+	Platform             string               `yaml:"-"`
+	Provider             string               `yaml:"provider,omitempty"`
+	DataDir              string               `yaml:"-"`
+	SiteSettingsPath     string               `yaml:"-"`
+	SiteDdevSettingsFile string               `yaml:"-"`
+	providerInstance     Provider             `yaml:"-"`
+	Commands             map[string][]Command `yaml:"hooks,omitempty"`
+	UploadDir            string               `yaml:"upload_dir,omitempty"`
+	WorkingDir           map[string]string    `yaml:"working_dir,omitempty"`
+	OmitContainers       []string             `yaml:"omit_containers,omitempty,flow"`
+	HostDBPort           string               `yaml:"host_db_port,omitempty"`
+	HostWebserverPort    string               `yaml:"host_webserver_port,omitempty"`
 	HostHTTPSPort         string               `yaml:"host_https_port,omitempty"`
 	WebImageExtraPackages []string             `yaml:"webimage_extra_packages,omitempty,flow"`
 	DBImageExtraPackages  []string             `yaml:"dbimage_extra_packages,omitempty,flow"`
@@ -1129,9 +1129,9 @@ func (app *DdevApp) StartAndWaitForSync(extraSleep int) error {
 
 // DetermineSettingsPathLocation figures out the path to the settings file for
 // an app based on the contents/existence of app.SiteSettingsPath and
-// app.SiteLocalSettingsPath.
+// app.SiteDdevSettingsFile.
 func (app *DdevApp) DetermineSettingsPathLocation() (string, error) {
-	possibleLocations := []string{app.SiteSettingsPath, app.SiteLocalSettingsPath}
+	possibleLocations := []string{app.SiteSettingsPath, app.SiteDdevSettingsFile}
 	for _, loc := range possibleLocations {
 		// If the file doesn't exist, it's safe to use
 		if !fileutil.FileExists(loc) {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -647,11 +647,11 @@ func TestDdevImportDB(t *testing.T) {
 			// Test that a settings file has correct hash_salt format
 			switch app.Type {
 			case ddevapp.AppTypeDrupal7:
-				drupalHashSalt, err := fileutil.FgrepStringInFile(app.SiteLocalSettingsPath, "$drupal_hash_salt")
+				drupalHashSalt, err := fileutil.FgrepStringInFile(app.SiteDdevSettingsFile, "$drupal_hash_salt")
 				assert.NoError(err)
 				assert.True(drupalHashSalt)
 			case ddevapp.AppTypeDrupal8:
-				settingsHashSalt, err := fileutil.FgrepStringInFile(app.SiteLocalSettingsPath, "settings['hash_salt']")
+				settingsHashSalt, err := fileutil.FgrepStringInFile(app.SiteDdevSettingsFile, "settings['hash_salt']")
 				assert.NoError(err)
 				assert.True(settingsHashSalt)
 			case ddevapp.AppTypeWordPress:

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -346,11 +346,11 @@ func createDrupal7SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	if err := writeDrupal7DdevSettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-		return "", fmt.Errorf("`failed to write` Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
+	if err := writeDrupal7DdevSettingsFile(drupalConfig, app.SiteDdevSettingsFile); err != nil {
+		return "", fmt.Errorf("`failed to write` Drupal settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 
-	return app.SiteLocalSettingsPath, nil
+	return app.SiteDdevSettingsFile, nil
 }
 
 // createDrupal8SettingsFile manages creation and modification of settings.php and settings.ddev.php.
@@ -365,11 +365,11 @@ func createDrupal8SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	if err := writeDrupal8DdevSettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
+	if err := writeDrupal8DdevSettingsFile(drupalConfig, app.SiteDdevSettingsFile); err != nil {
+		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 
-	return app.SiteLocalSettingsPath, nil
+	return app.SiteDdevSettingsFile, nil
 }
 
 // createDrupal6SettingsFile manages creation and modification of settings.php and settings.ddev.php.
@@ -386,11 +386,11 @@ func createDrupal6SettingsFile(app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	if err := writeDrupal6DdevSettingsFile(drupalConfig, app.SiteLocalSettingsPath); err != nil {
-		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteLocalSettingsPath, err)
+	if err := writeDrupal6DdevSettingsFile(drupalConfig, app.SiteDdevSettingsFile); err != nil {
+		return "", fmt.Errorf("failed to write Drupal settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 
-	return app.SiteLocalSettingsPath, nil
+	return app.SiteDdevSettingsFile, nil
 }
 
 // writeDrupal8DdevSettingsFile dynamically produces valid settings.ddev.php file by combining a configuration
@@ -598,7 +598,7 @@ func setDrupalSiteSettingsPaths(app *DdevApp) {
 	drupalConfig := NewDrupalSettings()
 	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
 	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettings)
-	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettingsDdev)
+	app.SiteDdevSettingsFile = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettingsDdev)
 }
 
 // isDrupal7App returns true if the app is of type drupal7
@@ -651,7 +651,7 @@ func drupal8PostStartAction(app *DdevApp) error {
 	}
 
 	if _, err = app.CreateSettingsFile(); err != nil {
-		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 	return nil
 }
@@ -671,7 +671,7 @@ func drupal7PostStartAction(app *DdevApp) error {
 	}
 
 	if _, err = app.CreateSettingsFile(); err != nil {
-		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 	return nil
 }
@@ -690,7 +690,7 @@ func drupal6PostStartAction(app *DdevApp) error {
 		util.Warning("Failed to WriteDrushConfig: %v", err)
 	}
 	if _, err = app.CreateSettingsFile(); err != nil {
-		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 	return nil
 }
@@ -705,7 +705,7 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 	makeWritable := []string{
 		settingsDir,
 		app.SiteSettingsPath,
-		app.SiteLocalSettingsPath,
+		app.SiteDdevSettingsFile,
 		path.Join(settingsDir, "services.yml"),
 	}
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -21,39 +21,39 @@ import (
 
 // DrupalSettings encapsulates all the configurations for a Drupal site.
 type DrupalSettings struct {
-	DeployName        string
-	DeployURL         string
-	DatabaseName      string
-	DatabaseUsername  string
-	DatabasePassword  string
-	DatabaseHost      string
-	DatabaseDriver    string
-	DatabasePort      string
-	DatabasePrefix    string
-	HashSalt          string
-	Signature         string
-	SitePath          string
-	SiteSettings      string
-	SiteSettingsLocal string
-	SyncDir           string
+	DeployName       string
+	DeployURL        string
+	DatabaseName     string
+	DatabaseUsername string
+	DatabasePassword string
+	DatabaseHost     string
+	DatabaseDriver   string
+	DatabasePort     string
+	DatabasePrefix   string
+	HashSalt         string
+	Signature        string
+	SitePath         string
+	SiteSettings     string
+	SiteSettingsDdev string
+	SyncDir          string
 }
 
 // NewDrupalSettings produces a DrupalSettings object with default.
 func NewDrupalSettings() *DrupalSettings {
 	return &DrupalSettings{
-		DatabaseName:      "db",
-		DatabaseUsername:  "db",
-		DatabasePassword:  "db",
-		DatabaseHost:      "db",
-		DatabaseDriver:    "mysql",
-		DatabasePort:      appports.GetPort("db"),
-		DatabasePrefix:    "",
-		HashSalt:          util.RandString(64),
-		Signature:         DdevFileSignature,
-		SitePath:          path.Join("sites", "default"),
-		SiteSettings:      "settings.php",
-		SiteSettingsLocal: "settings.ddev.php",
-		SyncDir:           path.Join("files", "sync"),
+		DatabaseName:     "db",
+		DatabaseUsername: "db",
+		DatabasePassword: "db",
+		DatabaseHost:     "db",
+		DatabaseDriver:   "mysql",
+		DatabasePort:     appports.GetPort("db"),
+		DatabasePrefix:   "",
+		HashSalt:         util.RandString(64),
+		Signature:        DdevFileSignature,
+		SitePath:         path.Join("sites", "default"),
+		SiteSettings:     "settings.php",
+		SiteSettingsDdev: "settings.ddev.php",
+		SyncDir:          path.Join("files", "sync"),
 	}
 }
 
@@ -290,12 +290,12 @@ func manageDrupalSettingsFile(app *DdevApp, drupalConfig *DrupalSettings, settin
 	}
 
 	if included {
-		output.UserOut.Printf("Existing %s file includes %s", drupalConfig.SiteSettings, drupalConfig.SiteSettingsLocal)
+		output.UserOut.Printf("Existing %s file includes %s", drupalConfig.SiteSettings, drupalConfig.SiteSettingsDdev)
 	} else {
-		output.UserOut.Printf("Existing %s file does not include %s, modifying to include ddev settings", drupalConfig.SiteSettings, drupalConfig.SiteSettingsLocal)
+		output.UserOut.Printf("Existing %s file does not include %s, modifying to include ddev settings", drupalConfig.SiteSettings, drupalConfig.SiteSettingsDdev)
 
 		if err := appendIncludeToDrupalSettingsFile(drupalConfig, app.SiteSettingsPath, appendTemplate); err != nil {
-			return fmt.Errorf("failed to include %s in %s: %v", drupalConfig.SiteSettingsLocal, drupalConfig.SiteSettings, err)
+			return fmt.Errorf("failed to include %s in %s: %v", drupalConfig.SiteSettingsDdev, drupalConfig.SiteSettings, err)
 		}
 	}
 
@@ -598,7 +598,7 @@ func setDrupalSiteSettingsPaths(app *DdevApp) {
 	drupalConfig := NewDrupalSettings()
 	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
 	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettings)
-	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettingsLocal)
+	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettingsDdev)
 }
 
 // isDrupal7App returns true if the app is of type drupal7
@@ -749,7 +749,7 @@ func createDrupal8SyncDir(app *DdevApp) error {
 // settingsHasInclude determines if the settings.php or equivalent includes settings.ddev.php or equivalent.
 // This is done by looking for the ddev settings file (settings.ddev.php) in settings.php.
 func settingsHasInclude(drupalConfig *DrupalSettings, siteSettingsPath string) (bool, error) {
-	included, err := fileutil.FgrepStringInFile(siteSettingsPath, drupalConfig.SiteSettingsLocal)
+	included, err := fileutil.FgrepStringInFile(siteSettingsPath, drupalConfig.SiteSettingsDdev)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -78,8 +78,8 @@ func NewDrushConfig(app *DdevApp) *DrushConfig {
 const drupal8SettingsTemplate = `<?php
 {{ $config := . }}
 // {{ $config.Signature }}: Automatically generated Drupal settings file.
-if (file_exists($app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}')) {
-  include $app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}';
+if (file_exists($app_root . '/' . $site_path . '/{{ $config.SiteSettingsDdev }}')) {
+  include $app_root . '/' . $site_path . '/{{ $config.SiteSettingsDdev }}';
 }
 `
 
@@ -87,8 +87,8 @@ if (file_exists($app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}
 // a Drupal 8 app's settings.php in the event that one exists.
 const drupal8SettingsAppendTemplate = `{{ $config := . }}
 // Automatically generated include for settings managed by ddev.
-if (file_exists($app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}')) {
-  include $app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}';
+if (file_exists($app_root . '/' . $site_path . '/{{ $config.SiteSettingsDdev }}')) {
+  include $app_root . '/' . $site_path . '/{{ $config.SiteSettingsDdev }}';
 }
 `
 
@@ -97,7 +97,7 @@ if (file_exists($app_root . '/' . $site_path . '/{{ $config.SiteSettingsLocal }}
 const drupal7SettingsTemplate = `<?php
 {{ $config := . }}
 // {{ $config.Signature }}: Automatically generated Drupal settings file.
-$ddev_settings = dirname(__FILE__) . '/{{ $config.SiteSettingsLocal }}';
+$ddev_settings = dirname(__FILE__) . '/{{ $config.SiteSettingsDdev }}';
 if (is_readable($ddev_settings)) {
   require $ddev_settings;
 }
@@ -107,7 +107,7 @@ if (is_readable($ddev_settings)) {
 // a Drupal 7 app's settings.php in the event that one exists.
 const drupal7SettingsAppendTemplate = `{{ $config := . }}
 // Automatically generated include for settings managed by ddev.
-$ddev_settings = dirname(__FILE__) . '/{{ $config.SiteSettingsLocal }}';
+$ddev_settings = dirname(__FILE__) . '/{{ $config.SiteSettingsDdev }}';
 if (is_readable($ddev_settings)) {
   require $ddev_settings;
 }
@@ -650,6 +650,9 @@ func drupal8PostStartAction(app *DdevApp) error {
 		util.Warning("Failed to WriteDrushConfig: %v", err)
 	}
 
+	if _, err = app.CreateSettingsFile(); err != nil {
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+	}
 	return nil
 }
 
@@ -667,6 +670,9 @@ func drupal7PostStartAction(app *DdevApp) error {
 		util.Warning("Failed to WriteDrushConfig: %v", err)
 	}
 
+	if _, err = app.CreateSettingsFile(); err != nil {
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+	}
 	return nil
 }
 
@@ -683,7 +689,9 @@ func drupal6PostStartAction(app *DdevApp) error {
 	if err != nil {
 		util.Warning("Failed to WriteDrushConfig: %v", err)
 	}
-
+	if _, err = app.CreateSettingsFile(); err != nil {
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+	}
 	return nil
 }
 

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -129,7 +129,7 @@ func TestWriteDrushConfig(t *testing.T) {
 			assert.NoError(err)
 			assert.True(d6StringFound)
 		default:
-			assert.False(fileutil.FileExists(drushFilePath))
+			assert.False(fileutil.FileExists(drushFilePath), "Drush settings file (%s) should not exist but it does (app.Type=%s)", drushFilePath, app.Type)
 		}
 
 		runTime()

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -192,3 +192,18 @@ func typo3ImportFilesAction(app *DdevApp, importPath, extPath string) error {
 
 	return nil
 }
+
+// typo3PostStartAction handles default post-start actions
+func typo3PostStartAction(app *DdevApp) error {
+	// Drush config has to be written after start because we don't know the ports until it's started
+	drushConfig := NewDrushConfig(app)
+	err := WriteDrushConfig(drushConfig, filepath.Join(filepath.Dir(app.SiteSettingsPath), "ddev_drush_settings.php"))
+	if err != nil {
+		util.Warning("Failed to WriteDrushConfig: %v", err)
+	}
+
+	if _, err = app.CreateSettingsFile(); err != nil {
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+	}
+	return nil
+}

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -15,52 +15,52 @@ import (
 
 // WordpressConfig encapsulates all the configurations for a WordPress site.
 type WordpressConfig struct {
-	WPGeneric         bool
-	DeployName        string
-	DeployURL         string
-	DatabaseName      string
-	DatabaseUsername  string
-	DatabasePassword  string
-	DatabaseHost      string
-	AuthKey           string
-	SecureAuthKey     string
-	LoggedInKey       string
-	NonceKey          string
-	AuthSalt          string
-	SecureAuthSalt    string
-	LoggedInSalt      string
-	NonceSalt         string
-	Docroot           string
-	TablePrefix       string
-	Signature         string
-	SiteSettings      string
-	SiteSettingsLocal string
-	AbsPath           string
+	WPGeneric        bool
+	DeployName       string
+	DeployURL        string
+	DatabaseName     string
+	DatabaseUsername string
+	DatabasePassword string
+	DatabaseHost     string
+	AuthKey          string
+	SecureAuthKey    string
+	LoggedInKey      string
+	NonceKey         string
+	AuthSalt         string
+	SecureAuthSalt   string
+	LoggedInSalt     string
+	NonceSalt        string
+	Docroot          string
+	TablePrefix      string
+	Signature        string
+	SiteSettings     string
+	SiteSettingsDdev string
+	AbsPath          string
 }
 
 // NewWordpressConfig produces a WordpressConfig object with defaults.
 func NewWordpressConfig(app *DdevApp, absPath string) *WordpressConfig {
 	return &WordpressConfig{
-		WPGeneric:         false,
-		DatabaseName:      "db",
-		DatabaseUsername:  "db",
-		DatabasePassword:  "db",
-		DatabaseHost:      "db",
-		DeployURL:         app.GetHTTPURL(),
-		Docroot:           "/var/www/html/docroot",
-		TablePrefix:       "wp_",
-		AuthKey:           util.RandString(64),
-		AuthSalt:          util.RandString(64),
-		LoggedInKey:       util.RandString(64),
-		LoggedInSalt:      util.RandString(64),
-		NonceKey:          util.RandString(64),
-		NonceSalt:         util.RandString(64),
-		SecureAuthKey:     util.RandString(64),
-		SecureAuthSalt:    util.RandString(64),
-		Signature:         DdevFileSignature,
-		SiteSettings:      "wp-config.php",
-		SiteSettingsLocal: "wp-config-ddev.php",
-		AbsPath:           absPath,
+		WPGeneric:        false,
+		DatabaseName:     "db",
+		DatabaseUsername: "db",
+		DatabasePassword: "db",
+		DatabaseHost:     "db",
+		DeployURL:        app.GetHTTPURL(),
+		Docroot:          "/var/www/html/docroot",
+		TablePrefix:      "wp_",
+		AuthKey:          util.RandString(64),
+		AuthSalt:         util.RandString(64),
+		LoggedInKey:      util.RandString(64),
+		LoggedInSalt:     util.RandString(64),
+		NonceKey:         util.RandString(64),
+		NonceSalt:        util.RandString(64),
+		SecureAuthKey:    util.RandString(64),
+		SecureAuthSalt:   util.RandString(64),
+		Signature:        DdevFileSignature,
+		SiteSettings:     "wp-config.php",
+		SiteSettingsDdev: "wp-config-ddev.php",
+		AbsPath:          absPath,
 	}
 }
 
@@ -292,7 +292,7 @@ func setWordpressSiteSettingsPaths(app *DdevApp) {
 
 	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
 	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, config.SiteSettings)
-	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, config.SiteSettingsLocal)
+	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, config.SiteSettingsDdev)
 }
 
 // isWordpressApp returns true if the app of of type wordpress

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -178,7 +178,7 @@ func createWordpressSettingsFile(app *DdevApp) (string, error) {
 	config := NewWordpressConfig(app, absPath)
 
 	//  write ddev settings file
-	if err := writeWordpressDdevSettingsFile(config, app.SiteLocalSettingsPath); err != nil {
+	if err := writeWordpressDdevSettingsFile(config, app.SiteDdevSettingsFile); err != nil {
 		return "", err
 	}
 
@@ -198,7 +198,7 @@ func createWordpressSettingsFile(app *DdevApp) (string, error) {
 		} else {
 			// Settings file exists and is not ddev-managed, alert the user to the location
 			// of the generated ddev settings file
-			util.Failed(wordpressConfigInstructions, app.SiteLocalSettingsPath)
+			util.Failed(wordpressConfigInstructions, app.SiteDdevSettingsFile)
 		}
 	} else {
 		// If settings file does not exist, write basic settings file including it
@@ -207,7 +207,7 @@ func createWordpressSettingsFile(app *DdevApp) (string, error) {
 		}
 	}
 
-	return app.SiteLocalSettingsPath, nil
+	return app.SiteDdevSettingsFile, nil
 }
 
 // writeWordpressSettingsFile dynamically produces valid wp-config.php file by combining a configuration
@@ -292,7 +292,7 @@ func setWordpressSiteSettingsPaths(app *DdevApp) {
 
 	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
 	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, config.SiteSettings)
-	app.SiteLocalSettingsPath = filepath.Join(settingsFileBasePath, config.SiteSettingsDdev)
+	app.SiteDdevSettingsFile = filepath.Join(settingsFileBasePath, config.SiteSettingsDdev)
 }
 
 // isWordpressApp returns true if the app of of type wordpress
@@ -393,7 +393,7 @@ func wordpressGetRelativeAbsPath(app *DdevApp) (string, error) {
 
 func wordpressPostStartAction(app *DdevApp) error {
 	if _, err := app.CreateSettingsFile(); err != nil {
-		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 	return nil
 }

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -388,3 +388,12 @@ func wordpressGetRelativeAbsPath(app *DdevApp) (string, error) {
 
 	return absPath, nil
 }
+
+// wordpressPostStartAction handles post-start actions
+
+func wordpressPostStartAction(app *DdevApp) error {
+	if _, err := app.CreateSettingsFile(); err != nil {
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteLocalSettingsPath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1423: Teams often share a project and don't run `ddev config` individually. So the settings.ddev.php or equivalent needs to be created on `ddev start`

## How this PR Solves The Problem:

Add settings creation into the post-start action.

## Manual Testing Instructions:

* Remove settings.ddev.php
* ddev start
* Verify that it exists again

Unfortunately this needs to be tested in every supported CMS; TYPO3 and Wordpress and Backdrop are the most likely places for unexpected consequences.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

