### PR TITLE
Make shebang lines more portable in host example.

### DIFF
--- a/docs/users/extend/custom-commands.md
+++ b/docs/users/extend/custom-commands.md
@@ -9,7 +9,7 @@ There are example commands provided in `ddev/commands/*/*.example` that can just
 To provide host commands, place a bash script in .ddev/commands/host. For example, a PHPStorm launcher to make the `ddev PHPStorm` command might go in .ddev/commands/host/phpstorm` with these contents:
 
 ```
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Description: Open PHPStorm with the current project
 ## Usage: phpstorm


### PR DESCRIPTION
It is typically recommended to use `#!/usr/bin/env bash` in shebang lines so that the correct version of Bash gets used. I'm updating the host example here. I've left the container examples alone because we have more knowledge of the container.

I think clarifying that these scripts ought to work with any programming language that can be executed from the command line (e.g. PHP) would also be good, but I'm not sure if I'm correct on that or if it's a useful addition.

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

