### PR TITLE
Use DNS for name resolution in most cases, fixes #416, fixes #834

### DIFF
--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -40,7 +40,6 @@ func TestCmdVersion(t *testing.T) {
 	assert.Contains(versionData["msg"], version.GetDBImage())
 	assert.Contains(versionData["msg"], version.DBAImg)
 	assert.Contains(versionData["msg"], version.DBATag)
-	assert.Contains(versionData["msg"], version.DDevTLD)
 	assert.NotEmpty(version.DockerVersion)
 	assert.NotEmpty(version.DockerComposeVersion)
 	assert.Contains(versionData["msg"], version.DockerVersion)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -127,6 +127,12 @@ var (
 	// lists of Debian packages to be added to related containers on build
 	webimageExtraPackages string
 	dbimageExtraPackages  string
+
+	// projectTLDArg specifies a project top-level-domain; defaults to ddevapp.DdevDefaultTLD
+	projectTLDArg string
+
+	// useDNSWhenPossibleArg specifies
+	useDNSWhenPossibleArg bool
 )
 
 var providerName = ddevapp.ProviderDefault
@@ -267,6 +273,10 @@ func init() {
 	ConfigCommand.Flags().StringVar(&webimageExtraPackages, "webimage-extra-packages", "", "A comma-delimited list of Debian packages that should be added to web container when the project is started")
 
 	ConfigCommand.Flags().StringVar(&dbimageExtraPackages, "dbimage-extra-packages", "", "A comma-delimited list of Debian packages that should be added to db container when the project is started")
+
+	ConfigCommand.Flags().StringVar(&projectTLDArg, "project-tld", ddevapp.DdevDefaultTLD, "set the top-level domain to be used for projects, defaults to "+ddevapp.DdevDefaultTLD)
+
+	ConfigCommand.Flags().BoolVarP(&useDNSWhenPossibleArg, "use-dns-when-possible", "", true, "Use DNS for hostname resolution instead of /etc/hosts when possible")
 
 	RootCmd.AddCommand(ConfigCommand)
 }
@@ -462,6 +472,14 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if cmd.Flag("dbimage-extra-packages").Changed {
 		app.WebImageExtraPackages = strings.Split(webimageExtraPackages, ",")
+	}
+
+	if cmd.Flag("use-dns-when-possible").Changed {
+		app.UseDNSWhenPossible = useDNSWhenPossibleArg
+	}
+
+	if cmd.Flag("project-tld").Changed {
+		app.ProjectTLD = projectTLDArg
 	}
 
 	if uploadDirArg != "" {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -139,6 +139,8 @@ func TestConfigSetValues(t *testing.T) {
 	dbaWorkingDir := "/custom/dba/dir"
 	phpMyAdminPort := "5000"
 	mailhogPort := "5001"
+	projectTLD := "nowhere.example.com"
+	useDNSWhenPossible := false
 
 	args := []string{
 		"config",
@@ -167,6 +169,8 @@ func TestConfigSetValues(t *testing.T) {
 		"--dbimage-extra-packages", dbimageExtraPackages,
 		"--phpmyadmin-port", phpMyAdminPort,
 		"--mailhog-port", mailhogPort,
+		"--project-tld", projectTLD,
+		fmt.Sprintf("--use-dns-when-possible=%t", useDNSWhenPossible),
 	}
 
 	out, err := exec.RunCommand(DdevBin, args)
@@ -206,6 +210,9 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(dbimageExtraPackagesSlice, app.DBImageExtraPackages)
 	assert.Equal(phpMyAdminPort, app.PHPMyAdminPort)
 	assert.Equal(mailhogPort, app.MailhogPort)
+	assert.Equal(useDNSWhenPossible, app.UseDNSWhenPossible)
+	assert.Equal(projectTLD, app.ProjectTLD)
+
 	// Test that container images and working dirs can be unset with default flags
 	args = []string{
 		"config",

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/util"
 
 	"github.com/drud/ddev/pkg/output"
 
@@ -9,7 +10,6 @@ import (
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
-	"github.com/drud/ddev/pkg/version"
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/spf13/cobra"
 )
@@ -53,6 +53,7 @@ to allow ddev to modify your hosts file.`,
 				output.UserOut.Fatal("Invalid arguments supplied. 'ddev hostname --remove-all' accepts no arguments.")
 			}
 
+			util.Warning("Attempting to remove inactive hostnames which use TLD %s", ddevapp.DdevDefaultTLD)
 			removeInactiveHostnames(hosts)
 
 			return
@@ -197,7 +198,7 @@ func removeInactiveHostnames(hosts goodhosts.Hosts) {
 				}
 
 				// Silently ignore those that may not be ddev-managed
-				if !strings.HasSuffix(h, version.DDevTLD) {
+				if !strings.HasSuffix(h, ddevapp.DdevDefaultTLD) {
 					continue
 				}
 

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/drud/ddev/pkg/version"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,9 +43,9 @@ func TestLogs(t *testing.T) {
 
 	ddevapp.WaitForSync(app, 2)
 
-	url := "http://" + v.Name + "." + version.DDevTLD + "/logtest.php"
-	_, err = testcommon.EnsureLocalHTTPContent(t, url, "Notice to demonstrate logging", 5)
-	assert.NoError(err)
+		url := "http://" + v.Name + "." + app.ProjectTLD + "/logtest.php"
+		_, err = testcommon.EnsureLocalHTTPContent(t, url, "Notice to demonstrate logging", 5)
+		assert.NoError(err)
 
 	args := []string{"logs"}
 	out, err := exec.RunCommand(DdevBin, args)

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -43,9 +43,9 @@ func TestLogs(t *testing.T) {
 
 	ddevapp.WaitForSync(app, 2)
 
-		url := "http://" + v.Name + "." + app.ProjectTLD + "/logtest.php"
-		_, err = testcommon.EnsureLocalHTTPContent(t, url, "Notice to demonstrate logging", 5)
-		assert.NoError(err)
+	url := "http://" + v.Name + "." + app.ProjectTLD + "/logtest.php"
+	_, err = testcommon.EnsureLocalHTTPContent(t, url, "Notice to demonstrate logging", 5)
+	assert.NoError(err)
 
 	args := []string{"logs"}
 	out, err := exec.RunCommand(DdevBin, args)

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -53,7 +53,7 @@ When `ddev start` runs, it outputs status messages to indicate the project envir
 
 ```
 Successfully started example-wordpress-site
-Your project can be reached at: http://example-wordpress-site.ddev.local and https://example-wordpress-site.ddev.local
+Your project can be reached at: http://example-wordpress-site.ddev.site and https://example-wordpress-site.ddev.site
 ```
 
 Quickstart instructions regarding database imports can be found under [Database Imports](#database-imports).
@@ -73,7 +73,7 @@ When `ddev start` runs, it outputs status messages to indicate the project envir
 
 ```
 Successfully started my-wordpress-site
-Your application can be reached at: http://my-wordpress-site.ddev.local
+Your application can be reached at: http://my-wordpress-site.ddev.site
 ```
 
 ### Drupal 6/7 Quickstart
@@ -103,10 +103,10 @@ When `ddev start` runs, it outputs status messages to indicate the project envir
 
 ```
 Successfully started my-drupal7-site
-Your project can be reached at: http://my-drupal7-site.ddev.local
+Your project can be reached at: http://my-drupal7-site.ddev.site
 ```
 
-If you want to run the Drupal install script, the next step is to hit "/install.php" on your project (like `http://my-drupal7-site.ddev.local/install.php`) or run drush site-install, `ddev exec drush site-install --yes`. 
+If you want to run the Drupal install script, the next step is to hit "/install.php" on your project (like `http://my-drupal7-site.ddev.site/install.php`) or run drush site-install, `ddev exec drush site-install --yes`. 
 
 Quickstart instructions for database imports can be found under [Database Imports](#database-imports).
 
@@ -137,7 +137,7 @@ When `ddev start` runs, it outputs status messages to indicate the project envir
 
 ```
 Successfully started my-drupal8-site
-Your project can be reached at: http://my-drupal8-site.ddev.local
+Your project can be reached at: http://my-drupal8-site.ddev.site
 ```
 
 ### TYPO3 Quickstart
@@ -167,7 +167,7 @@ When `ddev start` runs, it outputs status messages to indicate the project envir
 
 ```
 Successfully started example-typo3-site
-Your application can be reached at: http://example-typo3-site.ddev.local
+Your application can be reached at: http://example-typo3-site.ddev.site
 ```
 
 For those wanting/needing to connect to the database within the database container directly, please see the [developer tools page](https://ddev.readthedocs.io/en/stable/users/developer-tools/#using-development-tools-on-the-host-machine).
@@ -199,7 +199,7 @@ When `ddev start` runs, it outputs status messages to indicate the project envir
 
 ```
 Successfully started example-backdrop-site
-Your application can be reached at: http://example-backdrop-site.ddev.local
+Your application can be reached at: http://example-backdrop-site.ddev.site
 ```
 
 ### Database Imports
@@ -238,7 +238,7 @@ Creating local-drupal8-db
 Creating local-drupal8-web
 Waiting for the environment to become ready. This may take a couple of minutes...
 Successfully started drupal8
-Your project can be reached at: http://drupal8.ddev.local
+Your project can be reached at: http://drupal8.ddev.site
 ```
 
 And you can now visit your working project. Enjoy!
@@ -279,8 +279,8 @@ To see a list of your running projects you can use `ddev list`; `ddev list --all
 ```
 ➜  ddev list
 NAME     TYPE     LOCATION             URL(s)                      STATUS
-drupal8  drupal8  ~/workspace/drupal8  http://drupal8.ddev.local   running
-                                       https://drupal8.ddev.local
+drupal8  drupal8  ~/workspace/drupal8  http://drupal8.ddev.site   running
+                                       https://drupal8.ddev.site
 ```
 
 ```
@@ -297,8 +297,8 @@ You can also see more detailed information about a project by running `ddev desc
 
 ```
 NAME     TYPE     LOCATION             URL(s)                      STATUS
-drupal8  drupal8  ~/workspace/drupal8  http://drupal8.ddev.local   running
-                                       https://drupal8.ddev.local
+drupal8  drupal8  ~/workspace/drupal8  http://drupal8.ddev.site   running
+                                       https://drupal8.ddev.site
 
 Project Information
 -----------------
@@ -316,8 +316,8 @@ For example: mysql --host=127.0.0.1 --port=32768 --user=db --password=db --datab
 
 Other Services
 --------------
-MailHog:   	http://drupal8.ddev.local:8025
-phpMyAdmin:	http://drupal8.ddev.local:8036
+MailHog:   	http://drupal8.ddev.site:8025
+phpMyAdmin:	http://drupal8.ddev.site:8036
 
 DDEV ROUTER STATUS: healthy
 ```

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -498,3 +498,23 @@ If you do choose to send the diagnostics it helps us tremendously in our effort 
 ![usage_stats](images/usage_stats.png)
 
 Of course if you have any reservations about this, please just opt-out (`ddev config global --instrumentation-opt-in=false`). If you have any problems or concerns with it, we'd like to know. One person did report slow ddev command completion on a network that was apparently not friendly to sentry.io.
+
+## Using ddev offline, and top-level-domain options
+
+DDEV-Local attempts to make offline use work as well as possible, and you really shouldn't have to do anything to make it work:
+
+* It doesn't attempt instrumentation or update reporting if offline
+* It uses /etc/hosts entries instead of DNS resolution if DNS resolution fails
+
+However, it does not (yet) attempt to prevent docker pulls if a new docker image is required, so you'll want to make sure that you try a `ddev start` before going offline to make sure everything has been pulled.
+
+If youy have a project running when you're online (using DNS for name resolution) and you then go offline, you'll want to do a `ddev restart` to get the hostname added into /etc/hosts for name resolution.
+
+*Note that DNS name resolution never works with Docker Toolbox on Windows unless you run your own DNS server.*
+
+You have general options as well:
+
+In `.ddev/config.yaml` `use_dns_when_possible: false` will make ddev never try to use DNS for resolution, instead adding hostnames to /etc/hosts. You can also use `ddev config --use-dns-when-possible=false` to set this configuration option.
+In `.ddev/config.yaml` `project_tld: example.com` (or any other domain) can set ddev to use a project that could never be looked up in DNS. You can also use `ddev config --project-tld=example.com`
+
+You can slso set up a local DNS server like dnsmasq (Linux and macOS, `brew install dnsmasq`) or ([unbound](https://github.com/NLnetLabs/unbound) or many others on Windows) in your own host environment that serves the project_tld that you choose, and DNS resolution will work just fine. You'll likely want a wildcard A record pointing to 127.0.0.1 (on most ddev installations) or the Docker Toolbox IP address (often 192.168.99.100)

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -51,7 +51,7 @@ You generally don't have to worry about any of this, but it does keep things cle
 After your project is started, access the MailHog web interface at its default port:
 
 ```
-http://mysite.ddev.local:8025
+http://mysite.ddev.site:8025
 ```
 
 Please note this will not intercept emails if your application is configured to use SMTP or a 3rd-party ESP integration. If you are using SMTP for outgoing mail handling ([Swiftmailer](https://www.drupal.org/project/swiftmailer) or [SMTP](https://www.drupal.org/project/smtp) modules for example), update your application configuration to use `localhost` on port `1025` as the SMTP server locally in order to use MailHog.
@@ -63,7 +63,7 @@ Please note this will not intercept emails if your application is configured to 
 After your project is started, access the phpMyAdmin web interface at its default port:
 
 ```
-http://mysite.ddev.local:8036
+http://mysite.ddev.site:8036
 ```
 
 If you use the free [Sequel Pro](https://www.sequelpro.com/) database browser for macOS, run `ddev sequelpro` within a project folder, and Sequel Pro will launch and access the database for that project. 

--- a/docs/users/extend/additional-hostnames.md
+++ b/docs/users/extend/additional-hostnames.md
@@ -16,6 +16,8 @@ This configuration would result in working hostnames of mysite.ddev.site, extran
 
 **Although we recommend extreme care with this feature**, you can also provide additional_fqdn entries, which don't use the ".ddev.site" top-level domain.  **This feature populates your hosts file with entries which may hide the real DNS entries on the internet, causing way too much head-scratching.**
 
+**If you use a FQDN which is resolvable on the internet, you must use `use_dns_when_possible: false` or configure that with `ddev config --use-dns-when-possible=false`.
+
 ```
 name: somename
 

--- a/docs/users/extend/additional-hostnames.md
+++ b/docs/users/extend/additional-hostnames.md
@@ -12,9 +12,9 @@ additional_hostnames:
 - it.mysite
 ```
 
-This configuration would result in working hostnames of mysite.ddev.local, extraname.ddev.local, fr.mysite.ddev.local, es.mysite.ddev.local, and it.mysite.ddev.local (with full http and https URLs for each).
+This configuration would result in working hostnames of mysite.ddev.site, extraname.ddev.site, fr.mysite.ddev.site, es.mysite.ddev.site, and it.mysite.ddev.site (with full http and https URLs for each).
 
-**Although we recommend extreme care with this feature**, you can also provide additional_fqdn entries, which don't use the ".ddev.local" top-level domain.  **This feature populates your hosts file with entries which may hide the real DNS entries on the internet, causing way too much head-scratching.**
+**Although we recommend extreme care with this feature**, you can also provide additional_fqdn entries, which don't use the ".ddev.site" top-level domain.  **This feature populates your hosts file with entries which may hide the real DNS entries on the internet, causing way too much head-scratching.**
 
 ```
 name: somename
@@ -25,7 +25,7 @@ additional_fqdns:
 - anothersite.example.com
 ```
 
-This configuration would result in working FQDNs of somename.ddev.local, example.com, somesite.example.com, and anothersite.example.com.
+This configuration would result in working FQDNs of somename.ddev.site, example.com, somesite.example.com, and anothersite.example.com.
 
 **Note**: If you see ddev-router status become unhealthy in `ddev list`, it's most often a result of trying to use conflicting FQDNs in more than one project. "example.com" can only be assigned to one project, or it will break ddev-router.
 

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -14,7 +14,7 @@ This recipe adds an Apache Solr 5.4 container to a project. It will setup a solr
 - Ensure the configuration files must be present before running `ddev start`.
 
 **Interacting with Apache Solr**
-- The Solr admin interface will be accessible at: `http://<projectname>.ddev.local:8983/solr/` For example, if the project is named "myproject" the hostname will be: `http://myproject.ddev.local:8983/solr/`
+- The Solr admin interface will be accessible at: `http://<projectname>.ddev.site:8983/solr/` For example, if the project is named "myproject" the hostname will be: `http://myproject.ddev.site:8983/solr/`
 - To access the Solr container from the web container use: `http://solr:8983/solr/`
 - A Solr core is automatically created with the name "dev"; it can be accessed at the URL: http://solr:8983/solr/dev
 

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -32,7 +32,7 @@ When defining additional services for your project, we recommended you follow th
 
   - `com.ddev.app-url: $DDEV_URL`
 
-- Exposing ports for service: you can expose the port for a service to be accessible as `projectname.ddev.local:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
+- Exposing ports for service: you can expose the port for a service to be accessible as `projectname.ddev.site:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
 
   - Define only the internal port in the `ports` section for docker-compose. The `hostPort:containerPort` convention normally used to expose ports in docker should not be used here, since we are leveraging the ddev router to expose the ports.
 

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -51,7 +51,7 @@ _Use wp-cli to replace the production URL with development URL in the database o
 ```
 hooks:
   post-import-db:
-    - exec: wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local
+    - exec: wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.site
 ```
 
 ### `exec-host`: Execute a shell command on the host system.
@@ -75,10 +75,10 @@ hooks:
   post-start:
     # Install WordPress after start
     - exec: "wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db"
-    - exec: "wp core install --url=http://mysite.ddev.local --title=MySite --admin_user=admin --admin_email=admin@mail.test"
+    - exec: "wp core install --url=http://mysite.ddev.site --title=MySite --admin_user=admin --admin_email=admin@mail.test"
   post-import-db:
     # Update the URL of your project throughout your database after import
-    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.local"
+    - exec: "wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.site"
 ```
 
 ## Drupal 7 Example

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -30,7 +30,7 @@ For example, if there was a port conflict with a local apache http on port 80 ad
 router_http_port: 8000
 ```
 
-Then run `ddev start`. This changes the project's http URL to http://yoursite.ddev.local:8000.
+Then run `ddev start`. This changes the project's http URL to http://yoursite.ddev.site:8000.
 
 
 If the conflict is over port 8025, it's normally a conflict over the default port for mailhog. You can add to your .ddev/config.yaml

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -94,6 +94,8 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	// Provide a default app name based on directory name
 	app.Name = filepath.Base(app.AppRoot)
 	app.OmitContainers = globalconfig.DdevGlobalConfig.OmitContainers
+	app.ProjectTLD = DdevDefaultTLD
+	app.UseDNSWhenPossible = true
 
 	// These should always default to the latest image/tag names from the Version package.
 	app.WebImage = version.GetWebImage()
@@ -450,7 +452,7 @@ func (app *DdevApp) DockerComposeYAMLPath() string {
 
 // GetHostname returns the primary hostname of the app.
 func (app *DdevApp) GetHostname() string {
-	return app.Name + "." + version.DDevTLD
+	return app.Name + "." + app.ProjectTLD
 }
 
 // GetHostnames returns an array of all the configured hostnames.
@@ -463,7 +465,7 @@ func (app *DdevApp) GetHostnames() []string {
 	nameListMap[app.GetHostname()] = 1
 
 	for _, name := range app.AdditionalHostnames {
-		nameListMap[name+"."+version.DDevTLD] = 1
+		nameListMap[name+"."+app.ProjectTLD] = 1
 	}
 
 	for _, name := range app.AdditionalFQDNs {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -139,7 +139,7 @@ func TestHostName(t *testing.T) {
 	assert.NoError(err)
 	app.Name = util.RandString(32)
 
-	assert.Equal(app.GetHostname(), app.Name+"."+version.DDevTLD)
+	assert.Equal(app.GetHostname(), app.Name+"."+app.ProjectTLD)
 }
 
 // TestWriteDockerComposeYaml tests the writing of a docker-compose.yaml file.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -507,6 +507,7 @@ func TestConfigValidate(t *testing.T) {
 		PHPVersion:     PHPDefault,
 		MariaDBVersion: version.MariaDBDefaultVersion,
 		WebserverType:  WebserverDefault,
+		ProjectTLD:     DdevDefaultTLD,
 		Provider:       ProviderDefault,
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -109,6 +109,8 @@ type DdevApp struct {
 	PHPMyAdminPort        string               `yaml:"phpmyadmin_port,omitempty"`
 	WebImageExtraPackages []string             `yaml:"webimage_extra_packages,omitempty,flow"`
 	DBImageExtraPackages  []string             `yaml:"dbimage_extra_packages,omitempty,flow"`
+	ProjectTLD            string               `yaml:"project_tld,omitempty"`
+	UseDNSWhenPossible    bool                 `yaml:"use_dns_when_possible"`
 }
 
 // GetType returns the application type as a (lowercase) string
@@ -1428,12 +1430,14 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 	}
 
 	for _, name := range app.GetHostnames() {
-		hostIPs, err := net.LookupHost(name)
-		// If we had successful lookup and dockerIP matches
-		// (which won't happen on Docker Toolbox) then don't bother
-		// with adding to hosts file.
-		if err == nil && len(hostIPs) > 0 && hostIPs[0] == dockerIP {
-			continue
+		if app.UseDNSWhenPossible {
+			hostIPs, err := net.LookupHost(name)
+			// If we had successful lookup and dockerIP matches
+			// (which won't happen on Docker Toolbox) then don't bother
+			// with adding to hosts file.
+			if err == nil && len(hostIPs) > 0 && hostIPs[0] == dockerIP {
+				continue
+			}
 		}
 
 		// We likely won't hit the hosts.Has() as true because

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/mattn/go-shellwords"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1404,7 +1405,7 @@ func (app *DdevApp) HostName() string {
 	return app.GetHostname()
 }
 
-// AddHostsEntries will add the site URL to the host's /etc/hosts.
+// AddHostsEntries will (optionally) add the site URL to the host's /etc/hosts.
 func (app *DdevApp) AddHostsEntries() error {
 	dockerIP, err := dockerutil.GetDockerIP()
 	if err != nil {
@@ -1415,6 +1416,21 @@ func (app *DdevApp) AddHostsEntries() error {
 	if err != nil {
 		util.Failed("could not open hostfile: %v", err)
 	}
+
+	// As a one-time operation we'll add ddev.hostsfile, which allows
+	// a wildcard to refer to it if we're using DNS name resolution.
+	if !hosts.Has(dockerIP, "ddev.dockerip.hostsfile") {
+		_, err = osexec.LookPath("sudo")
+		if os.Getenv("DRUD_NONINTERACTIVE") != "" || err != nil {
+			util.Warning("You must manually add the following entry to your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname %s %s'", dockerIP, "ddev.dockerip.hostsfile", "ddev.dockerip.hostsfile", dockerIP)
+			return nil
+		}
+		err = addHostEntry("ddev.dockerip.hostsfile", dockerIP)
+		if err != nil {
+			return err
+		}
+	}
+
 	ipPosition := hosts.GetIPPosition(dockerIP)
 	if ipPosition != -1 && runtime.GOOS == "windows" {
 		hostsLine := hosts.Lines[ipPosition]
@@ -1427,29 +1443,42 @@ func (app *DdevApp) AddHostsEntries() error {
 
 	for _, name := range app.GetHostnames() {
 
-		if hosts.Has(dockerIP, name) {
+		hostIPs, err := net.LookupHost(name)
+		if err != nil && len(hostIPs) > 0 && hostIPs[0] == dockerIP {
 			continue
 		}
 
-		_, err = osexec.LookPath("sudo")
-		if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
-			util.Warning("You must manually add the following entry to your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname %s %s'", dockerIP, name, name, dockerIP)
-			return nil
+		if hosts.Has(dockerIP, name) {
+			continue
 		}
-
-		ddevFullpath, err := os.Executable()
-		util.CheckErr(err)
-
-		output.UserOut.Printf("ddev needs to add an entry to your hostfile.\nIt will require administrative privileges via the sudo command, so you may be required\nto enter your password for sudo. ddev is about to issue the command:")
-
-		hostnameArgs := []string{ddevFullpath, "hostname", name, dockerIP}
-		command := strings.Join(hostnameArgs, " ")
-		util.Warning(fmt.Sprintf("    sudo %s", command))
-		output.UserOut.Println("Please enter your password if prompted.")
-		_, err = exec.RunCommandPipe("sudo", hostnameArgs)
+		err = addHostEntry(name, dockerIP)
 		if err != nil {
-			util.Warning("Failed to execute sudo command, you will need to manually execute '%s' with administrative privileges", command)
+			return err
 		}
+	}
+
+	return nil
+}
+
+func addHostEntry(name string, ip string) error {
+	_, err := osexec.LookPath("sudo")
+	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
+		util.Warning("You must manually add the following entry to your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname %s %s'", ip, name, name, ip)
+		return nil
+	}
+
+	ddevFullpath, err := os.Executable()
+	util.CheckErr(err)
+
+	output.UserOut.Printf("ddev needs to add an entry to your hostfile.\nIt will require administrative privileges via the sudo command, so you may be required\nto enter your password for sudo. ddev is about to issue the command:")
+
+	hostnameArgs := []string{ddevFullpath, "hostname", name, ip}
+	command := strings.Join(hostnameArgs, " ")
+	util.Warning(fmt.Sprintf("    sudo %s", command))
+	output.UserOut.Println("Please enter your password if prompted.")
+	_, err = exec.RunCommandPipe("sudo", hostnameArgs)
+	if err != nil {
+		util.Warning("Failed to execute sudo command, you will need to manually execute '%s' with administrative privileges", command)
 	}
 	return nil
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -369,9 +369,9 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		// should uniqueify them.
 		app.AdditionalHostnames = []string{"sub1." + site.Name, "sub2." + site.Name, "subname.sub3." + site.Name, site.Name, site.Name, site.Name}
 
-		// sub1.<sitename>.ddev.local and sitename.ddev.local are deliberately included to prove they don't
+		// sub1.<sitename>.ddev.site and sitename.ddev.site are deliberately included to prove they don't
 		// cause ddev-router failures"
-		app.AdditionalFQDNs = []string{"one.example.com", "two.example.com", "a.one.example.com", site.Name + "." + version.DDevTLD, "sub1." + site.Name + "." + version.DDevTLD}
+		app.AdditionalFQDNs = []string{"one.example.com", "two.example.com", "a.one.example.com", site.Name + "." + app.ProjectTLD, "sub1." + site.Name + "." + app.ProjectTLD}
 
 		err = app.WriteConfig()
 		assert.NoError(err)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -95,7 +95,7 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - COLUMNS=$COLUMNS
       - LINES=$LINES
-      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
+      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
       - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:{{ .MailhogPort }}
       # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
@@ -167,7 +167,7 @@ services:
       - PMA_USER=db
       - PMA_PASSWORD=db
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.local:<port>
+      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       - HTTP_EXPOSE=${DDEV_PHPMYADMIN_PORT}:{{ .DBAPort }}
     healthcheck:
       interval: 90s
@@ -208,7 +208,7 @@ const ConfigInstructions = `
 # Key features of ddev's config.yaml:
 
 # name: <projectname> # Name of the project, automatically provides
-#   http://projectname.ddev.local and https://projectname.ddev.local
+#   http://projectname.ddev.site and https://projectname.ddev.site
 
 # type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
 
@@ -235,8 +235,8 @@ const ConfigInstructions = `
 # additional_hostnames:
 #  - somename
 #  - someothername
-# would provide http and https URLs for "somename.ddev.local"
-# and "someothername.ddev.local".
+# would provide http and https URLs for "somename.ddev.site"
+# and "someothername.ddev.site".
 
 # additional_fqdns:
 #  - example.com

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -298,6 +298,18 @@ const ConfigInstructions = `
 # Extra Debian packages that are needed in the dbimage can be added here
 # This is ignored if a free-form .ddev/db-build/Dockerfile is provided
 
+# use_dns_when_possible: true
+# If the host has internet access and the domain configured can successfully be looked up,
+# DNS will be used for hostname resolution instead of editing /etc/hosts
+# Defaults to true
+
+# project_tld: ddev.site
+# The top-level domain used for project URLs
+# The default "ddev.site" allows DNS lookup via a wildcard
+# For backward compatibility this can be changed to "ddev.local"
+
+
+
 # provider: default # Currently either "default" or "pantheon"
 #
 # Many ddev commands can be extended to run tasks after the ddev command is

--- a/pkg/ddevapp/values.go
+++ b/pkg/ddevapp/values.go
@@ -100,7 +100,7 @@ const (
 	AppTypeWordPress = "wordpress"
 )
 
-// Ports
+// Ports and other defaults
 const (
 	// DdevDefaultRouterHTTPPort is the default router HTTP port
 	DdevDefaultRouterHTTPPort = "80"
@@ -111,6 +111,8 @@ const (
 	DdevDefaultPHPMyAdminPort = "8036"
 	// DdevDefaultMailhogPort is the default router port for Mailhog
 	DdevDefaultMailhogPort = "8025"
+	// DdevDefaultTLD is the top-level-domain used by default, can be overridden
+	DdevDefaultTLD = "ddev.site"
 )
 
 // IsValidProvider is a helper function to determine if a provider value is valid, returning

--- a/pkg/dockerutil/testdata/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/test-compose-with-streams.yaml
@@ -11,7 +11,7 @@ services:
       DDEV_PROJECT_TYPE: typo3
       DDEV_ROUTER_HTTPS_PORT: '443'
       DDEV_ROUTER_HTTP_PORT: '80'
-      DDEV_URL: http://test-compose-with-streams.ddev.local
+      DDEV_URL: http://test-compose-with-streams.ddev.site
       DDEV_WEBSERVER_TYPE: nginx-fpm
       DDEV_XDEBUG_ENABLED: "false"
       DEPLOY_NAME: local
@@ -19,11 +19,11 @@ services:
       HTTPS_EXPOSE: 443:80
       HTTP_EXPOSE: 80:80,8025
       LINES: '25'
-      VIRTUAL_HOST: junk.ddev.local
+      VIRTUAL_HOST: junk.ddev.site
     image: TEST-COMPOSE-WITH-STREAMS-IMAGE
     labels:
       com.ddev.app-type: php
-      com.ddev.app-url: http://test-compose-with-streams.ddev.local
+      com.ddev.app-url: http://test-compose-with-streams.ddev.site
       com.ddev.approot: .
       com.ddev.platform: ddev
       com.ddev.site-name: test-compose-with-streams

--- a/pkg/servicetest/testdata/services/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.solr.yaml
@@ -14,9 +14,9 @@
 #
 # To access Solr after it is installed:
 # - The Solr admin interface will be accessible at:
-#   http://<projectname>.ddev.local:8983/solr/
+#   http://<projectname>.ddev.site:8983/solr/
 #   For example, if the project is named "myproject" the hostname will be:
-#   http://myproject.ddev.local:8983/solr/
+#   http://myproject.ddev.site:8983/solr/
 # - To access the Solr container from the web container use:
 #   http://solr:8983/solr/
 # - A Solr core is automatically created with the name "dev", i.e. it can be
@@ -45,10 +45,10 @@ services:
       com.ddev.app-url: $DDEV_URL
     environment:
       # This defines the host name the service should be accessible from. This
-      # will be sitename.ddev.local.
+      # will be sitename.ddev.site.
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # This defines the port the service should be accessible from at
-      # sitename.ddev.local.
+      # sitename.ddev.site.
       - HTTP_EXPOSE=8983
     volumes:
       # This exposes a mount to the host system `.ddev/solr-conf` directory.
@@ -62,7 +62,7 @@ services:
       - /solr-conf
   # This links the Solr service to the web service defined in the main
   # docker-compose.yml, allowing applications running in the web service to
-  # access the Solr service at sitename.ddev.local:8983.
+  # access the Solr service at sitename.ddev.site:8983.
   web:
     links:
       - solr:$DDEV_HOSTNAME

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -87,11 +87,6 @@ var DockerVersion = ""
 // DockerComposeVersion is filled with the version we find for docker-compose
 var DockerComposeVersion = ""
 
-// DDevTLD defines the top-level domain to use for DDev site URLs.
-var DDevTLD = "ddev.site"
-
-// TODO: Add configuration instead of just assigning
-
 // GetVersionInfo returns a map containing the version info defined above.
 func GetVersionInfo() map[string]string {
 	var err error
@@ -105,7 +100,6 @@ func GetVersionInfo() map[string]string {
 	versionInfo["router"] = RouterImage + ":" + RouterTag
 	versionInfo["ddev-ssh-agent"] = SSHAuthImage + ":" + SSHAuthTag
 	versionInfo["commit"] = COMMIT
-	versionInfo["domain"] = DDevTLD
 	versionInfo["build info"] = BUILDINFO
 	versionInfo["os"] = runtime.GOOS
 	if versionInfo["docker"], err = GetDockerVersion(); err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -87,8 +87,10 @@ var DockerVersion = ""
 // DockerComposeVersion is filled with the version we find for docker-compose
 var DockerComposeVersion = ""
 
-// DDevTLD defines the tld to use for DDev site URLs.
-const DDevTLD = "ddev.local"
+// DDevTLD defines the top-level domain to use for DDev site URLs.
+var DDevTLD = "ddev.site"
+
+// TODO: Add configuration instead of just assigning
 
 // GetVersionInfo returns a map containing the version info defined above.
 func GetVersionInfo() map[string]string {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -20,7 +20,6 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Contains(v["dba"], DBATag)
 	assert.Equal(COMMIT, v["commit"])
 	assert.Equal(runtime.GOOS, v["os"])
-	assert.Equal(DDevTLD, v["domain"])
 	assert.Equal(BUILDINFO, v["build info"])
 	assert.NotEmpty(v["docker-compose"])
 	assert.NotEmpty(v["docker"])


### PR DESCRIPTION
## The Problem/Issue/Bug:

It's icky messing with the hosts file and requires admin privileges.

Windows has a limit of 9 aliases on a line in the hosts file. 

OP #416 requested non-hosts-file name resolution
OP #834 requested the ability to change the TLD in use, as is provided here.

## How this PR Solves The Problem:

When the hostname is already resolvable, do not add it to the hosts file.

Note that this will require a transition to using "ddev.site" instead of "ddev.local"

## TODO:
- [x] Deal with the problem of a possible additional_fqdn that resolves already, provide a way to work around that.
- [x] Provide a way to completely turn off this behavior in config.yaml
- [x] This probably can't work with Docker Toolbox as currently envisioned (because the IP address is different)
- [x] Provide configuration that allows an orderly transition to using "ddev.site" instead of "ddev.local"
- [x] Change docs to use "ddev.site"
- [x] Docs must explain how this works
- [x] docs needs to say how to use ddev offline (may need `ddev start` to update, consider tld and useDNSwhen possible

## Manual Testing Instructions:

* Remove all ddev hostnames from /etc/hosts
* `ddev start` should not result in hostnames being added, and project should work normally.
* Try additional_hostnames and additional_fqdns. additional_fqdns that resolve in DNS should work just fine anyway. (the resolved IP is not correct, so we add to /etc/hosts)
* Test offline. It won't work until a restart, the restart should add to /etc/hosts
* Try changing the project_tld; everything should then use /etc/hosts, but it should work fine.

## Automated Testing Overview:

- [ ] Test behavior with DNS resolution turned off (I don't think we can do this successfully because the tests don't actually modify /etc/hosts or use sudo)
- [ ] Test behavior with TLD changed in config

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

