### PR TITLE
Fix nfstest.sh to use home dir instead of whole /Users (Test only)

### DIFF
--- a/.buildkite/nfstest.sh
+++ b/.buildkite/nfstest.sh
@@ -9,19 +9,8 @@ function cleanup {
 }
 trap cleanup EXIT
 
-OS=$(go env GOOS)
-
-case $OS in
-linux)
-  share=/home
-  ;;
-darwin)
-  share=/Users
-  ;;
-windows)
-  share=/C/Users
-  ;;
-esac
+mkdir -p ~/.ddev
+share="${HOME}/.ddev"
 
 # Find host.docker.internal name using host-docker-internal.sh script
 hostDockerInternal=$($(dirname $0)/../scripts/host-docker-internal.sh)

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -23,7 +23,14 @@ done
 
 mkcert -install
 
-sudo bash -c "printf '/home 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)\n/tmp 10.0.0.0/255.0.0.0(rw,sync,no_subtree_check) 172.16.0.0/255.240.0.0(rw,sync,no_subtree_check) 192.168.0.0/255.255.0.0(rw,sync,no_subtree_check)' >>/etc/exports"
+primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
+
+exports_line="${HOME} ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)"
+sudo bash -c "cat <<EOF >/etc/exports
+${HOME} ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)
+EOF"
+
+sudo bash -c "echo $exports_line  >/etc/exports"
 sudo service nfs-kernel-server restart
 
 # gotestsum

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -25,12 +25,10 @@ mkcert -install
 
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
 
-exports_line="${HOME} ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)"
 sudo bash -c "cat <<EOF >/etc/exports
 ${HOME} ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)
 EOF"
 
-sudo bash -c "echo $exports_line  >/etc/exports"
 sudo service nfs-kernel-server restart
 
 # gotestsum

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -32,7 +32,7 @@ GOTESTSUM_VERSION=0.3.2
 curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
 
 sudo bash -c "cat <<EOF >/etc/exports
-/Users -alldirs -mapall=$(id -u):$(id -g) localhost
+${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost
 /private/var -alldirs -mapall=$(id -u):$(id -g) localhost
 EOF"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

In #1616 we're changing what gets mounted by nfsd; The resulting testbot setup doesn't match what is shared, etc. So the testbots have to have some maintenance, and we need to check against what's actually shared.

## How this PR Solves The Problem:

Improve buildkite and circleci setup.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

