### PR TITLE
Solr - ulimits increase to avoid container crash

### DIFF
--- a/pkg/servicetest/testdata/services/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.solr.yaml
@@ -59,6 +59,10 @@ services:
       - solr-precreate
       - dev
       - /solr-conf
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
   # This links the Solr service to the web service defined in the main
   # docker-compose.yml, allowing applications running in the web service to
   # access the Solr service at sitename.ddev.site:8983.


### PR DESCRIPTION
## The Problem/Issue/Bug:
Upon using DDEV with Solr, I faced with this problem:
https://superuser.com/questions/1413352/running-jdk-8-in-docker-suddenly-broken-on-arch-linux-with-unable-to-allocate-f/1413390#1413390
The Solr 6.6 container exits immediately after start with this error message:
`library initialization failed - unable to allocate file descriptor table - out of memory`
 - in `docker log`

`ddev version v1.8.0`
`Docker version 18.09.6, build 481bc77`
`docker-compose version 1.23.2, build 1110ad01`
OS: `Linux hrabal 5.1.9-300.fc30.x86_64 #1 SMP Tue Jun 11 16:17:54 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux`

## How this PR Solves The Problem:
It increases the `ulimits` for the Solr container.

## Manual Testing Instructions:
Start a DDEV project with Solr available. See if the Solr container exits immediately or not.

## Automated Testing Overview:
If the Solr container is already covered by tests, this configuration is covered as well. If it isn't, it might be out of scope to add the full Solr bootstrapping as a new test for this fix.