### PR TITLE
Use much simpler TYPO3 trustedHostsPattern

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -3,29 +3,23 @@ package ddevapp
 import (
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"os"
 	"path/filepath"
 
 	"github.com/drud/ddev/pkg/archive"
-	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 )
 
-func typo3AdditionalConfigTemplate(app *DdevApp) string {
-	dockerIP, _ := dockerutil.GetDockerIP()
-	hostNames := append(app.GetHostnames(), "localhost", dockerIP)
-
-	return `<?php
+const typo3AdditionalConfigTemplate = `<?php
 /** ` + DdevFileSignature + `: Automatically generated TYPO3 AdditionalConfiguration.php file.
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
 
-/* TYPO3 v10 balks at ".*" in trustedHostsPattern, so ".*.*" is used to fool it.
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*.*'
+/* TYPO3 v10 balks at ".*" in trustedHostsPattern, so ".*.*" is used to fool it. */
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*.*';
 
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge(
     // on first install, this could be not set yet
@@ -53,7 +47,6 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = 'ImageMagick';
 $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path'] = '/usr/bin/';
 $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path_lzw'] = '/usr/bin/';
 `
-}
 
 // createTypo3SettingsFile creates the app's LocalConfiguration.php and
 // AdditionalConfiguration.php, adding things like database host, name, and
@@ -113,8 +106,7 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	if err != nil {
 		return err
 	}
-	contents := []byte(typo3AdditionalConfigTemplate(app))
-
+	contents := []byte(typo3AdditionalConfigTemplate)
 	err = ioutil.WriteFile(filePath, contents, 0644)
 	if err != nil {
 		return err

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -24,9 +24,8 @@ func typo3AdditionalConfigTemplate(app *DdevApp) string {
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  */
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '` +
-		strings.Join(hostNames, "(:\\\\d+)?|") +
-		`(:\\d+)?|.*\.ngrok\.io(:\\d+)?';
+/* TYPO3 v10 balks at ".*" in trustedHostsPattern, so ".*.*" is used to fool it.
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*.*'
 
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] = array_merge(
     // on first install, this could be not set yet


### PR DESCRIPTION
## The Problem/Issue/Bug:

Several recent PRs have tried to catch up with TYPO3 v1.10's rejection of ".*" as trustedHostsPattern, and it's gotten super complex.

## How this PR Solves The Problem:

Since TYPO3 only checks and complains about the literal `.*` we might as well fool it by using `.*.*`. It's for development after all!

## Manual Testing Instructions:

Install TYPO3 v10 using composer, then do an install
* Test with various hostnames/fqdns
* Test with ngrok/ddev share

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

