### PR TITLE
Make sure internet is active before trying operations that might hang, fixes #1601, Fixes #431

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/updatecheck"
 	"github.com/drud/ddev/pkg/util"
@@ -70,7 +71,7 @@ var RootCmd = &cobra.Command{
 			util.Warning("Could not perform update check: %v", err)
 		}
 
-		if timeToCheckForUpdates {
+		if timeToCheckForUpdates && nodeps.IsInternetActive() {
 			// Recreate the updatefile with current time so we won't do this again soon.
 			err = updatecheck.ResetUpdateTime(updateFile)
 			if err != nil {
@@ -115,7 +116,7 @@ var RootCmd = &cobra.Command{
 			uString = uString + " " + fullCommand[i]
 		}
 
-		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && version.SentryDSN != "" {
+		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && version.SentryDSN != "" && nodeps.IsInternetActive() {
 			_ = raven.CaptureMessageAndWait(uString, map[string]string{"severity-level": "info", "report-type": "usage"})
 		}
 	},

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -35,7 +35,8 @@ func IsDockerToolbox() bool {
 
 //IsInternetActive() checks to see if we have a viable
 // internet connection. It just tries a quick DNS query.
+// This requires that the named record be query-able.
 func IsInternetActive() bool {
-	_, err := net.LookupCNAME("trythis.ddev.site")
+	_, err := net.LookupHost("i-exist.ddev.site")
 	return err == nil
 }

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -1,6 +1,9 @@
 package nodeps
 
-import "os"
+import (
+	"net"
+	"os"
+)
 
 // ArrayContainsString returns true if slice contains element
 func ArrayContainsString(slice []string, element string) bool {
@@ -28,4 +31,11 @@ func IsDockerToolbox() bool {
 		return true
 	}
 	return false
+}
+
+//IsInternetActive() checks to see if we have a viable
+// internet connection. It just tries a quick DNS query.
+func IsInternetActive() bool {
+	_, err := net.LookupCNAME("trythis.ddev.site")
+	return err == nil
 }

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/ravenutils"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/evalphobia/logrus_sentry"
@@ -33,7 +34,7 @@ func LogSetUp() {
 	}
 
 	// Report errors and panics to Sentry
-	if version.SentryDSN != "" && !globalconfig.DdevNoSentry {
+	if version.SentryDSN != "" && !globalconfig.DdevNoSentry && nodeps.IsInternetActive() {
 		hook, err := logrus_sentry.NewAsyncWithTagsSentryHook(version.SentryDSN, ravenutils.RavenTags, levels)
 		if err == nil {
 			UserOut.Hooks.Add(hook)


### PR DESCRIPTION
## The Problem/Issue/Bug:

@mglaman reported that Sentry prevented ddev operation when off-internet on a plane in #1601 

## How this PR Solves The Problem:

Test connectivity via a DNS request before trying to:
* Use Sentry
* Check for available updates

This doesn't (yet?) attempt to anticipate docker pulls that would break. 

## Manual Testing Instructions:

DDEV_NO_SENTRY environment variable should be empty or deleted
SentryDSN variable should be set properly so that it's in the executable
Instrumentation should be enabled in ~/.ddev/global_config.yaml
* Use `ddev start` when connected/not connected to internet. When connected, you should see the Sentry event come through. (Study "ddev start" and click on "events"). When not connected to the internet you should have no interruption or problem.
* Test github release check by forcing it. `touch -mt 201705010101 ~/.ddev/.update` will make the update file force an update. Do that. With internet, a `ddev start` should update it, showing the check was completed. Do the touch again. Without internet, a `ddev start` should behave fine and not touch that file (so `ls -l ~/.ddev/.update` will still show May 1, 2017)

## Automated Testing Overview:

I'm not sure how to effectively build an automated test for this.

## Related Issue Link(s):

#1601 describes Sentry preventing offline usage of ddev
#431 is an old issue (perhaps speculative) describing a hang when the github version check occurs.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

