### PR TITLE
Fix ddev share anomalies

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -20,8 +20,8 @@ var DescribeCommand = &cobra.Command{
 information about a ddev project, including its name, location, url, and status.
 It also provides details for MySQL connections, and connection information for
 additional services like MailHog and phpMyAdmin. You can run 'ddev describe' from
-a project directory to stop that project, or you can specify a project to describe by
-running 'ddev stop <projectname>.`,
+a project directory to describe that project, or you can specify a project to describe by
+running 'ddev describe <projectname>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 1 {
 			util.Failed("Too many arguments provided. Please use 'ddev describe' or 'ddev describe [projectname]'")

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -19,7 +19,6 @@ var DdevShareCommand = &cobra.Command{
 ddev share --subdomain some-subdomain
 ddev share --use-http
 ddev share myproject`,
-	//Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 1 {
 			util.Failed("Too many arguments provided. Please use 'ddev share' or 'ddev share [projectname]'")

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -308,8 +308,8 @@ const ConfigInstructions = `
 # For backward compatibility this can be changed to "ddev.local"
 
 # ngrok_args: --subdomain mysite --auth "user:pass"
-# Provide extra arguments to the "ngrok http" command, see 
-# https://ngrok.com/docs#http
+# Provide extra flags to the "ngrok http" command, see 
+# https://ngrok.com/docs#http or run "ngrok http -h"
 
 # provider: default # Currently either "default" or "pantheon"
 #


### PR DESCRIPTION
## The Problem/Issue/Bug:

Testing for v1.9.0 release [here](https://github.com/drud/ddev/issues/1595#issuecomment-505458860) found a couple of problems with `ddev share`:

* extra arguments on the command line were being passed into ngrok
* Flags from config.yaml `ngrok_args` were being put in the wrong place in the ngrok command line.

## How this PR Solves The Problem:

* Remove the handling of `args` from the command
* Allow a single argument of projectname to be specified; if specified, use it.
* Put the flags from ngrok_args *after* the http section

## Manual Testing Instructions:

See [release testing](https://github.com/drud/ddev/issues/1595#issuecomment-505458860)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

