### PR TITLE
Get rid of TYPO3 trustedHostsPattern warning, fixes #1739

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -23,8 +23,8 @@ func typo3AdditionalConfigTemplate(app *DdevApp) string {
  */
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '` +
-		strings.Join(hostNames, "|") +
-		`';
+		strings.Join(hostNames, "(:\\d+)?|") +
+		`(:\\d+)?';
 
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge(
     // on first install, this could be not set yet

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -219,4 +219,3 @@ func typo3PostStartAction(app *DdevApp) error {
 	}
 	return nil
 }
-fixes #1739 Get rid of TYPO3 trustedHostsPattern warning

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -9,13 +9,15 @@ import (
 	"path/filepath"
 
 	"github.com/drud/ddev/pkg/archive"
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 )
 
 func typo3AdditionalConfigTemplate(app *DdevApp) string {
-	hostNames := append(app.GetHostnames(), "localhost", "127.0.0.1")
+	dockerIP, _ := dockerutil.GetDockerIP()
+	hostNames := append(app.GetHostnames(), "localhost", dockerIP)
 
 	return `<?php
 /** ` + DdevFileSignature + `: Automatically generated TYPO3 AdditionalConfiguration.php file.
@@ -23,7 +25,7 @@ func typo3AdditionalConfigTemplate(app *DdevApp) string {
  */
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '` +
-		strings.Join(hostNames, "(:\\d+)?|") +
+		strings.Join(hostNames, "(:\\\\d+)?|") +
 		`(:\\d+)?';
 
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge(


### PR DESCRIPTION
This sets trustedHostsPattern to all configured hosts + "localhost" and "127.0.0.1".

Please excuse my zero Go skills and correct me where needed.


## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

