### PR TITLE
WordPress: Fix wp-cli not working if $WP_CORE is provided

### DIFF
--- a/containers/ddev-webserver/files/usr/local/bin/wp
+++ b/containers/ddev-webserver/files/usr/local/bin/wp
@@ -3,5 +3,5 @@
 # WP-cli wrapper: Append path automatically so that user doesn't have to
 ##
 
-
+if [ ! -z ${DOCROOT:-} ]; then WEBSERVER_DOCROOT=${WEBSERVER_DOCROOT}/${DOCROOT}; fi
 /usr/local/bin/wp-cli "$@" --path="${WEBSERVER_DOCROOT:-/var/www/html}"

--- a/containers/ddev-webserver/files/usr/local/bin/wp
+++ b/containers/ddev-webserver/files/usr/local/bin/wp
@@ -1,7 +1,1 @@
-#!/usr/bin/env bash
-##
-# WP-cli wrapper: Append path automatically so that user doesn't have to
-##
-
-if [ ! -z ${DOCROOT:-} ]; then WEBSERVER_DOCROOT=${WEBSERVER_DOCROOT}/${DOCROOT}; fi
-/usr/local/bin/wp-cli "$@" --path="${WEBSERVER_DOCROOT:-/var/www/html}"
+wp-cli

--- a/containers/ddev-webserver/files/usr/local/bin/wp
+++ b/containers/ddev-webserver/files/usr/local/bin/wp
@@ -3,20 +3,5 @@
 # WP-cli wrapper: Append path automatically so that user doesn't have to
 ##
 
-PATH_OPTION=""
-if [ -n "$WP_CORE" ]; then
-  PATH_OPTION="--path=$WP_CORE"
-fi
 
-if [ "$(id -u)" = "0" ]; then
-
-  # Gather all arguments because string interpolation doesn't work for $@
-  args=""
-  for i in "$@"; do
-      args="$args \"$i\""
-  done
-
-  /usr/local/bin/wp-cli "$@" $PATH_OPTION --allow-root
-else
-  /usr/local/bin/wp-cli "$@" $PATH_OPTION
-fi
+/usr/local/bin/wp-cli "$@" --path="${WEBSERVER_DOCROOT:-/var/www/html}"

--- a/containers/ddev-webserver/files/usr/local/bin/wp
+++ b/containers/ddev-webserver/files/usr/local/bin/wp
@@ -2,6 +2,12 @@
 ##
 # WP-cli wrapper: Append path automatically so that user doesn't have to
 ##
+
+PATH_OPTION=""
+if [ -n "$WP_CORE" ]; then
+  PATH_OPTION="--path=$WP_CORE"
+fi
+
 if [ "$(id -u)" = "0" ]; then
 
   # Gather all arguments because string interpolation doesn't work for $@
@@ -10,7 +16,7 @@ if [ "$(id -u)" = "0" ]; then
       args="$args \"$i\""
   done
 
-  /usr/local/bin/wp-cli "$@" --path=$WP_CORE --allow-root
+  /usr/local/bin/wp-cli "$@" $PATH_OPTION --allow-root
 else
-  /usr/local/bin/wp-cli "$@" --path=$WP_CORE
+  /usr/local/bin/wp-cli "$@" $PATH_OPTION
 fi

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -6,7 +6,7 @@ Several useful developer tools are included inside the containers. Run `ddev des
 ### Command-line Tools in the Containers
 - MySQL Client (mysql) - Command-line interface for interacting with MySQL/MariaDB.
 - [Drush](http://www.drush.org) - Command-line shell and Unix scripting interface for Drupal.
-- [WP-CLI](http://wp-cli.org/) - Command-line tools for managing WordPress installations.
+- [WP-CLI](http://wp-cli.org/) - Command-line tools for managing WordPress installations, available both as "wp" and as "wp-cli".
 - npm and yarn
 - node
 - sqlite3

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20191104_heddn_drush_node_version" // Note that this can be overridden by make
+var WebTag = "20191113_jdoubleu_wp_cli" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:
The command `wp` (`wp-cli`) does not work properly if the `$WP_CORE` environment variable was not set, because the bash script at `/usr/local/bin/wp` appends an empty path option "`--path=`".

### Use Case
You might wonder why the `$WP_CORE` environment variable is not set.

This is a special use case where I am using the default `php` type along with [bedrock](https://roots.io/bedrock/). DDEV's [WordPress setup](https://ddev.readthedocs.io/en/latest/users/cli-usage/#wordpress-quickstart) is not compatible with [bedrock](https://roots.io/bedrock/).

In this case the `$WP_CORE` environment variable is not set automatically. However I still need to run `wp` (bedrock ships a [`.wp-cli.yml` config file](`$WP_CORE` environment variable).

## Workaround
Manually provide the `$WP_CORE` environment variable (see https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-environment-variables-to-a-container).

## How this PR Solves The Problem:
The `/usr/local/bin/wp` script only applies the `--path=` option to `wp-cli` if `$WP_CORE` is **not** empty.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

