### PR TITLE
Update to latest build-tools and golang

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -23,8 +23,9 @@ fi
 case $os in
 darwin)
     brew upgrade mkcert || brew install mkcert || true
+    brew upgrade golang || brew install golang || true
     ;;
 windows)
-    choco upgrade -y mkcert
+    choco upgrade -y mkcert golang
     ;;
 esac

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export PATH := $(EXTRA_PATH):$(PATH)
 
 # Not updating build-tools to get this, but this should be removed
 # when build-tools is updated.
-BUILD_IMAGE := drud/golang-build-container:v1.12.7
+# BUILD_IMAGE := drud/golang-build-container:v1.12.7
 
 GOMETALINTER_ARGS := --vendored-linters --disable-all --enable=gofmt --enable=vet --enable vetshadow --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode --deadline=4m
 GOLANGCI_LINT_ARGS ?= --out-format=line-number --disable-all --enable=gofmt --enable=govet --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -79,7 +79,7 @@ On windows the building is somewhat more difficult due to the build being bash/l
 * [chocolatey](https://chocolatey.org/install) installed
 * make for Windows 3.81 (Recommended package [choco install make](https://chocolatey.org/packages/make) on chocolatey.org)
 * git for windows (Recommended package [choco install git](https://chocolatey.org/packages/git.install))
-* Docker Desktop for Windows.
+* docker for windows.
 
 (You can certainly install the base gnu make package, and the traditional git for windows package should work fine. Chocolatey installs are recommended here because there are many, many ways to get mixes of unix-style components that absolutely don't work. Microsoft's lovely bash-for-windows is a great tool, but it's an actual Ubuntu environment so isn't a good place for testing Windows builds.)
 

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -34,7 +34,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.12.1
+BUILD_IMAGE ?= drud/golang-build-container:v1.13.0
 
 BUILD_BASE_DIR ?= $(PWD)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Golang v1.13 is out

## How this PR Solves The Problem:

Update to latest build-tools that has it; Also update golang on buildkite testbots.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

