### PR TITLE
Temporarily use a custom-built mkcert that works on Ubuntu 16.04 for CircleCI

### DIFF
--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -23,6 +23,10 @@ for item in osslsigncode golang mkcert ddev; do
     brew install $item || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item
 done
 
+# Temporarily overwrite the brew-loaded broken-on-Ubuntu1604 mkcert
+brew unlink mkcert
+sudo curl -sSL -o /usr/local/bin/mkcert -O https://github.com/rfay/mkcert/releases/download/v1.4.1-alpha1/mkcert-v1.4.1-alpha1-linux-amd64 && sudo chmod +x /usr/local/bin/mkcert
+
 mkcert -install
 
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')


### PR DESCRIPTION
## The Problem/Issue/Bug:

mkcert v1.4.0, recently released, is broken on Ubuntu 16.04, see PR https://github.com/FiloSottile/mkcert/pull/193 and issue https://github.com/FiloSottile/mkcert/pull/192

We use Ubuntu 16.04 for our CircleCI linux builds. 

## How this PR Solves The Problem:

The PR https://github.com/FiloSottile/mkcert/pull/193 solves this. Until it or something related comes through, we'll have to dodge with a private build (from https://github.com/rfay/mkcert/releases/tag/v1.4.1-alpha1)

## Manual Testing Instructions:

See if CircleCI builds

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

