### PR TITLE
Make sure that DDEV_HOST_DB_PORT is properly set where needed, fixes #1747

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ test: testpkg testcmd
 testcmd: $(BUILD_OS) setup
 	DDEV_NO_SENTRY=true CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
 
-testpkg: setup
-	DDEV_NO_SENTRY=true CGO_ENABLED=0 go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
+testpkg: $(BUILD_OS) setup
+	DDEV_NO_SENTRY=true CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
 
 setup:
 	@mkdir -p $(GOTMP)/{src,pkg/mod/cache,.cache}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1013,7 +1013,15 @@ func (app *DdevApp) DockerEnv() {
 		util.Warning("Warning: containers will run as root. This could be a security risk on Linux.")
 	}
 
+	// DDEV_HOST_DB_PORT is actually used for 2 things.
+	// 1. To specifify via docker-compose.yaml the value of host_db_port config. And it's expected to be empty
+	//    there if the host_db_port is empty.
+	// 2. To tell custom commands the db port. And it's expected always to be populated for them.
 	dbPort, _ := app.GetPublishedPort("db")
+	dbPortStr := strconv.Itoa(dbPort)
+	if app.HostDBPort != "" {
+		dbPortStr = app.HostDBPort
+	}
 
 	envVars := map[string]string{
 		"COMPOSE_PROJECT_NAME":          "ddev-" + app.Name,
@@ -1024,7 +1032,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_WEBIMAGE":                 app.WebImage,
 		"DDEV_BGSYNCIMAGE":              app.BgsyncImage,
 		"DDEV_APPROOT":                  app.AppRoot,
-		"DDEV_HOST_DB_PORT":             strconv.Itoa(dbPort),
+		"DDEV_HOST_DB_PORT":             dbPortStr,
 		"DDEV_HOST_WEBSERVER_PORT":      app.HostWebserverPort,
 		"DDEV_HOST_HTTPS_PORT":          app.HostHTTPSPort,
 		"DDEV_PHPMYADMIN_PORT":          app.PHPMyAdminPort,

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1017,8 +1017,11 @@ func (app *DdevApp) DockerEnv() {
 	// 1. To specifify via docker-compose.yaml the value of host_db_port config. And it's expected to be empty
 	//    there if the host_db_port is empty.
 	// 2. To tell custom commands the db port. And it's expected always to be populated for them.
-	dbPort, _ := app.GetPublishedPort("db")
+	dbPort, err := app.GetPublishedPort("db")
 	dbPortStr := strconv.Itoa(dbPort)
+	if dbPortStr == "-1" || err != nil {
+		dbPortStr = ""
+	}
 	if app.HostDBPort != "" {
 		dbPortStr = app.HostDBPort
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2552,15 +2552,20 @@ func TestHostDBPort(t *testing.T) {
 			assert.EqualValues(app.HostDBPort, dbPortStr)
 		}
 
-		// Running mysql against the container ensures that we can get there via the values
-		// in ddev describe
-		out, err := exec.RunCommand("mysql", []string{"--user=db", "--password=db", "--host=" + dockerIP, fmt.Sprintf("--port=%d", dbPort), "--database=db", `--execute=SELECT 1;`})
-		assert.NoError(err, "Failed to run mysql: %v", out)
-		assert.EqualValues("1\n1\n", out)
+		if !util.IsCommandAvailable("mysql") {
+			t.Log("Skipping mysql check because mysql tool not available")
+		} else {
+			// Running mysql against the container ensures that we can get there via the values
+			// in ddev describe
+			out, err := exec.RunCommand("mysql", []string{"--user=db", "--password=db", "--host=" + dockerIP, fmt.Sprintf("--port=%d", dbPort), "--database=db", `--execute=SELECT 1;`})
+			assert.NoError(err, "Failed to run mysql: %v", out)
+			assert.EqualValues("1\n1\n", out)
+		}
 
 		// Running the test host custom command "showport" ensures that the DDEV_HOST_DB_PORT
 		// is getting in there available to host custom commands.
-		out, err = exec.RunCommand(DdevBin, []string{"showport"})
+		_, _ = exec.RunCommand(DdevBin, []string{})
+		out, err := exec.RunCommand(DdevBin, []string{"showport"})
 		assert.NoError(err)
 		assert.EqualValues("DDEV_HOST_DB_PORT="+dbPortStr, strings.Trim(out, "\n"))
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2559,7 +2559,8 @@ func TestHostDBPort(t *testing.T) {
 			// in ddev describe
 			out, err := exec.RunCommand("mysql", []string{"--user=db", "--password=db", "--host=" + dockerIP, fmt.Sprintf("--port=%d", dbPort), "--database=db", `--execute=SELECT 1;`})
 			assert.NoError(err, "Failed to run mysql: %v", out)
-			assert.EqualValues("1\n1\n", out)
+			out = strings.Replace(out, "\r", "", -1)
+			assert.Contains(out, "1\n1\n")
 		}
 
 		// Running the test host custom command "showport" ensures that the DDEV_HOST_DB_PORT

--- a/pkg/ddevapp/testdata/TestHostDBPort/showport
+++ b/pkg/ddevapp/testdata/TestHostDBPort/showport
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## Description: show port
+## Usage: showport
+## Example: "ddev showport"
+
+# Shows the DDEV_HOST_DB_PORT
+
+echo "DDEV_HOST_DB_PORT=$DDEV_HOST_DB_PORT"


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1747: host_db_port was no longer working.

## How this PR Solves The Problem:

* Make sure that DDEV_HOST_DB_PORT is always set properly for docker-compose.yaml
* Make sure it's set for custom commands.
* Make sure the default ephemeral port also works.

## Manual Testing Instructions:

* Try with `host_db_port: <something>` and without
* `ddev start` and `ddev describe` should show you what you expect on the port
* Make sure that `ddev mysqlworkbench` works for each (requires having that going)

## Automated Testing Overview:

* Adds TestHostDBPort, which is a fairly robust exploration of this.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

