### PR TITLE
Add powerdown alias for poweroff, because I keep trying to use it

### DIFF
--- a/cmd/ddev/cmd/poweroff.go
+++ b/cmd/ddev/cmd/poweroff.go
@@ -13,6 +13,7 @@ var PoweroffCommand = &cobra.Command{
 	Long:    `ddev poweroff stops all projects and containers, equivalent to ddev stop -a --stop-ssh-agent`,
 	Example: `ddev poweroff`,
 	Args:    cobra.NoArgs,
+	Aliases: []string{"powerdown"},
 	Run: func(cmd *cobra.Command, args []string) {
 		powerOff()
 	},


### PR DESCRIPTION
## The Problem/Issue/Bug:

I keep typing `ddev powerdown` instead of `ddev poweroff`

## How this PR Solves The Problem:

Add a `powerdown` alias for `poweroff`

## Manual Testing Instructions:

Try `ddev powerdown` as well as `ddev poweroff`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

