### PR TITLE
Bump container versions for v1.9.0 release

### DIFF
--- a/docs/developers/release-checklist.md
+++ b/docs/developers/release-checklist.md
@@ -1,5 +1,5 @@
 ## `ddev` Release Checklist 
-- [ ] Create provisional tagged images. `git fetch upstream && git checkout upstream/master && cd containers` and `foreach item in *; do pushd $item; make push VERSION=<release_version> DOCKER_ARGS=--no-cache ; popd; done`
+- [ ] Create provisional tagged images. `git fetch upstream && git checkout upstream/master && cd containers` and `for item in *; do pushd $item; make push VERSION=<release_version> DOCKER_ARGS=--no-cache ; popd; done`
 - [ ] Update the default container versions in `pkg/version/version.go` and create a pull request
 - [ ] Ensure all updates have been merged into the master branch
 - [ ] Create a tag for the new version according to the instructions below, initiating a tag build

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,35 +45,35 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190622_timezone" // Note that this can be overridden by make
+var WebTag = "v1.9.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.8.0"
+var BaseDBTag = "v1.9.0"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "v1.8.0" // Note that this can be overridden by make
+var DBATag = "v1.9.0" // Note that this can be overridden by make
 
 // BgsyncImg defines the default bgsync image tag used for applications.
 var BgsyncImg = "drud/ddev-bgsync"
 
 // BgsyncTag defines the default phpmyadmin image tag used for applications.
-var BgsyncTag = "v1.8.0" // Note that this can be overridden by make
+var BgsyncTag = "v1.9.0" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20190527_dont_blow_away_existing_certs" // Note that this can be overridden by make
+var RouterTag = "v1.9.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.8.0"
+var SSHAuthTag = "v1.9.0"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

v1.9.0 needs new container versions. Here they are.

