### PR TITLE
Fixed order of hostname output, show https first, fixes #1580

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/drud/ddev/pkg/globalconfig"
@@ -454,7 +455,7 @@ func (app *DdevApp) GetHostnames() []string {
 	for k := range nameListMap {
 		nameListArray = append(nameListArray, k)
 	}
-
+	sort.Strings(nameListArray)
 	return nameListArray
 }
 

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -96,10 +96,8 @@ func RenderAppRow(table *uitable.Table, row map[string]interface{}) {
 		status = status + "\n" + syncStatus
 	}
 
-	urls := row["httpurl"].(string)
-	if row["httpsurl"] != "" {
-		urls = urls + "\n" + row["httpsurl"].(string)
-	}
+	urls := row["httpsurl"].(string) + "\n" + row["httpurl"].(string)
+
 	table.AddRow(
 		row["name"],
 		row["type"],


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1580: hostname output in various places can be random (because of underlying golang map), make it standard alpha order.

## How this PR Solves The Problem:

* Sort the array
* Also move the https URL before the http URL in `ddev list`, as it's given priority everywhere else at this point.

## Manual Testing Instructions:

* Add additional_hostnames to a project and `ddev start`. The output should be the same every time.
* Hostnames should also be added to /etc/hosts in the same correct alpha order.
* `ddev list` should show https URL first.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #1580 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

