### PR TITLE
WordPress: Use the secure URL for `WP_HOME`

### DIFF
--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -46,7 +46,7 @@ func NewWordpressConfig(app *DdevApp, absPath string) *WordpressConfig {
 		DatabaseUsername: "db",
 		DatabasePassword: "db",
 		DatabaseHost:     "db",
-		DeployURL:        app.GetHTTPURL(),
+		DeployURL:        app.GetHTTPSURL(),
 		Docroot:          "/var/www/html/docroot",
 		TablePrefix:      "wp_",
 		AuthKey:          util.RandString(64),

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -46,7 +46,7 @@ func NewWordpressConfig(app *DdevApp, absPath string) *WordpressConfig {
 		DatabaseUsername: "db",
 		DatabasePassword: "db",
 		DatabaseHost:     "db",
-		DeployURL:        app.GetHTTPSURL(),
+		DeployURL:        app.GetPrimaryURL(),
 		Docroot:          "/var/www/html/docroot",
 		TablePrefix:      "wp_",
 		AuthKey:          util.RandString(64),


### PR DESCRIPTION
## The Problem/Issue/Bug:
Every time I run `ddev config`, DDEV overrides the `wp-config-ddev.php` for the `WP_HOME` constant, and uses HTTP protocol for that URL.
However DDEV already defaults to secure URLs, this setting should match that too. 

## How this PR Solves The Problem:
Changes `DeployURL` to use a secure URL, so that `WP_HOME` can inherit that too.


