### PR TITLE
Add ddev share command, fixes #375

### DIFF
--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -46,6 +46,10 @@ if command -v ddev >/dev/null && [ "$(ddev version -j | jq -r .raw.commit)" \< "
   exit 4
 fi
 
+if ! command -v ngrok >/dev/null ; then
+    echo "ngrok is not installed" && exit 5
+fi
+
 $(dirname $0)/nfstest.sh
 
 echo "=== testbot $HOSTNAME seems to be set up OK ==="

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -24,6 +24,11 @@ chmod -R u+w ~/go/pkg && rm -rf ~/go/pkg/*
 
 # Kill off any running containers before sanetestbot.
 docker rm -f $(docker ps -aq) || true
+
+# Run any testbot maintenance taht may need to be done
+echo "--- running testbot_maintenance.sh"
+bash $(dirname $0)/testbot_maintenance.sh
+
 # Our testbot should be sane, run the testbot checker to make sure.
 echo "--- running sanetestbot.sh"
 ./.buildkite/sanetestbot.sh

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -25,7 +25,7 @@ chmod -R u+w ~/go/pkg && rm -rf ~/go/pkg/*
 # Kill off any running containers before sanetestbot.
 docker rm -f $(docker ps -aq) || true
 
-# Run any testbot maintenance taht may need to be done
+# Run any testbot maintenance that may need to be done
 echo "--- running testbot_maintenance.sh"
 bash $(dirname $0)/testbot_maintenance.sh
 

--- a/.buildkite/test_containers.sh
+++ b/.buildkite/test_containers.sh
@@ -41,6 +41,10 @@ cleanup
 # go clean -modcache  (Doesn't work due to current bug in golang)
 chmod -R u+w ~/go/pkg && rm -rf ~/go/pkg/*
 
+# Run any testbot maintenance that may need to be done
+echo "--- running testbot_maintenance.sh"
+bash $(dirname $0)/testbot_maintenance.sh
+
 # Our testbot should now be sane, run the testbot checker to make sure.
 ./.buildkite/sanetestbot.sh
 

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu
+
+os=$(go env GOOS)
+
+if ! command -v ngrok >/dev/null; then
+    case $os in
+    darwin)
+        brew cask install ngrok
+        ;;
+    windows)
+        choco install -y ngrok
+        ;;
+    linux)
+        curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && sudo unzip -d /usr/local/bin /tmp/ngrok.zip
+        ;;
+    esac
+fi

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -4,6 +4,7 @@ set -eu
 
 os=$(go env GOOS)
 
+# Install ngrok if it's not there.
 if ! command -v ngrok >/dev/null; then
     case $os in
     darwin)

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -8,6 +8,8 @@ set -x
 sudo apt-get update -qq
 sudo apt-get install -qq mysql-client realpath zip nsis jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
 
+curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && sudo unzip -d /usr/local/bin /tmp/ngrok.zip
+
 if [ ! -d /home/linuxbrew/.linuxbrew/bin ] ; then
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
 fi

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -8,7 +8,7 @@ set -x
 brew update >/dev/null 2>/dev/null
 
 # Get docker in first so we can install it and work on other things
-brew cask install docker
+brew cask install docker ngrok
 sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended
 nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 

--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -23,7 +23,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	}
 
 	testDir, _ := os.Getwd()
-	defer cmd.DevTestSites[0].Chdir()()
+	defer cmd.TestSites[0].Chdir()()
 
 	_, err := exec.RunCommand(cmd.DdevBin, []string{"start"})
 	require.NoError(t, err)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -131,8 +131,11 @@ var (
 	// projectTLDArg specifies a project top-level-domain; defaults to ddevapp.DdevDefaultTLD
 	projectTLDArg string
 
-	// useDNSWhenPossibleArg specifies
+	// useDNSWhenPossibleArg specifies to use DNS for lookup (or not), defaults to true
 	useDNSWhenPossibleArg bool
+
+	// ngrokArgs provides additional args to the ngrok command in `ddev share`
+	ngrokArgs string
 )
 
 var providerName = ddevapp.ProviderDefault
@@ -277,6 +280,8 @@ func init() {
 	ConfigCommand.Flags().StringVar(&projectTLDArg, "project-tld", ddevapp.DdevDefaultTLD, "set the top-level domain to be used for projects, defaults to "+ddevapp.DdevDefaultTLD)
 
 	ConfigCommand.Flags().BoolVarP(&useDNSWhenPossibleArg, "use-dns-when-possible", "", true, "Use DNS for hostname resolution instead of /etc/hosts when possible")
+
+	ConfigCommand.Flags().StringVarP(&ngrokArgs, "ngrok-args", "", "", "Provide extra args to ngrok in ddev share")
 
 	RootCmd.AddCommand(ConfigCommand)
 }
@@ -476,6 +481,10 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if cmd.Flag("use-dns-when-possible").Changed {
 		app.UseDNSWhenPossible = useDNSWhenPossibleArg
+	}
+
+	if cmd.Flag("ngrok-args").Changed {
+		app.NgrokArgs = ngrokArgs
 	}
 
 	if cmd.Flag("project-tld").Changed {

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -54,7 +54,7 @@ func TestDescribeBadArgs(t *testing.T) {
 func TestCmdDescribe(t *testing.T) {
 	assert := asrt.New(t)
 
-	for _, v := range DevTestSites {
+	for _, v := range TestSites {
 		// First, try to do a describe from another directory.
 		tmpdir := testcommon.CreateTmpDir("")
 		cleanup := testcommon.Chdir(tmpdir)
@@ -113,7 +113,7 @@ func TestCmdDescribe(t *testing.T) {
 // TestCmdDescribeAppFunction performs unit tests on the describeApp function from the working directory.
 func TestCmdDescribeAppFunction(t *testing.T) {
 	assert := asrt.New(t)
-	for i, v := range DevTestSites {
+	for i, v := range TestSites {
 		cleanup := v.Chdir()
 
 		app, err := ddevapp.GetActiveApp("")
@@ -155,7 +155,7 @@ func TestCmdDescribeAppUsingSitename(t *testing.T) {
 	defer testcommon.CleanupDir(tmpdir)
 	defer testcommon.Chdir(tmpdir)()
 
-	for _, v := range DevTestSites {
+	for _, v := range TestSites {
 		app, err := ddevapp.GetActiveApp(v.Name)
 		assert.NoError(err)
 		desc, err := app.Describe()
@@ -190,7 +190,7 @@ func TestCmdDescribeAppWithInvalidParams(t *testing.T) {
 	assert.Error(err)
 
 	// Change to a site's working directory and ensure a failure still occurs with a invalid site name.
-	cleanup := DevTestSites[0].Chdir()
+	cleanup := TestSites[0].Chdir()
 	_, err = ddevapp.GetActiveApp(util.RandString(16))
 	assert.Error(err)
 	cleanup()

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -11,7 +11,7 @@ import (
 // TestCmdExecBadArgs run `ddev exec` without the proper args
 func TestCmdExecBadArgs(t *testing.T) {
 	// Change to the first DevTestSite for the duration of this test.
-	defer DevTestSites[0].Chdir()()
+	defer TestSites[0].Chdir()()
 	assert := asrt.New(t)
 
 	args := []string{"exec"}
@@ -24,7 +24,7 @@ func TestCmdExecBadArgs(t *testing.T) {
 func TestCmdExec(t *testing.T) {
 
 	assert := asrt.New(t)
-	v := DevTestSites[0]
+	v := TestSites[0]
 	cleanup := v.Chdir()
 
 	// Test default invocation

--- a/cmd/ddev/cmd/import_test.go
+++ b/cmd/ddev/cmd/import_test.go
@@ -16,7 +16,7 @@ import (
 func TestImportTilde(t *testing.T) {
 	assert := asrt.New(t)
 
-	site := DevTestSites[0]
+	site := TestSites[0]
 
 	homedir, err := gohomedir.Dir()
 	assert.NoError(err)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -28,9 +28,9 @@ func TestCmdList(t *testing.T) {
 	assert.NoError(err, "error running ddev list -j: %v, output=%s", jsonOut)
 
 	siteList := getTestingSitesFromList(t, jsonOut)
-	assert.Equal(len(DevTestSites), len(siteList))
+	assert.Equal(len(TestSites), len(siteList))
 
-	for _, v := range DevTestSites {
+	for _, v := range TestSites {
 		app, err := ddevapp.GetActiveApp(v.Name)
 		assert.NoError(err)
 
@@ -66,7 +66,7 @@ func TestCmdList(t *testing.T) {
 	}
 
 	// Stop the first app
-	firstApp, err := ddevapp.GetActiveApp(DevTestSites[0].Name)
+	firstApp, err := ddevapp.GetActiveApp(TestSites[0].Name)
 	assert.NoError(err)
 	err = firstApp.Stop(false, false)
 	assert.NoError(err)
@@ -77,14 +77,14 @@ func TestCmdList(t *testing.T) {
 	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
-	assert.Equal(len(DevTestSites)-1, len(siteList))
+	assert.Equal(len(TestSites)-1, len(siteList))
 
 	// Now list without -A, make sure we show all projects
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
-	assert.Equal(len(DevTestSites), len(siteList))
+	assert.Equal(len(TestSites), len(siteList))
 
 	// Leave firstApp running for other tests
 	err = firstApp.Start()

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -67,19 +67,22 @@ func TestCmdList(t *testing.T) {
 
 	// Stop the first app
 	out, err = exec.RunCommand(DdevBin, []string{"stop", TestSites[0].Name})
-	assert.NoError(err, "error runnning ddev stop: %v output=%s", err, out)
+	assert.NoError(err, "error runnning ddev stop %v: %v output=%s", TestSites[0].Name, err, out)
+	t.Logf("Stopping first project with ddev stop %s", TestSites[0].Name)
 
 	// Execute "ddev list" and harvest json output.
 	// Now there should be one less project in list
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-jA"})
-	assert.NoError(err, "error runnning ddev list: %v output=%s", err, out)
+	assert.NoError(err, "error runnning ddev list: %v output=%s", err, jsonOut)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites)-1, len(siteList))
+	t.Logf("projects running with ddev list -jA: %v", siteList)
 
 	// Now list without -A, make sure we show all projects
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", err, out)
+	t.Logf("projects running with ddev list -j: %v", siteList)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites), len(siteList))

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -19,6 +19,12 @@ import (
 func TestCmdList(t *testing.T) {
 	assert := asrt.New(t)
 
+	// This gratuitous ddev start -a repopulates the ~/.ddev/global_config.yaml
+	// project list, which has been damaged by other tests which use
+	// direct app techniques.
+	_, err := exec.RunCommand(DdevBin, []string{"start", "-a"})
+	assert.NoError(err)
+
 	// Execute "ddev list" and harvest plain text output.
 	out, err := exec.RunCommand(DdevBin, []string{"list"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
@@ -65,11 +71,6 @@ func TestCmdList(t *testing.T) {
 
 	}
 
-	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
-	assert.NoError(err, "error runnning ddev list: %v output=%s", err, jsonOut)
-	siteList = getTestingSitesFromList(t, jsonOut)
-	t.Logf("all test projects with ddev list -j before stopping first: %v", siteList)
-
 	// Stop the first app
 	out, err = exec.RunCommand(DdevBin, []string{"stop", TestSites[0].Name})
 	t.Logf("Stopped first project with ddev stop %s", TestSites[0].Name)
@@ -89,7 +90,7 @@ func TestCmdList(t *testing.T) {
 	assert.NoError(err, "error runnning ddev list: %v output=%s", err, out)
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites), len(siteList))
-	t.Logf("test projects (including inactibve) shown with ddev list -j: %v", siteList)
+	t.Logf("test projects (including inactive) shown with ddev list -j: %v", siteList)
 
 	// Leave firstApp running for other tests
 	out, err = exec.RunCommand(DdevBin, []string{"start", TestSites[0].Name})

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -66,29 +66,27 @@ func TestCmdList(t *testing.T) {
 	}
 
 	// Stop the first app
-	firstApp, err := ddevapp.GetActiveApp(TestSites[0].Name)
-	assert.NoError(err)
-	err = firstApp.Stop(false, false)
-	assert.NoError(err)
+	out, err = exec.RunCommand(DdevBin, []string{"stop", TestSites[0].Name})
+	assert.NoError(err, "error runnning ddev stop: %v output=%s", err, out)
 
-	// Execute "ddev list" and harvest plain text output.
+	// Execute "ddev list" and harvest json output.
 	// Now there should be one less project in list
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-jA"})
-	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
+	assert.NoError(err, "error runnning ddev list: %v output=%s", err, out)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites)-1, len(siteList))
 
 	// Now list without -A, make sure we show all projects
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
-	assert.NoError(err, "error runnning ddev list: %v output=%s", out)
+	assert.NoError(err, "error runnning ddev list: %v output=%s", err, out)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites), len(siteList))
 
 	// Leave firstApp running for other tests
-	err = firstApp.Start()
-	assert.NoError(err)
+	out, err = exec.RunCommand(DdevBin, []string{"start", TestSites[0].Name})
+	assert.NoError(err, "error runnning ddev start: %v output=%s", err, out)
 }
 
 // getSitesFromList takes the json output of ddev list -j

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -65,6 +65,11 @@ func TestCmdList(t *testing.T) {
 
 	}
 
+	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
+	assert.NoError(err, "error runnning ddev list: %v output=%s", err, jsonOut)
+	siteList = getTestingSitesFromList(t, jsonOut)
+	t.Logf("all test projects with ddev list -j before stopping first: %v", siteList)
+
 	// Stop the first app
 	out, err = exec.RunCommand(DdevBin, []string{"stop", TestSites[0].Name})
 	t.Logf("Stopped first project with ddev stop %s", TestSites[0].Name)
@@ -82,7 +87,6 @@ func TestCmdList(t *testing.T) {
 	// Now list without -A, make sure we show all projects
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", err, out)
-
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites), len(siteList))
 	t.Logf("test projects (including inactibve) shown with ddev list -j: %v", siteList)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -67,25 +67,25 @@ func TestCmdList(t *testing.T) {
 
 	// Stop the first app
 	out, err = exec.RunCommand(DdevBin, []string{"stop", TestSites[0].Name})
+	t.Logf("Stopped first project with ddev stop %s", TestSites[0].Name)
 	assert.NoError(err, "error runnning ddev stop %v: %v output=%s", TestSites[0].Name, err, out)
-	t.Logf("Stopping first project with ddev stop %s", TestSites[0].Name)
 
 	// Execute "ddev list" and harvest json output.
-	// Now there should be one less project in list
+	// Now there should be one less active project in list
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-jA"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", err, jsonOut)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites)-1, len(siteList))
-	t.Logf("projects running with ddev list -jA: %v", siteList)
+	t.Logf("test projects active with ddev list -jA: %v", siteList)
 
 	// Now list without -A, make sure we show all projects
 	jsonOut, err = exec.RunCommand(DdevBin, []string{"list", "-j"})
 	assert.NoError(err, "error runnning ddev list: %v output=%s", err, out)
-	t.Logf("projects running with ddev list -j: %v", siteList)
 
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites), len(siteList))
+	t.Logf("test projects (including inactibve) shown with ddev list -j: %v", siteList)
 
 	// Leave firstApp running for other tests
 	out, err = exec.RunCommand(DdevBin, []string{"start", TestSites[0].Name})

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -30,7 +30,7 @@ func TestLogsNoConfig(t *testing.T) {
 func TestLogs(t *testing.T) {
 	assert := asrt.New(t)
 
-	v := DevTestSites[0]
+	v := TestSites[0]
 	// Copy our fatal error php into the docroot of testsite.
 	pwd, err := os.Getwd()
 	assert.NoError(err)

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -24,7 +24,7 @@ func TestCmdPauseContainers(t *testing.T) {
 	err := addSites()
 	require.NoError(t, err)
 
-	site := DevTestSites[0]
+	site := TestSites[0]
 	cleanup := site.Chdir()
 
 	out, err := exec.RunCommand(DdevBin, []string{"pause"})

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -13,7 +13,7 @@ import (
 // TestDevRestart runs `ddev restart` on the test apps
 func TestDevRestart(t *testing.T) {
 	assert := asrt.New(t)
-	site := DevTestSites[0]
+	site := TestSites[0]
 	cleanup := site.Chdir()
 
 	args := []string{"restart"}
@@ -33,7 +33,7 @@ func TestDevRestart(t *testing.T) {
 // TestDevRestartJSON runs `ddev restart -j` on the test apps and harvests and checks the output
 func TestDevRestartJSON(t *testing.T) {
 	assert := asrt.New(t)
-	site := DevTestSites[0]
+	site := TestSites[0]
 	cleanup := site.Chdir()
 	defer cleanup()
 

--- a/cmd/ddev/cmd/sequelpro_test.go
+++ b/cmd/ddev/cmd/sequelpro_test.go
@@ -17,7 +17,7 @@ func TestSequelproOperation(t *testing.T) {
 		t.SkipNow()
 	}
 	assert := asrt.New(t)
-	v := DevTestSites[0]
+	v := TestSites[0]
 	cleanup := v.Chdir()
 
 	_, err := ddevapp.GetActiveApp("")

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+var (
+	subdomain    string
+	proxyService string
+)
+
+// DdevShareCommand contains the "ddev logs" command
+var DdevShareCommand = &cobra.Command{
+	Use:   "share",
+	Short: "Share the project on the internet via localtunnel.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 1 {
+			util.Failed("Too many arguments provided. Please use 'ddev share' or 'ddev share [projectname]'")
+		}
+
+		apps, err := getRequestedProjects(args, false)
+		if err != nil {
+			util.Failed("Failed to get requested project(s): %v", err)
+		}
+
+		app := apps[0]
+		if app.SiteStatus() != ddevapp.SiteRunning {
+			util.Failed("Project is not yet running. Use 'ddev start' first.")
+		}
+		if subdomain == "" {
+			subdomain = app.Name
+		}
+
+		port, _ := app.GetWebContainerPublicPort()
+		p := strconv.Itoa(port)
+		localhost, _ := dockerutil.GetDockerIP()
+		lt, err := exec.LookPath("lt")
+
+		if err == nil && lt != "" && (proxyService == "localtunnel" || proxyService == "") {
+			args = []string{"--port", p, "--local-host", localhost, "--subdomain", subdomain, "--open"}
+			util.Success("Running %s %s", lt, strings.Join(args, " "))
+			cmd := exec.Command(lt, args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err = cmd.Start()
+			if err != nil {
+				util.Failed("failed to run %s: %v", lt, err)
+			}
+			err = cmd.Wait()
+			if err != nil {
+				util.Failed("failed to run %s (localtunnel): %v", lt, err)
+			}
+			os.Exit(0)
+		}
+
+		ng, err := exec.LookPath("ngrok")
+		if err == nil && ng != "" && proxyService == "ngrok" {
+			url := app.GetWebContainerDirectHTTPSURL()
+			args = []string{"http", url}
+			util.Success("Running %s %s", ng, strings.Join(args, " "))
+			cmd := exec.Command(ng, args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err = cmd.Start()
+			if err != nil {
+				util.Failed("failed to run %s: %v", ng, err)
+			}
+			err = cmd.Wait()
+			if err != nil {
+				util.Failed("failed to run %s: %v", ng, err)
+			}
+			os.Exit(0)
+		}
+
+	},
+}
+
+func init() {
+	DdevShareCommand.Flags().StringVarP(&subdomain, "subdomain", "S", "", "request an alternate subdomain")
+	DdevShareCommand.Flags().StringVarP(&proxyService, "proxy-service", "P", "", "choose a proxy service (localtunnel or ngrok)")
+	RootCmd.AddCommand(DdevShareCommand)
+
+}

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -32,6 +32,14 @@ ddev share --auth authkey`,
 			util.Failed("ngrok not found in path, please install it, see https://ngrok.com/download")
 		}
 		url := app.GetWebContainerDirectHTTPSURL()
+		useHTTPS, err := cmd.Flags().GetBool("https")
+		if err != nil {
+			util.Failed("failed to get https flag: %v", err)
+		}
+
+		if !useHTTPS {
+			url = app.GetWebContainerDirectHTTPURL()
+		}
 		ngrokArgs := []string{"http"}
 		if app.NgrokArgs != "" {
 			ngrokArgs = append(ngrokArgs, strings.Split(app.NgrokArgs, " ")...)
@@ -60,6 +68,8 @@ ddev share --auth authkey`,
 func init() {
 	RootCmd.AddCommand(DdevShareCommand)
 	DdevShareCommand.Flags().String("subdomain", "", `ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain"`)
+	DdevShareCommand.Flags().Bool("https", true, `Set to false to use unencrypted http local tunnel (required if you have no ngrok.com account)"`)
+
 	DdevShareCommand.Flags().Bool("inspect", false, `ngrok --inspect argument, as in "ngrok --inspect=true"`)
 
 	DdevShareCommand.Flags().String("auth", "", `ngrok --auth flag, as in --auth "user:pass"`)

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -63,6 +63,7 @@ ddev share --use-http`,
 			ngrokCmd.Stdout = os.Stdout
 			ngrokCmd.Stderr = os.Stderr
 			ngrokErr = ngrokCmd.Run()
+
 			// nil result means ngrok ran and exited normally.
 			// It seems to do this fine when hit by SIGTERM or SIGINT
 			if ngrokErr == nil {

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -13,11 +13,11 @@ import (
 var DdevShareCommand = &cobra.Command{
 	Use:   "share",
 	Short: "Share project on the internet via ngrok.",
-	Long:  `Use "ddev share" or add on extra ngrok commands, like "ddev share --subdomain my-reserved-subdomain"`,
+	Long:  `Use "ddev share" or add on extra ngrok commands, like "ddev share --subdomain my-reserved-subdomain". Although a few ngrok commands are supported directly, any ngrok flag can be added in the ngrok_args section of .ddev/config.yaml. You will need to create an account on ngrok.com and use the "ngrok authtoken" command to set up ngrok.`,
 	Example: `ddev share
 ddev share --subdomain some-subdomain
 ddev share --auth authkey`,
-	Args: cobra.ArbitraryArgs,
+	//Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil {
@@ -37,7 +37,10 @@ ddev share --auth authkey`,
 			ngrokArgs = append(ngrokArgs, strings.Split(app.NgrokArgs, " ")...)
 		}
 		ngrokArgs = append(ngrokArgs, url)
+		x := cmd.Flags().Args()
+		_ = x
 		ngrokArgs = append(ngrokArgs, args...)
+
 		util.Success("Running %s %s", ngrokLoc, strings.Join(ngrokArgs, " "))
 		ngrokCmd := exec.Command(ngrokLoc, ngrokArgs...)
 		ngrokCmd.Stdout = os.Stdout
@@ -56,5 +59,8 @@ ddev share --auth authkey`,
 
 func init() {
 	RootCmd.AddCommand(DdevShareCommand)
-	DdevShareCommand.Flags().SetInterspersed(false)
+	DdevShareCommand.Flags().String("subdomain", "", `ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain"`)
+	DdevShareCommand.Flags().Bool("inspect", false, `ngrok --inspect argument, as in "ngrok --inspect=true"`)
+
+	DdevShareCommand.Flags().String("auth", "", `ngrok --auth flag, as in --auth "user:pass"`)
 }

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -15,8 +15,8 @@ var (
 
 // DdevShareCommand contains the "ddev share" command
 var DdevShareCommand = &cobra.Command{
-	Use:   "share",
-	Short: "Share the project on the internet via ngrok.",
+	Use:   "share [projectname]",
+	Short: "Share project on the internet via ngrok.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 1 {
 			util.Failed("Too many arguments provided. Please use 'ddev share' or 'ddev share [projectname]'")
@@ -37,10 +37,14 @@ var DdevShareCommand = &cobra.Command{
 			util.Failed("ngrok not found in path, please install it, see https://ngrok.com/download")
 		}
 		url := app.GetWebContainerDirectHTTPSURL()
-		args = []string{"http", url}
+		args = []string{"http"}
 		if cmd.Flags().Changed("subdomain") {
 			args = append(args, "--subdomain", subdomain)
 		}
+		if app.NgrokArgs != "" {
+			args = append(args, strings.Split(app.NgrokArgs, " ")...)
+		}
+		args = append(args, url)
 		util.Success("Running %s %s", ngrokLoc, strings.Join(args, " "))
 		ngrokCmd := exec.Command(ngrokLoc, args...)
 		ngrokCmd.Stdout = os.Stdout
@@ -59,7 +63,7 @@ var DdevShareCommand = &cobra.Command{
 }
 
 func init() {
-	DdevShareCommand.Flags().StringVarP(&subdomain, "subdomain", "S", "", "request an alternate subdomain")
+	DdevShareCommand.Flags().StringVarP(&subdomain, "subdomain", "S", "", "request an alternate ngrok.io subdomain (must be reserved on ngrok site)")
 	RootCmd.AddCommand(DdevShareCommand)
 
 }

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -32,12 +32,12 @@ ddev share --auth authkey`,
 			util.Failed("ngrok not found in path, please install it, see https://ngrok.com/download")
 		}
 		url := app.GetWebContainerDirectHTTPSURL()
-		useHTTPS, err := cmd.Flags().GetBool("https")
+		useHTTP, err := cmd.Flags().GetBool("use-http")
 		if err != nil {
-			util.Failed("failed to get https flag: %v", err)
+			util.Failed("failed to get use-http flag: %v", err)
 		}
 
-		if !useHTTPS {
+		if useHTTP {
 			url = app.GetWebContainerDirectHTTPURL()
 		}
 		ngrokArgs := []string{"http"}
@@ -68,7 +68,7 @@ ddev share --auth authkey`,
 func init() {
 	RootCmd.AddCommand(DdevShareCommand)
 	DdevShareCommand.Flags().String("subdomain", "", `ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain"`)
-	DdevShareCommand.Flags().Bool("https", true, `Set to false to use unencrypted http local tunnel (required if you have no ngrok.com account)"`)
+	DdevShareCommand.Flags().Bool("use-http", false, `Set to true to use unencrypted http local tunnel (required if you do not have an ngrok.com account)"`)
 
 	DdevShareCommand.Flags().Bool("inspect", false, `ngrok --inspect argument, as in "ngrok --inspect=true"`)
 

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os/exec"
-	"syscall"
 	"testing"
 )
 
@@ -56,7 +55,7 @@ func TestShareCmd(t *testing.T) {
 				body, err := ioutil.ReadAll(resp.Body)
 				assert.NoError(err)
 				assert.Contains(string(body), site.Safe200URIWithExpectation.Expect)
-				err = cmd.Process.Signal(syscall.SIGTERM)
+				err = cmd.Process.Kill()
 				assert.NoError(err)
 				urlRead = true
 				break

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -54,6 +54,7 @@ func TestShareCmd(t *testing.T) {
 				assert.NoError(err)
 				defer resp.Body.Close()
 				body, err := ioutil.ReadAll(resp.Body)
+				assert.NoError(err)
 				assert.Contains(string(body), site.Safe200URIWithExpectation.Expect)
 				err = cmd.Process.Signal(syscall.SIGTERM)
 				assert.NoError(err)

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -60,7 +60,7 @@ func TestShareCmd(t *testing.T) {
 				err = cmd.Process.Kill()
 				assert.NoError(err)
 				urlRead = true
-				break
+				return
 			}
 		}
 		return

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestShareCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	oldDir, err := os.Getwd()
+	assert.NoError(err)
+	// nolint: errcheck
+	defer os.Chdir(oldDir)
+
+	tmpDir := testcommon.CreateTmpDir(t.Name())
+	err = os.Chdir(tmpDir)
+	assert.NoError(err)
+
+}

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os/exec"
+	"runtime"
 	"testing"
 )
 
@@ -43,14 +44,14 @@ func TestShareCmd(t *testing.T) {
 				case *json.SyntaxError:
 					continue
 				default:
-					t.Logf("failed unmarshalling %v: %v", logLine, err)
-					require.NoError(t, err)
+					t.Fatalf("failed unmarshalling %v: %v", logLine, err)
 				}
 			}
 			// If URL is provided, try to hit it and look for expected response
 			if url, ok := logData["url"]; ok {
 				resp, err := http.Get(url + site.Safe200URIWithExpectation.URI)
 				assert.NoError(err)
+				//nolint: errcheck
 				defer resp.Body.Close()
 				body, err := ioutil.ReadAll(resp.Body)
 				assert.NoError(err)
@@ -66,4 +67,6 @@ func TestShareCmd(t *testing.T) {
 	require.NoError(t, err)
 	_ = cmd.Wait()
 	assert.True(urlRead)
+	t.Logf("goprocs: %v", runtime.NumGoroutine())
+
 }

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -1,22 +1,69 @@
 package cmd
 
 import (
-	"github.com/drud/ddev/pkg/testcommon"
+	"bufio"
+	"encoding/json"
 	asrt "github.com/stretchr/testify/assert"
-	"os"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"net/http"
+	"os/exec"
+	"syscall"
 	"testing"
 )
 
+// TestShareCmd tests `ddev share`
 func TestShareCmd(t *testing.T) {
 	assert := asrt.New(t)
+	urlRead := false
 
-	oldDir, err := os.Getwd()
-	assert.NoError(err)
-	// nolint: errcheck
-	defer os.Chdir(oldDir)
+	site := TestSites[0]
+	defer site.Chdir()()
 
-	tmpDir := testcommon.CreateTmpDir(t.Name())
-	err = os.Chdir(tmpDir)
-	assert.NoError(err)
+	// Configure ddev/ngrok to use json output to stdout
+	cmd := exec.Command(DdevBin, "config", "--ngrok-args", "-log stdout -log-format=json")
+	err := cmd.Start()
+	require.NoError(t, err)
+	err = cmd.Wait()
+	require.NoError(t, err)
 
+	cmd = exec.Command(DdevBin, "share", "--use-http")
+	cmdReader, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	scanner := bufio.NewScanner(cmdReader)
+
+	// Read through the ngrok json output until we get the url it has opened
+	go func() {
+		for scanner.Scan() {
+			logLine := scanner.Text()
+			logData := make(map[string]string)
+
+			err := json.Unmarshal([]byte(logLine), &logData)
+			if err != nil {
+				switch err.(type) {
+				case *json.SyntaxError:
+					continue
+				default:
+					t.Logf("failed unmarshalling %v: %v", logLine, err)
+					require.NoError(t, err)
+				}
+			}
+			// If URL is provided, try to hit it and look for expected response
+			if url, ok := logData["url"]; ok {
+				resp, err := http.Get(url + site.Safe200URIWithExpectation.URI)
+				assert.NoError(err)
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				assert.Contains(string(body), site.Safe200URIWithExpectation.Expect)
+				err = cmd.Process.Signal(syscall.SIGTERM)
+				assert.NoError(err)
+				urlRead = true
+				break
+			}
+		}
+	}()
+	err = cmd.Start()
+	require.NoError(t, err)
+	_ = cmd.Wait()
+	assert.True(urlRead)
 }

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -44,7 +44,8 @@ func TestShareCmd(t *testing.T) {
 				case *json.SyntaxError:
 					continue
 				default:
-					t.Fatalf("failed unmarshalling %v: %v", logLine, err)
+					t.Errorf("failed unmarshalling %v: %v", logLine, err)
+					break
 				}
 			}
 			// If URL is provided, try to hit it and look for expected response
@@ -62,11 +63,14 @@ func TestShareCmd(t *testing.T) {
 				break
 			}
 		}
+		return
 	}()
 	err = cmd.Start()
 	require.NoError(t, err)
-	_ = cmd.Wait()
+	err = cmd.Wait()
+	t.Logf("cmd.Wait() err: %v", err)
 	assert.True(urlRead)
+	_ = cmdReader.Close()
 	t.Logf("goprocs: %v", runtime.NumGoroutine())
 
 }

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/drud/ddev/pkg/dockerutil"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,6 +61,8 @@ func TestCmdStop(t *testing.T) {
 	assert.NoError(err)
 	// All containers should now be gone
 	assert.Equal(0, len(containers))
+	t.Logf("goprocs: %v", runtime.NumGoroutine())
+
 }
 
 // TestCmdStopMissingProjectDirectory ensures the `ddev stop` command can operate on a project when the

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -46,23 +46,19 @@ func TestCmdStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure the --all option can remove all active apps
-	out, err := exec.RunCommand(DdevBin, []string{"stop", "--all", "-RO"})
+	out, err := exec.RunCommand(DdevBin, []string{"stop", "--all"})
 	assert.NoError(err, "ddev stop --all should succeed but failed, err: %v, output: %s", err, out)
-	out, err = exec.RunCommand(DdevBin, []string{"list"})
-	assert.NoError(err)
-	assert.Contains(out, "No ddev projects were found")
 	containers, err := dockerutil.GetDockerContainers(true)
 	assert.NoError(err)
 	// Just the ddev-ssh-agent should remain running (1 container)
 	assert.Equal(1, len(containers), "Not all projects were removed after ddev stop --all")
-	_, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "-RO", "--stop-ssh-agent"})
+	_, err = exec.RunCommand(DdevBin, []string{"stop", "--all", "--stop-ssh-agent"})
 	assert.NoError(err)
 	containers, err = dockerutil.GetDockerContainers(true)
 	assert.NoError(err)
 	// All containers should now be gone
 	assert.Equal(0, len(containers))
 	t.Logf("goprocs: %v", runtime.NumGoroutine())
-
 }
 
 // TestCmdStopMissingProjectDirectory ensures the `ddev stop` command can operate on a project when the

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -24,7 +24,7 @@ func TestCmdStop(t *testing.T) {
 	// Make sure we have running sites.
 	err := addSites()
 	require.NoError(t, err)
-	for _, site := range DevTestSites {
+	for _, site := range TestSites {
 		cleanup := site.Chdir()
 
 		out, err := exec.RunCommand(DdevBin, []string{"stop"})

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1353,14 +1353,14 @@ func (app *DdevApp) GetAllURLs() []string {
 	if GetCAROOT() != "" {
 		URLs = append(URLs, app.GetWebContainerDirectHTTPSURL())
 	} else {
-		URLs = append(URLs, app.GetWebContainerDirectURL())
+		URLs = append(URLs, app.GetWebContainerDirectHTTPURL())
 	}
 
 	return URLs
 }
 
-// GetWebContainerDirectURL returns the URL that can be used without the router to get to web container.
-func (app *DdevApp) GetWebContainerDirectURL() string {
+// GetWebContainerDirectHTTPURL returns the URL that can be used without the router to get to web container.
+func (app *DdevApp) GetWebContainerDirectHTTPURL() string {
 	// Get direct address of web container
 	dockerIP, err := dockerutil.GetDockerIP()
 	if err != nil {
@@ -1370,7 +1370,7 @@ func (app *DdevApp) GetWebContainerDirectURL() string {
 	return fmt.Sprintf("http://%s:%d", dockerIP, port)
 }
 
-// GetWebContainerDirectURL returns the URL that can be used without the router to get to web container.
+// GetWebContainerDirectHTTPSURL returns the URL that can be used without the router to get to web container via https.
 func (app *DdevApp) GetWebContainerDirectHTTPSURL() string {
 	// Get direct address of web container
 	dockerIP, err := dockerutil.GetDockerIP()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -112,6 +112,7 @@ type DdevApp struct {
 	ProjectTLD            string               `yaml:"project_tld,omitempty"`
 	UseDNSWhenPossible    bool                 `yaml:"use_dns_when_possible"`
 	MkcertEnabled         bool                 `yaml:"-"`
+	NgrokArgs             string               `yaml:"ngrok_args,omitempty"`
 }
 
 // GetType returns the application type as a (lowercase) string

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -927,7 +927,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		}
 
 		// Make sure we can do a simple hit against the host-mount of web container.
-		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetWebContainerDirectURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetWebContainerDirectHTTPURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
 
 		// We don't want all the projects running at once.
 		err = app.Stop(true, false)
@@ -2075,7 +2075,7 @@ func TestGetAllURLs(t *testing.T) {
 
 	expectedDirectAddress := app.GetWebContainerDirectHTTPSURL()
 	if ddevapp.GetCAROOT() == "" {
-		expectedDirectAddress = app.GetWebContainerDirectURL()
+		expectedDirectAddress = app.GetWebContainerDirectHTTPURL()
 	}
 
 	exists := urlMap[expectedDirectAddress]
@@ -2128,7 +2128,7 @@ func TestWebserverType(t *testing.T) {
 				assert.NoError(getLogsErr)
 				t.Fatalf("app.StartAndWaitForSync failure; err=%v, logs:\n=====\n%s\n=====\n", startErr, appLogs)
 			}
-			out, resp, err := testcommon.GetLocalHTTPResponse(t, app.GetWebContainerDirectURL()+"/servertype.php")
+			out, resp, err := testcommon.GetLocalHTTPResponse(t, app.GetWebContainerDirectHTTPURL()+"/servertype.php")
 			require.NoError(t, err)
 
 			expectedServerType := "Apache/2"

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -304,7 +304,9 @@ const ConfigInstructions = `
 # The default "ddev.site" allows DNS lookup via a wildcard
 # For backward compatibility this can be changed to "ddev.local"
 
-
+# ngrok_args: --subdomain mysite --auth "user:pass"
+# Provide extra arguments to the "ngrok http" command, see 
+# https://ngrok.com/docs#http
 
 # provider: default # Currently either "default" or "pantheon"
 #

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -87,7 +87,8 @@ func ReadGlobalConfig() error {
 	}
 
 	// ReadConfig config values from file.
-	err = yaml.Unmarshal(source, &DdevGlobalConfig)
+	DdevGlobalConfig = GlobalConfig{}
+	err = yaml.UnmarshalStrict(source, &DdevGlobalConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -114,7 +114,7 @@ func (site *TestSite) Prepare() error {
 
 	err = app.WriteConfig()
 	if err != nil {
-		return errors.Errorf("Failed to write site config for site %s, dir %s, err: %v", site.Name, site.Dir, err)
+		return errors.Errorf("Failed to write site config for site %s, dir %s, err: %v", app.Name, app.GetAppRoot(), err)
 	}
 
 	return nil


### PR DESCRIPTION
## The Problem/Issue/Bug:

#375 requests ngrok for sharing a view of a project. 

## How this PR Solves The Problem:

Spawn ngrok with proper config to share config, using `ddev share`

## Manual Testing Instructions:

* Install ngrok
* Create an account on ngrok.com
* Set up, https://dashboard.ngrok.com/get-started
* Start a project and `ddev share`
* Experiment with additional args other than --subdomain by adding them to `ngrok_args` in .ddev/config.yaml
* Consider a paid account to experiment with additional features (required for --subdomain)
* Experiment with `ddev share` with no account (Just comment out the token in ~/.ngrok2/ngrok.yml). It should work, but with a warning.

## Automated Testing Overview:

* TestShareCmd tests basic unauthenticated use of `ddev share`

## Related Issue Link(s):

OP #375 

## Release/Deployment notes:

The testbots have to have ngrok on them, they were updated by this PR. First time buildkite testbot maintenance via PR.
