### PR TITLE
Fix crash encountered with old global_config.yaml

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -164,7 +164,7 @@ func checkDdevVersionAndOptInSentry() error {
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true
 		}
-		globalconfig.DdevGlobalConfig.LastUsedVersion = version.COMMIT
+		globalconfig.DdevGlobalConfig.LastUsedVersion = version.VERSION
 		err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 		if err != nil {
 			return err

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -92,6 +92,9 @@ func ReadGlobalConfig() error {
 	if err != nil {
 		return err
 	}
+	if DdevGlobalConfig.ProjectList == nil {
+		DdevGlobalConfig.ProjectList = map[string]*ProjectInfo{}
+	}
 
 	err = ValidateGlobalConfig()
 	if err != nil {
@@ -102,7 +105,7 @@ func ReadGlobalConfig() error {
 
 // WriteGlobalConfig writes the global config into ~/.ddev.
 func WriteGlobalConfig(config GlobalConfig) error {
-
+	config.APIVersion = version.VERSION
 	err := ValidateGlobalConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
## The Problem/Issue/Bug:

A user upgrading from v1.5 to v1.9.0 had a nasty crash on every command. 

```
$ ddev config
You are reconfiguring the project at /Users/rfay/workspace/d8git.
The existing configuration will be updated and replaced.
Project name (d8git):

The docroot is the directory from which your site is served.
This is a relative path from your project root at /Users/rfay/workspace/d8git
You may leave this value blank if your site files are in the project root
Docroot Location (current directory):
Found a drupal8 codebase at /Users/rfay/workspace/d8git.
Project Type [php, drupal6, drupal7, drupal8, wordpress, typo3, backdrop] (drupal8):
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/drud/ddev/pkg/globalconfig.ReservePorts(0xc0001dd128, 0x5, 0x22bc008, 0x0, 0x0, 0xc0004b2000, 0x17)
	/workdir/pkg/globalconfig/global_config.go:241 +0x16d
github.com/drud/ddev/pkg/ddevapp.(*DdevApp).UpdateGlobalProjectList(0xc0003c0280, 0xc00024ad40, 0x17)
	/workdir/pkg/ddevapp/config.go:289 +0x108
github.com/drud/ddev/pkg/ddevapp.(*DdevApp).WriteConfig(0xc0003c0280, 0x0, 0x0)
	/workdir/pkg/ddevapp/config.go:182 +0x5b8
github.com/drud/ddev/cmd/ddev/cmd.handleConfigRun(0x228dce0, 0x22bc008, 0x0, 0x0)
	/workdir/cmd/ddev/cmd/config.go:199 +0x23b
github.com/spf13/cobra.(*Command).execute(0x228dce0, 0x22bc008, 0x0, 0x0, 0x228dce0, 0x22bc008)
	/workdir/vendor/github.com/spf13/cobra/command.go:766 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0x2290a00, 0x0, 0x0, 0x1824acd)
	/workdir/vendor/github.com/spf13/cobra/command.go:852 +0x2ec
github.com/spf13/cobra.(*Command).Execute(...)
	/workdir/vendor/github.com/spf13/cobra/command.go:800
github.com/drud/ddev/cmd/ddev/cmd.Execute()
	/workdir/cmd/ddev/cmd/root.go:131 +0x3e
main.main()
	/workdir/cmd/ddev/main.go:12 +0x20
```

His global_config.yaml was:
```
APIVersion: v1.5.0
omit_containers: []
instrumentation_opt_in: true
last_used_version: v1.5.0
```

## How this PR Solves The Problem:

The existing code assumed that the ProjectList (project_info) was already initialized, which it would have been from at least v1.8.0 on, but this was from v1.5.0, and it wasn't initialized. 

The code in question was https://github.com/drud/ddev/blob/d8892b78d71fcf5386ec1df396887b2e64a8441b/pkg/globalconfig/global_config.go#L243-L245

The basic solution is to make sure that the ProjectList gets initialized even if it's not encountered in the yaml.

## Manual Testing Instructions:

* Use the global_config.yaml above (or just delete project_list from existing one.
* ddev config

Without the patch it should panic. With the patch it should behave correctly.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

