### PR TITLE
Use drush launcher and drush8 in container, fixes #1488

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -4,7 +4,9 @@ ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3"
 ENV PHP_DEFAULT_VERSION="7.2"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 
-ENV DRUSH_VERSION=8.1.18
+ENV DRUSH_VERSION=8.2.3
+ENV DRUSH_LAUNCHER_VERSION=0.6.0
+ENV DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV WP_CLI_VERSION=2.1.0
 ENV MAILHOG_VERSION=1.0.0
 ENV BACKDROP_DRUSH_VERSION=0.1.0
@@ -97,8 +99,8 @@ RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2
 ADD files /
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN composer global require consolidation/cgr
-RUN /home/.composer/vendor/bin/cgr drush/drush:$DRUSH_VERSION && ln -s /home/.composer/vendor/bin/drush /usr/local/bin/drush
+RUN curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8 && chmod +x /usr/local/bin/drush8
+RUN curl -sSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush && chmod +x /usr/local/bin/drush
 RUN curl -sSL "https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_amd64" -o /usr/local/bin/mailhog
 RUN curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar" -o /usr/local/bin/wp-cli
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1368,7 +1368,7 @@ func TestDdevExec(t *testing.T) {
 				Cmd:     "drush status",
 			})
 			assert.NoError(err)
-			assert.Regexp("PHP configuration[ :]*/etc/php/[0-9].[0-9]/fpm/php.ini", out)
+			assert.Regexp("PHP configuration[ :]*/etc/php/[0-9].[0-9]/cli/php.ini", out)
 		case ddevapp.AppTypeWordPress:
 			out, _, err = app.Exec(&ddevapp.ExecOpts{
 				Service: "web",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "secure-DDEV_URL" // Note that this can be overridden by make
+var WebTag = "20190603_drush_launcher" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1488: "Drush launcher" has become the standard way to globally-launch drush. It picks up a site-local drush (the standard technique for drupal8) and with this installation falls back to using drush8, which will work for Drupal7 and Backdrop.

## How this PR Solves The Problem:

Change the install to install drush launcher and drush8

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

