### PR TITLE
Support timezone in container and PHP, fixes #1658, fixes #1417, #709

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -283,6 +283,9 @@ func init() {
 
 	ConfigCommand.Flags().StringVarP(&ngrokArgs, "ngrok-args", "", "", "Provide extra args to ngrok in ddev share")
 
+	ConfigCommand.Flags().String("timezone", "", "Specify timezone for containers and php, like Europe/London or America/Denver or GMT or UTC")
+
+
 	RootCmd.AddCommand(ConfigCommand)
 }
 
@@ -489,6 +492,13 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if cmd.Flag("project-tld").Changed {
 		app.ProjectTLD = projectTLDArg
+	}
+
+	if cmd.Flag("timezone").Changed {
+		app.Timezone, err = cmd.Flags().GetString("timezone")
+		if err != nil {
+			util.Failed("Incorrect timezone: %v", err)
+		}
 	}
 
 	if uploadDirArg != "" {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -285,7 +285,6 @@ func init() {
 
 	ConfigCommand.Flags().String("timezone", "", "Specify timezone for containers and php, like Europe/London or America/Denver or GMT or UTC")
 
-
 	RootCmd.AddCommand(ConfigCommand)
 }
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -141,6 +141,7 @@ func TestConfigSetValues(t *testing.T) {
 	mailhogPort := "5001"
 	projectTLD := "nowhere.example.com"
 	useDNSWhenPossible := false
+	timezone := "America/Chicago"
 
 	args := []string{
 		"config",
@@ -171,6 +172,7 @@ func TestConfigSetValues(t *testing.T) {
 		"--mailhog-port", mailhogPort,
 		"--project-tld", projectTLD,
 		fmt.Sprintf("--use-dns-when-possible=%t", useDNSWhenPossible),
+		"--timezone", timezone,
 	}
 
 	out, err := exec.RunCommand(DdevBin, args)
@@ -212,6 +214,7 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(mailhogPort, app.MailhogPort)
 	assert.Equal(useDNSWhenPossible, app.UseDNSWhenPossible)
 	assert.Equal(projectTLD, app.ProjectTLD)
+	assert.Equal(timezone, app.Timezone)
 
 	// Test that container images and working dirs can be unset with default flags
 	args = []string{

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -33,6 +33,8 @@ ENV COMPOSER_PROCESS_TIMEOUT 2000
 ENV NGINX_SITE_VARS '$WEBSERVER_DOCROOT,$NGINX_DOCROOT'
 ENV APACHE_SITE_VARS '$WEBSERVER_DOCROOT'
 
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime && dpkg-reconfigure --frontend noninteractive tzdata
+
 RUN apt-get -qq update && \
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
         procps \

--- a/containers/ddev-webserver/files/etc/php/5.6/apache2/php.ini
+++ b/containers/ddev-webserver/files/etc/php/5.6/apache2/php.ini
@@ -71,7 +71,7 @@ mbstring.http_input = pass
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/5.6/cgi/php.ini
+++ b/containers/ddev-webserver/files/etc/php/5.6/cgi/php.ini
@@ -71,7 +71,7 @@ mbstring.http_input = pass
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/5.6/cli/php.ini
+++ b/containers/ddev-webserver/files/etc/php/5.6/cli/php.ini
@@ -72,7 +72,7 @@ mbstring.http_input = pass
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/5.6/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/5.6/fpm/php.ini
@@ -71,7 +71,7 @@ mbstring.http_input = pass
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.0/apache2/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.0/apache2/php.ini
@@ -65,7 +65,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.0/cgi/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.0/cgi/php.ini
@@ -65,7 +65,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.0/cli/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.0/cli/php.ini
@@ -65,7 +65,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.0/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.0/fpm/php.ini
@@ -65,7 +65,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.1/apache2/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.1/apache2/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.1/cgi/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.1/cgi/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.1/cli/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.1/cli/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.1/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.1/fpm/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.2/apache2/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.2/apache2/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.2/cgi/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.2/cgi/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.2/cli/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.2/cli/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.2/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.2/fpm/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.3/apache2/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.3/apache2/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.3/cgi/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.3/cgi/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.3/cli/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.3/cli/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/files/etc/php/7.3/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.3/fpm/php.ini
@@ -64,7 +64,7 @@ default_socket_timeout = 60
 cli_server.color = On
 
 [Date]
-date.timezone = America/Denver
+date.timezone = UTC
 
 [Pdo_mysql]
 pdo_mysql.cache_size = 2000

--- a/containers/ddev-webserver/scripts/start.sh
+++ b/containers/ddev-webserver/scripts/start.sh
@@ -30,6 +30,11 @@ if [ -n "$DDEV_PHP_VERSION" ] ; then
 	export PHP_INI=/etc/php/${DDEV_PHP_VERSION}/fpm/php.ini
 fi
 
+# Set PHP timezone to configured $TZ if there is one
+if [ ! -z ${TZ} ]; then
+    perl -pi -e "s%date.timezone *=.*$%date.timezone = $TZ%g" $(find /etc/php -name php.ini)
+fi
+
 # If the user has provided custom PHP configuration, copy it into a directory
 # where PHP will automatically include it.
 if [ -d /mnt/ddev_config/php ] ; then

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -592,6 +592,7 @@ type composeYAMLVars struct {
 	DockerIP             string
 	IsWindowsFS          bool
 	Hostnames            []string
+	Timezone             string
 }
 
 // RenderComposeYAML renders the contents of docker-compose.yaml.
@@ -634,6 +635,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		MountType:            "bind",
 		WebMount:             "../",
 		Hostnames:            app.GetHostnames(),
+		Timezone:             app.Timezone,
 	}
 	if app.WebcacheEnabled {
 		templateVars.MountType = "volume"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/drud/ddev/pkg/globalconfig"
 
@@ -442,6 +443,10 @@ func (app *DdevApp) ValidateConfig() error {
 
 	if app.WebcacheEnabled && app.NFSMountEnabled {
 		return fmt.Errorf("webcache_enabled and nfs_mount_enabled cannot both be set to true, use one or the other")
+	}
+	_, err = time.LoadLocation(app.Timezone)
+	if err != nil {
+		return fmt.Errorf("invalid timezone %s: %v", app.Timezone, err)
 	}
 
 	return nil

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -551,6 +551,14 @@ func TestConfigValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	assert.Error(err)
 	assert.Contains(err.Error(), "invalid hostname")
+
+	app.Timezone = "xxx"
+	err = app.ValidateConfig()
+	assert.Error(err)
+	app.Timezone = "America/Chicago"
+	err = app.ValidateConfig()
+	assert.NoError(err)
+
 }
 
 // TestWriteConfig tests writing config values to file

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -552,13 +552,13 @@ func TestConfigValidate(t *testing.T) {
 	assert.Error(err)
 	assert.Contains(err.Error(), "invalid hostname")
 
+	app.AdditionalFQDNs = []string{}
 	app.Timezone = "xxx"
 	err = app.ValidateConfig()
 	assert.Error(err)
 	app.Timezone = "America/Chicago"
 	err = app.ValidateConfig()
 	assert.NoError(err)
-
 }
 
 // TestWriteConfig tests writing config values to file

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -8,14 +8,13 @@ import (
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/mattn/go-isatty"
 	"github.com/mattn/go-shellwords"
+	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
-
-	"golang.org/x/crypto/ssh/terminal"
 
 	"strings"
 
@@ -111,6 +110,7 @@ type DdevApp struct {
 	DBImageExtraPackages  []string             `yaml:"dbimage_extra_packages,omitempty,flow"`
 	ProjectTLD            string               `yaml:"project_tld,omitempty"`
 	UseDNSWhenPossible    bool                 `yaml:"use_dns_when_possible"`
+	Timezone              string               `yaml:"timezone"`
 	MkcertEnabled         bool                 `yaml:"-"`
 	NgrokArgs             string               `yaml:"ngrok_args,omitempty"`
 }

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -37,6 +37,7 @@ services:
     environment:
       - COLUMNS=$COLUMNS
       - LINES=$LINES
+      - TZ={{ .Timezone }}
     command: "$DDEV_MARIADB_LOCAL_COMMAND"
     healthcheck:
       interval: 5s
@@ -93,6 +94,7 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - COLUMNS=$COLUMNS
       - LINES=$LINES
+      - TZ={{ .Timezone }}
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
       - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:{{ .MailhogPort }}
@@ -162,6 +164,7 @@ services:
       - PMA_USER=db
       - PMA_PASSWORD=db
       - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - TZ={{ .Timezone }}
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       - HTTP_EXPOSE=${DDEV_PHPMYADMIN_PORT}:{{ .DBAPort }}
     healthcheck:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190618_prestissimo" // Note that this can be overridden by make
+var WebTag = "20190622_timezone" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

People have long needed the timezone to be more easily managed in the container and PHP environment.

#1658 requests that the default timezone for PHP be UTC
#1417 requests configuration of the timezone in config.yaml
#709 requested that it automatically be derived from user TZ, but that's a little hard

## How this PR Solves The Problem:

* Add timezone option to config.yaml
* If TZ is set in container (as result of config.yaml) then update php.ini files with the named timezone

## Manual Testing Instructions:

* Start without extra config. `ddev ssh` and `date` should show time in UTC, `php -r 'print  date_default_timezone_get();'` should show the UTC tz for php, as should `grep -r timezone /etc/php`
* Use `ddev config --timezone=America/Denver` to set timezone to Denver; `ddev ssh` to use `date` in the container; `date` should show time in UTC.  `php -r 'print  date_default_timezone_get();'` should show Denver now.
* Verify the correct tz in db container.

## Automated Testing Overview:

* Has pretty good improved test coverage.

## Related Issue Link(s):

## Release/Deployment notes:

* The [existing Stack Overflow article](https://stackoverflow.com/questions/50255466/how-can-i-set-the-timezone-in-my-ddev-containers) should be updated to show that the old technique is not needed.
