### PR TITLE
Make composer create accept any flags or args, and run interactively, fixes #1737

### DIFF
--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -43,7 +43,15 @@ func TestComposerCmd(t *testing.T) {
 
 	// Test create-project
 	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0
-	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log", "1.1.0"}
+	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
+	assert.Contains(out, "Created project in ")
+	ddevapp.WaitForSync(app, 2)
+	assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
+
+	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0 --no-install
+	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0", "--no-install"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 	assert.Contains(out, "Created project in ")

--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/mattn/go-isatty"
+	"os"
 	"runtime"
 	"strings"
 )
@@ -19,6 +21,7 @@ func (app *DdevApp) Composer(args []string) (string, string, error) {
 		Service: "web",
 		Dir:     "/var/www/html",
 		Cmd:     fmt.Sprintf("composer %s", strings.Join(args, " ")),
+		Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 	})
 	if err != nil {
 		return stdout, stderr, fmt.Errorf("composer command failed: %v", err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1737 points out that `ddev composer create` doesn't allow passing very many flags to composer create-project, and it causes all kinds of trouble.

## How this PR Solves The Problem:

* Stop validating flags
* Pass everything directly to composer create-project
* Turn on tty if available, so authentication can happen

## Manual Testing Instructions:

Try the operations in `ddev composer create -h`, which should cover all these things. The --no-install and --repository options are probably the most annoyances at this time.

## Automated Testing Overview:

* Added a --no-install example into the TestComposerCmd

## Related Issue Link(s):

OP #1737

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

