### PR TITLE
Revert to older makensis for homebrew, fixes #1773

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,14 +73,14 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v9
+        - homebrew-macos-v10
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - save_cache:
-        key: homebrew-macos-v9
+        key: homebrew-macos-v10
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -105,7 +105,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v9
+        - homebrew-macos-v10
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -118,7 +118,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macos-v9
+        key: homebrew-macos-v10
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -137,13 +137,13 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v9
+        - homebrew-macos-v10
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v9
+        key: homebrew-macos-v10
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -311,12 +311,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v9
+        - homebrew-macos-v10
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v9
+        key: homebrew-macos-v10
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -408,12 +408,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v9
+        - homebrew-macos-v10
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: RELEASE BUILD Circle VM setup
     - save_cache:
-        key: homebrew-macos-v9
+        key: homebrew-macos-v10
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,14 +73,14 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v10
+        - homebrew-macos-v11
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - save_cache:
-        key: homebrew-macos-v10
+        key: homebrew-macos-v11
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -105,7 +105,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v10
+        - homebrew-macos-v11
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -118,7 +118,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macos-v10
+        key: homebrew-macos-v11
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -137,13 +137,13 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v10
+        - homebrew-macos-v11
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v10
+        key: homebrew-macos-v11
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -311,12 +311,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v10
+        - homebrew-macos-v11
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v10
+        key: homebrew-macos-v11
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -408,12 +408,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v10
+        - homebrew-macos-v11
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: RELEASE BUILD Circle VM setup
     - save_cache:
-        key: homebrew-macos-v10
+        key: homebrew-macos-v11
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -20,12 +20,13 @@ nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 brew tap drud/ddev
 
 brew install mysql-client zip jq expect coreutils golang ddev mkcert osslsigncode ghr
-brew link mysql-client zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
+brew link mysql-client zip jq expect coreutils golang ddev mkcert osslsigncode ghr
 
 # makensis brew install was broken in a recent commit, see
 # https://github.com/Homebrew/homebrew-core/pull/39928#issuecomment-520263137
 # This uses the former recipe that worked fine.
 brew install https://raw.githubusercontent.com/drud/makensis/master/makensis.rb
+brew link makensis
 
 brew link --force mysql-client
 

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -19,8 +19,13 @@ nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 
 brew tap drud/ddev
 
-brew install mysql-client zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
+brew install mysql-client zip jq expect coreutils golang ddev mkcert osslsigncode ghr
 brew link mysql-client zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
+
+# makensis brew install was broken in a recent commit, see
+# https://github.com/Homebrew/homebrew-core/pull/39928#issuecomment-520263137
+# This uses the former recipe that worked fine.
+brew install https://raw.githubusercontent.com/drud/makensis/master/makensis.rb
 
 brew link --force mysql-client
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1773 we discovered that the release-build (in macOS) didn't build a usable windows installer. 

## How this PR Solves The Problem:

Revert to an older version (prior to https://github.com/Homebrew/homebrew-core/pull/39928)

This uses the homebrew recipe as it was before that PR.

## Manual Testing Instructions:

Build a release. Test it.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

