### PR TITLE
Useradd should set bash shell for user

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -730,7 +730,7 @@ FROM $BASE_IMAGE
 ARG username
 ARG uid
 ARG gid
-RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m --gid "$username" --comment '' "$username")
+RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username")
  `
 	if extraPackages != nil {
 		contents = contents + `


### PR DESCRIPTION
## The Problem/Issue/Bug:

The default shell is not currently being set when a user is created. This doesn't seem to have any practical problems, but it might as well be right.

This PR adds /bin/bash as the shell when creating the user.
