### PR TITLE
Add TYPO3 GFX configuration for ImageMagick6

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -34,6 +34,11 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_server'] = 'localhost:1025';
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'] = '*';
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = 1;
+
+// This GFX configuration allows processing by installed ImageMagick 6
+$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = 'ImageMagick';
+$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path'] = '/usr/bin/';
+$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path_lzw'] = '/usr/bin/';
 `
 
 // createTypo3SettingsFile creates the app's LocalConfiguration.php and


### PR DESCRIPTION
In order to configure system to process images. Otherwise possible
existing project configuration within LocalConfiguration.php might
prevent processing, due to configured GraphicsMagick or different paths.

Resolves: #1710 

## Automated Testing Overview:
I've didn't find instructions how to execute existing tests, therefore none were executed or adjusted or added.

## Related Issue Link(s):
#1710 
