### PR TITLE
TYPO3 AdditionalConfiguration.php: fix warning in array_merge()

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -20,13 +20,19 @@ const typo3AdditionalConfigTemplate = `<?php
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'], [
-                    'dbname' => 'db',
-                    'host' => 'db',
-                    'password' => 'db',
-                    'port' => '3306',
-                    'user' => 'db',
-]);
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge(
+    // on first install, this could be not set yet
+    isset($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'])
+        ? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']
+        : [],
+    [
+        'dbname' => 'db',
+        'host' => 'db',
+        'password' => 'db',
+        'port' => '3306',
+        'user' => 'db',
+    ]
+);
 
 // This mail configuration sends all emails to mailhog
 $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport'] = 'smtp';


### PR DESCRIPTION
## The Problem/Issue/Bug:
On first install, $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] could be still unset.

## How this PR Solves The Problem:
This sets this value to an empty value (not using null coalesce, thus PHP5-compatible) in that case.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

