### PR TITLE
Update typo3 quickstart with warning about https url [skip ci][ci skip]

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -145,7 +145,6 @@ ddev composer install
 
 ### TYPO3 Quickstart
 
-
 **Composer Setup Example**
 
 ```
@@ -157,12 +156,16 @@ ddev config --project-type typo3
 ddev restart
 ```
 
-When `ddev start` runs, it outputs status messages to indicate the project environment is starting. When the startup is complete, ddev outputs a message like the one below with a link to access your project in a browser.
+When the startup is complete, ddev outputs a message like the one below with a link to access your project in a browser.
 
 ```
 Successfully started example-typo3-site
-Your application can be reached at: http://example-typo3-site.ddev.site
+Your application can be reached at: https://example-typo3-site.ddev.site
 ```
+
+**A TYPO3 an install may fail if you use the https URL ("Trusted hosts pattern mismatch"). Please use "http" instead of "https" for the URL while doing the install.**
+
+If doing a basic TYPO3 install, you can then `touch public/FIRST_INSTALL` and hit the http URL top begin an installation.
 
 For those wanting/needing to connect to the database within the database container directly, please see the [developer tools page](https://ddev.readthedocs.io/en/stable/users/developer-tools/#using-development-tools-on-the-host-machine).
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

TYPO3 installation doesn't work with https URL; sometimes it's a silent 500 err with 
```
2019/07/25 18:01:55 [error] 2071#2071: *453 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught UnexpectedValueException: The current host header value does not match the configured trusted hosts pattern! Check the pattern defined in $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] and adapt it, if you want to allow the current host header 't3v9composer.ddev.site' for your installation. in /var/www/html/public/typo3/sysext/core/Classes/Utility/GeneralUtility.php:2830
Stack trace:
#0 /var/www/html/public/typo3/sysext/core/Classes/Utility/GeneralUtility.php(2882): TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('HTTP_HOST')
#1 /var/www/html/public/typo3/sysext/core/Classes/Utility/GeneralUtility.php(2891): TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_H...')
#2 /var/www/html/public/typo3/sysext/core/Classes/Utility/GeneralUtility.php(2894): TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_D...')
#3 /var/www/html/public/typo3/sysext/core/Classes/Utility/GeneralUtility.php(2908): TYPO3\CMS\Core\Utility\GeneralUtility::" while reading response header from upstream, client: 172.18.0.6, server: _, request: "GET / HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm.sock:", host: "t3v9composer.ddev.site"
```

and sometimes it's an explicit pink environment check warning about the trustedHostsPattern that actually lets you proceed.

## How this PR Solves The Problem:

Just adds a little docs. The easy approach is to use http; it's for install-time only that it's a problem.

