### PR TITLE
Leave the project_tld out of defaults in config.yaml

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -177,6 +177,9 @@ func (app *DdevApp) WriteConfig() error {
 	if appcopy.PHPMyAdminPort == DdevDefaultPHPMyAdminPort {
 		appcopy.PHPMyAdminPort = ""
 	}
+	if appcopy.ProjectTLD == DdevDefaultTLD {
+		appcopy.ProjectTLD = ""
+	}
 
 	// We now want to reserve the port we're writing for HostDBPort and HostWebserverPort and so they don't
 	// accidentally get used for other projects.

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -299,8 +299,9 @@ const ConfigInstructions = `
 # This is ignored if a free-form .ddev/db-build/Dockerfile is provided
 
 # use_dns_when_possible: true
-# If the host has internet access and the domain configured can successfully be looked up,
-# DNS will be used for hostname resolution instead of editing /etc/hosts
+# If the host has internet access and the domain configured can 
+# successfully be looked up, DNS will be used for hostname resolution 
+# instead of editing /etc/hosts
 # Defaults to true
 
 # project_tld: ddev.site


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noted that project_tld was being displayed with its default "ddev.site" in the config.yaml, and most people don't need to be bothered with that. It's explained in the comments below.

## How this PR Solves The Problem:

If it's set to the default, empty it for usage in writing config.yaml

## Manual Testing Instructions:

`ddev config` and see if project_tld is populated in config.yaml

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

