### PR TITLE
Improve NFS security posture, fixes #1471

### DIFF
--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -27,6 +27,7 @@ primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
 
 sudo bash -c "cat <<EOF >/etc/exports
 ${HOME} ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)
+/tmp ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)
 EOF"
 
 sudo service nfs-kernel-server restart

--- a/cmd/ddev/cmd/debug-nfsmount.go
+++ b/cmd/ddev/cmd/debug-nfsmount.go
@@ -46,7 +46,7 @@ var DebugNFSMountCmd = &cobra.Command{
 		if hostDockerInternal == "" {
 			hostDockerInternal = "host.docker.internal"
 		}
-		volume, err := dockerutil.CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": fmt.Sprintf("addr=%s,hard,nolock,rw", hostDockerInternal), "device": ":" + dockerutil.MassageWIndowsNFSMount(app.AppRoot)})
+		volume, err := dockerutil.CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": fmt.Sprintf("addr=%s,hard,nolock,rw", hostDockerInternal), "device": ":" + dockerutil.MassageWindowsNFSMount(app.AppRoot)})
 		//nolint: errcheck
 		defer dockerutil.RemoveVolume(testVolume)
 		if err != nil {

--- a/cmd/ddev/cmd/debug-nfsmount_test.go
+++ b/cmd/ddev/cmd/debug-nfsmount_test.go
@@ -42,5 +42,5 @@ func TestDebugNFSMount(t *testing.T) {
 	assert.Contains(out, "/nfsmount")
 	pwd, err := os.Getwd()
 	assert.NoError(err)
-	assert.Contains(out, ":"+dockerutil.MassageWIndowsNFSMount(pwd))
+	assert.Contains(out, ":"+dockerutil.MassageWindowsNFSMount(pwd))
 }

--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -16,11 +16,11 @@ Note that you can use the NFS setup described here (and the scripts provided) or
 
 __macOS Mojave (and later) warning:__ You'll need to give your terminal "Full disk access" before you (or the script provided) can edit /etc/exports. If you're using iterm2, here are [full instructions for iterm2](https://gitlab.com/gnachman/iterm2/wikis/fulldiskaccess). The basic idea is that in the Mac preferences -> Security and Privacy -> Privacy you need to give "Full Disk Access" permissions to your terminal app. Note that the "Full Disk Access" privilege is only needed when the /etc/exports file is being edited by you, normally a one-time event.
 
-Download, inspect, and run the macos_ddev_nfs_setup.sh script  from [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/macos_ddev_nfs_setup.sh)). This stops running ddev projects, adds the /Users directory to the /etc/exports config file that nfsd uses, and enabled nfsd to run on your computer. This is one-time setup. Note that this shares the /Users directory via NFS to any client, so it's critical to consider security issues and verify that your firewall is enabled and configured. If your DDEV-Local projects are set up outside /Users, you'll need to edit /etc/exports for the correct values.
+Download, inspect, and run the macos_ddev_nfs_setup.sh script  from [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/macos_ddev_nfs_setup.sh)). This stops running ddev projects, adds your home directory to the /etc/exports config file that nfsd uses, and enabled nfsd to run on your computer. This is one-time setup. Note that this shares the /Users directory via NFS to any client, so it's critical to consider security issues and verify that your firewall is enabled and configured. If your DDEV-Local projects are set up outside /Users, you'll need to edit /etc/exports for the correct values.
 
 ### Windows NFS Setup
 
-The executable components required for Windows NFS (winnfsd and nssm) are packaged with the ddev_windows_installer in each release, so if you've used the windows installer, they're available already. To enable winnfsd as a service, please download, inspect and run the script "windows_ddev_nfs_setup.sh" installed by the installer (or download from [windows_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/windows_ddev_nfs_setup.sh)) in a git-bash session on windows. This is one-time setup. Note that this shares the C:\ directory via NFS to any local client, so it's critical to consider security issues and verify that your firewall is enabled and configured. If your DDEV-Local projects are set up outside C:\, you'll need to edit the ~/.ddev/nfs_exports.sh created by the script and then restart the service with `sudo nssm restart nfsd`.
+The executable components required for Windows NFS (winnfsd and nssm) are packaged with the ddev_windows_installer in each release, so if you've used the windows installer, they're available already. To enable winnfsd as a service, please download, inspect and run the script "windows_ddev_nfs_setup.sh" installed by the installer (or download from [windows_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/windows_ddev_nfs_setup.sh)) in a git-bash session on windows. If your DDEV-Local projects are set up outside your home directory, you'll need to edit the ~/.ddev/nfs_exports.sh created by the script and then restart the service with `sudo nssm restart nfsd`.
 
 **Firewall issues**: On Windows 10 you will likely run afoul of the Windows Defender Firewall, and it will be necessary to allow winnfsd to bypass it. If you're getting a timeout with no information after `ddev start`, try going to "Windows Defender Firewall" -> "Allow an app or feature through Windows Defender Firewall", "Change Settings", "Allow another app". Then choose C:\Program Files\ddev\winnfsd.exe, assuming that's where you installed winnfsd.
 
@@ -30,7 +30,7 @@ Also see the debugging section below, and the special WIndows debugging section.
 
 Note that for all Linux systems, you can and should install and configure the NFS daemon and configure /etc/exports as you see fit and share the directories that you choose to share. The Debian/Ubuntu Linux script is just one way of accomplishing it. 
 
-Download, inspect, and run the [debian_ubuntu_linux_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh)). This stops running ddev projects, adds the /home directory to the /etc/exports config file that nfs uses, and installs nfs-kernel-server  on your computer. This is one-time setup. Note that this shares the /home directory via NFS to all non-routeable ("public") IP addresses in your network, so it's critical to consider security issues and verify that your firewall is enabled and configured. If your DDEV-Local projects are set up outside /home, you'll need to edit /etc/exports for the correct values and restart nfs-kernel-server.
+Download, inspect, and run the [debian_ubuntu_linux_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh)). This stops running ddev projects, adds your home directory to the /etc/exports config file that nfs uses, and installs nfs-kernel-server  on your computer. This is one-time setup. Note that this shares the /home directory via NFS to all non-routeable ("public") IP addresses in your network, so it's critical to consider security issues and verify that your firewall is enabled and configured. If your DDEV-Local projects are set up outside /home, you'll need to edit /etc/exports for the correct values and restart nfs-kernel-server.
 
 ### Debugging `ddev start` failures with `nfs_mount_enabled: true`
 
@@ -39,8 +39,8 @@ There are a number of reasons that the NFS mount can fail on `ddev start`:
 * NFS Server not running
 * Trying to start more than one NFS server. (This is typically only an issue on Windows)
 * NFS exports overlap. This is typically an issue if you've had another NFS setup (like vagrant). You'll need to reconfigure your exports paths so they don't overlap.
-* Path of project not shared in `/etc/exports` (or `~/.ddev/nfs_exports.txt` on WIndows)
-* Docker container IP not listed in /etc/exports (Linux)
+* Path of project not shared in `/etc/exports` (or `~/.ddev/nfs_exports.txt` on Windows)
+* Primary IP address not properly listed in /etc/exports (Linux)
 
 Tools to debug and solve permission problems:
 
@@ -49,7 +49,7 @@ Tools to debug and solve permission problems:
 * Inspect the /etc/exports (or `~/.ddev/nfs_exports.txt` on Windows).
 * Restart the server (`sudo nfsd restart` on macOS, `sudo nssm restart nfsd` on Windows, `sudo systemctl restart nfs-kernel-server` on Debian/Ubuntu, other commaonds for other Unices).
 * `showmount -e` on macOS or Linux will show the shared mounts.
-* On Linux, you may have to experiment with the client IP addresses in the /etc/exports. Temporarily set the share in /etc/exports to `/home *`, which shares /home with any client, and `sudo systemctl restart nfs-kernel-server`. Then start a ddev project doing an nfs mount, and `showmount -a` and you'll find out what the assigned IP address of the docker client is. You can add that address range to /etc/exports.
+* On Linux, the primary IP address needs to be in /etc/exports. Temporarily set the share in /etc/exports to `/home *`, which shares /home with any client, and `sudo systemctl restart nfs-kernel-server`. Then start a ddev project doing an nfs mount, and `showmount -a` and you'll find out what the primary IP address in use is. You can add that address to /etc/exports.
 
 ### Windows-specific NFS debugging
 
@@ -57,7 +57,7 @@ Tools to debug and solve permission problems:
 
 1. Stop the running winnfsd service: `sudo nssm stop nfsd`
 2. Run winnfsd manually in the foreground: `winnfsd "C:\\"`. If it returns to the shell prompt immediately there's likely another nfsd service running. 
-3. In another windows, in a ddev project directory, `ddev debug nfsmount` to see if it can mount successfully. (The project need not be started.). `ddev debug nfsmount` is successful, then everything is probably going to work.
+3. In another window, in a ddev project directory, `ddev debug nfsmount` to see if it can mount successfully. (The project need not be started.). `ddev debug nfsmount` is successful, then everything is probably going to work.
 4. After verifying that ~/.ddev/nfs_exports.txt has a line that includes your project directories, `sudo nssm start nfsd` and `nssm status nfsd`. The status command should show SERVICE_RUNNING.
 5. These [nssm](https://nssm.cc/) commands may be useful: `nssm help`, `sudo nssm start nfsd`, `sudo nssm stop nfsd`, `nssm status nfsd`, `sudo nssm edit nfsd` (pops up a window that may be hidden), and `sudo nssm remove nfsd` (also pops up a window, doesn't work predictably if you haven't already stopped the service). 
 6. nssm logs failures and what it's doing to the system event log. Run "Event Viewer" and filter events as in the image below: ![Windows Event Viewer](images/windows_event_viewer.png).

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -643,7 +643,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		if runtime.GOOS == "windows" {
 			// WinNFSD can only handle a mountpoint like /C/Users/rfay/workspace/d8git
 			// and completely chokes in C:\Users\rfay...
-			templateVars.NFSSource = dockerutil.MassageWIndowsNFSMount(app.AppRoot)
+			templateVars.NFSSource = dockerutil.MassageWindowsNFSMount(app.AppRoot)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2308,7 +2308,7 @@ func TestNFSMount(t *testing.T) {
 		Cmd:     "findmnt -T .",
 	})
 	assert.NoError(err)
-	assert.Contains(stdout, ":"+dockerutil.MassageWIndowsNFSMount(app.AppRoot))
+	assert.Contains(stdout, ":"+dockerutil.MassageWindowsNFSMount(app.AppRoot))
 
 	// Create a host-side dir symlink; give a second for it to sync, make sure it can be used in container.
 	err = os.Symlink(".ddev", "nfslinked_.ddev")

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -647,12 +647,14 @@ func MassageWindowsHostMountpoint(mountPoint string) string {
 	return mountPoint
 }
 
-// MassageWIndowsNFSMount changes C:\Path\to\something to /C/Path/to/something
-func MassageWIndowsNFSMount(mountPoint string) string {
+// MassageWindowsNFSMount changes C:\Path\to\something to /c/Path/to/something
+func MassageWindowsNFSMount(mountPoint string) string {
 	if string(mountPoint[1]) == ":" {
 		pathPortion := strings.Replace(mountPoint[2:], `\`, "/", -1)
 		drive := string(mountPoint[0])
-		mountPoint = "/" + drive + pathPortion
+		// Because we use $HOME to get home in exports, and $HOME has /c/Users/xxx
+		// change the drive to lower case.
+		mountPoint = "/" + strings.ToLower(drive) + pathPortion
 	}
 	return mountPoint
 }

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -356,7 +356,7 @@ func TestRemoveVolume(t *testing.T) {
 		testVolume,
 		"local",
 		map[string]string{"type": "nfs", "o": "addr=host.docker.internal,hard,nolock,rw",
-			"device": ":" + MassageWIndowsNFSMount(pwd)},
+			"device": ":" + MassageWindowsNFSMount(pwd)},
 	)
 	assert.NoError(err)
 

--- a/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
+++ b/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
@@ -52,7 +52,7 @@ echo "== Setting up nfs..."
 # You are welcome to edit and limit it to the addresses you prefer.
 FILE=/etc/exports
 LINE="${HOME} ${primary_ip}(rw,sync,no_subtree_check)"
-grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )
+grep -qF -- "$LINE" "$FILE" 2>/dev/null || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )
 
 echo "== Restarting nfs-kernel-server..."
 sudo systemctl restart nfs-kernel-server

--- a/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
+++ b/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
@@ -29,13 +29,12 @@ mkdir -p ~/.ddev
 docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
 
 echo "
-+--------------------------------------+
++-----------------------------------------------------+
 | Setup native NFS on Linux for Docker
-| Allowing NFS access to /home has
-| security implications you should
-| consider. You'll want your firewall
-| turned on.
-+--------------------------------------+
+| Only primary IP of machine is allowed client access;
+| Your home directory is shared by default.
+| But, of course, pay attention to security.
++-----------------------------------------------------+
 "
 echo "Stopping running ddev projects"
 

--- a/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
+++ b/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
@@ -45,13 +45,14 @@ echo "Installing nfs-kernel-server"
 sudo apt-get update -qq
 sudo apt-get install -qq nfs-kernel-server
 
+primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
 echo "== Setting up nfs..."
 # Share /home folder. If the projects are elsewhere the /etc/exports will need
 # to be adapted. This grants access to all unrouteable ("public") IP addresses
 # (10.*, 172.16-172.28..., 192.168.*)
 # You are welcome to edit and limit it to the addresses you prefer.
 FILE=/etc/exports
-LINE="/home 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)"
+LINE="${HOME} ${primary_ip}(rw,sync,no_subtree_check)"
 grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )
 
 echo "== Restarting nfs-kernel-server..."

--- a/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
+++ b/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
@@ -25,7 +25,8 @@ if [[ $EUID -eq 0 ]]; then
   exit 103
 fi
 
-docker run --rm -t -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
+mkdir -p ~/.ddev
+docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
 
 echo "
 +--------------------------------------+

--- a/scripts/macos_ddev_nfs_setup.sh
+++ b/scripts/macos_ddev_nfs_setup.sh
@@ -22,13 +22,12 @@ mkdir -p ~/.ddev
 docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
 
 echo "
-+--------------------------------------+
++-------------------------------------------+
 | Setup native NFS on macOS for Docker
-| Allowing NFS access to /Users has
-| security implications you should
-| consider. You'll want your firewall
-| turned on.
-+--------------------------------------+
+| Only localhost is allowed access;
+| Your home directory is shared by default.
+| But, of course, pay attention to security.
++-------------------------------------------+
 "
 echo "Stopping running ddev projects"
 echo ""

--- a/scripts/macos_ddev_nfs_setup.sh
+++ b/scripts/macos_ddev_nfs_setup.sh
@@ -18,7 +18,8 @@ if [[ $EUID -eq 0 ]]; then
   exit 102
 fi
 
-docker run --rm -t -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
+mkdir -p ~/.ddev
+docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
 
 echo "
 +--------------------------------------+

--- a/scripts/macos_ddev_nfs_setup.sh
+++ b/scripts/macos_ddev_nfs_setup.sh
@@ -38,7 +38,7 @@ ddev stop -a || true
 echo "== Setting up nfs..."
 # Share /Users folder. If the projects are elsewhere the /etc/exports will need
 # to be adapted.
-LINE="/Users -alldirs -mapall=$(id -u):$(id -g) localhost"
+LINE="${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost"
 FILE=/etc/exports
 sudo bash -c "echo >> $FILE" || ( echo "Unable to edit /etc/exports, need Full Disk Access on Mojave and later" && exit 103 )
 grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )

--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -13,12 +13,9 @@ DDEV_WINDOWS_GID=1000
 
 nfs_addr=127.0.0.1
 # Get IP address for docker toolbox docker host
-if [ "${DOCKER_TOOLBOX_INSTALL_PATH}" != "" ] ; then
+if [ "${DOCKER_TOOLBOX_INSTALL_PATH:-}" != "" ] ; then
     hostDockerInternalIP=$(echo $DOCKER_HOST | awk -F '.' ' { sub(/tcp:\/\//,"",$1); printf ("%d.%d.%d.1", $1, $2, $3) }')
     nfs_addr=${hostDockerInternalIP}
-fi
-
-  nfs_addr=192.168.99.100
 fi
 
 mkdir -p ~/.ddev

--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -11,6 +11,16 @@ set -o nounset
 DDEV_WINDOWS_UID=1000
 DDEV_WINDOWS_GID=1000
 
+nfs_addr=127.0.0.1
+# Get IP address for docker toolbox docker host
+if [ "${DOCKER_TOOLBOX_INSTALL_PATH}" != "" ] ; then
+    hostDockerInternalIP=$(echo $DOCKER_HOST | awk -F '.' ' { sub(/tcp:\/\//,"",$1); printf ("%d.%d.%d.1", $1, $2, $3) }')
+    nfs_addr=${hostDockerInternalIP}
+fi
+
+  nfs_addr=192.168.99.100
+fi
+
 mkdir -p ~/.ddev
 docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 101)
 
@@ -46,7 +56,7 @@ else
 # Additional lines can be added for additional directories or drives.
 C:\ > /C" >"$HOME/.ddev/nfs_exports.txt"
 fi
-sudo nssm install nfsd "${winnfsd}" -id ${DDEV_WINDOWS_UID} ${DDEV_WINDOWS_GID} -log off -pathFile "\"$HOMEDRIVE$HOMEPATH\.ddev\nfs_exports.txt\""
+sudo nssm install nfsd "${winnfsd}" -id ${DDEV_WINDOWS_UID} ${DDEV_WINDOWS_GID} -addr $nfs_addr -log off -pathFile "\"$HOMEDRIVE$HOMEPATH\.ddev\nfs_exports.txt\""
 sudo nssm start nfsd || true
 sleep 2
 nssm status nfsd

--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -41,7 +41,7 @@ if ! command -v winnfsd.exe >/dev/null; then
     echo "winnfsd.exe does not seem to be installed or is not in the PATH"
     exit 102
 fi
-winnfsd=$(where winnfsd.exe)
+winnfsd=$(command -v winnfsd.exe)
 
 if [ -f "$HOME/.ddev/nfs_exports.txt" ]; then
     printf "$HOME/.ddev/nfs_exports.txt already exists, not overwriting it, you will be responsible for its exports.\n"

--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -51,7 +51,7 @@ else
 # You can edit these yourself to match your workflow
 # But nfs must share your project directory
 # Additional lines can be added for additional directories or drives.
-C:\ > /C" >"$HOME/.ddev/nfs_exports.txt"
+${HOMEDRIVE}${HOMEPATH} > ${HOME}" >"$HOME/.ddev/nfs_exports.txt"
 fi
 sudo nssm install nfsd "${winnfsd}" -id ${DDEV_WINDOWS_UID} ${DDEV_WINDOWS_GID} -addr $nfs_addr -log off -pathFile "\"$HOMEDRIVE$HOMEPATH\.ddev\nfs_exports.txt\""
 sudo nssm start nfsd || true

--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -11,6 +11,10 @@ set -o nounset
 DDEV_WINDOWS_UID=1000
 DDEV_WINDOWS_GID=1000
 
+mkdir -p ~/.ddev
+docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 101)
+
+
 status=uninstalled
 if nssm status nfsd 2>/dev/null ; then
     status=$(nssm status nfsd)
@@ -28,7 +32,7 @@ fi
 
 if ! command -v winnfsd.exe >/dev/null; then
     echo "winnfsd.exe does not seem to be installed or is not in the PATH"
-    exit 101
+    exit 102
 fi
 winnfsd=$(where winnfsd.exe)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1471 points out that our approach to NFS security is lax at best. This issue will try to improve that situation, or at least inform users on how they can do what needs to be done in their environment.

## How this PR Solves The Problem:

* Improve NFS install scripts with better docker recipe

## TODO
- [x] Script improvements per https://github.com/drud/ddev/issues/1471#issuecomment-494553699
- [x] Docs improvements for each platform

## Manual Testing Instructions:

* Uninstall any existing nfsd. Windows: `sudo nssm stop nfsd; sudo nssm uninstall nfsd; rm ~/.ddev/nfs_exports.txt`. Linux: `sudo apt-get remove nfs-kernel-server nfs-common; sudo rm /etc/exports`. macOS: `sudo nfsd disable; sudo rm /etc/exports`
* The NFS install scripts have to be re-tested on all 4 OS environments.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

