### PR TITLE
Bump ddev-webserver and ddev-ssh-agent to v1.10.2

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190807_bash_path" // Note that this can be overridden by make
+var WebTag = "v1.10.2" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
@@ -77,7 +77,7 @@ var RouterTag = "v1.10.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "20190808_less_groups"
+var SSHAuthTag = "v1.10.2"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Preparing for a v1.10.2 release; two images have changed version.

