### PR TITLE
Pre-enable common apache modules, fixes #1672

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -140,7 +140,7 @@ RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.lo
 
 RUN for v in $PHP_VERSIONS; do a2dismod $v; done
 RUN a2dismod mpm_event
-RUN a2enmod ssl
+RUN a2enmod ssl headers expires
 
 # ssh is very particular about permissions in ~/.ssh
 RUN chmod -R go-w /home/.ssh

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.9.0" // Note that this can be overridden by make
+var WebTag = "20190626_apache" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1672 suggests that we enable a few common apache modules by default

## How this PR Solves The Problem:

Enable headers, expires

## Manual Testing Instructions:

* configure a project for apache-fpm and `ddev start`
* `ddev ssh`
* `apachectl -M` shows modules enabled; expires and headers should be in that list now.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #1672

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

