### PR TITLE
Take correct action on custom commands if project not running, fixes #1716

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -123,6 +123,12 @@ func makeContainerCmd(app *ddevapp.DdevApp, fullPath, name string, service strin
 	return func(cmd *cobra.Command, args []string) {
 		app.DockerEnv()
 
+		if app.SiteStatus() != ddevapp.SiteRunning {
+			err := app.Start()
+			if err != nil {
+				util.Failed("Failed to start project for custom command: %v", err)
+			}
+		}
 		osArgs := []string{}
 		if len(os.Args) > 2 {
 			osArgs = os.Args[2:]

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -95,7 +95,14 @@ func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string) func(*cobra.Comman
 	}
 
 	return func(cmd *cobra.Command, cobraArgs []string) {
+		if app.SiteStatus() != ddevapp.SiteRunning {
+			err := app.Start()
+			if err != nil {
+				util.Failed("Failed to start project for custom command: %v", err)
+			}
+		}
 		app.DockerEnv()
+
 		osArgs := []string{}
 		if len(os.Args) > 2 {
 			osArgs = os.Args[2:]
@@ -104,8 +111,6 @@ func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string) func(*cobra.Comman
 		if runtime.GOOS == "windows" {
 			// Sadly, not sure how to have a bash interpreter without this.
 			//bashPath := `C:\Program Files\Git\bin\bash.exe`
-
-			//args = []string{"-c", fullPath}
 			args := []string{fullPath}
 			args = append(args, osArgs...)
 			err = exec.RunInteractiveCommand(windowsBashPath, args)
@@ -121,14 +126,14 @@ func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string) func(*cobra.Comman
 // makeContainerCmd creates the command which will app.Exec to a container command
 func makeContainerCmd(app *ddevapp.DdevApp, fullPath, name string, service string) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
-		app.DockerEnv()
-
 		if app.SiteStatus() != ddevapp.SiteRunning {
 			err := app.Start()
 			if err != nil {
 				util.Failed("Failed to start project for custom command: %v", err)
 			}
 		}
+		app.DockerEnv()
+
 		osArgs := []string{}
 		if len(os.Args) > 2 {
 			osArgs = os.Args[2:]

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -57,13 +57,13 @@ ddev stop --all --stop-ssh-agent`,
 		// Iterate through the list of projects built above, removing each one.
 		for _, project := range projects {
 			if project.SiteStatus() == ddevapp.SiteStopped {
-				util.Warning("Project %s is not currently running. Try 'ddev start'.", project.GetName())
+				util.Success("Project %s is already stopped.", project.GetName())
 			}
 
 			// We do the snapshot if either --snapshot or --remove-data UNLESS omit-snapshot is set
 			doSnapshot := (createSnapshot || removeData) && !omitSnapshot
 			if err := project.Stop(removeData, doSnapshot); err != nil {
-				util.Failed("Failed to remove project %s: \n%v", project.GetName(), err)
+				util.Failed("Failed to stop project %s: \n%v", project.GetName(), err)
 			}
 			if unlist {
 				project.RemoveGlobalProjectInfo()


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1716 points out that custom command handling when the project is not running is really ugly; it tries to take action, but finds no container to execute in.

## How this PR Solves The Problem:

* For both host and container commands, if the project is not running, start it.

## Manual Testing Instructions:

* `ddev mysql` with project stopped.
* Enable the host-side `phpstorm` command by `cd .ddev/commands/host && ln -s phpstorm.example phpstorm` and `ddev phpstorm`. It should start the project first. mysqlworkbench is more fun with this, because it actually wants the mysqlserver running, but it runs on the host.

## Automated Testing Overview:
* No changes, it seems this is really just finesse.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

