### PR TITLE
Stop building image tarballs by default

### DIFF
--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -8,7 +8,7 @@ set -o pipefail
 set -o nounset
 
 ARTIFACTS=${1:-/artifacts}
-BUILD_IMAGE_TARBALLS=${2:-true}
+BUILD_IMAGE_TARBALLS=${2:-false}
 BASE_DIR=$PWD
 
 sudo mkdir -p $ARTIFACTS && sudo chmod 777 $ARTIFACTS


### PR DESCRIPTION
## The Problem/Issue/Bug:

* The Circleci build has been creating image tarballs for every single build. We only need them on release builds.

## How this PR Solves The Problem:

Change the default behavior

## Manual Testing Instructions:

* Make sure that tarballs aren't built in normal circle build
* Do a dummy release to make sure that they *are* built on a release build (if specified by the script)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

