### PR TITLE
Use webimage_extra_packages for PHP module addon example [skip ci][ci skip]

### DIFF
--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -128,11 +128,12 @@ hooks:
       - exec: composer install -d /var/www/html/
 ```
 
-## Adding Additional PHP Modules Example
+## Adding Additional Debian Packages (PHP Modules) Example
 
 ```
-hooks:
-    post-start:
-      # Install php modules and then tell php-fpm to reload
-      - exec: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y php7.1-ldap php7.1-tidy && killall -HUP php-fpm
+webimage_extra_packages: ["php7.2-ldap", "php7.2-tidy"]
+dbimage_extra_packages: ["vim"]
 ```
+
+```
+dbimage_extra_packages```


### PR DESCRIPTION

## The Problem/Issue/Bug:

The docs still showed adding extra PHP modules with post-start hooks.

## How this PR Solves The Problem:

Update doc to use webimage_extra_packages

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

