### PR TITLE
[TASK] Combine all TYPO3_CONF_VARS into one recursively merged array

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -17,35 +17,39 @@ const typo3AdditionalConfigTemplate = `<?php
 /** ` + DdevFileSignature + `: Automatically generated TYPO3 AdditionalConfiguration.php file.
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
-
-/* TYPO3 v10 balks at ".*" in trustedHostsPattern, so ".*.*" is used to fool it. */
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*.*';
-
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge(
-    // on first install, this could be not set yet
-    isset($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'])
-        ? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']
-        : [],
+$GLOBALS['TYPO3_CONF_VARS'] = array_merge_recursive(
+    $GLOBALS['TYPO3_CONF_VARS'],
     [
-        'dbname' => 'db',
-        'host' => 'db',
-        'password' => 'db',
-        'port' => '3306',
-        'user' => 'db',
+        'DB' => [
+            'Connections' => [
+                'Default' => [
+                    'dbname'   => 'db',
+                    'host'     => 'db',
+                    'password' => 'db',
+                    'port'     => '3306',
+                    'user'     => 'db',
+                ]
+            ]
+        ],
+        // This GFX configuration allows processing by installed ImageMagick 6
+        'GFX' => [
+            'processor' => 'ImageMagick',
+            'processor_path' => '/usr/bin/',
+            'processor_path_lzw' => '/usr/bin/'
+        ],
+        // This mail configuration sends all emails to mailhog
+        'MAIL' => [
+            'transport' => 'smtp',
+            'transport_smtp_server' => 'localhost:1025'
+        ],
+        'SYS' => [
+            'trustedHostsPattern' => '.*.*',
+            'devIPmask' => '*',
+            'displayErrors' => 1
+        ]
     ]
 );
 
-// This mail configuration sends all emails to mailhog
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport'] = 'smtp';
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_server'] = 'localhost:1025';
-
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'] = '*';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = 1;
-
-// This GFX configuration allows processing by installed ImageMagick 6
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = 'ImageMagick';
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path'] = '/usr/bin/';
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path_lzw'] = '/usr/bin/';
 `
 
 // createTypo3SettingsFile creates the app's LocalConfiguration.php and

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -17,7 +17,7 @@ const typo3AdditionalConfigTemplate = `<?php
 /** ` + DdevFileSignature + `: Automatically generated TYPO3 AdditionalConfiguration.php file.
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
-$GLOBALS['TYPO3_CONF_VARS'] = array_merge_recursive(
+$GLOBALS['TYPO3_CONF_VARS'] = array_replace_recursive(
     $GLOBALS['TYPO3_CONF_VARS'],
     [
         'DB' => [


### PR DESCRIPTION
This will make it easier for developers to add keys or new sections to
the TYPO3_CONF_VARS. Also it won't run into problems when keys are not
set by the DefaultConfiguration.php

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

