### PR TITLE
Bind router functions only on docker interface (usually localhost), fixes #1662

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -59,17 +59,20 @@ func StartDdevRouter() error {
 	}
 	defer util.CheckClose(f)
 
-	templ := template.New("compose template")
+	templ := template.New("routerTemplate")
 	templ, err := templ.Parse(DdevRouterTemplate)
 	if err != nil {
 		return err
 	}
+
+	dockerIP, _ := dockerutil.GetDockerIP()
 
 	templateVars := map[string]interface{}{
 		"router_image":    version.RouterImage,
 		"router_tag":      version.RouterTag,
 		"ports":           newExposedPorts,
 		"compose_version": version.DockerComposeFileFormatVersion,
+		"dockerIP":        dockerIP,
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -80,7 +80,6 @@ services:
     ports:
       - "{{ .DockerIP }}:$DDEV_HOST_WEBSERVER_PORT:80"
       - "{{ .DockerIP }}:$DDEV_HOST_HTTPS_PORT:443"
-      - "{{ .MailhogPort }}"
     environment:
       - DOCROOT=$DDEV_DOCROOT
       - DDEV_PHP_VERSION=$DDEV_PHP_VERSION
@@ -392,7 +391,7 @@ services:
     image: {{ .router_image }}:{{ .router_tag }}
     container_name: ddev-router
     ports:
-      {{ range $port := .ports }}- "{{ $port }}:{{ $port }}"
+      {{ $dockerIP := .dockerIP }}{{ range $port := .ports }}- "{{ $dockerIP }}:{{ $port }}:{{ $port }}"
       {{ end }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro


### PR DESCRIPTION
## The Problem/Issue/Bug:

ddev-router was binding its ports on all network interfaces, see #1662. This allowed everybody on the local network to access http, https, and most importantly phpMyAdmin without any controls at all. 

## How this PR Solves The Problem:

Bind the web and phpMyAdmin (and mailHog) ports only on the docker IP.

## Manual Testing Instructions:

* Start a project
* Attempt to access from another computer or direct to non-docker ip. 

For example, if your laptop's main IP address is `192.168.1.140` then `curl http://192.168.1.140:80` should not connect (assumes ddev is listening on 80)

## Automated Testing Overview:

* No new tests

## Related Issue Link(s):

OP #1662
https://github.com/drud/ddev/pull/1502 fixed this for an earlier set of ports, based on #1491 

## Release/Deployment notes:

* Announce in release notes
* Note that the local ephemeral binding mailhog (to 127.0.0.1) goes away here, it didn't seem to be necessary.