### PR TITLE
1646 documentation not parsing markdown lists correctly

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -8,12 +8,14 @@ If you need a service not provided here, see [Defining an additional service wit
 This recipe adds an Apache Solr 5.4 container to a project. It will setup a solr core with the solr configuration you define.
 
 **Installation:**
+
 - Copy [docker-compose.solr.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/services/docker-compose.solr.yaml) to the .ddev folder for your project.
 - Create the folder path .ddev/solr/conf.
 - Copy the solr configuration files for your project to .ddev/solr/conf. _e.g., using Drupal Search API Solr, you would copy the solr-conf/5.x/ contents from the module code base into .ddev/solr/conf._
 - Ensure the configuration files must be present before running `ddev start`.
 
 **Interacting with Apache Solr**
+
 - The Solr admin interface will be accessible at: `http://<projectname>.ddev.site:8983/solr/` For example, if the project is named "myproject" the hostname will be: `http://myproject.ddev.site:8983/solr/`
 - To access the Solr container from the web container use: `http://solr:8983/solr/`
 - A Solr core is automatically created with the name "dev"; it can be accessed at the URL: http://solr:8983/solr/dev
@@ -22,10 +24,12 @@ This recipe adds an Apache Solr 5.4 container to a project. It will setup a solr
 This recipe adds a Memcached 1.5 container to a project. The default configuration allocates 128 MB of RAM for the Memcached instance; to change that or other command line arguments, edit the `command` array within the docker-compose file.
 
 **Installation:**
+
 - Copy [docker-compose.memcached.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/services/docker-compose.memcached.yaml) to the .ddev folder for your project.
 - Run `ddev start`.
 
 **Interacting with Memcached**
+
 - The Memcached instance will listen on TCP port 11211 (the Memcached default).
 - Configure your application to access Memcached on the host:port `memcached:11211`.
 - To reach the Memcached admin interface, run `ddev ssh` to connect to the web container, then use `nc` or `telnet` to connect to the Memcached container on port 11211, i.e. `nc memcached 11211`. You can then run commands such as `stats` to see usage information.
@@ -34,9 +38,11 @@ This recipe adds a Memcached 1.5 container to a project. The default configurati
 This recipe adds a [Beanstalk](https://beanstalkd.github.io/) container to a project.
 
 **Installation:**
+
 - Copy [docker-compose.beanstalk.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/services/docker-compose.beanstalkd.yaml) to the .ddev folder for your project.
 - Run `ddev start`.
 
 **Interacting with the Beanstalk Queue**
+
 - The Beanstalk instance will listen on TCP port 11300 (the beanstalkd default).
 - Configure your application to access Beanstalk on the host:port `beanstalk:11300`.

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -7,6 +7,7 @@ xdebug is a server-side tool: It is installed automatically on the container and
 All IDEs basically work the same: They listen on a port and react when they're contacted there. So IDEs other than those listed here should work fine, if listening on the default xdebug port 9000.
 
 **Key facts:**
+
 * You need to explicitly enable xdebug in your config.yaml with `xdebug_enabled: true` (it's disabled by default). After changing, `ddev start` again.
 * The debug server port on the IDE must be set to port 9000, which is the default and is probably already set in most IDEs. (If you need to change the xdebug port due to a port conflict on your host computer, you can do it with a PHP override, explained below.)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

- gh-1646

## How this PR Solves The Problem:

- In some documentation, bolded text (e.g. `**I am some bold text**`) is used instead of headings, sometimes with only one newline after the end of the bolded section. In this situation the bold text and whatever follows are parsed as the contents of a `<p>` element.
- This PR adds an extra newline basically wherever `\*\*\n[^\n]` happens. This should enable the markdown to be parsed correctly.

## Manual Testing Instructions:

- I don't know. Does readthedocs.io have a test branch? :smile:

## Automated Testing Overview:

- None--I'm not aware of any way the project has to test documentation changes.

## Related Issue Link(s):

- gh-1646

## Release/Deployment notes:

- This is only a documentation change.

