### PR TITLE
Fix capitalization error on gitigore webimageExtra dbimageExtra, fixes #1610

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -848,7 +848,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db", ".bgsync*", "config.*.y*ml", ".webImageExtra", ".dbImageExtra", "*-build/Dockerfile.example")
+	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db", ".bgsync*", "config.*.y*ml", ".webimageExtra", ".dbimageExtra", "*-build/Dockerfile.example")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}


### PR DESCRIPTION

## The Problem/Issue/Bug:

#1610 points out that there is a capitalization error in the generated .ddev/.gitignore. 

## How this PR Solves The Problem:

Fix it

## Manual Testing Instructions
On Linux, or other case-sensitive filesystem:
* Check out a project from git
* Make sure it's clean (`ddev status`)
* `ddev config --webimage-extra-packages=php-ldap --db-image-extra-packages=vim
* `ddev start`
* Verify it's still clean `git status`
* `ls -lad .ddev/.*image*` to make sure the gitignored directories are in there.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

