### PR TITLE
Provide docker pull input on ddev start, fixes #1656

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -747,6 +747,14 @@ func (app *DdevApp) Start() error {
 	_ = dockerutil.RemoveVolume(app.GetWebcacheVolName())
 	_ = dockerutil.RemoveVolume(app.GetNFSMountVolName())
 
+	// Pull the main images with full output, since docker-compose up won't
+	// show enough output.
+	for _, imageName := range []string{app.WebImage, app.DBImage} {
+		err = dockerutil.Pull(imageName)
+		if err != nil {
+			return err
+		}
+	}
 	_, _, err = dockerutil.ComposeCmd(files, "up", "--build", "-d")
 	if err != nil {
 		return err

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -620,13 +620,10 @@ func Pull(imageName string) error {
 	if exists {
 		return nil
 	}
-	client := GetDockerClient()
-
-	repoTag := strings.Split(imageName, ":")
-	if len(repoTag) != 2 {
-		return fmt.Errorf("Provided image valid: %s", imageName)
-	}
-	err = client.PullImage(docker.PullImageOptions{Repository: repoTag[0], Tag: repoTag[1], OutputStream: os.Stdout}, docker.AuthConfiguration{})
+	cmd := exec.Command("docker", "pull", imageName)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
 	return err
 }
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -611,6 +611,25 @@ func ImageExistsLocally(imageName string) (bool, error) {
 	return false, nil
 }
 
+// Pull pulls image if it doesn't exist locally.
+func Pull(imageName string) error {
+	exists, err := ImageExistsLocally(imageName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	client := GetDockerClient()
+
+	repoTag := strings.Split(imageName, ":")
+	if len(repoTag) != 2 {
+		return fmt.Errorf("Provided image valid: %s", imageName)
+	}
+	err = client.PullImage(docker.PullImageOptions{Repository: repoTag[0], Tag: repoTag[1], OutputStream: os.Stdout}, docker.AuthConfiguration{})
+	return err
+}
+
 // GetExposedContainerPorts takes a container pointer and returns an array
 // of exposed ports (and error)
 func GetExposedContainerPorts(containerID string) ([]string, error) {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our webimage is quite large, and downloading a new one takes some time, especially on a slower internet connection.

#1656 points out that we could at least provide some feedback while that's happening. `docker-composer up` is not that good at doing this; `docker-compose pull` can be forced to. But rather than that, 

## How this PR Solves The Problem:

Implement dockerutil.Pull() to pull the image with feedback, and do that on Start (if the container doesn't exist) 

## Manual Testing Instructions:

* Stop all projects, `ddev rm -a`
* Find out the current web image using `ddev version` and delete it, for example `docker rmi drud/ddev-webserver:20190622_timezone`
* ddev start

You should see a wonderful amount of feedback about the download

## Automated Testing Overview:

Nothing added

## Related Issue Link(s):

OP #1656

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

