### PR TITLE
Router should not blow away existing certificates on startup

### DIFF
--- a/containers/ddev-router/docker-entrypoint.sh
+++ b/containers/ddev-router/docker-entrypoint.sh
@@ -31,6 +31,7 @@ mkcert -install
 # It's unknown what docker event causes an attempt to use these files, but they might as well exist
 # to prevent it.
 mkcert -cert-file /etc/nginx/certs/.crt -key-file /etc/nginx/certs/.key "*.ddev.local" 127.0.0.1 localhost
-mkcert -cert-file /etc/nginx/certs/master.crt -key-file /etc/nginx/certs/master.key "*.ddev.local" 127.0.0.1 localhost
-
+if [ ! -f /etc/nginx/certs/master.crt ]; then
+  mkcert -cert-file /etc/nginx/certs/master.crt -key-file /etc/nginx/certs/master.key "*.ddev.local" "*.ddev.site" 127.0.0.1 localhost
+fi
 exec "$@"

--- a/containers/ddev-router/gen-cert.sh.tmpl
+++ b/containers/ddev-router/gen-cert.sh.tmpl
@@ -3,5 +3,4 @@ set -euo pipefail
 set -x
 
 # mkcert is fully capable of generating all needed names in a single container.
-mkcert -cert-file /etc/nginx/certs/master.crt -key-file /etc/nginx/certs/master.key {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }} {{ trim $host }} {{ end }} 127.0.0.1 localhost
-
+mkcert -cert-file /etc/nginx/certs/master.crt -key-file /etc/nginx/certs/master.key {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }} {{ trim $host }} {{ end }} 127.0.0.1 localhost "*.ddev.local" "*.ddev.site"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -69,7 +69,7 @@ var BgsyncTag = "v1.8.0" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.8.0" // Note that this can be overridden by make
+var RouterTag = "20190527_dont_blow_away_existing_certs" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

If the ddev-router is paused and then started, it loses any existing certificates in the router's nginx config. It shouldn't do that; it works OK in many cases because of default "*.ddev.local" added there, but doesn't work if people have subdomains like "xx.yy.ddev.local", for example. 

## How this PR Solves The Problem:

Don't recreate certs in master.crt unless the file does not exist.

## Manual Testing Instructions:

* Create a project with name "x.y.ddev.local"
* Verify that https works with it.
* `ddev pause`
* `ddev start`
* It should still work, even though you see the router being restarted

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

