### PR TITLE
Use --renew-anon-volumes with docker-compose up to improve test reliability

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -748,7 +748,7 @@ func (app *DdevApp) Start() error {
 			return err
 		}
 	}
-	_, _, err = dockerutil.ComposeCmd(files, "up", "--build", "-d")
+	_, _, err = dockerutil.ComposeCmd(files, "up", "--build", "-d", "--renew-anon-volumes")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

In the long-running issue about `mkdir /c; file exists` there was a comment that --renew-anonymous-volumes fixed this for them. https://github.com/docker/for-win/issues/1560#issuecomment-516773475

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

