### PR TITLE
Don't let sentry call home if not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,10 @@ endif
 test: testpkg testcmd
 
 testcmd: $(BUILD_OS) setup
-	DDEV_NO_SENTRY=true CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
+	DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./cmd/... $(TESTARGS)
 
 testpkg: $(BUILD_OS) setup
-	DDEV_NO_SENTRY=true CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
+	DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags '$(LDFLAGS)' ./pkg/... $(TESTARGS)
 
 setup:
 	@mkdir -p $(GOTMP)/{src,pkg/mod/cache,.cache}

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -164,6 +164,11 @@ func init() {
 	if err != nil {
 		util.Failed("Failed to read global config file %s: %v", globalconfig.GetGlobalConfigPath(), err)
 	}
+
+	if !globalconfig.DdevNoInstrumentation && globalconfig.DdevGlobalConfig.InstrumentationOptIn {
+		ddevapp.SetInstrumentationBaseTags()
+	}
+
 }
 
 func instrumentationNotSetUpWarning() {
@@ -179,7 +184,7 @@ func instrumentationNotSetUpWarning() {
 // from the last saved version. If it is, prompt to request anon ddev usage stats
 // and update the info.
 func checkDdevVersionAndOptInInstrumentation() error {
-	if !output.JSONOutput && version.COMMIT != globalconfig.DdevGlobalConfig.LastUsedVersion && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoSentry {
+	if !output.JSONOutput && version.COMMIT != globalconfig.DdevGlobalConfig.LastUsedVersion && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoInstrumentation {
 		allowStats := util.Confirm("It looks like you have a new ddev release.\nMay we send anonymous ddev usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/latest/users/cli-usage/#opt-in-usage-information\nPermission to beam up?")
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// We don't want the tests reporting to Sentry.
-	_ = os.Setenv("DDEV_NO_SENTRY", "true")
+	_ = os.Setenv("DDEV_NO_INSTRUMENTATION", "true")
 
 	// If GOTEST_SHORT is an integer, then use it as index for a single usage
 	// in the array. Any value can be used, it will default to just using the

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -2,19 +2,8 @@ package main
 
 import (
 	"github.com/drud/ddev/cmd/ddev/cmd"
-	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/version"
-	"github.com/getsentry/raven-go"
 )
 
 func main() {
 	cmd.Execute()
-}
-
-func init() {
-	if !globalconfig.DdevNoSentry {
-		_ = raven.SetDSN(version.SentryDSN)
-		ddevapp.SetInstrumentationBaseTags()
-	}
 }

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -13,4 +13,4 @@ var ValidOmitContainers = map[string]bool{
 	DBAContainer:          true,
 }
 
-var DdevNoSentry = os.Getenv("DDEV_NO_SENTRY") == "true"
+var DdevNoInstrumentation = os.Getenv("DDEV_NO_INSTRUMENTATION") == "true"

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -33,7 +33,7 @@ func LogSetUp() {
 	}
 
 	// Report errors and panics to Sentry
-	if version.SentryDSN != "" && !globalconfig.DdevNoSentry && nodeps.IsInternetActive() {
+	if version.SentryDSN != "" && !globalconfig.DdevNoInstrumentation && globalconfig.DdevGlobalConfig.InstrumentationOptIn && nodeps.IsInternetActive() {
 		hook, err := logrus_sentry.NewAsyncWithTagsSentryHook(version.SentryDSN, nodeps.InstrumentationTags, levels)
 		if err == nil {
 			UserOut.Hooks.Add(hook)

--- a/pkg/output/text_formatter.go
+++ b/pkg/output/text_formatter.go
@@ -128,6 +128,7 @@ func (f *TextFormatter) Format(entry *log.Entry) ([]byte, error) {
 	}
 
 	if entry.Level == log.FatalLevel && globalconfig.DdevGlobalConfig.InstrumentationOptIn && version.SentryDSN != "" {
+		_ = raven.SetDSN(version.SentryDSN)
 		_ = raven.CaptureMessageAndWait("Failed:"+entry.Message, map[string]string{"severity-level": "fatal", "report-type": "util-fail"})
 	}
 	b.WriteByte('\n')


### PR DESCRIPTION
## The Problem/Issue/Bug:

Sentry's initialization can actually call home, and it's not inside our code that prevents that.

## How this PR Solves The Problem:

* Move sentry initialization to where it's actually needed (which isn't much any more)
* Change the DDEV_NO_SENTRY environment variable (normally used only by developers) to DDEV_NO_INSTRUMENTATION

## Manual Testing Instructions:

* With instrumentation turned off via DDEV_NO_INSTRUMENTATION create an error (like ddev start in uninitiialized directory). Verify that it doesn't come through on Sentry.
* With instrumentation turned off in global_config.yaml do the same thing. Should not come through on sentry.
* Do the converse of each of these and make sure the sentry error comes through.
* With instrumentation turned off, make sure that a ddev command like start doesn't come through on segment. Use the debug tab in segment to view.
* With instrumentation turned on, verify that it *does* come through.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

