### PR TITLE
Make sure EOL at end of file is there in config.yaml, fixes #1740

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -232,9 +232,9 @@ func getBackdropUploadDir(app *DdevApp) string {
 
 // getBackdropHooks for appending as byte array.
 func getBackdropHooks() []byte {
-	backdropHooks := `
-#  post-import-db:
-#    - exec: drush cc all`
+	backdropHooks := `#  post-import-db:
+#    - exec: drush cc all
+`
 	return []byte(backdropHooks)
 }
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -602,16 +602,15 @@ func getDrupalUploadDir(app *DdevApp) string {
 }
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db
-const Drupal8Hooks = `
-# post-import-db:
+const Drupal8Hooks = `# post-import-db:
 #   - exec: drush cr
 #   - exec: drush updb
 `
 
 // Drupal7Hooks adds a d7-specific hooks example for post-import-db
-const Drupal7Hooks = `
-#  post-import-db:
-#    - exec: drush cc all`
+const Drupal7Hooks = `#  post-import-db:
+#    - exec: drush cc all
+`
 
 // getDrupal7Hooks for appending as byte array
 func getDrupal7Hooks() []byte {

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -342,7 +342,8 @@ const ConfigInstructions = `
 # See https://ddev.readthedocs.io/en/stable/users/extending-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
-#hooks:`
+#hooks:
+`
 
 // SequelproTemplate is the template for Sequelpro config.
 var SequelproTemplate = `<?xml version="1.0" encoding="UTF-8"?>

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -124,9 +124,9 @@ func getTypo3UploadDir(app *DdevApp) string {
 }
 
 // Typo3Hooks adds a TYPO3-specific hooks example for post-import-db
-const Typo3Hooks = `
-#  post-start:
-#    - exec: composer install -d /var/www/html`
+const Typo3Hooks = `#  post-start:
+#    - exec: composer install -d /var/www/html
+`
 
 // getTypo3Hooks for appending as byte array
 func getTypo3Hooks() []byte {

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -65,10 +65,10 @@ func NewWordpressConfig(app *DdevApp, absPath string) *WordpressConfig {
 }
 
 // wordPressHooks adds a wp-specific hooks example for post-start
-const wordPressHooks = `
-# Un-comment to emit the WP CLI version after ddev start.
+const wordPressHooks = `# Un-comment to emit the WP CLI version after ddev start.
 #  post-start:
-#    - exec: wp cli version`
+#    - exec: wp cli version
+`
 
 // getWordpressHooks for appending as byte array
 func getWordpressHooks() []byte {


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1740 requests that .ddev/config.yaml not lose EOL at end of file.

## How this PR Solves The Problem:

Try to fix it everywhere.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

