### PR TITLE
Docker Desktop 2.1.0.0 (19.03.1) doesn't let you install as root

### DIFF
--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -3,12 +3,17 @@
 set -o errexit
 set -x
 
+# Docker desktop after 31259 refuses to install using root
+DOCKER_URL=https://download.docker.com/mac/stable/31259/Docker.dmg
+curl -O -sSL $DOCKER_URL
+open -W Docker.dmg && cp -r /Volumes/Docker/Docker.app /Applications
 
 # Basic tools
 brew update >/dev/null 2>/dev/null
 
 # Get docker in first so we can install it and work on other things
-brew cask install docker ngrok
+brew cask install ngrok
+
 sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended
 nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 


### PR DESCRIPTION

## The Problem/Issue/Bug:

Docker Desktop 2.1.0.0 (19.03.1) doesn't let you install as root
This breaks our macOS installation on CircleCI.
This uses 18.09 docker instead on CircleCI. Pretty sad.

This PR reverts back to earlier docker desktop for use on CircleCI. 

Docker issues: 
* https://github.com/docker/for-mac/issues/2359
* https://github.com/docker/for-mac/issues/882


