### PR TITLE
Add ngrok.io domain to trustedHostsPattern in TYPO3 config

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -26,7 +26,7 @@ func typo3AdditionalConfigTemplate(app *DdevApp) string {
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '` +
 		strings.Join(hostNames, "(:\\\\d+)?|") +
-		`(:\\d+)?';
+		`(:\\d+)?|.*\.ngrok.io(:\\d+)?';
 
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge(
     // on first install, this could be not set yet

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -26,7 +26,7 @@ func typo3AdditionalConfigTemplate(app *DdevApp) string {
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '` +
 		strings.Join(hostNames, "(:\\\\d+)?|") +
-		`(:\\d+)?|.*\.ngrok.io(:\\d+)?';
+		`(:\\d+)?|.*\.ngrok\.io(:\\d+)?';
 
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge(
     // on first install, this could be not set yet


### PR DESCRIPTION
with the implementation of the "ddev share" option accessing the page via *.ngrok.io
throws an exception and the trustedHostsPattern must be altered manually.