### PR TITLE
add 1.10 example files to .gitignore

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -902,7 +902,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db", ".bgsync*", "config.*.y*ml", ".webimageBuild", ".dbimageBuild", ".bgsyncimageBuild", ".sshimageBuild", ".webimageExtra", ".dbimageExtra", ".webimageBuild", ".dbimageBuild", "*-build/Dockerfile.example")
+	err := CreateGitIgnore(dir, "commands/*/*.example", "commands/*/README.txt", "homeadditions/*.example", "homeadditions/README.txt", "import.yaml", "docker-compose.yaml", "db_snapshots", "sequelpro.spf", "import-db", ".bgsync*", "config.*.y*ml", ".webimageBuild", ".dbimageBuild", ".bgsyncimageBuild", ".sshimageBuild", ".webimageExtra", ".dbimageExtra", ".webimageBuild", ".dbimageBuild", "*-build/Dockerfile.example")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}


### PR DESCRIPTION
.example and README.txt files are recreated by ddev on `ddev start` and do not need to be versioned.

The same is true for commands/db/mysql actually, but as that actually is a custom command, I tend to leave it.

