### PR TITLE
Pull all important images during start if needed, friendlier to users

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -742,7 +742,7 @@ func (app *DdevApp) Start() error {
 
 	// Pull the main images with full output, since docker-compose up won't
 	// show enough output.
-	for _, imageName := range []string{app.WebImage, app.DBImage} {
+	for _, imageName := range []string{app.WebImage, app.DBImage, app.DBAImage, version.GetSSHAuthImage(), version.GetRouterImage()} {
 		err = dockerutil.Pull(imageName)
 		if err != nil {
 			return err

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -147,6 +147,16 @@ func GetBgsyncImage() string {
 	return fmt.Sprintf("%s:%s", BgsyncImg, BgsyncTag)
 }
 
+// GetSSHAuthImage returns the correctly formatted sshauth image:tag reference
+func GetSSHAuthImage() string {
+	return fmt.Sprintf("%s:%s", SSHAuthImage, SSHAuthTag)
+}
+
+// GetRouterImage returns the correctly formatted router image:tag reference
+func GetRouterImage() string {
+	return fmt.Sprintf("%s:%s", RouterImage, RouterTag)
+}
+
 // GetDockerComposeVersion runs docker-compose -v to get the current version
 func GetDockerComposeVersion() (string, error) {
 	if DockerComposeVersion != "" {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Earlier we had added a pull of the web and db images during start (if they didn't exist), but I noticed that the first-time pull of the ddev-ssh-agent and dba and router images also caused a mysterious pause during upgrade. 

This PR just adds all the key images to the download.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

