### PR TITLE
Use sh instead of bash for ddevapp.Exec

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -14,7 +14,7 @@ import (
 // execDirArg allows a configurable container execution directory
 var execDirArg string
 
-// DdevExecCmd allows users to execute arbitrary bash commands within a container.
+// DdevExecCmd allows users to execute arbitrary sh commands within a container.
 var DdevExecCmd = &cobra.Command{
 	Use:     "exec <command>",
 	Aliases: []string{"."},

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/nodeps"
 	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -32,9 +33,15 @@ var DdevSSHCmd = &cobra.Command{
 
 		app.DockerEnv()
 
+		// Use bash for our containers, sh for 3rd-party containers
+		// that may not have bash.
+		shell := "bash"
+		if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, serviceType) {
+			shell = "sh"
+		}
 		err = app.ExecWithTty(&ddevapp.ExecOpts{
 			Service: serviceType,
-			Cmd:     "sh",
+			Cmd:     shell,
 			Dir:     sshDirArg,
 		})
 

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -34,7 +34,7 @@ var DdevSSHCmd = &cobra.Command{
 
 		err = app.ExecWithTty(&ddevapp.ExecOpts{
 			Service: serviceType,
-			Cmd:     "bash",
+			Cmd:     "sh",
 			Dir:     sshDirArg,
 		})
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -447,7 +447,7 @@ To run privileged commands, sudo can be passed into `ddev exec`. For example, to
 Commands can also be executed using the shorter `ddev . <cmd>` alias.
 
 ### SSH Into Containers
-The `ddev ssh` command will open an interactive sh shell session to the container for a ddev service. The web service is connected to by default. The session can be ended by typing `exit`. To connect to another service, use the `--service` flag to specify the service you want to connect to. For example, to connect to the database container, you would run `ddev ssh --service db`. To specify the destination directory, use the `--dir` flag. For example, to connect to the database container and be placed into the `/home` directory, you would run `ddev ssh --service db --dir /home`.
+The `ddev ssh` command will open an interactive bash or sh shell session to the container for a ddev service. The web service is connected to by default. The session can be ended by typing `exit`. To connect to another service, use the `--service` flag to specify the service you want to connect to. For example, to connect to the database container, you would run `ddev ssh --service db`. To specify the destination directory, use the `--dir` flag. For example, to connect to the database container and be placed into the `/home` directory, you would run `ddev ssh --service db --dir /home`.
 
 If you want to use your personal ssh keys within the web container, that's possible. Use `ddev auth ssh` to add the keys from your ~/.ssh directory and provide a passphrase, and then those keys will be usable from within the web container. You generally only have to `ddev auth ssh` one time per computer reboot.
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -447,7 +447,7 @@ To run privileged commands, sudo can be passed into `ddev exec`. For example, to
 Commands can also be executed using the shorter `ddev . <cmd>` alias.
 
 ### SSH Into Containers
-The `ddev ssh` command will open an interactive bash shell session to the container for a ddev service. The web service is connected to by default. The session can be ended by typing `exit`. To connect to another service, use the `--service` flag to specify the service you want to connect to. For example, to connect to the database container, you would run `ddev ssh --service db`. To specify the destination directory, use the `--dir` flag. For example, to connect to the database container and be placed into the `/home` directory, you would run `ddev ssh --service db --dir /home`.
+The `ddev ssh` command will open an interactive sh shell session to the container for a ddev service. The web service is connected to by default. The session can be ended by typing `exit`. To connect to another service, use the `--service` flag to specify the service you want to connect to. For example, to connect to the database container, you would run `ddev ssh --service db`. To specify the destination directory, use the `--dir` flag. For example, to connect to the database container and be placed into the `/home` directory, you would run `ddev ssh --service db --dir /home`.
 
 If you want to use your personal ssh keys within the web container, that's possible. Use `ddev auth ssh` to add the keys from your ~/.ssh directory and provide a passphrase, and then those keys will be usable from within the web container. You generally only have to `ddev auth ssh` one time per computer reboot.
 

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -8,7 +8,7 @@ We have included several useful developer tools in our containers. Run `ddev des
 - [Drush](http://www.drush.org) - Command-line shell and Unix scripting interface for Drupal.
 - [WP-CLI](http://wp-cli.org/) - Command-line tools for managing WordPress installations.
 
-These tools can be accessed for single commands using [`ddev exec <command>`](cli-usage.md#executing-commands-in-containers) or [`ddev ssh`](cli-usage.md#ssh-into-containers) for an interactive bash session.
+These tools can be accessed for single commands using [`ddev exec <command>`](cli-usage.md#executing-commands-in-containers) or [`ddev ssh`](cli-usage.md#ssh-into-containers) for an interactive sh session.
 
 ### DDEV and Composer 
 We have included a built-in command to simplify use of [Composer](https://getcomposer.org/), the dependency manager for PHP, that allows a user to create and manage projects without having Composer installed on the host machine. Generally, executing any Composer command through DDEV is as simple as prepending the command with `ddev`. DDEV will execute the command at the project root in the web container, passing all arguments and flags to Composer. To execute Composer in other directories within the container, use `ddev ssh` or `ddev exec -d <dir>`. For example:

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -8,7 +8,7 @@ We have included several useful developer tools in our containers. Run `ddev des
 - [Drush](http://www.drush.org) - Command-line shell and Unix scripting interface for Drupal.
 - [WP-CLI](http://wp-cli.org/) - Command-line tools for managing WordPress installations.
 
-These tools can be accessed for single commands using [`ddev exec <command>`](cli-usage.md#executing-commands-in-containers) or [`ddev ssh`](cli-usage.md#ssh-into-containers) for an interactive sh session.
+These tools can be accessed for single commands using [`ddev exec <command>`](cli-usage.md#executing-commands-in-containers) or [`ddev ssh`](cli-usage.md#ssh-into-containers) for an interactive bash or sh session.
 
 ### DDEV and Composer 
 We have included a built-in command to simplify use of [Composer](https://getcomposer.org/), the dependency manager for PHP, that allows a user to create and manage projects without having Composer installed on the host machine. Generally, executing any Composer command through DDEV is as simple as prepending the command with `ddev`. DDEV will execute the command at the project root in the web container, passing all arguments and flags to Composer. To execute Composer in other directories within the container, use `ddev ssh` or `ddev exec -d <dir>`. For example:

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -834,7 +834,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	// - Quoted to delay pipes and other features to container, like `"ls -l -a | grep junk"`
 	// Note that a set quoted on the host in ddev exec will come through as a single arg
 
-	exec = append(exec, "bash", "-c", opts.Cmd)
+	exec = append(exec, "sh", "-c", opts.Cmd)
 
 	files, err := app.ComposeFiles()
 	if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -834,7 +834,13 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	// - Quoted to delay pipes and other features to container, like `"ls -l -a | grep junk"`
 	// Note that a set quoted on the host in ddev exec will come through as a single arg
 
-	exec = append(exec, "sh", "-c", opts.Cmd)
+	// Use bash for our containers, sh for 3rd-party containers
+	// that may not have bash.
+	shell := "bash"
+	if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, opts.Service) {
+		shell = "sh"
+	}
+	exec = append(exec, shell, "-c", opts.Cmd)
 
 	files, err := app.ComposeFiles()
 	if err != nil {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1590,7 +1590,7 @@ func TestDdevDescribe(t *testing.T) {
 		out, logsErr := app.CaptureLogs("web", false, "")
 		assert.NoError(logsErr)
 
-		healthcheck, inspectErr := exec.RunCommandPipe("bash", []string{"-c", fmt.Sprintf("docker inspect ddev-%s-web|jq -r '.[0].State.Health.Log[-1]'", app.Name)})
+		healthcheck, inspectErr := exec.RunCommandPipe("sh", []string{"-c", fmt.Sprintf("docker inspect ddev-%s-web|jq -r '.[0].State.Health.Log[-1]'", app.Name)})
 		assert.NoError(inspectErr)
 
 		t.Fatalf("app.StartAndWaitForSync(%s) failed: %v, \nweb container healthcheck='%s', \n=== web container logs=\n%s\n=== END web container logs ===", site.Name, err, healthcheck, out)
@@ -1955,7 +1955,7 @@ func TestHttpsRedirection(t *testing.T) {
 			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 			assert.NoError(getLogsErr)
 			// Get healthcheck status on bgsync container
-			healthcheck, inspectErr := exec.RunCommandPipe("bash", []string{"-c", fmt.Sprintf("docker inspect ddev-%s-bgsync|jq -r '.[0].State.Health.Log[-1]'", app.Name)})
+			healthcheck, inspectErr := exec.RunCommandPipe("sh", []string{"-c", fmt.Sprintf("docker inspect ddev-%s-bgsync|jq -r '.[0].State.Health.Log[-1]'", app.Name)})
 			assert.NoError(inspectErr)
 
 			t.Fatalf("app.StartAndWaitForSync failure; err=%v \n===== container logs ===\n%s\n===== bgsync health info ===\n%s\n========\n", startErr, appLogs, healthcheck)


### PR DESCRIPTION
## The Problem/Issue/Bug:

A couple of people ran into trouble using `ddev exec` and `ddev ssh` with 3rd-party containers that did not have bash on them in v1.8.0

## How this PR Solves The Problem:

* Use "sh" for `ddev ssh` except on our own containers, where we know bash is there; in that case use it.
* Use "sh" for ddevapp.Exec()

## Manual Testing Instructions

* Use ddev ssh on one of our containers and on a 3rd party container
* Use ddev exec on one of ours and on a 3rd-party container
* Make sure that an exec hook still works. 

Unfortunately, we don't have the ability to target hooks yet, so 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

