### PR TITLE
Bump containers to tags to v1.11.0 for release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,35 +49,35 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190819_update_mkcert" // Note that this can be overridden by make
+var WebTag = "v1.11.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.10.0"
+var BaseDBTag = "v1.11.0"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "drud/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "v1.10.0" // Note that this can be overridden by make
+var DBATag = "v1.11.0" // Note that this can be overridden by make
 
 // BgsyncImg defines the default bgsync image tag used for applications.
 var BgsyncImg = "drud/ddev-bgsync"
 
 // BgsyncTag defines the default phpmyadmin image tag used for applications.
-var BgsyncTag = "v1.10.0" // Note that this can be overridden by make
+var BgsyncTag = "v1.11.0" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20190819_update_mkcert" // Note that this can be overridden by make
+var RouterTag = "v1.11.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.10.2"
+var SSHAuthTag = "v1.11.0"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Bump containers to v1.11.0

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

