### PR TITLE
Fix Makefile problem with no_v_version [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ VERSION := $(shell git describe --tags --always --dirty)
 # Some things insist on having the version without the leading 'v', so provide a
 # $(NO_V_VERSION) without it.
 # no_v_version removes the front v, keeps the special to 20 chars, simplifies complex version strings
-NO_V_VERSION=$(shell echo $(VERSION) | awk -F- '{ sub(/^./, "", $$1); base=$$1; second=$$2$$3$$4$$5; gsub(/\./,"",second); $$1=""; printf("%s-%.20s",base, second) } ')
+NO_V_VERSION=$(shell echo $(VERSION) | awk -F- '{ sub(/^./, "", $$1); base=$$1; second=$$2$$3$$4$$5; gsub(/\./,"",second); $$1=""; printf(base); if (second != "") printf("-%.20s",second); } ')
 GITHUB_ORG := drud
 
 #


### PR DESCRIPTION
## The Problem/Issue/Bug:

The Makefile had a change earlier to support long versions that doesn't work with a simple version (no -), like v1.10.0.

This fixes that one line in the makefile.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

