### PR TITLE
Improve ddev start and ddev list performance

### DIFF
--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -22,7 +22,9 @@ var continuousSleepTime = 1
 var ListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List projects",
-	Long:  `List projects. Shows active projects by default, includes stopped projects with --all`,
+	Long:  `List projects. Shows all projects by default, shows active projects only with --active-only`,
+	Example: `ddev list
+ddev list -A`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for {
 			apps, err := ddevapp.GetProjects(activeOnly)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -690,6 +690,15 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
+	// Pull the main images with full output, since docker-compose up won't
+	// show enough output.
+	for _, imageName := range []string{app.WebImage, app.DBImage, app.DBAImage, version.GetSSHAuthImage(), version.GetRouterImage()} {
+		err = dockerutil.Pull(imageName)
+		if err != nil {
+			return err
+		}
+	}
+
 	if !nodeps.ArrayContainsString(app.OmitContainers, "ddev-ssh-agent") {
 		err = app.EnsureSSHAgentContainer()
 		if err != nil {
@@ -740,14 +749,6 @@ func (app *DdevApp) Start() error {
 	_ = dockerutil.RemoveVolume(app.GetWebcacheVolName())
 	_ = dockerutil.RemoveVolume(app.GetNFSMountVolName())
 
-	// Pull the main images with full output, since docker-compose up won't
-	// show enough output.
-	for _, imageName := range []string{app.WebImage, app.DBImage, app.DBAImage, version.GetSSHAuthImage(), version.GetRouterImage()} {
-		err = dockerutil.Pull(imageName)
-		if err != nil {
-			return err
-		}
-	}
 	_, _, err = dockerutil.ComposeCmd(files, "up", "--build", "-d")
 	if err != nil {
 		return err

--- a/pkg/ddevapp/mkcert.go
+++ b/pkg/ddevapp/mkcert.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,10 @@ var caROOT = ""
 
 func GetCAROOT() string {
 	if caROOT != "" {
+		return caROOT
+	}
+	if globalconfig.DdevGlobalConfig.MkcertCARoot != "" {
+		caROOT = globalconfig.DdevGlobalConfig.MkcertCARoot
 		return caROOT
 	}
 	_, err := exec.LookPath("mkcert")
@@ -31,5 +36,8 @@ func GetCAROOT() string {
 		return ""
 	}
 	caROOT = root
+	globalconfig.DdevGlobalConfig.MkcertCARoot = root
+	_ = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+
 	return caROOT
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -586,27 +586,11 @@ func RemoveContainer(id string, timeout uint) error {
 func ImageExistsLocally(imageName string) (bool, error) {
 	client := GetDockerClient()
 
-	images, err := client.ListImages(docker.ListImagesOptions{
-		Filter: imageName,
-	})
-
-	if err != nil {
-		return false, err
+	// If inspect succeeeds, we have an image.
+	_, err := client.InspectImage(imageName)
+	if err == nil {
+		return true, nil
 	}
-
-	if len(images) == 0 {
-		return false, nil
-	}
-
-	for _, i := range images {
-		// RepoTags is a slice in the format of <repo-name>:<tag>, like drud/ddev-webserver:v1.2.3
-		for _, tag := range i.RepoTags {
-			if tag == imageName {
-				return true, nil
-			}
-		}
-	}
-
 	return false, nil
 }
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -38,10 +38,11 @@ type GlobalConfig struct {
 	APIVersion           string                  `yaml:"APIVersion"`
 	OmitContainers       []string                `yaml:"omit_containers,flow"`
 	InstrumentationOptIn bool                    `yaml:"instrumentation_opt_in"`
+	InstrumentationUser  string                  `yaml:"instrumentation_user,omitempty"`
 	LastUsedVersion      string                  `yaml:"last_used_version"`
 	ProjectList          map[string]*ProjectInfo `yaml:"project_info"`
 	DeveloperMode        bool                    `yaml:"developer_mode,omitempty"`
-	InstrumentationUser  string                  `yaml:"instrumentation_user,omitempty"`
+	MkcertCARoot         string                  `yaml:"mkcert_caroot"`
 }
 
 // GetGlobalConfigPath() gets the path to global config file


### PR DESCRIPTION
## The Problem/Issue/Bug:

@ultimike pointed out in Slack that ddev start and ddev list seem to take longer than they used to. I took a little time to look and found that there were serious problems with two things:

* dockerutil.Pull() uses dockerutil.ImageExistsLocally(), for every important image, on every start. And ImageExistsLocally() was mighty slow.
* GetCAROOT() for mkcert was running `mkcert -CAROOT` at least once on every start and list, and that command is mightily slow, taking almost 2 seconds. 

## How this PR Solves The Problem:

* Improve and speed up ImageExistsLocally() quite radically. Much simpler now too.
* Store CAROOT in global config, so we don't have to run mkcert to find it out. 

## Manual Testing Instructions:

`ddev start` with and without this
`ddev list` with and without this.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

There are two other things I discovered studying this that are not covered by this PR:

- Second in impact is the initial getProjects(). Which is ALSO doing all the app.Describe() - so that's being done twice.
- GetActiveProjects() calls app.Init() (doesn't seem right) which calls NewApp() which calls SetInstrumentationAppTags(), which does the Describe().  SetInstrumentationAppTags() should be lazy, only done when we're about to send stuff. On start or whatever.
