### PR TITLE
Remove Sentry 'Usage' sends

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -9,7 +9,6 @@ import (
 	"github.com/drud/ddev/pkg/updatecheck"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
-	"github.com/getsentry/raven-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -119,15 +118,12 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 			fullCommand[i], fullCommand[j] = fullCommand[j], fullCommand[i]
 		}
 
-		uString := strings.Join(fullCommand, " ")
 		event := ""
 		if len(fullCommand) > 1 {
 			event = fullCommand[1]
 		}
 
-		instrumentationNotSetUpWarning()
-		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && version.SentryDSN != "" && nodeps.IsInternetActive() && len(fullCommand) > 1 {
-			_ = raven.CaptureMessageAndWait("Usage: "+uString, map[string]string{"severity-level": "info", "report-type": "usage"})
+		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && version.SegmentKey != "" && nodeps.IsInternetActive() && len(fullCommand) > 1 {
 			ddevapp.SendInstrumentationEvents(event)
 		}
 	},

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -101,8 +101,6 @@ func SegmentEvent(client analytics.Client, hashedID string, event string) error 
 func SendInstrumentationEvents(event string) {
 
 	if globalconfig.DdevGlobalConfig.InstrumentationOptIn && nodeps.IsInternetActive() {
-		_ = raven.CaptureMessageAndWait("Usage: ddev "+event, map[string]string{"severity-level": "info", "report-type": "usage"})
-
 		client := analytics.New(version.SegmentKey)
 
 		err := SegmentUser(client, GetInstrumentationUser())


### PR DESCRIPTION
## The Problem/Issue/Bug:

Now that Segment is integrated for instrumentation, the "Usage:" reports to Sentry are obsolete. Remove those. Leave the error pushes in there.

## How this PR Solves The Problem:

Removes the Usage: push to Sentry.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

