### PR TITLE
Change ddev list to default to showing all

### DIFF
--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -12,8 +12,8 @@ import (
 // continuous, if set, makes list continuously output
 var continuous bool
 
-// showAll, if set, shows non-running projects in addition to running/paused
-var showAll bool
+// activeOnly, if set, shows only running projects
+var activeOnly bool
 
 // continuousSleepTime is time to sleep between reads with --continuous
 var continuousSleepTime = 1
@@ -25,7 +25,7 @@ var DdevListCmd = &cobra.Command{
 	Long:  `List projects. Shows active projects by default, includes stopped projects with --all`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for {
-			apps, err := ddevapp.GetProjects(!showAll)
+			apps, err := ddevapp.GetProjects(activeOnly)
 			if err != nil {
 				util.Failed("failed getting GetProjects: %v", err)
 			}
@@ -56,7 +56,7 @@ var DdevListCmd = &cobra.Command{
 }
 
 func init() {
-	DdevListCmd.Flags().BoolVarP(&showAll, "all", "a", false, "If set, all projects will be displayed, even stopped projects.")
+	DdevListCmd.Flags().BoolVarP(&activeOnly, "active-only", "A", false, "If set, only currently active projects will be displayed.")
 	DdevListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted until the command is stopped.")
 	DdevListCmd.Flags().IntVarP(&continuousSleepTime, "continuous-sleep-interval", "I", 1, "Time in seconds between ddev list --continous output lists.")
 

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -27,7 +27,7 @@ func TestCmdList(t *testing.T) {
 	jsonOut, err := exec.RunCommand(DdevBin, []string{"list", "-j"})
 	assert.NoError(err, "error running ddev list -j: %v, output=%s", jsonOut)
 
-	siteList := getSitesFromList(t, jsonOut)
+	siteList := getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(DevTestSites), len(siteList))
 
 	for _, v := range DevTestSites {
@@ -61,7 +61,6 @@ func TestCmdList(t *testing.T) {
 
 	}
 
-	// Now check behavior of --all
 	// Stop the first app
 	firstApp, err := ddevapp.GetActiveApp(DevTestSites[0].Name)
 	assert.NoError(err)
@@ -70,14 +69,14 @@ func TestCmdList(t *testing.T) {
 
 	// Execute "ddev list" and harvest plain text output.
 	// Now there should be one less project in list
-	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
+	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-jA"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
 
-	siteList = getSitesFromList(t, jsonOut)
+	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(DevTestSites)-1, len(siteList))
 
-	// Now list with -a, make sure we show all projects
-	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j", "-a"})
+	// Now list without -A, make sure we show all projects
+	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
@@ -89,7 +88,7 @@ func TestCmdList(t *testing.T) {
 }
 
 // getSitesFromList takes the json output of ddev list -j
-// and returns the list of sites ddev list returns as an array
+// and returns the list of *test* sites ddev list returns as an array
 // of interface{}
 func getSitesFromList(t *testing.T, jsonOut string) []interface{} {
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -41,13 +41,14 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 	for _, name := range names {
 		var exists bool
 		// If the requested project name is found in the docker map, OK
-		// If not, if we find it in the globl project list, OK
+		// If not, if we find it in the globl project list, (if it has approot)
 		// Otherwise, error.
 		if requestedProjectsMap[name], exists = allProjectMap[name]; !exists {
-			if _, exists = globalconfig.DdevGlobalConfig.ProjectList[name]; exists {
+			p := globalconfig.GetProject(name)
+			if p != nil && p.AppRoot != "" {
 				requestedProjectsMap[name] = &ddevapp.DdevApp{Name: name}
 			} else {
-				return nil, fmt.Errorf("could not find requested project %s", name)
+				return nil, fmt.Errorf("could not find requested project %s, you may need to use \"ddev start\" to add it to the project catalog", name)
 			}
 		}
 	}

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -274,24 +274,24 @@ How do you know if DDEV manages a settings file? You will see the following comm
 
 ## Listing project information
 
-To see a list of your running projects you can use `ddev list`; `ddev list --all` will show all projects including stopped projects.
+To see a list of your projects you can use `ddev list`; `ddev list --active-only` will show only projects currently running or paused.
+
+➜  ddev list 
+NAME          TYPE     LOCATION                   URL(s)                                STATUS
+d8git         drupal8  ~/workspace/d8git          https://d8git.ddev.local              running
+                                                  http://d8git.ddev.local
+hobobiker     drupal6  ~/workspace/hobobiker.com                                        stopped
+```
 
 ```
-➜  ddev list
+➜  ddev list --active-only
 NAME     TYPE     LOCATION             URL(s)                      STATUS
 drupal8  drupal8  ~/workspace/drupal8  http://drupal8.ddev.site   running
                                        https://drupal8.ddev.site
 ```
 
 ```
-➜  ddev list --all
-NAME          TYPE     LOCATION                   URL(s)                                STATUS
-d8git         drupal8  ~/workspace/d8git          https://d8git.ddev.local              running
-                                                  http://d8git.ddev.local
-hobobiker     drupal6  ~/workspace/hobobiker.com                                        stopped
-t3v9composer  typo3    ~/workspace/t3v9composer   https://t3v9composer.ddev.local:8443  running
-                                                  http://t3v9composer.ddev.local:8080
-```
+
 
 You can also see more detailed information about a project by running `ddev describe` from its working directory. You can also run `ddev describe [project-name]` from any location to see the detailed information for a running project.
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

@ultimike and @rickmanelius both recommended that the new global site listing default to `ddev list --all`, as they both got caught by missing actual global projects. 

## How this PR Solves The Problem:

`ddev list` shows all.
`ddev list --active-only` shows only sites active in docker.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

