### PR TITLE
Quiet down healthchecks to save battery and CPU usage, fixes #1663

### DIFF
--- a/containers/ddev-dbserver/10.1/Dockerfile
+++ b/containers/ddev-dbserver/10.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.1.38-bionic
+FROM mariadb:10.1.40-bionic
 
 ENV MYSQL_DATABASE db
 ENV MYSQL_USER db
@@ -26,4 +26,4 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 3306
 # The following line overrides any cmd entry
 CMD []
-HEALTHCHECK --interval=2s --retries=30 CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=1s --retries=30 --timeout=120s CMD ["/healthcheck.sh"]

--- a/containers/ddev-dbserver/10.1/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/10.1/files/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -eu
 set -o pipefail
 
 SOCKET=/var/tmp/mysql.sock
+rm -f /tmp/healthy
 
 # Wait for mysql server to be ready.
 function serverwait {

--- a/containers/ddev-dbserver/10.1/files/healthcheck.sh
+++ b/containers/ddev-dbserver/10.1/files/healthcheck.sh
@@ -3,6 +3,25 @@
 ## mysql health check for docker. original source: https://github.com/docker-library/healthcheck/blob/master/mysql/docker-healthcheck
 
 set -eo pipefail
+sleeptime=59
 
-mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null
+# Since docker doesn't provide a lazy period for startup,
+# we track health. If the last check showed healthy
+# as determined by existence of /tmp/healthy, then
+# sleep at startup. This requires the timeout to be set
+# higher than the sleeptime used here.
+if [ -f /tmp/healthy ]; then
+    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
+    sleep ${sleeptime}
+fi
+
+
+if mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
+    printf "healthy"
+    touch /tmp/healthy
+    exit 0
+fi
+
+rm -f /tmp/healthy
+exit 1
 

--- a/containers/ddev-dbserver/10.2/Dockerfile
+++ b/containers/ddev-dbserver/10.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.2.22
+FROM mariadb:10.2.25
 
 ENV MYSQL_DATABASE db
 ENV MYSQL_USER db
@@ -26,4 +26,4 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 3306
 # The following line overrides any cmd entry
 CMD []
-HEALTHCHECK --interval=2s --retries=30 CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=1s --retries=30 --timeout=120s CMD ["/healthcheck.sh"]

--- a/containers/ddev-dbserver/10.2/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/10.2/files/docker-entrypoint.sh
@@ -5,6 +5,8 @@ set -o pipefail
 
 SOCKET=/var/tmp/mysql.sock
 
+rm -f /tmp/healthy
+
 # Wait for mysql server to be ready.
 function serverwait {
 	for i in {60..0};

--- a/containers/ddev-dbserver/10.2/files/healthcheck.sh
+++ b/containers/ddev-dbserver/10.2/files/healthcheck.sh
@@ -3,6 +3,25 @@
 ## mysql health check for docker. original source: https://github.com/docker-library/healthcheck/blob/master/mysql/docker-healthcheck
 
 set -eo pipefail
+sleeptime=59
 
-mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null
+# Since docker doesn't provide a lazy period for startup,
+# we track health. If the last check showed healthy
+# as determined by existence of /tmp/healthy, then
+# sleep at startup. This requires the timeout to be set
+# higher than the sleeptime used here.
+if [ -f /tmp/healthy ]; then
+    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
+    sleep ${sleeptime}
+fi
+
+
+if mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
+    printf "healthy"
+    touch /tmp/healthy
+    exit 0
+fi
+
+rm -f /tmp/healthy
+exit 1
 

--- a/containers/ddev-router/Dockerfile
+++ b/containers/ddev-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15.12
+FROM nginx:1.17.0
 
 ENV MKCERT_VERSION=v1.3.0
 
@@ -34,4 +34,4 @@ ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["forego", "start", "-r"]
 WORKDIR /app/
 
-HEALTHCHECK --interval=5s --retries=5 CMD /app/healthcheck.sh
+HEALTHCHECK --interval=1s --retries=10 --timeout=120s CMD /app/healthcheck.sh

--- a/containers/ddev-router/Dockerfile
+++ b/containers/ddev-router/Dockerfile
@@ -34,4 +34,4 @@ ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["forego", "start", "-r"]
 WORKDIR /app/
 
-HEALTHCHECK --interval=1s --retries=10 --timeout=120s CMD /app/healthcheck.sh
+HEALTHCHECK --interval=1s --retries=10 --timeout=120s --start-period=10s CMD /app/healthcheck.sh

--- a/containers/ddev-router/docker-entrypoint.sh
+++ b/containers/ddev-router/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+rm -f /tmp/healthy
+
 # Warn if the DOCKER_HOST socket does not exist
 if [[ $DOCKER_HOST = unix://* ]]; then
 	socket_file=${DOCKER_HOST#unix://}

--- a/containers/ddev-router/healthcheck.sh
+++ b/containers/ddev-router/healthcheck.sh
@@ -2,7 +2,39 @@
 set -eu
 set -o pipefail
 
-# Check nginx config
-nginx -t || exit 1
+sleeptime=59
+
+# Since docker doesn't provide a lazy period for startup,
+# we track health. If the last check showed healthy
+# as determined by existence of /tmp/healthy, then
+# sleep at startup. This requires the timeout to be set
+# higher than the sleeptime used here.
+if [ -f /tmp/healthy ]; then
+    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
+    sleep ${sleeptime}
+fi
+
+config=false
+connect=false
+
+if nginx -t ; then
+    config=true
+    printf "nginx config: OK  "
+fi
+
 # Check our healthcheck endpoint
-curl --fail --connect-timeout 2 --retry 2 http://127.0.0.1/healthcheck || (echo "ddev-router healthcheck endpoint not responding" && exit 2)
+if curl --fail --connect-timeout 2 --retry 2 http://127.0.0.1/healthcheck; then
+    connect=true
+    echo "nginx healthcheck endpoint: OK "
+else
+    echo "ddev-router healthcheck endpoint not responding "
+fi
+
+if [ ${config} = true -a ${connect} = true ]; then
+    printf "healthy"
+    touch /tmp/healthy
+    exit 0
+fi
+
+rm -f /tmp/healthy
+exit 1

--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -22,7 +22,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-FROM alpine:3.8
+FROM alpine:3.10
 
 # Install dependencies
 RUN apk add --no-cache \
@@ -48,7 +48,7 @@ RUN ln -s $SSH_KEY_DIR /home/.ssh
 
 RUN mkdir ${SOCKET_DIR} && mkdir ${SSH_KEY_DIR} && chmod 777 ${SOCKET_DIR} ${SSH_KEY_DIR}
 
-HEALTHCHECK --interval=2s --retries=5 CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=1s --retries=5 --timeout=120s CMD ["/healthcheck.sh"]
 
 VOLUME ${SOCKET_DIR}
 

--- a/containers/ddev-ssh-agent/files/entry.sh
+++ b/containers/ddev-ssh-agent/files/entry.sh
@@ -21,6 +21,7 @@
 
 
 set -eo pipefail
+rm -f /tmp/healthy
 
 # Print a debug message if debug mode is on ($DEBUG is not empty)
 # @param message

--- a/containers/ddev-ssh-agent/files/healthcheck.sh
+++ b/containers/ddev-ssh-agent/files/healthcheck.sh
@@ -3,7 +3,21 @@
 # ddev-ssh-agent healthcheck
 
 set -eo pipefail
+sleeptime=59
 
 # Make sure that both socat and ssh-agent are running
-killall -0 socat && killall -0 ssh-agent
+# Since docker doesn't provide a lazy period for startup,
+# we track health. If the last check showed healthy
+# as determined by existence of /tmp/healthy, then
+# sleep at startup. This requires the timeout to be set
+# higher than the sleeptime used here.
+if [ -f /tmp/healthy ]; then
+    sleep ${sleeptime}
+fi
+if killall -0 socat ssh-agent; then
+    touch /tmp/healthy
+    exit 0
+fi
+rm -f /tmp/healthy
+exit 1
 

--- a/containers/ddev-ssh-agent/files/healthcheck.sh
+++ b/containers/ddev-ssh-agent/files/healthcheck.sh
@@ -12,9 +12,11 @@ sleeptime=59
 # sleep at startup. This requires the timeout to be set
 # higher than the sleeptime used here.
 if [ -f /tmp/healthy ]; then
+    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
     sleep ${sleeptime}
 fi
 if killall -0 socat ssh-agent; then
+    printf "healthy"
     touch /tmp/healthy
     exit 0
 fi

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -151,6 +151,6 @@ RUN chmod ugo+x /start.sh /healthcheck.sh
 
 
 EXPOSE 80 8025
-HEALTHCHECK --interval=3s --retries=6 CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=1s --retries=10 --timeout=120s CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]

--- a/containers/ddev-webserver/scripts/healthcheck.sh
+++ b/containers/ddev-webserver/scripts/healthcheck.sh
@@ -23,7 +23,7 @@ htmlaccess=false
 mailhog=false
 if curl --fail -s 127.0.0.1/phpstatus >/dev/null ; then
     phpstatus=true
-    printf "phpstatus: Ok "
+    printf "phpstatus: OK "
 else
     printf "phpstatus FAILED "
 fi

--- a/containers/ddev-webserver/scripts/healthcheck.sh
+++ b/containers/ddev-webserver/scripts/healthcheck.sh
@@ -4,6 +4,49 @@
 
 set -eo pipefail
 
-curl --fail -s 127.0.0.1/phpstatus >/dev/null && printf "phpstatus: OK, " || (printf "phpstatus FAILED" && exit 1)
-ls /var/www/html >/dev/null && printf "/var/www/html: OK, " || (printf "/var/www/html access FAILED" && exit 2)
-curl --fail -s localhost:8025 >/dev/null && printf "mailhog: OK" || (printf "mailhog FAILED" && exit 3)
+sleeptime=59
+
+# Make sure that both phpstatus, mounted code, and mailhog
+# are working.
+# Since docker doesn't provide a lazy period for startup,
+# we track health. If the last check showed healthy
+# as determined by existence of /tmp/healthy, then
+# sleep at startup. This requires the timeout to be set
+# higher than the sleeptime used here.
+if [ -f /tmp/healthy ]; then
+    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
+    sleep ${sleeptime}
+fi
+
+phpstatus=false
+htmlaccess=false
+mailhog=false
+if curl --fail -s 127.0.0.1/phpstatus >/dev/null ; then
+    phpstatus=true
+    printf "phpstatus: Ok "
+else
+    printf "phpstatus FAILED "
+fi
+
+if ls /var/www/html >/dev/null; then
+    htmlstatus=true
+    printf "/var/www/html: OK "
+else
+    printf "/var/www/html access FAILED"
+fi
+
+if curl --fail -s localhost:8025 >/dev/null; then
+    mailhog=true
+    printf "mailhog: OK " ;
+else
+    printf "mailhog FAILED "
+fi
+
+if ${phpstatus} = true -a ${htmlaccess} = true -a ${mailhog} = true ; then
+    touch /tmp/healthy
+    exit 0
+fi
+rm -f /tmp/healthy
+exit 1
+
+

--- a/containers/ddev-webserver/scripts/start.sh
+++ b/containers/ddev-webserver/scripts/start.sh
@@ -2,6 +2,8 @@
 set -x
 set -o errexit nounset pipefail
 
+rm -f /tmp/healthy
+
 # If DDEV_PHP_VERSION isn't set, use a reasonable default
 DDEV_PHP_VERSION="${DDEV_PHP_VERSION:-$PHP_DEFAULT_VERSION}"
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -40,9 +40,10 @@ services:
       - TZ={{ .Timezone }}
     command: "$DDEV_MARIADB_LOCAL_COMMAND"
     healthcheck:
-      interval: 5s
-      retries: 12
-      start_period: 60s
+      interval: 1s
+      retries: 10
+      start_period: 10s
+      timeout: 120s
   web:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
     {{ if .WebBuildContext }}
@@ -169,7 +170,7 @@ services:
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       - HTTP_EXPOSE=${DDEV_PHPMYADMIN_PORT}:{{ .DBAPort }}
     healthcheck:
-      interval: 90s
+      interval: 120s
       timeout: 2s
       retries: 1
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -114,9 +114,10 @@ services:
     {{ range $hostname := .Hostnames }}- "ddev-router:{{ $hostname }}" 
     {{ end }}
     healthcheck:
-      interval: 4s
-      retries: 6
+      interval: 1s
+      retries: 10
       start_period: 10s
+      timeout: 120s
 {{ if .WebcacheEnabled }}
   bgsync:
     container_name: ddev-${DDEV_SITENAME}-bgsync

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -399,9 +399,10 @@ services:
       - ddev-global-cache:/mnt/ddev-global-cache:rw
     restart: "no"
     healthcheck:
-      interval: 6s
-      retries: 6
+      interval: 1s
+      retries: 10
       start_period: 10s
+      timeout: 120s
 
 networks:
    default:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -427,8 +427,10 @@ services:
     environment:
       - SSH_AUTH_SOCK=/tmp/.ssh-agent/socket
     healthcheck:
-      interval: 2s
-      retries: 5
+      interval: 1s
+      retries: 2
+      start_period: 10s
+      timeout: 62s
 networks:
   default:
     external:

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -126,11 +126,11 @@ func TestGetContainerHealth(t *testing.T) {
 	healthDetail, err := ContainerWait(15, labels)
 	assert.NoError(err)
 
-	assert.Equal("phpstatus: Ok /var/www/html: OK mailhog: OK ", healthDetail)
+	assert.Equal("phpstatus: OK /var/www/html: OK mailhog: OK ", healthDetail)
 
 	status, healthDetail = GetContainerHealth(container)
 	assert.Equal(status, "healthy")
-	assert.Equal("phpstatus: Ok /var/www/html: OK mailhog: OK ", healthDetail)
+	assert.Equal("phpstatus: OK /var/www/html: OK mailhog: OK ", healthDetail)
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -64,7 +64,6 @@ func TestMain(m *testing.M) {
 			},
 			Env: []string{"HOTDOG=superior-to-corndog", "POTATO=future-fry"},
 		},
-		//          "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
 		HostConfig: &docker.HostConfig{
 			PortBindings: map[docker.Port][]docker.PortBinding{
 				"80/tcp": {

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -126,11 +126,11 @@ func TestGetContainerHealth(t *testing.T) {
 	healthDetail, err := ContainerWait(15, labels)
 	assert.NoError(err)
 
-	assert.Equal("phpstatus: OK, /var/www/html: OK, mailhog: OK", healthDetail)
+	assert.Equal("phpstatus: Ok /var/www/html: OK mailhog: OK ", healthDetail)
 
 	status, healthDetail = GetContainerHealth(container)
 	assert.Equal(status, "healthy")
-	assert.Equal("phpstatus: OK, /var/www/html: OK, mailhog: OK", healthDetail)
+	assert.Equal("phpstatus: Ok /var/www/html: OK mailhog: OK ", healthDetail)
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ var WebTag = "20190626_healthcheck" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.9.0"
+var BaseDBTag = "20190626_healthcheck"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -69,7 +69,7 @@ var BgsyncTag = "v1.9.0" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.9.0" // Note that this can be overridden by make
+var RouterTag = "20190626_healthcheck" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190626_apache" // Note that this can be overridden by make
+var WebTag = "20190626_healthcheck" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -73,7 +73,7 @@ var RouterTag = "v1.9.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.9.0"
+var SSHAuthTag = "20190626_healthcheck"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1663 complains about the constant running of the ddev-ssh-agent healthcheck, which uses CPU and battery. But really most of the containers have this problem, and with the other ones it multiplies.

Docker provides us only the "interval" configuration for healthcheck, which is *both* the time to wait before the first healthcheck *and* how often to run it after that. 

In ddev, we mostly care about when it *first* becomes ready and usable, and it doesn't often need to be checked after that, but we were always stymied by Docker's design mistake here.

## How this PR Solves The Problem:

This is admittedly a hacky approach, but

* Use a 1 second interval. Docker will wait only 1 second before trying it the first time, and will try thereafter every 1 second.
* Use a long 120s timeout, meaning docker will wait that long for a response
* Track the health status out-of-band, by creating /tmp/healthy when we find it's healthy.
* If the healthcheck finds on startup that it most recently was healthy, sleep for a defined time (configured here to a minute or so) before checking. That slows down the whole healthcheck routine.
* The start script deletes /tmp/healthy. This solves the case where a container is docker-stopped (paused in ddev parlance) and then started. The start script on resuming deletes /tmp/healthy so we get a fresh start checking healthy.

## Manual Testing Instructions:

`ddev stop -a --stop-ssh-agent` and `ddev start`
Look at your computer's CPU usage.
Look at `docker events`, you should see far less than previously.
An interesting tool is `docker inspect ddev-router | jq ".[].State.Health"`, which shows the last few healthchecks and their result (change container name as necessary). This is particularly interesting early in the life of a container.

## Automated Testing Overview:

None provided. 

## Related Issue Link(s):

OP #1663 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

