### PR TITLE
Stop reporting last status from ddev ssh, fixes #1681

### DIFF
--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -39,15 +39,11 @@ var DdevSSHCmd = &cobra.Command{
 		if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, serviceType) {
 			shell = "sh"
 		}
-		err = app.ExecWithTty(&ddevapp.ExecOpts{
+		_ = app.ExecWithTty(&ddevapp.ExecOpts{
 			Service: serviceType,
 			Cmd:     shell,
 			Dir:     sshDirArg,
 		})
-
-		if err != nil {
-			util.Failed("Failed to ssh %s: %s", app.GetName(), err)
-		}
 	},
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1681 notes that `ddev ssh` will display an error on exit if the last shell command returned an error. 

## How this PR Solves The Problem:

Stop reporting the results of ExecWithTty() when using it in the ssh command.

## Manual Testing Instructions:

`ddev ssh`, cause an error with `ls /tmp/junk`, then "exit" or <ctrl-d>
You should not see an error.

## Automated Testing Overview:
No testing changes

## Related Issue Link(s):

OP #1681

## Release/Deployment notes:

Note that this removes all error checking on the ExecWithTty() command. 
