### PR TITLE
Track and list stopped/removed projects, fixes #642

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -o nounset
 set -x
 
-rm -rf ~/.ddev/Test*
+rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml
 
 # There are discrepancies in golang hash checking in 1.11+, so kill off modcache to solve.
 # See https://github.com/golang/go/issues/27925

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ testpkg: setup
 	DDEV_NO_SENTRY=true CGO_ENABLED=0 go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
 
 setup:
-	@(mv -f ~/.ddev/global_config.yaml ~/.ddev/global_config.yaml.bak 2>/dev/null && echo "Warning: Removed your global ddev config file") || true
 	@mkdir -p $(GOTMP)/{src,pkg/mod/cache,.cache}
 	@mkdir -p $(TESTTMP)
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -169,8 +169,8 @@ func TestConfigSetValues(t *testing.T) {
 		"--mailhog-port", mailhogPort,
 	}
 
-	_, err = exec.RunCommand(DdevBin, args)
-	assert.NoError(err)
+	out, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err, "error running ddev %v: %v, output=%s", args, err, out)
 
 	configFile := filepath.Join(tmpdir, ".ddev", "config.yaml")
 	configContents, err := ioutil.ReadFile(configFile)

--- a/cmd/ddev/cmd/debug-nfsmount_test.go
+++ b/cmd/ddev/cmd/debug-nfsmount_test.go
@@ -32,7 +32,7 @@ func TestDebugNFSMount(t *testing.T) {
 
 	// Running config creates a line in global config
 	//nolint: errcheck
-	defer exec.RunCommand("remove", []string{"--remove-data"})
+	defer exec.RunCommand(DdevBin, []string{"stop", "-RO"})
 
 	// Test basic `ddev debug nfsmount`
 	args = []string{"debug", "nfsmount"}

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -43,7 +43,7 @@ running 'ddev stop <projectname>.`,
 		}
 
 		// Do not show any describe output if we can't find the project.
-		if project.SiteStatus() == ddevapp.SiteNotFound {
+		if project.SiteStatus() == ddevapp.SiteStopped {
 			util.Failed("no project found. have you run 'ddev start'?")
 		}
 

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -29,7 +29,7 @@ running 'ddev stop <projectname>.`,
 
 		projects, err := getRequestedProjects(args, false)
 		if err != nil {
-			util.Failed("Failed to find requested project '%v' to describe it: %v", args[0], err)
+			util.Failed("Failed to describe project(s): %v", err)
 		}
 		project := projects[0]
 

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -32,7 +32,7 @@ var DdevExecCmd = &cobra.Command{
 			util.Failed("Failed to exec command: %v", err)
 		}
 
-		if strings.Contains(app.SiteStatus(), ddevapp.SiteNotFound) {
+		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
 			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -24,60 +24,59 @@ func TestCmdExecBadArgs(t *testing.T) {
 func TestCmdExec(t *testing.T) {
 
 	assert := asrt.New(t)
-	for _, v := range DevTestSites {
-		cleanup := v.Chdir()
+	v := DevTestSites[0]
+	cleanup := v.Chdir()
 
-		// Test default invocation
-		args := []string{"exec", "pwd"}
-		out, err := exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-		assert.Contains(out, "/var/www/html")
+	// Test default invocation
+	args := []string{"exec", "pwd"}
+	out, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(out, "/var/www/html")
 
-		// Test specifying service
-		args = []string{"-s", "db", "exec", "pwd"}
-		out, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-		assert.Contains(out, "/")
+	// Test specifying service
+	args = []string{"-s", "db", "exec", "pwd"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(out, "/")
 
-		// Test specifying working directory
-		args = []string{"exec", "-d", "/bin", "pwd"}
-		out, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-		assert.Contains(out, "/bin")
+	// Test specifying working directory
+	args = []string{"exec", "-d", "/bin", "pwd"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(out, "/bin")
 
-		// Test specifying service and working directory
-		args = []string{"exec", "-s", "db", "-d", "/var", "pwd"}
-		out, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-		assert.Contains(out, "/var")
+	// Test specifying service and working directory
+	args = []string{"exec", "-s", "db", "-d", "/var", "pwd"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(out, "/var")
 
-		// Test sudo
-		args = []string{"exec", "sudo", "whoami"}
-		out, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-		assert.Contains(out, "root")
+	// Test sudo
+	args = []string{"exec", "sudo", "whoami"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(out, "root")
 
-		// Test that an nonexistant working directory generates an error
-		args = []string{"exec", "-d", "/does/not/exist", "pwd"}
-		out, err = exec.RunCommand(DdevBin, args)
-		assert.Error(err)
-		assert.Contains(out, "no such file or directory")
+	// Test that an nonexistant working directory generates an error
+	args = []string{"exec", "-d", "/does/not/exist", "pwd"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.Error(err)
+	assert.Contains(out, "no such file or directory")
 
-		args = []string{"exec", "ls >/var/www/html/TestCmdExec-${OSTYPE}.txt"}
-		_, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-linux-gnu.txt"))
+	args = []string{"exec", "ls >/var/www/html/TestCmdExec-${OSTYPE}.txt"}
+	_, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-linux-gnu.txt"))
 
-		args = []string{"exec", "ls >/dev/null && touch /var/www/html/TestCmdExec-touch-all-in-one.txt"}
-		_, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-touch-all-in-one.txt"))
+	args = []string{"exec", "ls >/dev/null && touch /var/www/html/TestCmdExec-touch-all-in-one.txt"}
+	_, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-touch-all-in-one.txt"))
 
-		args = []string{"exec", "true", "&&", "touch", "/var/www/html/TestCmdExec-touch-separate-args.txt"}
-		_, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-		assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-touch-separate-args.txt"))
+	args = []string{"exec", "true", "&&", "touch", "/var/www/html/TestCmdExec-touch-separate-args.txt"}
+	_, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.FileExists(filepath.Join(v.Dir, "TestCmdExec-touch-separate-args.txt"))
 
-		cleanup()
-	}
+	cleanup()
 }

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -164,7 +164,7 @@ func removeInactiveHostnames(hosts goodhosts.Hosts) {
 
 	// Get the list active hosts names to preserve
 	activeHostNames := make(map[string]bool)
-	for _, app := range ddevapp.GetDockerProjects() {
+	for _, app := range ddevapp.GetActiveProjects() {
 		for _, h := range app.GetHostnames() {
 			activeHostNames[h] = true
 		}

--- a/cmd/ddev/cmd/import_test.go
+++ b/cmd/ddev/cmd/import_test.go
@@ -16,38 +16,37 @@ import (
 func TestImportTilde(t *testing.T) {
 	assert := asrt.New(t)
 
-	for _, site := range DevTestSites {
+	site := DevTestSites[0]
 
-		homedir, err := gohomedir.Dir()
-		assert.NoError(err)
-		cwd, _ := os.Getwd()
-		testFile := filepath.Join(homedir, "testfile.tar.gz")
-		err = fileutil.CopyFile(filepath.Join(cwd, "testdata", "testfile.tar.gz"), testFile)
-		assert.NoError(err)
+	homedir, err := gohomedir.Dir()
+	assert.NoError(err)
+	cwd, _ := os.Getwd()
+	testFile := filepath.Join(homedir, "testfile.tar.gz")
+	err = fileutil.CopyFile(filepath.Join(cwd, "testdata", "testfile.tar.gz"), testFile)
+	assert.NoError(err)
 
-		cleanup := site.Chdir()
-		defer rmFile(testFile)
+	cleanup := site.Chdir()
+	defer rmFile(testFile)
 
-		// this ~ should be expanded by shell
-		args := []string{"import-files", "--src", "~/testfile.tar.gz"}
-		out, err := exec.RunCommand(DdevBin, args)
-		if err != nil {
-			t.Log("Error Output from ddev import-files:", out, site)
-		}
-		assert.NoError(err)
-		assert.Contains(string(out), "Successfully imported files")
-
-		// this ~ is not expanded by shell, ddev should convert it to a valid path
-		args = []string{"import-files", "--src=~/testfile.tar.gz"}
-		out, err = exec.RunCommand(DdevBin, args)
-		if err != nil {
-			t.Log("Error Output from ddev import-files:", out, site)
-		}
-		assert.NoError(err)
-		assert.Contains(string(out), "Successfully imported files")
-
-		cleanup()
+	// this ~ should be expanded by shell
+	args := []string{"import-files", "--src", "~/testfile.tar.gz"}
+	out, err := exec.RunCommand(DdevBin, args)
+	if err != nil {
+		t.Log("Error Output from ddev import-files:", out, site)
 	}
+	assert.NoError(err)
+	assert.Contains(string(out), "Successfully imported files")
+
+	// this ~ is not expanded by shell, ddev should convert it to a valid path
+	args = []string{"import-files", "--src=~/testfile.tar.gz"}
+	out, err = exec.RunCommand(DdevBin, args)
+	if err != nil {
+		t.Log("Error Output from ddev import-files:", out, site)
+	}
+	assert.NoError(err)
+	assert.Contains(string(out), "Successfully imported files")
+
+	cleanup()
 
 	assert.NoError(nil)
 }

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -15,6 +15,9 @@ var continuous bool
 // showAll, if set, shows non-running projects in addition to running/paused
 var showAll bool
 
+// continuousSleepTime is time to sleep between reads with --continuous
+var continuousSleepTime = 1
+
 // DdevListCmd represents the list command
 var DdevListCmd = &cobra.Command{
 	Use:   "list",
@@ -47,13 +50,15 @@ var DdevListCmd = &cobra.Command{
 				break
 			}
 
-			time.Sleep(time.Second)
+			time.Sleep(time.Duration(continuousSleepTime) * time.Second)
 		}
 	},
 }
 
 func init() {
 	DdevListCmd.Flags().BoolVarP(&showAll, "all", "a", false, "If set, all projects will be displayed, even stopped projects.")
-	DdevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted once per second")
+	DdevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted until the command is stopped.")
+	DdevListCmd.Flags().IntVarP(&continuousSleepTime, "continuous-sleep-interval", "I", 1, "Time in seconds between ddev list --continous output lists.")
+
 	RootCmd.AddCommand(DdevListCmd)
 }

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -18,7 +18,7 @@ var DdevListCmd = &cobra.Command{
 	Long:  `List projects.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for {
-			apps := ddevapp.GetDockerProjects()
+			apps := ddevapp.GetActiveProjects()
 			appDescs := make([]map[string]interface{}, 0)
 
 			if len(apps) < 1 {

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -12,17 +12,17 @@ import (
 // continuous, if set, makes list continuously output
 var continuous bool
 
-// all, if set, shows non-running projects in addition to running/paused
-var all bool
+// showAll, if set, shows non-running projects in addition to running/paused
+var showAll bool
 
 // DdevListCmd represents the list command
 var DdevListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List projects",
-	Long:  `List projects.`,
+	Long:  `List projects. Shows active projects by default, includes stopped projects with --all`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for {
-			apps, err := ddevapp.GetProjects()
+			apps, err := ddevapp.GetProjects(!showAll)
 			if err != nil {
 				util.Failed("failed getting GetProjects: %v", err)
 			}
@@ -53,7 +53,7 @@ var DdevListCmd = &cobra.Command{
 }
 
 func init() {
-	DdevListCmd.Flags().BoolVarP(&all, "all", "a", false, "If set, all projects will be displayed, even if not running.")
+	DdevListCmd.Flags().BoolVarP(&showAll, "all", "a", false, "If set, all projects will be displayed, even stopped projects.")
 	DdevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted once per second")
 	RootCmd.AddCommand(DdevListCmd)
 }

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -14,8 +14,8 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDevList runs the binary with "ddev list" and checks the results
-func TestDevList(t *testing.T) {
+// TestCmdList runs the binary with "ddev list" and checks the results
+func TestCmdList(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Execute "ddev list" and harvest plain text output.

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -21,12 +21,12 @@ func TestCmdList(t *testing.T) {
 	// Execute "ddev list" and harvest plain text output.
 	args := []string{"list"}
 	out, err := exec.RunCommand(DdevBin, args)
-	assert.NoError(err)
+	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
 
 	// Execute "ddev list -j" and harvest the json output
 	args = []string{"list", "-j"}
 	jsonOut, err := exec.RunCommand(DdevBin, args)
-	assert.NoError(err)
+	assert.NoError(err, "error running ddev list -j: %v, output=%s", jsonOut)
 
 	logItems, err := unmarshalJSONLogs(jsonOut)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -70,6 +70,35 @@ func TestCmdList(t *testing.T) {
 
 	}
 
+	// Now check behavior of --all
+	// Stop the first app
+	firstApp, err := ddevapp.GetActiveApp(DevTestSites[0].Name)
+	assert.NoError(err)
+	err = firstApp.Stop(false, false)
+	assert.NoError(err)
+
+	// Execute "ddev list" and harvest plain text output.
+	// Now there should be one less project in list
+	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
+	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
+
+	logItems, err = unmarshalJSONLogs(jsonOut)
+	assert.NoError(err)
+
+	assert.Equal(len(DevTestSites), len(logItems)-1)
+
+	// Now list with -a, make sure we show all projects
+	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j", "-a"})
+	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
+
+	logItems, err = unmarshalJSONLogs(jsonOut)
+	assert.NoError(err)
+
+	assert.Equal(len(DevTestSites), len(logItems))
+
+	// Leave firstApp running for other tests
+	err = firstApp.Start()
+	assert.NoError(err)
 }
 
 // TestCmdListContinuous tests the --continuous flag for ddev list.

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"github.com/stretchr/testify/require"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,25 +20,15 @@ func TestCmdList(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Execute "ddev list" and harvest plain text output.
-	args := []string{"list"}
-	out, err := exec.RunCommand(DdevBin, args)
+	out, err := exec.RunCommand(DdevBin, []string{"list"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
 
 	// Execute "ddev list -j" and harvest the json output
-	args = []string{"list", "-j"}
-	jsonOut, err := exec.RunCommand(DdevBin, args)
+	jsonOut, err := exec.RunCommand(DdevBin, []string{"list", "-j"})
 	assert.NoError(err, "error running ddev list -j: %v, output=%s", jsonOut)
 
-	logItems, err := unmarshalJSONLogs(jsonOut)
-	assert.NoError(err)
-
-	// The list should be the last item; there may be a warning
-	// or other info before that.
-	data := logItems[len(logItems)-1]
-	assert.EqualValues(data["level"], "info")
-
-	raw, ok := data["raw"].([]interface{})
-	assert.True(ok)
+	siteList := getSitesFromList(t, jsonOut)
+	assert.Equal(len(DevTestSites), len(siteList))
 
 	for _, v := range DevTestSites {
 		app, err := ddevapp.GetActiveApp(v.Name)
@@ -51,16 +42,16 @@ func TestCmdList(t *testing.T) {
 
 		// Look through list results in json for this site.
 		found := false
-		for _, listitem := range raw {
-			_ = listitem
+		for _, listitem := range siteList {
 			item, ok := listitem.(map[string]interface{})
 			assert.True(ok)
 			// Check to see that we can find our item
 			if item["name"] == v.Name {
 				found = true
-				assert.Contains(item["httpurl"], app.HostName())
-				assert.Contains(item["httpsurl"], app.HostName())
-				assert.EqualValues(app.GetType(), item["type"])
+				assert.Equal(app.GetHTTPURL(), item["httpurl"])
+				assert.Equal(app.GetHTTPSURL(), item["httpsurl"])
+				assert.Equal(app.Name, item["name"])
+				assert.Equal(app.GetType(), item["type"])
 				assert.EqualValues(ddevapp.RenderHomeRootedDir(app.GetAppRoot()), item["shortroot"])
 				assert.EqualValues(app.GetAppRoot(), item["approot"])
 				break
@@ -82,23 +73,53 @@ func TestCmdList(t *testing.T) {
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
 
-	logItems, err = unmarshalJSONLogs(jsonOut)
-	assert.NoError(err)
-
-	assert.Equal(len(DevTestSites), len(logItems)-1)
+	siteList = getSitesFromList(t, jsonOut)
+	assert.Equal(len(DevTestSites)-1, len(siteList))
 
 	// Now list with -a, make sure we show all projects
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j", "-a"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
 
-	logItems, err = unmarshalJSONLogs(jsonOut)
-	assert.NoError(err)
-
-	assert.Equal(len(DevTestSites), len(logItems))
+	siteList = getTestingSitesFromList(t, jsonOut)
+	assert.Equal(len(DevTestSites), len(siteList))
 
 	// Leave firstApp running for other tests
 	err = firstApp.Start()
 	assert.NoError(err)
+}
+
+// getSitesFromList takes the json output of ddev list -j
+// and returns the list of sites ddev list returns as an array
+// of interface{}
+func getSitesFromList(t *testing.T, jsonOut string) []interface{} {
+	assert := asrt.New(t)
+
+	logItems, err := unmarshalJSONLogs(jsonOut)
+	assert.NoError(err)
+	data := logItems[len(logItems)-1]
+	assert.EqualValues(data["level"], "info")
+
+	raw, ok := data["raw"].([]interface{})
+	assert.True(ok)
+	return raw
+}
+
+// getTestingSitesFromList() finds only the ddev list items that
+// have names starting with "Test"
+func getTestingSitesFromList(t *testing.T, jsonOut string) []interface{} {
+	assert := asrt.New(t)
+
+	baseRaw := getSitesFromList(t, jsonOut)
+	testSites := make([]interface{}, 0)
+	for _, listItem := range baseRaw {
+		item, ok := listItem.(map[string]interface{})
+		assert.True(ok)
+
+		if strings.HasPrefix(item["name"].(string), "Test") {
+			testSites = append(testSites, listItem)
+		}
+	}
+	return testSites
 }
 
 // TestCmdListContinuous tests the --continuous flag for ddev list.

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -25,7 +25,7 @@ var DdevLogsCmd = &cobra.Command{
 			util.Failed("Failed to retrieve logs: %v", err)
 		}
 
-		if strings.Contains(app.SiteStatus(), ddevapp.SiteNotFound) {
+		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
 			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -31,29 +31,28 @@ func TestLogsNoConfig(t *testing.T) {
 func TestLogs(t *testing.T) {
 	assert := asrt.New(t)
 
-	for _, v := range DevTestSites {
-		// Copy our fatal error php into the docroot of testsite.
-		pwd, err := os.Getwd()
-		assert.NoError(err)
-		err = fileutil.CopyFile(filepath.Join(pwd, "testdata", "logtest.php"), filepath.Join(v.Dir, v.Docroot, "logtest.php"))
-		assert.NoError(err)
-		cleanup := v.Chdir()
+	v := DevTestSites[0]
+	// Copy our fatal error php into the docroot of testsite.
+	pwd, err := os.Getwd()
+	assert.NoError(err)
+	err = fileutil.CopyFile(filepath.Join(pwd, "testdata", "logtest.php"), filepath.Join(v.Dir, v.Docroot, "logtest.php"))
+	assert.NoError(err)
+	cleanup := v.Chdir()
 
-		app, err := ddevapp.NewApp(v.Dir, true, "")
-		assert.NoError(err)
+	app, err := ddevapp.NewApp(v.Dir, true, "")
+	assert.NoError(err)
 
-		ddevapp.WaitForSync(app, 2)
+	ddevapp.WaitForSync(app, 2)
 
-		url := "http://" + v.Name + "." + version.DDevTLD + "/logtest.php"
-		_, err = testcommon.EnsureLocalHTTPContent(t, url, "Notice to demonstrate logging", 5)
-		assert.NoError(err)
+	url := "http://" + v.Name + "." + version.DDevTLD + "/logtest.php"
+	_, err = testcommon.EnsureLocalHTTPContent(t, url, "Notice to demonstrate logging", 5)
+	assert.NoError(err)
 
-		args := []string{"logs"}
-		out, err := exec.RunCommand(DdevBin, args)
+	args := []string{"logs"}
+	out, err := exec.RunCommand(DdevBin, args)
 
-		assert.NoError(err)
-		assert.Contains(string(out), "Server started")
-		assert.Contains(string(out), "Notice to demonstrate logging", "PHP notice not found for project %s output='%s", v.Name, string(out))
-		cleanup()
-	}
+	assert.NoError(err)
+	assert.Contains(string(out), "Server started")
+	assert.Contains(string(out), "Notice to demonstrate logging", "PHP notice not found for project %s output='%s", v.Name, string(out))
+	cleanup()
 }

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -31,7 +31,7 @@ func TestCmdPauseContainers(t *testing.T) {
 		assert.NoError(err, "ddev pause should succeed but failed, err: %v, output: %s", err, out)
 		assert.Contains(out, "has been paused")
 
-		apps := ddevapp.GetDockerProjects()
+		apps := ddevapp.GetActiveProjects()
 
 		for _, app := range apps {
 			if app.GetName() != site.Name {
@@ -51,7 +51,7 @@ func TestCmdPauseContainers(t *testing.T) {
 	assert.NoError(err, "ddev pause --all should succeed but failed, err: %v, output: %s", err, out)
 
 	// Confirm all sites are stopped.
-	apps := ddevapp.GetDockerProjects()
+	apps := ddevapp.GetActiveProjects()
 	for _, app := range apps {
 		assert.True(app.SiteStatus() == ddevapp.SitePaused, "All sites should be stopped, but %s status: %s", app.GetName(), app.SiteStatus())
 	}

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -24,34 +24,33 @@ func TestCmdPauseContainers(t *testing.T) {
 	err := addSites()
 	require.NoError(t, err)
 
-	for _, site := range DevTestSites {
-		cleanup := site.Chdir()
+	site := DevTestSites[0]
+	cleanup := site.Chdir()
 
-		out, err := exec.RunCommand(DdevBin, []string{"pause"})
-		assert.NoError(err, "ddev pause should succeed but failed, err: %v, output: %s", err, out)
-		assert.Contains(out, "has been paused")
+	out, err := exec.RunCommand(DdevBin, []string{"pause"})
+	assert.NoError(err, "ddev pause should succeed but failed, err: %v, output: %s", err, out)
+	assert.Contains(out, "has been paused")
 
-		apps := ddevapp.GetActiveProjects()
+	apps := ddevapp.GetActiveProjects()
 
-		for _, app := range apps {
-			if app.GetName() != site.Name {
-				continue
-			}
-
-			assert.True(app.SiteStatus() == ddevapp.SitePaused)
+	for _, app := range apps {
+		if app.GetName() != site.Name {
+			continue
 		}
 
-		cleanup()
+		assert.True(app.SiteStatus() == ddevapp.SitePaused)
 	}
+
+	cleanup()
 
 	// Re-create running sites.
 	err = addSites()
 	require.NoError(t, err)
-	out, err := exec.RunCommand(DdevBin, []string{"pause", "--all"})
+	out, err = exec.RunCommand(DdevBin, []string{"pause", "--all"})
 	assert.NoError(err, "ddev pause --all should succeed but failed, err: %v, output: %s", err, out)
 
 	// Confirm all sites are stopped.
-	apps := ddevapp.GetActiveProjects()
+	apps = ddevapp.GetActiveProjects()
 	for _, app := range apps {
 		assert.True(app.SiteStatus() == ddevapp.SitePaused, "All sites should be stopped, but %s status: %s", app.GetName(), app.SiteStatus())
 	}

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -13,52 +13,50 @@ import (
 // TestDevRestart runs `ddev restart` on the test apps
 func TestDevRestart(t *testing.T) {
 	assert := asrt.New(t)
-	for _, site := range DevTestSites {
-		cleanup := site.Chdir()
+	site := DevTestSites[0]
+	cleanup := site.Chdir()
 
-		args := []string{"restart"}
-		out, err := exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
+	args := []string{"restart"}
+	out, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
 
-		app, err := ddevapp.GetActiveApp("")
-		if err != nil {
-			assert.Fail("Could not find an active ddev configuration: %v", err)
-		}
-
-		assert.Contains(string(out), "Your project can be reached at")
-		assert.Contains(string(out), strings.Join(app.GetAllURLs(), ", "))
-		cleanup()
+	app, err := ddevapp.GetActiveApp("")
+	if err != nil {
+		assert.Fail("Could not find an active ddev configuration: %v", err)
 	}
+
+	assert.Contains(string(out), "Your project can be reached at")
+	assert.Contains(string(out), strings.Join(app.GetAllURLs(), ", "))
+	cleanup()
 }
 
 // TestDevRestartJSON runs `ddev restart -j` on the test apps and harvests and checks the output
 func TestDevRestartJSON(t *testing.T) {
 	assert := asrt.New(t)
-	for _, site := range DevTestSites {
-		cleanup := site.Chdir()
-		defer cleanup()
+	site := DevTestSites[0]
+	cleanup := site.Chdir()
+	defer cleanup()
 
-		app, err := ddevapp.GetActiveApp("")
-		if err != nil {
-			assert.Fail("Could not find an active ddev configuration: %v", err)
-		}
-
-		args := []string{"restart", "-j"}
-		out, err := exec.RunCommand(DdevBin, args)
-		assert.NoError(err)
-
-		logItems, err := unmarshalJSONLogs(out)
-		assert.NoError(err)
-
-		// The key item should be the last item; there may be a warning
-		// or other info before that.
-
-		var item map[string]interface{}
-		for _, item = range logItems {
-			if item["level"] == "info" && item["msg"] != nil && strings.Contains(item["msg"].(string), "Your project can be reached at "+strings.Join(app.GetAllURLs(), ", ")) {
-				break
-			}
-		}
-		assert.Contains(item["msg"], "Your project can be reached at "+strings.Join(app.GetAllURLs(), ", "))
+	app, err := ddevapp.GetActiveApp("")
+	if err != nil {
+		assert.Fail("Could not find an active ddev configuration: %v", err)
 	}
+
+	args := []string{"restart", "-j"}
+	out, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+
+	logItems, err := unmarshalJSONLogs(out)
+	assert.NoError(err)
+
+	// The key item should be the last item; there may be a warning
+	// or other info before that.
+
+	var item map[string]interface{}
+	for _, item = range logItems {
+		if item["level"] == "info" && item["msg"] != nil && strings.Contains(item["msg"].(string), "Your project can be reached at "+strings.Join(app.GetAllURLs(), ", ")) {
+			break
+		}
+	}
+	assert.Contains(item["msg"], "Your project can be reached at "+strings.Join(app.GetAllURLs(), ", "))
 }

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -20,17 +20,33 @@ import (
 var (
 	// DdevBin is the full path to the drud binary
 	DdevBin      = "ddev"
-	DevTestSites = []testcommon.TestSite{{
-		Name:                          "TestMainCmdWordpress",
-		SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
-		ArchiveInternalExtractionPath: "wordpress-0.4.0/",
-		FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
-		DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
-		HTTPProbeURI:                  "wp-admin/setup-config.php",
-		Docroot:                       "htdocs",
-		Type:                          ddevapp.AppTypeWordPress,
-		Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
-	},
+	DevTestSites = []testcommon.TestSite{
+		{
+			Name:                          "TestCmdWordpress",
+			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
+			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
+			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
+			HTTPProbeURI:                  "wp-admin/setup-config.php",
+			Docroot:                       "htdocs",
+			Type:                          ddevapp.AppTypeWordPress,
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
+		},
+		{
+			Name:                          "TestCmdDrupal8",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.6.1.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-8.6.1/",
+			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/drupal8_6_1_files.tar.gz",
+			FilesZipballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/drupal8_files.zip",
+			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/drupal8_6_1_db.tar.gz",
+			DBZipURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/drupal8_db.zip",
+			FullSiteTarballURL:            "",
+			Type:                          ddevapp.AppTypeDrupal8,
+			Docroot:                       "",
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "Drupal is an open source content management platform"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/node/1", Expect: "this is a post with an image"},
+			FilesImageURI:                 "/sites/default/files//2017-04/pexels-photo-265186.jpeg",
+		},
 	}
 )
 
@@ -59,7 +75,7 @@ func TestMain(m *testing.M) {
 	// Attempt to stop/remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
 	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent"}); err != nil {
-		log.Warnf("Failed to stop/remove all running projects: %v", err)
+		log.Warnf("Failed to stop all running projects: %v", err)
 	}
 
 	for i := range DevTestSites {
@@ -167,7 +183,7 @@ func removeSites() {
 	for _, site := range DevTestSites {
 		_ = site.Chdir()
 
-		args := []string{"remove", "-RO"}
+		args := []string{"stop", "-RO"}
 		out, err := exec.RunCommand(DdevBin, args)
 		if err != nil {
 			log.Errorf("Failed to run ddev remove -RO command, err: %v, output: %s\n", err, out)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 
 	// Attempt to stop/remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
-	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent", "--remove-data", "--omit-snapshot"}); err != nil {
+	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent", "--unlist"}); err != nil {
 		log.Warnf("Failed to stop/remove all running projects: %v", err)
 	}
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 
 	// Attempt to stop/remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
-	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent", "--unlist"}); err != nil {
+	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent"}); err != nil {
 		log.Warnf("Failed to stop/remove all running projects: %v", err)
 	}
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 
 	// Attempt to stop/remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
-	if _, err = exec.RunCommand(DdevBin, []string{"remove", "--all", "--stop-ssh-agent"}); err != nil {
+	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent", "--remove-data"}); err != nil {
 		log.Warnf("Failed to stop/remove all running projects: %v", err)
 	}
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 
 	// Attempt to stop/remove all running containers before starting a test.
 	// If no projects are running, this will exit silently and without error.
-	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent", "--remove-data"}); err != nil {
+	if _, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent", "--remove-data", "--omit-snapshot"}); err != nil {
 		log.Warnf("Failed to stop/remove all running projects: %v", err)
 	}
 

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -23,7 +23,7 @@ var DdevSSHCmd = &cobra.Command{
 			util.Failed("Failed to ssh: %v", err)
 		}
 
-		if strings.Contains(app.SiteStatus(), ddevapp.SiteNotFound) {
+		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
 			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -32,7 +32,7 @@ func TestCmdStart(t *testing.T) {
 	assert.NoError(err, "ddev start --all should succeed but failed, err: %v, output: %s", err, out)
 
 	// Confirm all sites are running.
-	apps := ddevapp.GetDockerProjects()
+	apps := ddevapp.GetActiveProjects()
 	for _, app := range apps {
 		assert.True(app.SiteStatus() == ddevapp.SiteRunning, "All sites should be running, but %s status: %s", app.GetName(), app.SiteStatus())
 	}

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -62,7 +62,7 @@ To snapshot the database on stop, use "ddev stop --snapshot"; A snapshot is auto
 				util.Failed("Failed to remove project %s: \n%v", project.GetName(), err)
 			}
 			if unlist {
-				project.Unlist()
+				project.RemoveGlobalProjectInfo()
 			}
 
 			util.Success("Project %s has been stopped.", project.GetName())

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -21,6 +21,8 @@ var omitSnapshot bool
 // Stop the ddev-ssh-agent
 var stopSSHAgent bool
 
+var unlist bool
+
 // DdevStopCmd represents the remove command
 var DdevStopCmd = &cobra.Command{
 	Use:     "stop [projectname ...]",
@@ -59,6 +61,9 @@ To snapshot the database on stop, use "ddev stop --snapshot"; A snapshot is auto
 			if err := project.Stop(removeData, doSnapshot); err != nil {
 				util.Failed("Failed to remove project %s: \n%v", project.GetName(), err)
 			}
+			if unlist {
+				project.Unlist()
+			}
 
 			util.Success("Project %s has been stopped.", project.GetName())
 		}
@@ -78,6 +83,7 @@ func init() {
 
 	DdevStopCmd.Flags().BoolVarP(&stopAll, "all", "a", false, "Stop and remove all running or container-stopped projects")
 	DdevStopCmd.Flags().BoolVarP(&stopSSHAgent, "stop-ssh-agent", "", false, "Stop the ddev-ssh-agent container")
+	DdevStopCmd.Flags().BoolVarP(&unlist, "unlist", "U", false, "Remove the project from global project list, it won't show in ddev list until started again")
 
 	RootCmd.AddCommand(DdevStopCmd)
 }

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -50,7 +50,7 @@ To snapshot the database on stop, use "ddev stop --snapshot"; A snapshot is auto
 
 		// Iterate through the list of projects built above, removing each one.
 		for _, project := range projects {
-			if project.SiteStatus() == ddevapp.SiteNotFound {
+			if project.SiteStatus() == ddevapp.SiteStopped {
 				util.Warning("Project %s is not currently running. Try 'ddev start'.", project.GetName())
 			}
 

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -32,7 +32,7 @@ func TestCmdStop(t *testing.T) {
 		assert.Contains(out, "has been stopped")
 
 		// Ensure the site that was just stopped does not appear in the list of sites
-		apps := ddevapp.GetDockerProjects()
+		apps := ddevapp.GetActiveProjects()
 		for _, app := range apps {
 			assert.True(app.GetName() != site.Name)
 		}

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -49,7 +49,7 @@ func TestCmdStop(t *testing.T) {
 	assert.NoError(err, "ddev stop --all should succeed but failed, err: %v, output: %s", err, out)
 	out, err = exec.RunCommand(DdevBin, []string{"list"})
 	assert.NoError(err)
-	assert.Contains(out, "No ddev projects were found")
+	assert.Contains(out, "There are no active ddev projects")
 	containers, err := dockerutil.GetDockerContainers(true)
 	assert.NoError(err)
 	// Just the ddev-ssh-agent should remain running (1 container)

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -49,7 +49,7 @@ func TestCmdStop(t *testing.T) {
 	assert.NoError(err, "ddev stop --all should succeed but failed, err: %v, output: %s", err, out)
 	out, err = exec.RunCommand(DdevBin, []string{"list"})
 	assert.NoError(err)
-	assert.Contains(out, "no active ddev projects")
+	assert.Contains(out, "No ddev projects were found")
 	containers, err := dockerutil.GetDockerContainers(true)
 	assert.NoError(err)
 	// Just the ddev-ssh-agent should remain running (1 container)

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -49,7 +49,7 @@ func TestCmdStop(t *testing.T) {
 	assert.NoError(err, "ddev stop --all should succeed but failed, err: %v, output: %s", err, out)
 	out, err = exec.RunCommand(DdevBin, []string{"list"})
 	assert.NoError(err)
-	assert.Contains(out, "There are no active ddev projects")
+	assert.Contains(out, "No ddev projects were found")
 	containers, err := dockerutil.GetDockerContainers(true)
 	assert.NoError(err)
 	// Just the ddev-ssh-agent should remain running (1 container)

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -20,16 +20,16 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 		return append(requestedProjects, project), nil
 	}
 
-	allDockerProjects := ddevapp.GetDockerProjects()
+	activeProjects := ddevapp.GetActiveProjects()
 
 	// If all projects are requested, return here
 	if all {
-		return allDockerProjects, nil
+		return activeProjects, nil
 	}
 
 	// Convert all projects slice into map indexed by project name to prevent duplication
 	allDockerProjectMap := map[string]*ddevapp.DdevApp{}
-	for _, project := range allDockerProjects {
+	for _, project := range activeProjects {
 		allDockerProjectMap[project.Name] = project
 	}
 

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -20,17 +20,20 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 		return append(requestedProjects, project), nil
 	}
 
-	activeProjects := ddevapp.GetActiveProjects()
+	allProjects, err := ddevapp.GetProjects()
+	if err != nil {
+		return nil, err
+	}
 
 	// If all projects are requested, return here
 	if all {
-		return activeProjects, nil
+		return allProjects, nil
 	}
 
 	// Convert all projects slice into map indexed by project name to prevent duplication
-	allDockerProjectMap := map[string]*ddevapp.DdevApp{}
-	for _, project := range activeProjects {
-		allDockerProjectMap[project.Name] = project
+	allProjectMap := map[string]*ddevapp.DdevApp{}
+	for _, project := range allProjects {
+		allProjectMap[project.Name] = project
 	}
 
 	// Select requested projects
@@ -40,14 +43,13 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 		// If the requested project name is found in the docker map, OK
 		// If not, if we find it in the globl project list, OK
 		// Otherwise, error.
-		if requestedProjectsMap[name], exists = allDockerProjectMap[name]; !exists {
+		if requestedProjectsMap[name], exists = allProjectMap[name]; !exists {
 			if _, exists = globalconfig.DdevGlobalConfig.ProjectList[name]; exists {
 				requestedProjectsMap[name] = &ddevapp.DdevApp{Name: name}
 			} else {
 				return nil, fmt.Errorf("could not find requested project %s", name)
 			}
 		}
-
 	}
 
 	// Convert map back to slice

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -20,7 +20,7 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 		return append(requestedProjects, project), nil
 	}
 
-	allProjects, err := ddevapp.GetProjects()
+	allProjects, err := ddevapp.GetProjects(false)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -274,7 +274,7 @@ How do you know if DDEV manages a settings file? You will see the following comm
 
 ## Listing project information
 
-To see a list of your running projects you can use `ddev list`; `ddev list --all` will show all projects including stopped projects
+To see a list of your running projects you can use `ddev list`; `ddev list --all` will show all projects including stopped projects.
 
 ```
 ➜  ddev list
@@ -321,6 +321,17 @@ phpMyAdmin:	http://drupal8.ddev.local:8036
 
 DDEV ROUTER STATUS: healthy
 ```
+
+## Removing projects from your collection known to ddev
+
+To remove a project from ddev's listing you can use the destructive option (deletes database, removes item from ddev's list, removes hostname entry in hosts file):
+
+`ddev stop --remove-data <projectname>` or to skip the snapshot, `ddev stop --remove-data --omit-snapshot <projectname>`
+
+Or if you just want it not to show up in `ddev list --all` any more, this command will unlist it until the next time you `ddev start` or `ddev config` the project.
+
+`ddev stop --unlist <projectname>`
+
 
 ## Importing assets for an existing project
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -274,13 +274,23 @@ How do you know if DDEV manages a settings file? You will see the following comm
 
 ## Listing project information
 
-To see a list of your current projects you can use `ddev list`.
+To see a list of your running projects you can use `ddev list`; `ddev list --all` will show all projects including stopped projects
 
 ```
 ➜  ddev list
 NAME     TYPE     LOCATION             URL(s)                      STATUS
 drupal8  drupal8  ~/workspace/drupal8  http://drupal8.ddev.local   running
                                        https://drupal8.ddev.local
+```
+
+```
+➜  ddev list --all
+NAME          TYPE     LOCATION                   URL(s)                                STATUS
+d8git         drupal8  ~/workspace/d8git          https://d8git.ddev.local              running
+                                                  http://d8git.ddev.local
+hobobiker     drupal6  ~/workspace/hobobiker.com                                        stopped
+t3v9composer  typo3    ~/workspace/t3v9composer   https://t3v9composer.ddev.local:8443  running
+                                                  http://t3v9composer.ddev.local:8080
 ```
 
 You can also see more detailed information about a project by running `ddev describe` from its working directory. You can also run `ddev describe [project-name]` from any location to see the detailed information for a running project.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -178,7 +178,7 @@ func (app *DdevApp) WriteConfig() error {
 
 	// We now want to reserve the port we're writing for HostDBPort and HostWebserverPort and so they don't
 	// accidentally get used for other projects.
-	err := app.CheckAndReserveHostPorts()
+	err := app.UpdateGlobalProjectList()
 	if err != nil {
 		return err
 	}
@@ -261,9 +261,9 @@ RUN echo "Built from ` + app.DBImage + `" >/var/tmp/built-from.txt
 	return nil
 }
 
-// CheckAndReserveHostPorts checks that configured host ports are not already
+// UpdateGlobalProjectList checks that configured host ports are not already
 // reserved by another project.
-func (app *DdevApp) CheckAndReserveHostPorts() error {
+func (app *DdevApp) UpdateGlobalProjectList() error {
 	portsToReserve := []string{}
 	if app.HostDBPort != "" {
 		portsToReserve = append(portsToReserve, app.HostDBPort)
@@ -281,7 +281,12 @@ func (app *DdevApp) CheckAndReserveHostPorts() error {
 			return err
 		}
 	}
-	err := globalconfig.ReservePorts(app.Name, portsToReserve)
+	// TODO: Make sure there isn't already a conflicting project
+	err := globalconfig.SetProjectAppRoot(app.Name, app.AppRoot)
+	if err != nil {
+		return err
+	}
+	err = globalconfig.ReservePorts(app.Name, portsToReserve)
 
 	return err
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -261,8 +261,12 @@ RUN echo "Built from ` + app.DBImage + `" >/var/tmp/built-from.txt
 	return nil
 }
 
-// UpdateGlobalProjectList checks that configured host ports are not already
-// reserved by another project.
+// UpdateGlobalProjectList updates any information about project that
+// is tracked in global project list:
+// - approot
+// - configured host ports
+// checks that configured host ports are not already
+// reserved by another project
 func (app *DdevApp) UpdateGlobalProjectList() error {
 	portsToReserve := []string{}
 	if app.HostDBPort != "" {
@@ -281,14 +285,16 @@ func (app *DdevApp) UpdateGlobalProjectList() error {
 			return err
 		}
 	}
-	// TODO: Make sure there isn't already a conflicting project
-	err := globalconfig.SetProjectAppRoot(app.Name, app.AppRoot)
+	err := globalconfig.ReservePorts(app.Name, portsToReserve)
 	if err != nil {
 		return err
 	}
-	err = globalconfig.ReservePorts(app.Name, portsToReserve)
+	err = globalconfig.SetProjectAppRoot(app.Name, app.AppRoot)
+	if err != nil {
+		return err
+	}
 
-	return err
+	return nil
 }
 
 // ReadConfig reads project configuration from the config.yaml file

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -75,10 +75,10 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 		return nil, fmt.Errorf("ddev config is not useful in home directory (%s)", homeDir)
 	}
 
+	app.AppRoot = AppRoot
 	if !fileutil.FileExists(AppRoot) {
 		return app, fmt.Errorf("project root %s does not exist", AppRoot)
 	}
-	app.AppRoot = AppRoot
 	app.ConfigPath = app.GetConfigPath("config.yaml")
 	app.APIVersion = version.DdevVersion
 	app.Type = AppTypePHP

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -56,7 +56,7 @@ const SiteStarting = "starting"
 const SiteStopped = "stopped"
 
 // SiteDirMissing defines the string used to denote when a site is missing its application directory.
-const SiteDirMissing = "app directory missing"
+const SiteDirMissing = "project directory missing"
 
 // SiteConfigMissing defines the string used to denote when a site is missing its .ddev/config.yml file.
 const SiteConfigMissing = ".ddev/config.yaml missing"

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1301,6 +1301,12 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	return err
 }
 
+// Unlist just removes from global projectinfo so it won't
+// show in ddev list and related until restarted.
+func (app *DdevApp) Unlist() {
+	_ = globalconfig.RemoveProjectInfo(app.Name)
+}
+
 // RemoveGlobalProjectInfo() deletes the project from ProjectList
 func (app *DdevApp) RemoveGlobalProjectInfo() {
 	_ = globalconfig.RemoveProjectInfo(app.Name)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -942,7 +942,6 @@ func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines
 
 // CaptureLogs returns logs for a site's given container.
 // See docker.LogsOptions for more information about valid tailLines values.
-// TODO: Reimplement this so it doesn't use the util.CaptureUserOut()
 func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines string) (string, error) {
 	client := dockerutil.GetDockerClient()
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -52,8 +52,8 @@ const SiteRunning = "running"
 // SiteStarting
 const SiteStarting = "starting"
 
-// SiteNotFound defines the string used to denote a site where the containers were not found/do not exist.
-const SiteNotFound = "not found"
+// SiteStopped defines the string used to denote a site where the containers were not found/do not exist, but the project is there.
+const SiteStopped = "stopped"
 
 // SiteDirMissing defines the string used to denote when a site is missing its application directory.
 const SiteDirMissing = "app directory missing"
@@ -443,7 +443,7 @@ func (app *DdevApp) SiteStatus() string {
 			return ""
 		}
 		if container == nil {
-			statuses[service] = SiteNotFound
+			statuses[service] = SiteStopped
 		} else {
 			status, _ := dockerutil.GetContainerHealth(container)
 
@@ -681,7 +681,8 @@ func (app *DdevApp) Start() error {
 	}
 
 	// Make sure that any ports allocated are available.
-	err = app.CheckAndReserveHostPorts()
+	// and of course add to global project list as well
+	err = app.UpdateGlobalProjectList()
 	if err != nil {
 		return err
 	}
@@ -1054,7 +1055,7 @@ func (app *DdevApp) DockerEnv() {
 func (app *DdevApp) Pause() error {
 	app.DockerEnv()
 
-	if app.SiteStatus() == SiteNotFound {
+	if app.SiteStatus() == SiteStopped {
 		return fmt.Errorf("no project to stop")
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1301,12 +1301,6 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	return err
 }
 
-// Unlist just removes from global projectinfo so it won't
-// show in ddev list and related until restarted.
-func (app *DdevApp) Unlist() {
-	_ = globalconfig.RemoveProjectInfo(app.Name)
-}
-
 // RemoveGlobalProjectInfo() deletes the project from ProjectList
 func (app *DdevApp) RemoveGlobalProjectInfo() {
 	_ = globalconfig.RemoveProjectInfo(app.Name)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -161,7 +161,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	count := len(ddevapp.GetDockerProjects())
+	count := len(ddevapp.GetActiveProjects())
 	if count > 0 {
 		log.Fatalf("ddevapp tests require no projects running. You have %v project(s) running.", count)
 	}
@@ -575,7 +575,7 @@ func TestStartWithoutDdevConfig(t *testing.T) {
 	}
 }
 
-// TestGetApps tests the GetDockerProjects function to ensure it accurately returns a list of running applications.
+// TestGetApps tests the GetActiveProjects function to ensure it accurately returns a list of running applications.
 func TestGetApps(t *testing.T) {
 	assert := asrt.New(t)
 
@@ -591,7 +591,7 @@ func TestGetApps(t *testing.T) {
 		assert.NoError(err)
 	}
 
-	apps := ddevapp.GetDockerProjects()
+	apps := ddevapp.GetActiveProjects()
 	assert.Equal(len(TestSites), len(apps))
 
 	for _, testSite := range TestSites {
@@ -1788,7 +1788,7 @@ func TestCleanupWithoutCompose(t *testing.T) {
 
 }
 
-// TestGetappsEmpty ensures that GetDockerProjects returns an empty list when no applications are running.
+// TestGetappsEmpty ensures that GetActiveProjects returns an empty list when no applications are running.
 func TestGetAppsEmpty(t *testing.T) {
 	assert := asrt.New(t)
 
@@ -1809,7 +1809,7 @@ func TestGetAppsEmpty(t *testing.T) {
 		switchDir()
 	}
 
-	apps := ddevapp.GetDockerProjects()
+	apps := ddevapp.GetActiveProjects()
 	assert.Equal(0, len(apps), "Expected to find no apps but found %d apps=%v", len(apps), apps)
 }
 
@@ -1834,7 +1834,7 @@ func TestListWithoutDir(t *testing.T) {
 	packageDir, _ := os.Getwd()
 
 	// startCount is the count of apps at the start of this adventure
-	apps := ddevapp.GetDockerProjects()
+	apps := ddevapp.GetActiveProjects()
 	startCount := len(apps)
 
 	testDir := testcommon.CreateTmpDir("TestStartWithoutDdevConfig")
@@ -1867,7 +1867,7 @@ func TestListWithoutDir(t *testing.T) {
 
 	testcommon.CleanupDir(testDir)
 
-	apps = ddevapp.GetDockerProjects()
+	apps = ddevapp.GetActiveProjects()
 
 	assert.EqualValues(len(apps), startCount+1)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -229,7 +229,7 @@ func TestMain(m *testing.M) {
 			log.Fatalf("TestMain shutdown: app.Init() failed on site %s in dir %s, err=%v", TestSites[i].Name, TestSites[i].Dir, err)
 		}
 
-		if app.SiteStatus() != ddevapp.SiteNotFound {
+		if app.SiteStatus() != ddevapp.SiteStopped {
 			err = app.Stop(true, false)
 			if err != nil {
 				log.Fatalf("TestMain shutdown: app.Stop() failed on site %s, err=%v", TestSites[i].Name, err)
@@ -1802,7 +1802,7 @@ func TestGetAppsEmpty(t *testing.T) {
 		err := app.Init(site.Dir)
 		assert.NoError(err)
 
-		if app.SiteStatus() != ddevapp.SiteNotFound {
+		if app.SiteStatus() != ddevapp.SiteStopped {
 			err = app.Stop(true, false)
 			assert.NoError(err)
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -134,11 +134,6 @@ func init() {
 func TestMain(m *testing.M) {
 	output.LogSetUp()
 
-	// Ensure the ddev directory is created before tests run.
-	_ = globalconfig.GetGlobalDdevDir()
-	globalConfigFile := globalconfig.GetGlobalConfigPath()
-	_ = os.Rename(globalConfigFile, globalConfigFile+".bak")
-
 	// Since this may be first time ddev has been used, we need the
 	// ddev_default network available.
 	dockerutil.EnsureDdevNetwork()
@@ -237,9 +232,6 @@ func TestMain(m *testing.M) {
 		}
 		site.Cleanup()
 	}
-
-	_ = os.Remove(globalConfigFile)
-	_ = os.Rename(globalConfigFile+".bak", globalConfigFile)
 
 	os.Exit(testRun)
 }

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -144,8 +144,8 @@ func TestPantheonPull(t *testing.T) {
 	defer testcommon.Chdir(testDir)()
 
 	// Move into the properly named pantheon site (must match pantheon sitename)
-	siteDir := testDir + "/" + pantheonTestSiteName
-	err := os.MkdirAll(siteDir+"/sites/default", 0777)
+	siteDir := filepath.Join(testDir, pantheonTestSiteName)
+	err := os.MkdirAll(filepath.Join(siteDir, "sites/default"), 0777)
 	assert.NoError(err)
 	err = os.Chdir(siteDir)
 	assert.NoError(err)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -121,7 +121,7 @@ func RenderRouterStatus() string {
 	badRouter := "\nThe router is not yet healthy. Your projects may not be accessible.\nIf it doesn't become healthy try running 'ddev start' on a project to recreate it."
 
 	switch status {
-	case SiteNotFound:
+	case SiteStopped:
 		renderedStatus = color.RedString(status) + badRouter
 	case "healthy":
 		renderedStatus = color.CyanString(status)
@@ -143,7 +143,7 @@ func GetRouterStatus() (string, string) {
 	container, err := dockerutil.FindContainerByLabels(label)
 
 	if err != nil || container == nil {
-		status = SiteNotFound
+		status = SiteStopped
 	} else {
 		status, logOutput = dockerutil.GetContainerHealth(container)
 	}

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -138,9 +138,7 @@ func RenderRouterStatus() string {
 // return status and most recent log
 func GetRouterStatus() (string, string) {
 	var status, logOutput string
-
-	label := map[string]string{"com.docker.compose.service": "ddev-router"}
-	container, err := dockerutil.FindContainerByLabels(label)
+	container, err := FindDdevRouter()
 
 	if err != nil || container == nil {
 		status = SiteStopped

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -139,7 +139,7 @@ func RenderSSHAuthStatus() string {
 	var renderedStatus string
 
 	switch status {
-	case SiteNotFound:
+	case SiteStopped:
 		renderedStatus = color.RedString(status)
 	case "healthy":
 		renderedStatus = color.CyanString(status)
@@ -159,10 +159,10 @@ func GetSSHAuthStatus() string {
 
 	if err != nil {
 		util.Error("Failed to execute FindContainerByLabels(%v): %v", label, err)
-		return SiteNotFound
+		return SiteStopped
 	}
 	if container == nil {
-		return SiteNotFound
+		return SiteStopped
 	}
 	health, _ := dockerutil.GetContainerHealth(container)
 	return health

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -23,8 +23,8 @@ import (
 	gohomedir "github.com/mitchellh/go-homedir"
 )
 
-// GetDockerProjects returns an array of ddev applications.
-func GetDockerProjects() []*DdevApp {
+// GetActiveProjects returns an array of ddev applications.
+func GetActiveProjects() []*DdevApp {
 	apps := make([]*DdevApp, 0)
 	labels := map[string]string{
 		"com.ddev.platform":          "ddev",

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"path"
 	"path/filepath"
@@ -82,7 +83,7 @@ func RenderAppRow(table *uitable.Table, row map[string]interface{}) {
 	switch {
 	case strings.Contains(status, SitePaused):
 		status = color.YellowString(status)
-	case strings.Contains(status, SiteNotFound):
+	case strings.Contains(status, SiteStopped):
 		status = color.RedString(status)
 	case strings.Contains(status, SiteDirMissing):
 		status = color.RedString(status)
@@ -315,4 +316,22 @@ func CheckForMissingProjectFiles(project *DdevApp) error {
 	}
 
 	return nil
+}
+
+// GetProjects returns projects that are listed
+// in globalconfig projectlist but don't show up from docker.
+func GetProjects() ([]*DdevApp, error) {
+	apps := []*DdevApp{}
+	// TODO: This should use a get method instead of directly accessing
+	for _, info := range globalconfig.DdevGlobalConfig.ProjectList {
+		// Skip if AppRoot hasn't been placed in globalconfig
+		if info.AppRoot != "" {
+			activeApp, err := NewApp(info.AppRoot, true, ProviderDefault)
+			if err != nil {
+				return nil, err
+			}
+			apps = append(apps, activeApp)
+		}
+	}
+	return apps, nil
 }

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -325,17 +325,21 @@ func CheckForMissingProjectFiles(project *DdevApp) error {
 
 // GetProjects returns projects that are listed
 // in globalconfig projectlist.
-func GetProjects() ([]*DdevApp, error) {
+// if activeOnly is true, only show projects that aren't stopped
+// (or broken, missing config, missing files)
+func GetProjects(activeOnly bool) ([]*DdevApp, error) {
 	apps := []*DdevApp{}
 	// TODO: This should use a get method instead of directly accessing
 	for name, info := range globalconfig.DdevGlobalConfig.ProjectList {
 		// Skip if AppRoot hasn't been placed in globalconfig
 		if info.AppRoot != "" {
-			activeApp, err := NewApp(info.AppRoot, true, ProviderDefault)
+			app, err := NewApp(info.AppRoot, true, ProviderDefault)
 			if err != nil {
-				activeApp.Name = name
+				app.Name = name
 			}
-			apps = append(apps, activeApp)
+			if !activeOnly || (app.SiteStatus() != SiteStopped && app.SiteStatus() != SiteConfigMissing && app.SiteStatus() != SiteDirMissing) {
+				apps = append(apps, app)
+			}
 		}
 	}
 	sort.Slice(apps, func(i, j int) bool { return apps[i].Name < apps[j].Name })

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -29,6 +29,7 @@ func init() {
 }
 
 type ProjectInfo struct {
+	AppRoot       string   `yaml:"approot"`
 	UsedHostPorts []string `yaml:"used_host_ports,omitempty,flow"`
 }
 
@@ -239,6 +240,19 @@ func ReservePorts(projectName string, ports []string) error {
 		DdevGlobalConfig.ProjectList[projectName] = &ProjectInfo{}
 	}
 	DdevGlobalConfig.ProjectList[projectName].UsedHostPorts = ports
+	err := WriteGlobalConfig(DdevGlobalConfig)
+	return err
+}
+
+// SetProjectAppRoot() sets the approot in the ProjectInfo of global config
+func SetProjectAppRoot(projectName string, appRoot string) error {
+	// If the project doesn't exist, add it.
+	_, ok := DdevGlobalConfig.ProjectList[projectName]
+	if !ok {
+		DdevGlobalConfig.ProjectList[projectName] = &ProjectInfo{}
+	}
+	DdevGlobalConfig.ProjectList[projectName].AppRoot = appRoot
+	// TODO: Aren't we going to end up doing this more than we need to?
 	err := WriteGlobalConfig(DdevGlobalConfig)
 	return err
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -256,7 +256,7 @@ func SetProjectAppRoot(projectName string, appRoot string) error {
 		return fmt.Errorf("project %s project root %s does not exist", projectName, appRoot)
 	}
 	if DdevGlobalConfig.ProjectList[projectName].AppRoot != "" && DdevGlobalConfig.ProjectList[projectName].AppRoot != appRoot {
-		return fmt.Errorf("project %s project root is already set to %s, refusing to change it to %s; you can `ddev rm --unlist` and start again if the listed project root is in error.", projectName, DdevGlobalConfig.ProjectList[projectName].AppRoot, appRoot)
+		return fmt.Errorf("project %s project root is already set to %s, refusing to change it to %s; you can `ddev rm --unlist` and start again if the listed project root is in error", projectName, DdevGlobalConfig.ProjectList[projectName].AppRoot, appRoot)
 	}
 	DdevGlobalConfig.ProjectList[projectName].AppRoot = appRoot
 	err := WriteGlobalConfig(DdevGlobalConfig)

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -251,8 +251,10 @@ func SetProjectAppRoot(projectName string, appRoot string) error {
 	if !ok {
 		DdevGlobalConfig.ProjectList[projectName] = &ProjectInfo{}
 	}
+	if DdevGlobalConfig.ProjectList[projectName].AppRoot != "" && DdevGlobalConfig.ProjectList[projectName].AppRoot != appRoot {
+		return fmt.Errorf("project %s appRoot is already set to %s, refusing to change it to %s", projectName, DdevGlobalConfig.ProjectList[projectName].AppRoot, appRoot)
+	}
 	DdevGlobalConfig.ProjectList[projectName].AppRoot = appRoot
-	// TODO: Aren't we going to end up doing this more than we need to?
 	err := WriteGlobalConfig(DdevGlobalConfig)
 	return err
 }
@@ -268,4 +270,9 @@ func RemoveProjectInfo(projectName string) error {
 		}
 	}
 	return nil
+}
+
+// GetGlobalProjectList() returns the global project list map
+func GetGlobalProjectList() map[string]*ProjectInfo {
+	return DdevGlobalConfig.ProjectList
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -251,12 +251,26 @@ func SetProjectAppRoot(projectName string, appRoot string) error {
 	if !ok {
 		DdevGlobalConfig.ProjectList[projectName] = &ProjectInfo{}
 	}
+	// Can't use fileutil.FileExists because of import cycle.
+	if _, err := os.Stat(appRoot); err != nil {
+		return fmt.Errorf("project %s project root %s does not exist", projectName, appRoot)
+	}
 	if DdevGlobalConfig.ProjectList[projectName].AppRoot != "" && DdevGlobalConfig.ProjectList[projectName].AppRoot != appRoot {
-		return fmt.Errorf("project %s appRoot is already set to %s, refusing to change it to %s", projectName, DdevGlobalConfig.ProjectList[projectName].AppRoot, appRoot)
+		return fmt.Errorf("project %s project root is already set to %s, refusing to change it to %s; you can `ddev rm --unlist` and start again if the listed project root is in error.", projectName, DdevGlobalConfig.ProjectList[projectName].AppRoot, appRoot)
 	}
 	DdevGlobalConfig.ProjectList[projectName].AppRoot = appRoot
 	err := WriteGlobalConfig(DdevGlobalConfig)
 	return err
+}
+
+// GetProject returns a project given name provided,
+// or nil if not found.
+func GetProject(projectName string) *ProjectInfo {
+	project, ok := DdevGlobalConfig.ProjectList[projectName]
+	if !ok {
+		return nil
+	}
+	return project
 }
 
 // RemoveProjectInfo() removes the ProjectInfo line for a project

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -4,8 +4,10 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"os"
 	"strconv"
 	"testing"
 )
@@ -46,4 +48,61 @@ func TestGetFreePort(t *testing.T) {
 
 		assert.NoError(err, "failed to 'docker %v': %v", dockerCommand, err)
 	}
+}
+
+// TestSetProjectAppRoot tests behavior of SetProjectAppRoot
+// This also tests RemoveProject
+func TestSetProjectAppRoot(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Make sure conflicting approot results in error
+	// Make sure empty project works
+	// Make sure existing project with no approot works
+
+	// Non-existing approot should cause a fail
+	err := globalconfig.SetProjectAppRoot("junk", "/nowhere/junk-approot-1")
+	assert.Error(err)
+
+	// Create a project in a valid directory
+	tmpDir := testcommon.CreateTmpDir(t.Name())
+	defer os.RemoveAll(tmpDir)
+	err = globalconfig.SetProjectAppRoot(t.Name(), tmpDir)
+	assert.NoError(err)
+	defer globalconfig.RemoveProjectInfo(t.Name())
+
+	// nolint: errcheck
+	project := globalconfig.GetProject(t.Name())
+	require.NotNil(t, project)
+
+	// Try to set approot to existing but conflicting approot
+	tmpDir2 := testcommon.CreateTmpDir(t.Name())
+	// nolint: errcheck
+	defer os.RemoveAll(tmpDir2)
+	err = globalconfig.SetProjectAppRoot(t.Name(), tmpDir2)
+	assert.Error(err)
+
+	// Make sure that the approot didn't accidentally get changed to
+	// bad approot
+	p2 := globalconfig.GetProject(t.Name())
+	assert.Equal(tmpDir, p2.AppRoot)
+
+	err = globalconfig.RemoveProjectInfo(t.Name())
+	assert.NoError(err)
+
+	// Make sure after removal the project is gone
+	p3 := globalconfig.GetProject(t.Name())
+	assert.Nil(p3)
+
+	// ReservePorts will create the project, but without an approot
+	err = globalconfig.ReservePorts(t.Name(), []string{})
+	assert.NoError(err)
+	project = globalconfig.GetProject(t.Name())
+	require.NotNil(t, project)
+	assert.Empty(project.AppRoot)
+
+	err = globalconfig.SetProjectAppRoot(t.Name(), tmpDir)
+	assert.NoError(err)
+
+	project = globalconfig.GetProject(t.Name())
+	assert.Equal(tmpDir, project.AppRoot)
 }

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -68,6 +68,7 @@ func TestSetProjectAppRoot(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	err = globalconfig.SetProjectAppRoot(t.Name(), tmpDir)
 	assert.NoError(err)
+	//nolint: errcheck
 	defer globalconfig.RemoveProjectInfo(t.Name())
 
 	// nolint: errcheck

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -130,6 +130,7 @@ func (site *TestSite) Cleanup() {
 	// CleanupDir checks its own errors.
 	CleanupDir(site.Dir)
 
+	_ = globalconfig.RemoveProjectInfo(site.Name)
 	siteData := filepath.Join(globalconfig.GetGlobalDdevDir(), site.Name)
 	if fileutil.FileExists(siteData) {
 		CleanupDir(siteData)

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -142,12 +142,6 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
 	}
 
-	out, err := exec.RunCommand(DdevBin, []string{"stop", "--all"})
-	assert.NoError(err, "ddev stop --all should succeed but failed, err: %v, output: %s", err, out)
-
-	router, _ := ddevapp.FindDdevRouter()
-	require.Empty(t, router)
-
 	// It's not ideal to copy/paste this archive around, but we don't actually care about the contents
 	// of the archive for this test, only that it exists and can be extracted. This should (knock on wood)
 	//not need to be updated over time.
@@ -160,7 +154,7 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 	//nolint: errcheck
 	defer globalconfig.RemoveProjectInfo(site.Name)
 
-	err = site.Prepare()
+	err := site.Prepare()
 	require.NoError(t, err, "Prepare() failed on TestSite.Prepare() site=%s, err=%v", site.Name, err)
 
 	cleanup := site.Chdir()

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/globalconfig"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -97,6 +98,8 @@ func TestValidTestSite(t *testing.T) {
 
 	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"stop", "-RO", site.Name})
+	//nolint: errcheck
+	defer globalconfig.RemoveProjectInfo(site.Name)
 	err = site.Prepare()
 	require.NoError(t, err, "Prepare() failed on TestSite.Prepare() site=%s, err=%v", site.Name, err)
 
@@ -151,8 +154,11 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 	site := TestSites[0]
 	site.Name = "TestGetLocalHTTPResponse"
 
+	_, _ = exec.RunCommand(DdevBin, []string{"stop", "-RO", site.Name})
 	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"stop", "-RO", site.Name})
+	//nolint: errcheck
+	defer globalconfig.RemoveProjectInfo(site.Name)
 
 	err = site.Prepare()
 	require.NoError(t, err, "Prepare() failed on TestSite.Prepare() site=%s, err=%v", site.Name, err)

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -83,6 +83,10 @@ func TestValidTestSite(t *testing.T) {
 	startingDir, err := os.Getwd()
 	assert.NoError(err, "Could not get current directory.")
 
+	if os.Getenv("DDEV_BINARY_FULLPATH") != "" {
+		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
+	}
+
 	// It's not ideal to copy/paste this archive around, but we don't actually care about the contents
 	// of the archive for this test, only that it exists and can be extracted. This should (knock on wood)
 	//not need to be updated over time.

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -107,6 +107,9 @@ func TestValidTestSite(t *testing.T) {
 
 	cleanup := site.Chdir()
 	defer cleanup()
+	//nolint: errcheck
+	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", site.Name})
+
 	currentDir, err := os.Getwd()
 	assert.NoError(err)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Not all projects have been visible to `ddev list` and related commands. This is a longstanding issue and affects ddev-ui, but is more relevant now that `ddev stop` actually removes containers, effectively removing ddev's knowledge of the existence of the project.

## How this PR Solves The Problem:

* Add stopped projects (which have no containers) to global config, and query from there.

## TODO:

- [x] Sort projects by active and then by name
- [x] TestMain must not remove all projects, it needs to just remove projects like "Test*"
- [x] `ddev list` should probably show only active and paused projects. Add `ddev list --all` for the rest.
- [x] Need a new `ddev stop` flag that just stops and removes from global config, doesn't do everything else (nondestructive). Use that in cmd's root_test.go setup so it's not so dangerous.
- [x] Docs: 
    - Projects don't get added until they're started once
    - How to delete a project from global config


## Manual Testing Instructions:

* Test functionality with ddev-ui if it's still working
* `ddev stop -a` and `ddev list` and `ddev list --all` (which will show stopped/removed projects)
* Start a few projects and `ddev list`

There are so *very* many things that can be broken with this (starting/stopping/pausing by name, whether running or not, conflicting stuff in docker from what's in global config). Please spend some serious time poking at it, and trying to make sure you can recreate bugs.

## Automated Testing Overview:

- [x] Test for consistency between docker containers and global config project list
- [x] Test for behavior when global projectlist is not fully populated (as will be the case for lots of people)
- [ ] Test for situation where there are broken or empty projects in global config

## Related Issue Link(s):

OP #642 
This should also make ddev-ui work consistently assuming it gets revived.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

