### PR TITLE
MailhogPort and friends should not normally show in config.yaml

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -169,6 +169,16 @@ func (app *DdevApp) WriteConfig() error {
 		appcopy.BgsyncImage = ""
 	}
 
+	if appcopy.MailhogPort == DdevDefaultMailhogPort {
+		appcopy.MailhogPort = ""
+	}
+	if appcopy.PHPMyAdminPort == DdevDefaultPHPMyAdminPort {
+		appcopy.PHPMyAdminPort = ""
+	}
+	if appcopy.Provider == ProviderDefault || appcopy.Provider == "" {
+		appcopy.Provider = ""
+	}
+
 	// We now want to reserve the port we're writing for HostDBPort and HostWebserverPort and so they don't
 	// accidentally get used for other projects.
 	err := app.CheckAndReserveHostPorts()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -100,6 +100,7 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	app.DBImage = version.GetDBImage(version.MariaDBDefaultVersion)
 	app.DBAImage = version.GetDBAImage()
 	app.BgsyncImage = version.GetBgsyncImage()
+	app.Provider = ProviderDefault
 
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
@@ -126,12 +127,10 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 
 	// Allow override with provider.
 	// Otherwise we accept whatever might have been in config file if there was anything.
-	if provider == "" && app.Provider != "" {
+	if provider == "" && app.Provider != ProviderDefault {
 		// Do nothing. This is the case where the config has a provider and no override is provided. Config wins.
-	} else if provider == ProviderPantheon || provider == ProviderDrudS3 || provider == ProviderDefault {
+	} else if provider == ProviderPantheon || provider == ProviderDrudS3 {
 		app.Provider = provider // Use the provider passed-in. Function argument wins.
-	} else if provider == "" && app.Provider == "" {
-		app.Provider = ProviderDefault // Nothing passed in, nothing configured. Set c.Provider to default
 	} else {
 		return app, fmt.Errorf("provider '%s' is not implemented", provider)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Recently we added the ability to configure the mailhog port and phpmyadmin port in config.yaml. However, it really shouldn't show as an active item by default, can confuse people thinking they should mess with it.

## How this PR Solves The Problem:

Do the same as we do with the images; if they're set to default, don't include them in the output config.yaml
This also makes `provider` not show in the config.yaml unless it has been overridden. Most people who aren't using Pantheon won't need to see that ever.

## Manual Testing Instructions:

`ddev config`. The resultant config.yaml should not show a mailhog_port or phpmyadmin_port (although the commend shows how to do so.)

## Automated Testing Overview:

None added.

## Related Issue Link(s):

#1594 added the PHPMyAdmin and Mailhog port configuration



