### PR TITLE
Add ddev poweroff command, fixes #1588

### DIFF
--- a/cmd/ddev/cmd/poweroff.go
+++ b/cmd/ddev/cmd/poweroff.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// PoweroffCommand contains the "ddev share" command
+var PoweroffCommand = &cobra.Command{
+	Use:     "poweroff",
+	Short:   "Completely stop all projects and containers",
+	Long:    `ddev poweroff stops all projects and containers, equivalent to ddev stop -a --stop-ssh-agent`,
+	Example: `ddev poweroff`,
+	Args:    cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		projects, err := ddevapp.GetProjects(true)
+		if err != nil {
+			util.Failed("Failed to get project(s): %v", err)
+		}
+
+		// Iterate through the list of projects built above, removing each one.
+		for _, project := range projects {
+			if project.SiteStatus() == ddevapp.SiteStopped {
+				util.Warning("Project %s is not currently running. Try 'ddev start'.", project.GetName())
+			}
+
+			// We do the snapshot if either --snapshot or --remove-data UNLESS omit-snapshot is set
+			doSnapshot := (createSnapshot || removeData) && !omitSnapshot
+			if err := project.Stop(removeData, doSnapshot); err != nil {
+				util.Failed("Failed to remove project %s: \n%v", project.GetName(), err)
+			}
+			if unlist {
+				project.RemoveGlobalProjectInfo()
+			}
+
+			util.Success("Project %s has been stopped.", project.GetName())
+		}
+
+		if err := ddevapp.RemoveSSHAgentContainer(); err != nil {
+			util.Error("Failed to remove ddev-ssh-agent: %v", err)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(PoweroffCommand)
+}

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -40,6 +40,10 @@ To remove database contents, use "ddev stop --remove-data".
 To snapshot the database on stop, use "ddev stop --snapshot"; A snapshot is automatically created on
 "ddev stop --remove-data" unless you use "ddev stop --remove-data --omit-snapshot".
 `,
+	Example: `ddev stop
+ddev stop proj1 proj2 proj3
+ddev stop --all
+ddev stop --all --stop-ssh-agent`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if createSnapshot && omitSnapshot {
 			util.Failed("Illegal option combination: --snapshot and --omit-snapshot:")


### PR DESCRIPTION
## The Problem/Issue/Bug:

People just want to shut it all off. They don't want to remember `ddev stop -a --stop-ssh-agent`

Lando pioneered "poweroff" and people resonate to it.

## How this PR Solves The Problem:

Add poweroff which is the same as `ddev stop -a --stop-ssh-agent`

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

