### PR TITLE
Fix d6/d7 quick start install step

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -106,7 +106,7 @@ Successfully started my-drupal7-site
 Your project can be reached at: http://my-drupal7-site.ddev.local
 ```
 
-Next step is to run the install script. This can be done by either going to your local site `/install.php` or running drush site-install, `drush si`. 
+If you want to run the Drupal install script, the next step is to hit "/install.php" on your project (like `http://my-drupal7-site.ddev.local/install.php`) or running drush site-install, `ddev exec drush site-install --yes`. 
 
 Quickstart instructions for database imports can be found under [Database Imports](#database-imports).
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -106,7 +106,7 @@ Successfully started my-drupal7-site
 Your project can be reached at: http://my-drupal7-site.ddev.local
 ```
 
-If you want to run the Drupal install script, the next step is to hit "/install.php" on your project (like `http://my-drupal7-site.ddev.local/install.php`) or running drush site-install, `ddev exec drush site-install --yes`. 
+If you want to run the Drupal install script, the next step is to hit "/install.php" on your project (like `http://my-drupal7-site.ddev.local/install.php`) or run drush site-install, `ddev exec drush site-install --yes`. 
 
 Quickstart instructions for database imports can be found under [Database Imports](#database-imports).
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -106,6 +106,8 @@ Successfully started my-drupal7-site
 Your project can be reached at: http://my-drupal7-site.ddev.local
 ```
 
+Next step is to run the install script. This can be done by either going to your local site `/install.php` or running drush site-install, `drush si`. 
+
 Quickstart instructions for database imports can be found under [Database Imports](#database-imports).
 
 ### Drupal 8 Quickstart


### PR DESCRIPTION
Users are now instructed to either run the install via '/install.php' or 'druhs si'.

## The Problem/Issue/Bug:
The quick start docs were missing the d6/d7 step of running the install script. 

## How this PR Solves The Problem:
Updated the doc to include those changes

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

