### PR TITLE
Use --no-install-recommends for apt-get install of *image_extra_packages

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -734,7 +734,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
  `
 	if extraPackages != nil {
 		contents = contents + `
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ` + strings.Join(extraPackages, " ") + "\n"
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 	return WriteImageDockerfile(fullpath, []byte(contents))
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -734,7 +734,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
  `
 	if extraPackages != nil {
 		contents = contents + `
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ` + strings.Join(extraPackages, " ") + "\n"
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ` + strings.Join(extraPackages, " ") + "\n"
 	}
 	return WriteImageDockerfile(fullpath, []byte(contents))
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

@thomaskieslich pointed out in https://github.com/drud/ddev/issues/1715#issuecomment-519569449  that our implementation in the dockerfile build of *image_extra_packages should have `--no-install-recommends` to lighten the install load. 


## How this PR Solves The Problem:

Add the --no-install-recommends

## Manual Testing Instructions:

Per the quoted issue, add cron and verify its operation.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

