### PR TITLE
Only output segment/sentry info when DRUD_DEBUG=true, fixes #1684

### DIFF
--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -5,7 +5,7 @@ import (
 	"github.com/denisbrodbeck/machineid"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/getsentry/raven-go"
 	"gopkg.in/segmentio/analytics-go.v3"
@@ -107,16 +107,16 @@ func SendInstrumentationEvents(event string) {
 
 		err := SegmentUser(client, GetInstrumentationUser())
 		if err != nil {
-			util.Warning("error sending hashedHostID to segment: %v", err)
+			output.UserOut.Debugf("error sending hashedHostID to segment: %v", err)
 		}
 
 		err = SegmentEvent(client, GetInstrumentationUser(), event)
 		if err != nil {
-			util.Warning("error sending event to segment: %v", err)
+			output.UserOut.Debugf("error sending event to segment: %v", err)
 		}
 		err = client.Close()
 		if err != nil {
-			util.Warning("segment analytics client.close() failed: %v", err)
+			output.UserOut.Debugf("segment analytics client.close() failed: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1684 put us on notice that if things go wrong with sentry or segment, there's no reason to expose that to the customer.

## How this PR Solves The Problem:

For a limited set of things, use output.Userout.Debugf() instead of anything else (like util.Warning()). That at least limits the possibilities, and those things will only be shown if DRUD_DEBUG=true

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

