### PR TITLE
Escape composer versions in docs so they work in Windows cmd

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -29,7 +29,7 @@ web container. Projects will be installed to a temporary directory and moved to
 the project root directory after installation. Any existing files in the
 project root will be deleted when creating a project.`,
 	Example: `ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev --no-interaction
-ddev composer create typo3/cms-base-distribution ^9
+ddev composer create "typo3/cms-base-distribution:^9"
 ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev --no-interaction --no-install
 ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -151,7 +151,7 @@ ddev composer install
 mkdir my-typo3-site
 cd my-typo3-site
 ddev config --project-type php
-ddev composer create typo3/cms-base-distribution ^9 --no-interaction --prefer-dist
+ddev composer create typo3/cms-base-distribution ^9.5 --no-interaction --prefer-dist
 ddev config --project-type typo3
 ddev restart
 ```

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -151,7 +151,7 @@ ddev composer install
 mkdir my-typo3-site
 cd my-typo3-site
 ddev config --project-type php
-ddev composer create typo3/cms-base-distribution ^9.5 --no-interaction --prefer-dist
+ddev composer create typo3/cms-base-distribution "^9" --no-interaction --prefer-dist
 ddev config --project-type typo3
 ddev restart
 ```

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -151,7 +151,7 @@ ddev composer install
 mkdir my-typo3-site
 cd my-typo3-site
 ddev config --project-type php
-ddev composer create typo3/cms-base-distribution "^9" --no-interaction --prefer-dist
+ddev composer create "typo3/cms-base-distribution:^9" --no-interaction --prefer-dist
 ddev config --project-type typo3
 ddev restart
 ```

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -18,11 +18,11 @@ We have included a built-in command to simplify use of [Composer](https://getcom
 
 Additionally, Composer can be used to initialize new projects with `ddev composer create`. This command supports limited argument and flag options, and will install a new project to the project root in `/var/www/html`. The package and version arguments are required:
 
-`ddev composer create [<flags>] <package> <version>`
+`ddev composer create [<flags>] "<package>:<version>"`
 
 For example:
 
-`ddev composer create --no-dev typo3/cms-base-distribution ^9`
+`ddev composer create --no-dev "typo3/cms-base-distribution:^9"`
 
 To execute a fully-featured `composer create-project` command, you can execute the command from within the container after executing `ddev ssh`, or pass the full command to `ddev exec`, like so:
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
`  [InvalidArgumentException]
  Could not find package typo3/cms-base-distribution with version 9.`

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

