### PR TITLE
Add target app arguments to ddev restart and ddev ssh

### DIFF
--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -1,53 +1,50 @@
 package cmd
 
 import (
-	"os"
 	"strings"
 
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
 
-// DdevRestartCmd rebuilds an apps settings
-var DdevRestartCmd = &cobra.Command{
-	Use:   "restart",
-	Short: "Restart a project.",
-	Long:  `Restart removes the containers for a project and starts them back up again.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if len(args) > 0 {
-			err := cmd.Usage()
-			util.CheckErr(err)
-			os.Exit(0)
-		}
+var restartAll bool
 
+// RestartCmd rebuilds an apps settings
+var RestartCmd = &cobra.Command{
+	Use:   "restart [projects]",
+	Short: "Restart a project or several projects.",
+	Long:  `Stops named projects and then starts them back up again.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
 		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := ddevapp.GetActiveApp("")
+		projects, err := getRequestedProjects(args, restartAll)
 		if err != nil {
-			util.Failed("Failed to restart: %v", err)
+			util.Failed("Failed to get project(s): %v", err)
 		}
 
-		output.UserOut.Printf("Restarting project %s...", app.GetName())
-		err = app.Stop(false, false)
-		if err != nil {
-			util.Failed("Failed to restart %s: %v", app.GetName(), err)
-		}
+		for _, app := range projects {
 
-		err = app.Start()
-		if err != nil {
-			util.Failed("Failed to restart %s: %v", app.GetName(), err)
-		}
+			output.UserOut.Printf("Restarting project %s...", app.GetName())
+			err = app.Stop(false, false)
+			if err != nil {
+				util.Failed("Failed to restart %s: %v", app.GetName(), err)
+			}
 
-		util.Success("Successfully restarted %s", app.GetName())
-		util.Success("Your project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
+			err = app.Start()
+			if err != nil {
+				util.Failed("Failed to restart %s: %v", app.GetName(), err)
+			}
+
+			util.Success("Restarted %s", app.GetName())
+			util.Success("Your project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
+		}
 	},
 }
 
 func init() {
-	RootCmd.AddCommand(DdevRestartCmd)
-
+	RestartCmd.Flags().BoolVarP(&restartAll, "all", "a", false, "restart all projects")
+	RootCmd.AddCommand(RestartCmd)
 }

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -14,14 +14,17 @@ var sshDirArg string
 
 // DdevSSHCmd represents the ssh command.
 var DdevSSHCmd = &cobra.Command{
-	Use:   "ssh",
+	Use: "ssh [projectname]",
+
 	Short: "Starts a shell session in the container for a service. Uses web service by default.",
 	Long:  `Starts a shell session in the container for a service. Uses web service by default. To start a shell session for another service, run "ddev ssh --service <service>`,
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := ddevapp.GetActiveApp("")
+		projects, err := getRequestedProjects(args, false)
 		if err != nil {
-			util.Failed("Failed to ssh: %v", err)
+			util.Failed("Failed to ddev ssh: %v", err)
 		}
+		app := projects[0]
 
 		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
 			util.Failed("Project is not currently running. Try 'ddev start'.")

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -57,6 +57,6 @@ any directory by running 'ddev start projectname [projectname ...]'`,
 }
 
 func init() {
-	StartCmd.Flags().BoolVarP(&startAll, "all", "a", false, "Start all stopped projects")
+	StartCmd.Flags().BoolVarP(&startAll, "all", "a", false, "Start all projects")
 	RootCmd.AddCommand(StartCmd)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

* @cyberswat pointed out the other day that `ddev restart` should take project args (and -a). Just a matter of consistency.
* Also `ddev ssh` has always needed a project arg, so you can run it even if you're not in the directory.

## How this PR Solves The Problem:

Add the args

## Manual Testing Instructions:

* `ddev restart -a`
* `ddev restart <project1> <project2>
* ddev ssh 
* ddev ssh <project>

## Automated Testing Overview:

I didn't add any tests.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

