### PR TITLE
Allow users to bind router on all network interfaces, fixes #1798

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -43,6 +43,9 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 			globalconfig.DdevGlobalConfig.OmitContainers = strings.Split(omitContainers, ",")
 		}
 	}
+	if cmd.Flag("router-bind-all-interfaces").Changed {
+		globalconfig.DdevGlobalConfig.RouterBindAllInterfaces, _ = cmd.Flags().GetBool("router-bind-all-interfaces")
+	}
 	err = globalconfig.ValidateGlobalConfig()
 	if err != nil {
 		util.Failed("Invalid configuration in %s: %v", globalconfig.GetGlobalConfigPath(), err)
@@ -55,11 +58,13 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 	util.Success("Global configuration:")
 	output.UserOut.Printf("instrumentation-opt-in=%v", globalconfig.DdevGlobalConfig.InstrumentationOptIn)
 	output.UserOut.Printf("omit-containers=[%s]", strings.Join(globalconfig.DdevGlobalConfig.OmitContainers, ","))
+	output.UserOut.Printf("router-bind-all-interfaces=%v", globalconfig.DdevGlobalConfig.RouterBindAllInterfaces)
 }
 
 func init() {
 	configGlobalCommand.Flags().StringVarP(&omitContainers, "omit-containers", "", "", "omit-containers=dba,ddev-ssh-agent")
 	configGlobalCommand.Flags().BoolVarP(&instrumentationOptIn, "instrumentation-opt-in", "", false, "instrmentation-opt-in=true")
+	configGlobalCommand.Flags().Bool("router-bind-all-interfaces", false, "router-bind-all-interfaces-in=true")
 
 	ConfigCommand.AddCommand(configGlobalCommand)
 }

--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -64,7 +64,7 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 func init() {
 	configGlobalCommand.Flags().StringVarP(&omitContainers, "omit-containers", "", "", "omit-containers=dba,ddev-ssh-agent")
 	configGlobalCommand.Flags().BoolVarP(&instrumentationOptIn, "instrumentation-opt-in", "", false, "instrmentation-opt-in=true")
-	configGlobalCommand.Flags().Bool("router-bind-all-interfaces", false, "router-bind-all-interfaces-in=true")
+	configGlobalCommand.Flags().Bool("router-bind-all-interfaces", false, "router-bind-all-interfaces=true")
 
 	ConfigCommand.AddCommand(configGlobalCommand)
 }

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -34,13 +34,13 @@ func TestCmdGlobalConfig(t *testing.T) {
 	args := []string{"config", "global"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]")
+	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nrouter-bind-all-interfaces=false")
 
 	// Update a config
-	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent"}
+	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent", "--router-bind-all-interfaces=true"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]")
+	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]\nrouter-bind-all-interfaces=true")
 
 	err = globalconfig.ReadGlobalConfig()
 	assert.NoError(err)

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -48,6 +48,6 @@ The $HOME/.ddev/global_config.yaml has a few key global config options.
 |---|---|---|
 | omit_containers | Allows the project to not load specified containers | For example, `omit_containers: [ "dba", "ddev-ssh-agent"]`. Currently only these containers are supported. Note that you cannot omit the "db" container in the global configuration, but you can in the per-project .ddev/config.yaml |
 | instrumentation_opt_in | Opt in or out of instrumentation reporting | If true, anonymous usage information is sent to ddev via [segment](https://segment.com) or [sentry](https://sentry.io) |
-| router_bind_all_interfaces | Bind on all network interfaces | If true, ddev-router will bind on all network interfaces instead of just localhost, exposing ddev projects to your local network. If you set this to true, you may consider `omit_containers: ["dba"]` so that the PHPMyAdmin port is not available |
+| router_bind_all_interfaces | Bind on all network interfaces | If true, ddev-router will bind on all network interfaces instead of just localhost, exposing ddev projects to your local network. If you set this to true, you may consider `omit_containers: ["dba"]` so that the PHPMyAdmin port is not available.  |
 | developer_mode | Set developer mode | If true, developer_mode is set. This is not currently used. |
 

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -39,3 +39,15 @@ the .ddev/config.yaml is the primary configuration for the project.
 | ngrok_args | Extra flags for ngrok when using the `ddev share` command | For example, `--subdomain mysite --auth user:pass`. See [ngrok docs on http flags](https://ngrok.com/docs#http) |
 | provider| hosting provider for `ddev pull` | "pantheon" or "drud-aws" or "default" |
 | hooks | | See [Extending Commands](../../extending-commands.md) for more information. |
+
+## global_config.yaml Options
+
+The $HOME/.ddev/global_config.yaml has a few key global config options.
+
+| Item  | Description   | Notes  |
+|---|---|---|
+| omit_containers | Allows the project to not load specified containers | For example, `omit_containers: [ "dba", "ddev-ssh-agent"]`. Currently only these containers are supported. Note that you cannot omit the "db" container in the global configuration, but you can in the per-project .ddev/config.yaml |
+| instrumentation_opt_in | Opt in or out of instrumentation reporting | If true, anonymous usage information is sent to ddev via [segment](https://segment.com) or [sentry](https://sentry.io) |
+| router_bind_all_interfaces | Bind on all network interfaces | If true, ddev-router will bind on all network interfaces instead of just localhost, exposing ddev projects to your local network. If you set this to true, you may consider `omit_containers: ["dba"]` so that the PHPMyAdmin port is not available |
+| developer_mode | Set developer mode | If true, developer_mode is set. This is not currently used. |
+

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strconv"
 
 	"strings"
 
@@ -71,7 +72,7 @@ func StartDdevRouter() error {
 		"router_image":               version.RouterImage,
 		"router_tag":                 version.RouterTag,
 		"ports":                      newExposedPorts,
-		"router_bind_all_interfaces": globalconfig.DdevGlobalConfig.RouterBindAllInterfaces,
+		"router_bind_all_interfaces": strconv.FormatBool(globalconfig.DdevGlobalConfig.RouterBindAllInterfaces),
 		"compose_version":            version.DockerComposeFileFormatVersion,
 		"dockerIP":                   dockerIP,
 	}

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"path"
 	"sort"
-	"strconv"
-
 	"strings"
 
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -72,7 +70,7 @@ func StartDdevRouter() error {
 		"router_image":               version.RouterImage,
 		"router_tag":                 version.RouterTag,
 		"ports":                      newExposedPorts,
-		"router_bind_all_interfaces": strconv.FormatBool(globalconfig.DdevGlobalConfig.RouterBindAllInterfaces),
+		"router_bind_all_interfaces": globalconfig.DdevGlobalConfig.RouterBindAllInterfaces,
 		"compose_version":            version.DockerComposeFileFormatVersion,
 		"dockerIP":                   dockerIP,
 	}

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -68,11 +68,12 @@ func StartDdevRouter() error {
 	dockerIP, _ := dockerutil.GetDockerIP()
 
 	templateVars := map[string]interface{}{
-		"router_image":    version.RouterImage,
-		"router_tag":      version.RouterTag,
-		"ports":           newExposedPorts,
-		"compose_version": version.DockerComposeFileFormatVersion,
-		"dockerIP":        dockerIP,
+		"router_image":               version.RouterImage,
+		"router_tag":                 version.RouterTag,
+		"ports":                      newExposedPorts,
+		"router_bind_all_interfaces": globalconfig.DdevGlobalConfig.RouterBindAllInterfaces,
+		"compose_version":            version.DockerComposeFileFormatVersion,
+		"dockerIP":                   dockerIP,
 	}
 
 	err = templ.Execute(&doc, templateVars)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -418,9 +418,9 @@ services:
   ddev-router:
     image: {{ .router_image }}:{{ .router_tag }}
     container_name: ddev-router
-    ports:
-      {{ $dockerIP := .dockerIP }}{{ range $port := .ports }}- {{ if not .router_bind_all_interfaces }} "{{ $dockerIP }}:{{ $port }}:{{ $port }}" {{ else }} "{{ $port }}:{{ $port }}" {{ end }} 
-      {{ end }}
+    ports:{{ $dockerIP := .dockerIP }}{{ if not .router_bind_all_interfaces }}{{ range $port := .ports }}
+    - "{{ $dockerIP }}:{{ $port }}:{{ $port }}"{{ end }}{{ else }}{{ range $port := .ports }}
+    - "{{ $port }}:{{ $port }}"{{ end }}{{ end }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ddev-global-cache:/mnt/ddev-global-cache:rw

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -419,7 +419,7 @@ services:
     image: {{ .router_image }}:{{ .router_tag }}
     container_name: ddev-router
     ports:
-      {{ $dockerIP := .dockerIP }}{{ range $port := .ports }}- "{{ $dockerIP }}:{{ $port }}:{{ $port }}"
+      {{ $dockerIP := .dockerIP }}{{ range $port := .ports }}- {{ if not .router_bind_all_interfaces }} "{{ $dockerIP }}:{{ $port }}:{{ $port }}" {{ else }} "{{ $port }}:{{ $port }}" {{ end }} 
       {{ end }}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -38,12 +38,12 @@ type GlobalConfig struct {
 	APIVersion              string                  `yaml:"APIVersion"`
 	OmitContainers          []string                `yaml:"omit_containers,flow"`
 	InstrumentationOptIn    bool                    `yaml:"instrumentation_opt_in"`
+	RouterBindAllInterfaces bool                    `yaml:"router_bind_all_interfaces"`
+	DeveloperMode           bool                    `yaml:"developer_mode,omitempty"`
 	InstrumentationUser     string                  `yaml:"instrumentation_user,omitempty"`
 	LastUsedVersion         string                  `yaml:"last_used_version"`
-	ProjectList             map[string]*ProjectInfo `yaml:"project_info"`
-	DeveloperMode           bool                    `yaml:"developer_mode,omitempty"`
 	MkcertCARoot            string                  `yaml:"mkcert_caroot"`
-	RouterBindAllInterfaces bool                    `yaml:"router_bind_all_interfaces"`
+	ProjectList             map[string]*ProjectInfo `yaml:"project_info"`
 }
 
 // GetGlobalConfigPath() gets the path to global config file
@@ -128,9 +128,11 @@ func WriteGlobalConfig(config GlobalConfig) error {
 #
 # instrumentation_user: <your_username> # can be used to give ddev specific info about who you are
 # developer_mode: true # (defaults to false) is not used widely at this time.
-# yaml_find_all_interfaces: false  # If true, the ddev-router will bind web ports on all
-#    network interfaces instead of just localhost, so others on your network can 
-#    access it.
+# router_bind_all_interfaces: false  # (defaults to false)
+#    If true, ddev-router will bind http/s, PHPMyAdmin, and MailHog ports on all
+#    network interfaces instead of just localhost, so others on your local network can
+#    access those ports. Note that this exposes the PHPMyAdmin and MailHog ports as well, which
+#    can be a major security issue, so be aware of your actions.
 `
 	cfgbytes = append(cfgbytes, instructions...)
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -35,14 +35,15 @@ type ProjectInfo struct {
 
 // GlobalConfig is the struct defining ddev's global config
 type GlobalConfig struct {
-	APIVersion           string                  `yaml:"APIVersion"`
-	OmitContainers       []string                `yaml:"omit_containers,flow"`
-	InstrumentationOptIn bool                    `yaml:"instrumentation_opt_in"`
-	InstrumentationUser  string                  `yaml:"instrumentation_user,omitempty"`
-	LastUsedVersion      string                  `yaml:"last_used_version"`
-	ProjectList          map[string]*ProjectInfo `yaml:"project_info"`
-	DeveloperMode        bool                    `yaml:"developer_mode,omitempty"`
-	MkcertCARoot         string                  `yaml:"mkcert_caroot"`
+	APIVersion              string                  `yaml:"APIVersion"`
+	OmitContainers          []string                `yaml:"omit_containers,flow"`
+	InstrumentationOptIn    bool                    `yaml:"instrumentation_opt_in"`
+	InstrumentationUser     string                  `yaml:"instrumentation_user,omitempty"`
+	LastUsedVersion         string                  `yaml:"last_used_version"`
+	ProjectList             map[string]*ProjectInfo `yaml:"project_info"`
+	DeveloperMode           bool                    `yaml:"developer_mode,omitempty"`
+	MkcertCARoot            string                  `yaml:"mkcert_caroot"`
+	RouterBindAllInterfaces bool                    `yaml:"router_bind_all_interfaces"`
 }
 
 // GetGlobalConfigPath() gets the path to global config file
@@ -127,6 +128,9 @@ func WriteGlobalConfig(config GlobalConfig) error {
 #
 # instrumentation_user: <your_username> # can be used to give ddev specific info about who you are
 # developer_mode: true # (defaults to false) is not used widely at this time.
+# yaml_find_all_interfaces: false  # If true, the ddev-router will bind web ports on all
+#    network interfaces instead of just localhost, so others on your network can 
+#    access it.
 `
 	cfgbytes = append(cfgbytes, instructions...)
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -132,7 +132,8 @@ func WriteGlobalConfig(config GlobalConfig) error {
 #    If true, ddev-router will bind http/s, PHPMyAdmin, and MailHog ports on all
 #    network interfaces instead of just localhost, so others on your local network can
 #    access those ports. Note that this exposes the PHPMyAdmin and MailHog ports as well, which
-#    can be a major security issue, so be aware of your actions.
+#    can be a major security issue, so choose wisely. Consider omit_containers[dba] to avoid
+#    exposing PHPMyAdmin.
 `
 	cfgbytes = append(cfgbytes, instructions...)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1798: In ddev v1.10, the feature/bug where ddev bound to all network interfaces was removed. Previously everyone on a local network could access ddev sites (and PHPMyAdmin). 

It was a surprise to find out that there were people relying on this feature/bug to share projects with others or to use ddev for CI/CD/Staging applications.

## How this PR Solves The Problem:

Allow a new global configuration option  in ~/.ddev/global_config.yaml: `router_bind_all_interfaces: true` that uses the original behavior. 

## Manual Testing Instructions:

```
ddev poweroff
ddev config global --router-bind-all-interfaces=true
ddev start
```
* Inspect ~/.ddev/router_compose.yaml; you should see the port bindings without IP addresses specified.
* Access project from an IP address on the machine that is *not* localhost

## Automated Testing Overview:

* Adds testing only for the ddev config global option; it seems too hard to know what ip addresses to use in so many testing environments.

## Related Issue Link(s):

#1794 requested this configuration
#1792 also
https://github.com/drud/ddev-contrib/pull/9 provided an interesting workaround that used the ddev-router in an unusual way.

## Release/Deployment notes:

It's important for people to understand the security implications. 
At least using `omit_containers: [dba]` in the ~/.ddev/global_config.yaml is recommended, as that prevents the PHPMyAdmin interface from being used across the local network.
