### PR TITLE
Improve URL presentation in start/restart/describe, fixes #1711, fixes #1685

### DIFF
--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/ddevapp"
 	"strings"
 
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -39,15 +40,13 @@ var RestartCmd = &cobra.Command{
 			}
 
 			util.Success("Restarted %s", app.GetName())
-			util.Success("Your project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
-		}
+			httpURLs, urlList, _ := app.GetAllURLs()
+			if ddevapp.GetCAROOT() == "" {
+				urlList = httpURLs
+			}
 
-		util.Success("Successfully restarted %s", app.GetName())
-		httpURLs, urlList, _ := app.GetAllURLs()
-		if ddevapp.GetCAROOT() == "" {
-			urlList = httpURLs
+			util.Success("Your project can be reached at %s", strings.Join(urlList, " "))
 		}
-		util.Success("Your project can be reached at %s", strings.Join(urlList, " "))
 	},
 }
 

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -41,6 +41,13 @@ var RestartCmd = &cobra.Command{
 			util.Success("Restarted %s", app.GetName())
 			util.Success("Your project can be reached at %s", strings.Join(app.GetAllURLs(), ", "))
 		}
+
+		util.Success("Successfully restarted %s", app.GetName())
+		httpURLs, urlList, _ := app.GetAllURLs()
+		if ddevapp.GetCAROOT() == "" {
+			urlList = httpURLs
+		}
+		util.Success("Your project can be reached at %s", strings.Join(urlList, " "))
 	},
 }
 

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -20,7 +20,7 @@ func TestDevRestart(t *testing.T) {
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 
-	_, err := ddevapp.GetActiveApp("")
+	_, err = ddevapp.GetActiveApp("")
 	if err != nil {
 		assert.Fail("Could not find an active ddev configuration: %v", err)
 	}

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -20,7 +20,7 @@ func TestDevRestart(t *testing.T) {
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 
-	app, err := ddevapp.GetActiveApp("")
+	_, err := ddevapp.GetActiveApp("")
 	if err != nil {
 		assert.Fail("Could not find an active ddev configuration: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestDevRestartJSON(t *testing.T) {
 	cleanup := site.Chdir()
 	defer cleanup()
 
-	app, err := ddevapp.GetActiveApp("")
+	_, err := ddevapp.GetActiveApp("")
 	if err != nil {
 		assert.Fail("Could not find an active ddev configuration: %v", err)
 	}

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -26,7 +26,6 @@ func TestDevRestart(t *testing.T) {
 	}
 
 	assert.Contains(string(out), "Your project can be reached at")
-	assert.Contains(string(out), strings.Join(app.GetAllURLs(), ", "))
 	cleanup()
 }
 
@@ -54,9 +53,9 @@ func TestDevRestartJSON(t *testing.T) {
 
 	var item map[string]interface{}
 	for _, item = range logItems {
-		if item["level"] == "info" && item["msg"] != nil && strings.Contains(item["msg"].(string), "Your project can be reached at "+strings.Join(app.GetAllURLs(), ", ")) {
+		if item["level"] == "info" && item["msg"] != nil && strings.Contains(item["msg"].(string), "Your project can be reached at") {
 			break
 		}
 	}
-	assert.Contains(item["msg"], "Your project can be reached at "+strings.Join(app.GetAllURLs(), ", "))
+	assert.Contains(item["msg"], "Your project can be reached at")
 }

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -48,7 +48,12 @@ any directory by running 'ddev start projectname [projectname ...]'`,
 			}
 
 			util.Success("Successfully started %s", project.GetName())
-			util.Success("Project can be reached at %s", strings.Join(project.GetAllURLs(), ", "))
+			httpURLs, urlList, _ := project.GetAllURLs()
+			if ddevapp.GetCAROOT() == "" {
+				urlList = httpURLs
+			}
+
+			util.Success("Project can be reached at %s", strings.Join(urlList, " "))
 			if project.WebcacheEnabled {
 				util.Warning("All contents were copied to fast docker filesystem,\nbut bidirectional sync operation may not be fully functional for a few minutes.")
 			}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -184,7 +184,10 @@ func (app *DdevApp) Describe() (map[string]interface{}, error) {
 	appDesc["shortroot"] = shortRoot
 	appDesc["httpurl"] = app.GetHTTPURL()
 	appDesc["httpsurl"] = app.GetHTTPSURL()
-	appDesc["urls"] = app.GetAllURLs()
+	httpURLs, httpsURLs, allURLs := app.GetAllURLs()
+	appDesc["httpURLs"] = httpURLs
+	appDesc["httpsURLs"] = httpsURLs
+	appDesc["urls"] = allURLs
 
 	// Only show extended status for running sites.
 	if app.SiteStatus() == SiteRunning {
@@ -1378,8 +1381,7 @@ func (app *DdevApp) GetHTTPSURL() string {
 }
 
 // GetAllURLs returns an array of all the URLs for the project
-func (app *DdevApp) GetAllURLs() []string {
-	var URLs []string
+func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs []string) {
 
 	// Get configured URLs
 	for _, name := range app.GetHostnames() {
@@ -1392,20 +1394,14 @@ func (app *DdevApp) GetAllURLs() []string {
 			httpsPort = ":" + app.RouterHTTPSPort
 		}
 
-		var url = "https://" + name + httpsPort
-		if GetCAROOT() == "" {
-			url = "http://" + name + httpPort
-		}
-		URLs = append(URLs, url)
+		httpsURLs = append(httpsURLs, "https://"+name+httpsPort)
+		httpURLs = append(httpURLs, "http://"+name+httpPort)
 	}
 
-	if GetCAROOT() != "" {
-		URLs = append(URLs, app.GetWebContainerDirectHTTPSURL())
-	} else {
-		URLs = append(URLs, app.GetWebContainerDirectHTTPURL())
-	}
+	httpsURLs = append(httpsURLs, app.GetWebContainerDirectHTTPSURL())
+	httpURLs = append(httpURLs, app.GetWebContainerDirectHTTPURL())
 
-	return URLs
+	return httpURLs, httpsURLs, append(httpURLs, httpsURLs...)
 }
 
 // GetWebContainerDirectHTTPURL returns the URL that can be used without the router to get to web container.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2163,8 +2163,8 @@ func TestGetAllURLs(t *testing.T) {
 		urlMap[u] = true
 	}
 
-	// We expect two URLs for each hostname (http/https) and one direct web container address.
-	expectedNumUrls := len(app.GetHostnames()) + 1
+	// We expect two URLs for each hostname (http/https) and two direct web container address.
+	expectedNumUrls := len(app.GetHostnames())*2 + 2
 	assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d", len(urlMap))
 
 	// Ensure urlMap contains direct address of the web container
@@ -2258,7 +2258,7 @@ func TestWebserverType(t *testing.T) {
 func TestInternalAndExternalAccessToURL(t *testing.T) {
 	assert := asrt.New(t)
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("TestInternalAndExternalAccessToURL"))
+	runTime := testcommon.TimeTrack(time.Now(), t.Name())
 
 	site := TestSites[0]
 	app := new(ddevapp.DdevApp)
@@ -2293,7 +2293,7 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		}
 
 		// We expect two URLs for each hostname (http/https) and two direct web container addresses.
-		expectedNumUrls := len(app.GetHostnames()) + 1
+		expectedNumUrls := len(app.GetHostnames())*2 + 2
 		assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d", len(urlMap))
 
 		_, _, URLList := app.GetAllURLs()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -392,7 +392,8 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		}
 
 		t.Logf("Testing these URLs: %v", app.GetAllURLs())
-		for _, url := range app.GetAllURLs() {
+		_, _, allURLs := app.GetAllURLs()
+		for _, url := range allURLs {
 			_, _ = testcommon.EnsureLocalHTTPContent(t, url+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
 		}
 
@@ -2153,7 +2154,7 @@ func TestGetAllURLs(t *testing.T) {
 	err = app.StartAndWaitForSync(0)
 	require.NoError(t, err)
 
-	urls := app.GetAllURLs()
+	_, _, urls := app.GetAllURLs()
 
 	// Convert URLs to map[string]bool
 	urlMap := make(map[string]bool)
@@ -2282,7 +2283,7 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		err = app.StartAndWaitForSync(5)
 		assert.NoError(err)
 
-		urls := app.GetAllURLs()
+		_, _, urls := app.GetAllURLs()
 
 		// Convert URLs to map[string]bool
 		urlMap := make(map[string]bool)
@@ -2294,7 +2295,8 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		expectedNumUrls := len(app.GetHostnames()) + 1
 		assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d", len(urlMap))
 
-		URLList := append(app.GetAllURLs(), "http://localhost", "http://localhost")
+		_, _, URLList := app.GetAllURLs()
+		URLList = append(URLList, "http://localhost", "http://localhost")
 		for _, item := range URLList {
 			// Make sure internal (web container) access is successful
 			parts, err := url.Parse(item)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -391,7 +391,8 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 			assert.True(check, "Container check on %s failed", containerType)
 		}
 
-		t.Logf("Testing these URLs: %v", app.GetAllURLs())
+		_, _, urls := app.GetAllURLs()
+		t.Logf("Testing these URLs: %v", urls)
 		_, _, allURLs := app.GetAllURLs()
 		for _, url := range allURLs {
 			_, _ = testcommon.EnsureLocalHTTPContent(t, url+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1711 requested easy access to the http URLs
#1685 requested URLs that could be clickable without possible dangling commas

## How this PR Solves The Problem:

* `ddev start` and `ddev restart` now output space-separated list of URLs on start
* `ddev describe` provides a table of *all* URLS, including both http and https, even if mkcert is in action.
* Improved verbiage around mysql access in ddev describe

```
ddev start d8git
Starting d8git...
...
Successfully started d8git
Project can be reached at https://a.ddev.site https://d8git.ddev.site https://127.0.0.1:32773
```

```
ddev describe d8git

NAME   TYPE     LOCATION           URL                      STATUS 
d8git  drupal8  ~/workspace/d8git  https://d8git.ddev.site  running

Project Information
-------------------
PHP version:   	7.2 
MariaDB version	10.2

URLs
----
http://a.ddev.site     
http://d8git.ddev.site 
http://127.0.0.1:32774 
https://a.ddev.site    
https://d8git.ddev.site
https://127.0.0.1:32773


MySQL/MariaDB Credentials
-------------------------
Username: "db", Password: "db", Default database: "db"

or use root credentials when needed: Username: "root", Password: "root"

Database hostname and port INSIDE container: db:3306
To connect to db server inside container or in project settings files: 
mysql --host=db --user=db --password=db --database=db
Database hostname and port from HOST: 127.0.0.1:32770
To connect to mysql from your host machine, 
mysql --host=127.0.0.1 --port=32770 --user=db --password=db --database=db
```


## Manual Testing Instructions:
* `ddev start`, make sure output URLs are not encumbered by punctation
* `ddev describe`, make sure all URLs are available and not encumbered by punctuation.

## Automated Testing Overview:

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

