### PR TITLE
Fix broken link to extending commands, docs only [skip ci][ci skip]

### DIFF
--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -38,7 +38,7 @@ the .ddev/config.yaml is the primary configuration for the project.
 | project_tld | defaults to "ddev.site" so project urls become "someproject.ddev.site" | This can be changed to anything that works for you; to keep things the way they were before ddev v1.9, use "ddev.local" |
 | ngrok_args | Extra flags for ngrok when using the `ddev share` command | For example, `--subdomain mysite --auth user:pass`. See [ngrok docs on http flags](https://ngrok.com/docs#http) |
 | provider| hosting provider for `ddev pull` | "pantheon" or "drud-aws" or "default" |
-| hooks | | See [Extending Commands](../../extending-commands.md) for more information. |
+| hooks | | See [Extending Commands](../extending-commands.md) for more information. |
 
 ## global_config.yaml Options
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

There was a broken link on the config.yaml page to the extending commands section.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

