### PR TITLE
Pre-seed passwd and group files for ddev-ssh-agent

### DIFF
--- a/containers/ddev-ssh-agent/files/etc/group
+++ b/containers/ddev-ssh-agent/files/etc/group
@@ -1,0 +1,10 @@
+root:x:0:
+daemon:x:1:
+bin:x:2:
+sys:x:3:
+adm:x:4:
+sudo:x:27:
+shadow:x:42:
+utmp:x:43:
+plugdev:x:46:
+nogroup:x:65534:

--- a/containers/ddev-ssh-agent/files/etc/passwd
+++ b/containers/ddev-ssh-agent/files/etc/passwd
@@ -1,0 +1,7 @@
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+_apt:x:100:65534::/nonexistent:/bin/false

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -77,7 +77,7 @@ var RouterTag = "v1.10.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.10.1"
+var SSHAuthTag = "20190808_less_groups"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

A user with the username "mail" reported trouble starting the ssh-agent; it turns out the ddev-ssh-agent already had that as a group name, which it doesn't need.

````
PS C:\Users\mail\ddev\test> ddev start                                                                                  Starting test...
Building ddev-ssh-agent
Service 'ddev-ssh-agent' failed to build: The command '/bin/sh -c (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m --gid "$username" --comment '' "$username")' returned a non-zero code: 9
Failed to start test: failed to start ddev-ssh-agent: Failed to run docker-compose [-f C:\Users\mail/.ddev/ssh-auth-compose.yaml -p ddev-ssh-agent up --build --force-recreate -d], err='exit status 1', stdout='Step 1/6 : ARG BASE_IMAGE
Step 2/6 : FROM $BASE_IMAGE
 ---> 8bc25c9cac34
Step 3/6 : ARG username
 ---> Using cache
 ---> dcd6780e1111
Step 4/6 : ARG uid
 ---> Using cache
 ---> 1a876b049020
Step 5/6 : ARG gid
 ---> Using cache
 ---> 49883978654a
Step 6/6 : RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m --gid "$username" --comment '' "$username")
 ---> Running in e0f362b2a4f4
groupadd: group 'mail' already exists
groupadd: group 'mail' already exists
useradd: user 'mail' already exists
useradd: user 'mail' already exists
', stderr='Building ddev-ssh-agent
Service 'ddev-ssh-agent' failed to build: The command '/bin/sh -c (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m --gid "$username" --comment '' "$username")' returned a non-zero code: 9'
```

The workaround for this user was to temporarily `ddev config global --omit-containers=ddev-ssh-agent` so the ssh-agent doesn't try to start; many people don't need it.

## How this PR Solves The Problem:

Pre-seeds the ddev-ssh-agent /etc/passwd and /etc/group files with only (possibly) needed usernames and group names.

There's an argument here to have a fallback username for this situation. But it's pretty unusual.

## Manual Testing Instructions:

Try starting a project with username "mail". Or maybe don't.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

