### PR TITLE
Timezone docs in config.yaml and add config docs to documentation, fixes #1691

### DIFF
--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -36,6 +36,6 @@ the .ddev/config.yaml is the primary configuration for the project.
 | dbimage_extra_packages| Add extra Debian packages to the ddev-dbserver. | For example, `dbimage_extra_packages: ["less"]` will add those that package. |
 | use_dns_when_possible | defaults to true (using DNS instead of editing /etc/hosts) | If set to false, ddev will always update the /etc/hosts file with the project hostname instead of using DNS for name resolution |
 | project_tld | defaults to "ddev.site" so project urls become "someproject.ddev.site" | This can be changed to anything that works for you; to keep things the way they were before ddev v1.9, use "ddev.local" |
-| ngrok_args | Extra flags for ngrok when using the `ddev share` command | For example, `--subdomain mysite --auth "user:pass"`. See [ngrok docs on http flags](https://ngrok.com/docs#http) |
+| ngrok_args | Extra flags for ngrok when using the `ddev share` command | For example, `--subdomain mysite --auth user:pass`. See [ngrok docs on http flags](https://ngrok.com/docs#http) |
 | provider| hosting provider for `ddev pull` | "pantheon" or "drud-aws" or "default" |
 | hooks | | See [Extending Commands](../../extending-commands.md) for more information. |

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -1,0 +1,41 @@
+<h1>.ddev/config.yaml options</h1>
+
+Each project has a (hidden) directory named .ddev, and
+the .ddev/config.yaml is the primary configuration for the project.
+
+* You can override the config.yaml with extra files named "config.*.yaml". For example, many teams use `config.local.yaml` for configuration that is specific to one environment, and that is not intended to be checked into the team's default config.yaml.
+* Most configuration options take effect on `ddev start`
+* Nearly all configuration options have equivalent `ddev config` flags, so you can use ddev config instead of editing the config.yaml. See `ddev help config` to see all the flags.
+
+| Item  | Description   | Notes  |
+|---|---|---|
+| name  | Project name   | Must be unique on the host (no two projects can have the same name). It's best if this is the same as the directory name.   |
+| type | Project type | php/drupal6/drupal7/drupal8/backdrop/typo3wordpress. Project type "php" does not try to do any CMS configuration or settings file management, and can work with any project|
+| docroot | Relative path of the docroot (where index.php or index.html is) from the project root| |
+| php_version | 5.6/7.0/7.1/7.2/7.3 | It is only possible to provide the major version (like "7.3"), not a minor version like "7.3.2", and it is only possible to use the provided php versions. |
+| webimage | docker image to use for webserver | It is unusual to change the default and is not recommended, but the webimage can be overridden with a correctly crafted image, probably derived from drud/ddev-webserver |
+| dbimage | docker image to use for db server | It is unusual to change the default and is not recommended, but the dbimage can be overridden with a correctly crafted image, probably derived from drud/ddev-dbserver |
+| dbaimage | docker image to use for dba server (phpMyAdmin server) | It is unusual to change the default and is not recommended, but the dbimage can be overridden with a correctly crafted image, probably derived from drud/phpmyadmin |
+| router_http_port | Port used by the router for http |  Defaults to port 80. This can be changed if there is a conflict on the host over port 80 |
+| router_https_port | Port used by the router for https |Defaults to 443, usually only changed if there is a conflicting process using port 443 |
+| xdebug_enabled | "true" enables xdebug | Many people prefer to use `ddev exec enable_xdebug` and `ddev exec disable_xdebug` instead of configuring this, because xdebug has a significant performance impact. |
+| webserver_type | nginx-fpm or apache-fpm or apache-cgi | The default is nginx-fpm, and it works best for many projects |
+| timezone | timezone to use in container and in PHP configuration | It can be set to any valid timezone, see [timezone list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). For example "Europe/Dublin" or "MST7MDT". The default is UTC. |
+| additional_hostnames | array of extra hostnames | `additional_hostnames: ["somename", "someothername"]` would provide http and https URLs for "somename.ddev.site" and "someothername.ddev.site". |
+| additional_fqdns | extra fully-qualified domain names | `additional_fqdns: ["example.com", "sub1.example.com"]` would provide http and https URLs for "example.com" and "sub1.example.com". Please take care with this because it can cause great confusion and adds extraneous items to your /etc/hosts file. |
+| upload_dir | Relative path to upload directory used by `ddev import-files` | |
+| working_dir | explicitly specify the working directory used by `ddev exec` and `ddev ssh` | `working_dir: { web:  "/var/www", db: "/etc" }` would set the working directories for the web and db containers. |
+| omit_containers | Allows the project to not load specified containers | For example, `omit_containers: ["dba", "ddev-ssh-agent"]`. Currently only these containers are supported. These containers can also be omitted globally in the ~/.ddev/global_config.yaml. |
+| nfs_mount_enabled | Allows using NFS to mount the project into the container for performance reasons | See [nfsmount_enabled documentation](../../performance.md). This requires configuration on the host before it can be used. |
+| host_https_port | Specify a specific and persistent https port for direct binding to the localhost interface | This is not commonly used, but a specific port can be provided here and the https URL will always remain the same. For example, if you put "59001", the project will always use "https://127.0.0.1:59001". for the localhost URL. (Note that the named URL is more commonly used and for most purposes is better.) If this is not set the port will change from `ddev start` to `ddev start` |
+| host_webserver_port | Specify a specific and persistent http port for direct binding to the localhost interface | This is not commonly used, but a specific port can be provided here and the https URL will always remain the same. For example, if you put "59000", the project will always use "http://127.0.0.1:59000". for the localhost URL. (Note that the named URL is more commonly used and for most purposes is better.) If this is not set the port will change from `ddev start` to `ddev start` |
+| host_db_port | localhost binding port for database server | If specified here, the database port will remain consistent. This is useful for configuration of host-side database browsers. Note, though, that `ddev sequelpro` and `ddev mysql` do all this automatically, as does the sample command `ddev mysqlworkbench`. |
+| phpmyadmin_port | port used for PHPMyAdmin URL | This is sometimes changed from the default 8036 when a port conflict is discovered |
+| mailhog_port | port used in Mailhog URL | this can be changed from the default 8025 in case of port conflicts |
+| webimage_extra_packages| Add extra Debian packages to the ddev-webserver. | For example, `webimage_extra_packages: [php-yaml, php7.3-ldap]` will add those two packages |
+| dbimage_extra_packages| Add extra Debian packages to the ddev-dbserver. | For example, `dbimage_extra_packages: ["less"]` will add those that package. |
+| use_dns_when_possible | defaults to true (using DNS instead of editing /etc/hosts) | If set to false, ddev will always update the /etc/hosts file with the project hostname instead of using DNS for name resolution |
+| project_tld | defaults to "ddev.site" so project urls become "someproject.ddev.site" | This can be changed to anything that works for you; to keep things the way they were before ddev v1.9, use "ddev.local" |
+| ngrok_args | Extra flags for ngrok when using the `ddev share` command | For example, `--subdomain mysite --auth "user:pass"`. See [ngrok docs on http flags](https://ngrok.com/docs#http) |
+| provider| hosting provider for `ddev pull` | "pantheon" or "drud-aws" or "default" |
+| hooks | | See [Extending Commands](../../extending-commands.md) for more information. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ pages:
     - 'Using Developer Tools with ddev': 'users/developer-tools.md'
     - 'PHP Step Debugging': 'users/step-debugging.md'
     - 'Extending ddev':
+      - '.ddev/config.yaml Options': 'users/extend/config_yaml.md'
       - 'Additional Project Hostnames': 'users/extend/additional-hostnames.md'
       - 'Extending and Customizing Environments': 'users/extend/customization-extendibility.md'
       - 'Additional Services': 'users/extend/additional-services.md'

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -579,12 +580,15 @@ func TestConfigValidate(t *testing.T) {
 	assert.Contains(err.Error(), "invalid hostname")
 
 	app.AdditionalFQDNs = []string{}
-	app.Timezone = "xxx"
-	err = app.ValidateConfig()
-	assert.Error(err)
-	app.Timezone = "America/Chicago"
-	err = app.ValidateConfig()
-	assert.NoError(err)
+	// Timezone validation isn't possible on Windows.
+	if runtime.GOOS != "windows" {
+		app.Timezone = "xxx"
+		err = app.ValidateConfig()
+		assert.Error(err)
+		app.Timezone = "America/Chicago"
+		err = app.ValidateConfig()
+		assert.NoError(err)
+	}
 }
 
 // TestWriteConfig tests writing config values to file

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -330,7 +330,7 @@ const ConfigInstructions = `
 # If you prefer you can change this to "ddev.local" to preserve
 # pre-v1.9 behavior.
 
-# ngrok_args: --subdomain mysite --auth "user:pass"
+# ngrok_args: --subdomain mysite --auth username:pass
 # Provide extra flags to the "ngrok http" command, see 
 # https://ngrok.com/docs#http or run "ngrok http -h"
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -227,7 +227,7 @@ const ConfigInstructions = `
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "7.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3"
+# php_version: "7.2"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3"
 
 # You can explicitly specify the webimage, dbimage, dbaimage lines but this
 # is not recommended, as the images are often closely tied to ddev's' behavior,
@@ -242,8 +242,17 @@ const ConfigInstructions = `
 # router_https_port: <port> # Port for https (defaults to 443)
 
 # xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
+# Note that for most people the commands 
+# "ddev exec enable_xdebug" and "ddev exec disable_xdebug" work better,
+# as leaving xdebug enabled all the time is a big performance hit.
 
 # webserver_type: nginx-fpm  # Can be set to apache-fpm or apache-cgi as well
+
+# timezone: Europe/Berlin
+# This is the timezone used in the containers and by PHP;
+# it can be set to any valid timezone, 
+# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# For example Europe/Dublin or MST7MDT
 
 # additional_hostnames:
 #  - somename

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -314,11 +314,9 @@ const ConfigInstructions = `
 
 # webimage_extra_packages: [php-yaml, php7.3-ldap]
 # Extra Debian packages that are needed in the webimage can be added here
-# This is ignored if a free-form .ddev/web-build/Dockerfile is provided
 
 # dbimage_extra_packages: [telnet,netcat]
 # Extra Debian packages that are needed in the dbimage can be added here
-# This is ignored if a free-form .ddev/db-build/Dockerfile is provided
 
 # use_dns_when_possible: true
 # If the host has internet access and the domain configured can 
@@ -329,7 +327,8 @@ const ConfigInstructions = `
 # project_tld: ddev.site
 # The top-level domain used for project URLs
 # The default "ddev.site" allows DNS lookup via a wildcard
-# For backward compatibility this can be changed to "ddev.local"
+# If you prefer you can change this to "ddev.local" to preserve
+# pre-v1.9 behavior.
 
 # ngrok_args: --subdomain mysite --auth "user:pass"
 # Provide extra flags to the "ngrok http" command, see 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #1691 points out that config.yaml timezone didn't get documented anywhere
* In lots of cases we don't have anything in the official documentation about configuration options.
* Windows can't validate the timezone, but it was making a really annoying statement to this effect every time any ddev command was launched

## How this PR Solves The Problem:

* Add docs to config.yaml (update with `ddev config`)
* Add docs to ddev.readthedocs.io
* Turn off the complaint about validation on Windows. Invalid timezones are ignored (and UTC is used) by both Linux and PHP.

## Manual Testing Instructions:

Read the docs. 

## Automated Testing Overview:

No changes

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

