### PR TITLE
Ignore .sshimageBuild and .bgsyncimageBuild directories by default, fixes #1762

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -902,7 +902,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db", ".bgsync*", "config.*.y*ml", ".webimageBuild", ".dbimageBuild", "bgsyncimageBuild", "sshimageBuild", ".webimageExtra", ".dbimageExtra", ".webimageBuild", ".dbimageBuild", "*-build/Dockerfile.example")
+	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db", ".bgsync*", "config.*.y*ml", ".webimageBuild", ".dbimageBuild", ".bgsyncimageBuild", ".sshimageBuild", ".webimageExtra", ".dbimageExtra", ".webimageBuild", ".dbimageBuild", "*-build/Dockerfile.example")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:
Issue #1762 
.sshimageBuild and .bgsyncimageBuild are not ignored by default after performing a `ddev config`

## How this PR Solves The Problem:
Adjusts the `pkg/ddevapp/config.go` file to ignore the directories

## Manual Testing Instructions:
`ddev config` should add `.sshimagebuild` and `.bgsyncimagebuild` to the `.ddev/.gitignore` file

## Automated Testing Overview:
Tests were not added due to the simplicity of the change.

## Related Issue Link(s):
Issue: #1762 

## Release/Deployment notes:
A new `ddev config` run should add the `.`s to the filenames in the `.gitignore` file in `.ddev` if the file is marked to be auto generated/altered.

