### PR TITLE
Add optional real username for instrumentation

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -41,6 +41,7 @@ type GlobalConfig struct {
 	LastUsedVersion      string                  `yaml:"last_used_version"`
 	ProjectList          map[string]*ProjectInfo `yaml:"project_info"`
 	DeveloperMode        bool                    `yaml:"developer_mode,omitempty"`
+	InstrumentationUser  string                  `yaml:"instrumentation_user,omitempty"`
 }
 
 // GetGlobalConfigPath() gets the path to global config file


### PR DESCRIPTION
## The Problem/Issue/Bug:

There will be times like developer work where we might as well have an identifiable user in segment. This adds an optional global_config.yaml item `instrumentation_user`

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

