### PR TITLE
[BUGFIX] Add closing tag on troubleshooting page

### DIFF
--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -123,7 +123,7 @@ Database snapshots from MariaDB 10.1 (normally from before ddev v1.3) cannot be 
  
 
 ## Windows-Specific Issues
-<a name="windows-hosts-file-limited">
+<a name="windows-hosts-file-limited"></a>
 ### Windows Hosts File limited to 10 hosts per IP address line
 
 On Windows only, there is a limit to the number of hosts that can be placed in one line. But since all ddev hosts are typically on the same IP address (typically 127.0.0.1, localhost), they can really add up. As soon as you have more than 10 entries there, your browser won't be able to resolve the addresses beyond the 10th entry.


### PR DESCRIPTION
## The Problem/Issue/Bug:
Within the docs on https://ddev.readthedocs.io/en/stable/users/troubleshooting/ an a-Tag is not closed properly which leads to wrong formatted texts.

## How this PR Solves The Problem:
This PR closes the a-Tag.

## Manual Testing Instructions:
Simply open https://ddev.readthedocs.io/en/stable/users/troubleshooting/ and scroll to "Windows-Specific Issues"

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Release/Deployment notes:
Doc related only.

