### PR TITLE
Improve linux setup script and docs [skip ci][ci skip]

### DIFF
--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -28,9 +28,13 @@ Also see the debugging section below, and the special WIndows debugging section.
 
 ### Debian/Ubuntu Linux NFS Setup
 
+The nfsmount_enabled feature does not really add performance on Linux systems because Docker on Linux is already quite fast. The primary reason for using it on a Linux systme would be just to keep consistent with other team members working on other host OSs.
+
 Note that for all Linux systems, you can and should install and configure the NFS daemon and configure /etc/exports as you see fit and share the directories that you choose to share. The Debian/Ubuntu Linux script is just one way of accomplishing it. 
 
-Download, inspect, and run the [debian_ubuntu_linux_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh)). This stops running ddev projects, adds your home directory to the /etc/exports config file that nfs uses, and installs nfs-kernel-server  on your computer. This is one-time setup. Note that this shares the /home directory via NFS to all non-routeable ("public") IP addresses in your network, so it's critical to consider security issues and verify that your firewall is enabled and configured. If your DDEV-Local projects are set up outside /home, you'll need to edit /etc/exports for the correct values and restart nfs-kernel-server.
+Download, inspect, and run the [debian_ubuntu_linux_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh)). This stops running ddev projects, adds your home directory to the /etc/exports config file that nfs uses, and installs nfs-kernel-server  on your computer. This is one-time setup. 
+
+Note that the script sets up a very restrictive /etc/exports that is based on the primary IP address of the Linux system at the time the script is run. You may want to edit it to make it less restrictive, or make it very open and use your firewall to control access.
 
 ### Debugging `ddev start` failures with `nfs_mount_enabled: true`
 

--- a/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
+++ b/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
@@ -29,12 +29,21 @@ mkdir -p ~/.ddev
 docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
 
 echo "
-+-----------------------------------------------------+
++-------------------------------------------------------------------------+
 | Setup native NFS on Linux for Docker
-| Only primary IP of machine is allowed client access;
+| Only the primary IP of machine is allowed client access;
 | Your home directory is shared by default.
 | But, of course, pay attention to security.
-+-----------------------------------------------------+
+|
+| Please note that ddev NFS support on Linux is not a particular
+| performance gain, since docker on Linux is already very fast.
+| You may not need/want to use it.
+| If you do use it, this script sets of very restrictive /etc/exports that
+| you will probably need to modify to suit your needs, especially if you're
+| using DHCP and your IP address changes periodically.
+| Please see https://ddev.readthedocs.io/en/stable/users/performance/#debianubuntu-linux-nfs-setup
+| for more information.
++-------------------------------------------------------------------------+
 "
 echo "Stopping running ddev projects"
 
@@ -47,9 +56,13 @@ sudo apt-get install -qq nfs-kernel-server
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
 echo "== Setting up nfs..."
 # Share /home folder. If the projects are elsewhere the /etc/exports will need
-# to be adapted. This grants access to all unrouteable ("public") IP addresses
-# (10.*, 172.16-172.28..., 192.168.*)
+# to be adapted. This grants access ONLY to the host machine's primary IP address
+# (at the time the script was run)
+# You may need to adapt it to be less restrictive in your environment,
+# or of course just use the firewall to restrict access.
 # You are welcome to edit and limit it to the addresses you prefer.
+# Please see https://ddev.readthedocs.io/en/stable/users/performance/#debianubuntu-linux-nfs-setup
+# for more information.
 FILE=/etc/exports
 LINE="${HOME} ${primary_ip}(rw,sync,no_subtree_check)"
 grep -qF -- "$LINE" "$FILE" 2>/dev/null || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )


### PR DESCRIPTION
## The Problem/Issue/Bug:

The "improved" Linux NFS setup script is very strict, and might not work out for real people in a DHCP environment.

And nfsmount_enabled is not particularly useful on Linux anyway.

See Testing for v1.9.0 release [here](https://github.com/drud/ddev/issues/1595#issuecomment-505458860) 


## How this PR Solves The Problem:

Add docs and info in the script to help Linux users to measure and respond to these issues.


