### PR TITLE
Simplify NO_V_VERSION, should work with real tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,8 @@ DdevVersion ?= $(VERSION)
 VERSION := $(shell git describe --tags --always --dirty)
 # Some things insist on having the version without the leading 'v', so provide a
 # $(NO_V_VERSION) without it.
-# no_v_version removes the front v, keeps the special to 20 chars, simplifies complex version strings
-NO_V_VERSION=$(shell echo $(VERSION) | awk -F- '{ sub(/^./, "", $$1); base=$$1; hash=$$3; gsub(/\./,"",second);   $$1=""; printf(base); if (hash != "") printf("-%.20s",hash); } ')
-
+# no_v_version removes the front v, for Chocolatey mostly
+NO_V_VERSION=$(shell echo $(VERSION) | awk  -F"-" '{ OFS="-"; sub(/^./, "", $$1); printf $$0; }')
 GITHUB_ORG := drud
 
 #


### PR DESCRIPTION
## The Problem/Issue/Bug:

The chocolatey build has a "no-v" view of version reality. We've tried to work around this again and again. But in https://github.com/drud/ddev/pull/1809 we just stopped building chocolatey on routine builds because it's so tweaky and has unknown version constraints. That solved the immediate problem.

However, the code that was in the makefile for the version transformation wasn't adequate and results in failures for tags like "v1.11.0-alpha1".

## How this PR Solves The Problem:

Stop doing anything but removing the initial v. That works for real releases of almost all types. WE CAN HOPE.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

