### PR TITLE
Improve handling of linux case where docker0 is down

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -617,7 +617,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 
 	hostDockerInternalIP, err := dockerutil.GetHostDockerInternalIP()
 	if err != nil {
-		return "", err
+		util.Warning("Could not determine host.docker.internal IP address: %v", err)
 	}
 
 	// The fallthrough default for hostDockerInternalIdentifier is the

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -710,6 +710,8 @@ func GetHostDockerInternalIP() (string, error) {
 			components := strings.Split(addr, " ")
 			if len(components) == 2 {
 				hostDockerInternal = components[1]
+			} else {
+				return "", fmt.Errorf("docker0 interface IP address cannot be determined. You may need to 'ip link set docker0 up' or restart docker or reboot to get xdebug or nfsmount_enabled to work")
 			}
 		}
 	} else if nodeps.IsDockerToolbox() {


### PR DESCRIPTION
## The Problem/Issue/Bug:

There are occasional cases where the docker0 interface is DOWN on Linux. I've seen this  a few times. It means we cannot detect the correct address for host.docker.internal, and thus it doesn't get into docker-compose.yaml extra_hosts, and then xdebug can't work and nfsmount_enabled can't work.

## How this PR Solves The Problem:

Report this situation and suggest options.

## Manual Testing Instructions:

On linux, `sudo ip link set docker0 down` and then `ddev start`. Hopefully you'll see the error.  The problem happens when `ip address show dev docker0` doesn't display an IP address.

## Automated Testing Overview:

No idea how this would be testable.
