### PR TITLE
Make ddev ssh use a bash login shell

### DIFF
--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -44,7 +44,7 @@ var DdevSSHCmd = &cobra.Command{
 		}
 		_ = app.ExecWithTty(&ddevapp.ExecOpts{
 			Service: serviceType,
-			Cmd:     shell,
+			Cmd:     shell + " -l",
 			Dir:     sshDirArg,
 		})
 	},


### PR DESCRIPTION
## The Problem/Issue/Bug:

It would be more natural for ddev to use a login shell on `ddev ssh`, so use `bash -l` instead of just `bash` for `ddev ssh`.

## How this PR Solves The Problem:

Add "-l" to the command invocation.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

