### PR TITLE
Use testdata with longer timeouts on dockerutil tests (tests only)

### DIFF
--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -28,4 +28,10 @@ services:
       com.ddev.platform: ddev
       com.ddev.site-name: TestComposeWithStreams
     restart: "no"
+    healthcheck:
+      interval: 1s
+      retries: 25
+      start_period: 20s
+      timeout: 120s
+
 version: '3.6'

--- a/pkg/dockerutil/testdata/docker-compose.yml
+++ b/pkg/dockerutil/testdata/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       com.ddev.site-name: test
       com.ddev.platform: local
       com.ddev.app-type: wordpress
+    healthcheck:
+      interval: 1s
+      retries: 25
+      start_period: 20s
+      timeout: 120s
 networks:
   default:
     external:


### PR DESCRIPTION
## The Problem/Issue/Bug:

Some dockerutil tests occasionally give odd results, perhaps because the docker-compose.yaml used doesn't provide proper healthcheck intervals that match current containers.

## How this PR Solves The Problem:

Update to what we use in the regular docker-compose.yaml

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

