### PR TITLE
Make settings.php manipulation optional

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/mitchellh/go-homedir"
-	"os"
-	"strings"
 
 	"path/filepath"
 
@@ -136,6 +137,9 @@ var (
 
 	// ngrokArgs provides additional args to the ngrok command in `ddev share`
 	ngrokArgs string
+
+	// omitSettingsPhp skips generating a database settings file.
+	omitSettingsPhp bool
 )
 
 var providerName = ddevapp.ProviderDefault
@@ -293,6 +297,8 @@ func init() {
 	ConfigCommand.Flags().StringVarP(&ngrokArgs, "ngrok-args", "", "", "Provide extra args to ngrok in ddev share")
 
 	ConfigCommand.Flags().String("timezone", "", "Specify timezone for containers and php, like Europe/London or America/Denver or GMT or UTC")
+
+	ConfigCommand.Flags().BoolVar(&omitSettingsPhp, "omit-settings-php", false, "Do not write a database settings file and do not modify the existing settings file")
 
 	RootCmd.AddCommand(ConfigCommand)
 }
@@ -496,6 +502,10 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if cmd.Flag("ngrok-args").Changed {
 		app.NgrokArgs = ngrokArgs
+	}
+
+	if cmd.Flag("omit-settings-php").Changed {
+		app.OmitSettingsPhp = omitSettingsPhp
 	}
 
 	if cmd.Flag("project-tld").Changed {

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -88,6 +88,13 @@ func init() {
 // CreateSettingsFile creates the settings file (like settings.php) for the
 // provided app is the apptype has a settingsCreator function.
 func (app *DdevApp) CreateSettingsFile() (string, error) {
+	// If the user has asked us to skip settings file manipulation, then just bail
+	// out early.
+	if app.OmitSettingsPhp {
+		util.Warning("Skipping creation of settings file.")
+		return "", nil
+	}
+
 	app.SetApptypeSettingsPaths()
 
 	// If neither settings file options are set, then don't continue. Return

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3,17 +3,18 @@ package ddevapp
 import (
 	"bytes"
 	"fmt"
-	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/lextoumbourou/goodhosts"
-	"github.com/mattn/go-isatty"
-	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/lextoumbourou/goodhosts"
+	"github.com/mattn/go-isatty"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"strings"
 
@@ -32,7 +33,7 @@ import (
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 // containerWaitTimeout is the max time we wait for all containers to become ready.
@@ -112,6 +113,7 @@ type DdevApp struct {
 	MkcertEnabled         bool                  `yaml:"-"`
 	NgrokArgs             string                `yaml:"ngrok_args,omitempty"`
 	Timezone              string                `yaml:"timezone"`
+	OmitSettingsPhp       bool                  `yaml:"omit_settings_php,omitempty"`
 }
 
 // GetType returns the application type as a (lowercase) string


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our settings.php already has configuration for ddev and we'd prefer to own the responsibility of managing the file on our own.

## How this PR Solves The Problem:

Allows users to opt out of settings file management by doing `ddev config --omit-settings-php`. Subsequent `ddev config`s will remember this and continue to not manipulate settings.php.

Probably still needs docs and tests, but I'm opening this PR early to see if this is a desired feature.

## Manual Testing Instructions:

Run `ddev config --omit-settings-php` and verify the following:

1. `settings.php` isn't modified
2. `settings.ddev.php` isn't generated
3. `sites/default/.gitignore` isn't generated
4. `omit_settings_php: true` is included in `.ddev/config.yaml`
5. Another `ddev config` does all of those same things ^^

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

No tests currently. Happy to add them if needed. Same with docs.

## Related Issue Link(s):

n/a

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

