### PR TITLE
Change nfs mounting for macOS Catalina, fixes #1869

### DIFF
--- a/.buildkite/nfstest.sh
+++ b/.buildkite/nfstest.sh
@@ -10,7 +10,12 @@ function cleanup {
 trap cleanup EXIT
 
 mkdir -p ~/.ddev
-share="${HOME}/.ddev"
+
+# Handle new macOS Catalina /System/Volumes/Data share path.
+share=${HOME}/.ddev
+if [ -d "/System/Volumes/Data${HOME}/.ddev" ] ; then
+    share="/System/Volumes/Data${HOME}/.ddev"
+fi
 
 # Find host.docker.internal name using host-docker-internal.sh script
 hostDockerInternal=$($(dirname $0)/../scripts/host-docker-internal.sh)

--- a/cmd/ddev/cmd/debug-nfsmount_test.go
+++ b/cmd/ddev/cmd/debug-nfsmount_test.go
@@ -3,9 +3,12 @@ package cmd
 import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -42,5 +45,10 @@ func TestDebugNFSMount(t *testing.T) {
 	assert.Contains(out, "/nfsmount")
 	pwd, err := os.Getwd()
 	assert.NoError(err)
-	assert.Contains(out, ":"+dockerutil.MassageWindowsNFSMount(pwd))
+
+	source := pwd
+	if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", source)) {
+		source = filepath.Join("/System/Volumes/Data", source)
+	}
+	assert.Contains(out, ":"+dockerutil.MassageWindowsNFSMount(source))
 }

--- a/docs/developers/buildkite-testmachine-setup.md
+++ b/docs/developers/buildkite-testmachine-setup.md
@@ -50,7 +50,7 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 3. Run docker manually and go through its configuration routine.
 3. Run `iterm`. On Mojave it may prompt for requiring full disk access permissions, follow through with that.
 3. Set up nfsd by running `macos_ddev_nfs_setup.sh`
-4. Add the path `/private/var` to `/etc/exports` and `sudo nfsd restart`.
+4. Add the path `/private/var` or on Catalina `/System/Volumes/Data/private/var` to `/etc/exports` and `sudo nfsd restart`.
 5. Edit the buildkite-agent.cfg in /usr/local/etc/buildkite-agent.cfg to add 
     * the agent token 
     * Tags, like `"os=macos,osvariant=highsierra,dockertype=dockerformac"`

--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -57,7 +57,7 @@ Tools to debug and solve permission problems:
 
 ### macOS Catalina Upgrades
 
-If you're upgrading an existing NFS/ddev setup and you've upgraded to macOS Catalina, the share path format in /etc/exports has been changed. If you previously had a line in /etc/exports like `/Users/rfay -alldirs -mapall=501:20 localhost` it will have to be changed to something like `/System/Volumes/Data/Users/rfay/workspace -alldirs -mapall=501:20 localhost` (Add "/System/Volumes/Data" to the front of the shared path.) The setup script [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/macos_ddev_nfs_setup.sh) will also handle this, but it won't remove any obsolete or broken lines.
+If you're upgrading an existing NFS/ddev setup and you've upgraded to macOS Catalina, the share path format in /etc/exports has been changed. If you previously had a line in /etc/exports like `/Users/rfay -alldirs -mapall=501:20 localhost` it will have to be changed to something like `/System/Volumes/Data/Users/rfay/workspace -alldirs -mapall=501:20 localhost` (Add "/System/Volumes/Data" to the front of the shared path.) You can also just run the NFS setup script [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/macos_ddev_nfs_setup.sh) again and it will handle this, but it won't remove any obsolete or broken lines.
 
 ### macOS-specific NFS debugging
 

--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -59,6 +59,21 @@ Tools to debug and solve permission problems:
 
 If you're upgrading an existing NFS/ddev setup and you've upgraded to macOS Catalina, the share path format in /etc/exports has been changed. If you previously had a line in /etc/exports like `/Users/rfay -alldirs -mapall=501:20 localhost` it will have to be changed to something like `/System/Volumes/Data/Users/rfay/workspace -alldirs -mapall=501:20 localhost` (Add "/System/Volumes/Data" to the front of the shared path.) You can also just run the NFS setup script [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/macos_ddev_nfs_setup.sh) again and it will handle this, but it won't remove any obsolete or broken lines.
 
+So Catalina upgrade step-by-step:
+
+* Edit /etc/exports or run the NFS setup script [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/macos_ddev_nfs_setup.sh) again. If you previously had a line in /etc/exports like `/Users/rfay -alldirs -mapall=501:20 localhost` it will have to be changed to something like `/System/Volumes/Data/Users/rfay -alldirs -mapall=501:20 localhost` (Add "/System/Volumes/Data" to the front of the shared path.)
+* `sudo nfsd restart`
+* Use `ddev debug nfsmount` in a project directory to make sure it gives successful output like
+    ```
+    $ ddev debug nfsmount
+    Successfully accessed NFS mount of /Users/rfay/workspace/d8composer
+    TARGET    SOURCE                                                FSTYPE OPTIONS
+    /nfsmount :/System/Volumes/Data/Users/rfay/workspace/d8composer nfs    rw,relatime,vers=3,rsize=65536,wsize=65536,namlen=255,hard,nolock,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=192.168.65.2,mountvers=3,mountproto=tcp,local_lock=all,addr=192.168.65.2
+    /nfsmount/.ddev
+    ```
+
+Remember to use `ddev debug nfsmount` to verify
+
 ### macOS-specific NFS debugging
 
 * Use `showmount -e` to find out what is exported via NFS. If you don't see a parent of your project directory in there, then NFS can't work.

--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -55,6 +55,18 @@ Tools to debug and solve permission problems:
 * `showmount -e` on macOS or Linux will show the shared mounts.
 * On Linux, the primary IP address needs to be in /etc/exports. Temporarily set the share in /etc/exports to `/home *`, which shares /home with any client, and `sudo systemctl restart nfs-kernel-server`. Then start a ddev project doing an nfs mount, and `showmount -a` and you'll find out what the primary IP address in use is. You can add that address to /etc/exports.
 
+### macOS Catalina Upgrades
+
+If you're upgrading an existing NFS/ddev setup and you've upgraded to macOS Catalina, the share path format in /etc/exports has been changed. If you previously had a line in /etc/exports like `/Users/rfay -alldirs -mapall=501:20 localhost` it will have to be changed to something like `/System/Volumes/Data/Users/rfay/workspace -alldirs -mapall=501:20 localhost` (Add "/System/Volumes/Data" to the front of the shared path.) The setup script [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/macos_ddev_nfs_setup.sh) will also handle this, but it won't remove any obsolete or broken lines.
+
+### macOS-specific NFS debugging
+
+* Use `showmount -e` to find out what is exported via NFS. If you don't see a parent of your project directory in there, then NFS can't work.
+* If nothing is showing, use `nfsd checkexports` and read carefully for errors
+* Use `ps -ef | grep nfsd` to make sure nfsd is running
+* Restart nfsd with `sudo nfsd restart`
+* Run Console.app and put "nfsd" in the search box at the top. `sudo nfsd restart` and read the messages carefully.
+
 ### Windows-specific NFS debugging
 
 * You can only have one NFS daemon running, so if another application has installed one, you'll want to use that NFS daemon and reconfigure it to allow NFS mounts of your projects. 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -663,6 +663,10 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		templateVars.MountType = "volume"
 		templateVars.WebMount = "nfsmount"
 		templateVars.NFSSource = app.AppRoot
+		// Workaround for Catalina sharing nfs as /System/Volumes/Data
+		if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", app.AppRoot)) {
+			templateVars.NFSSource = filepath.Join("/System/Volumes/Data", app.AppRoot)
+		}
 		if runtime.GOOS == "windows" {
 			// WinNFSD can only handle a mountpoint like /C/Users/rfay/workspace/d8git
 			// and completely chokes in C:\Users\rfay...

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2398,7 +2398,12 @@ func TestNFSMount(t *testing.T) {
 		Cmd:     "findmnt -T .",
 	})
 	assert.NoError(err)
-	assert.Contains(stdout, ":"+dockerutil.MassageWindowsNFSMount(app.AppRoot))
+
+	source := app.AppRoot
+	if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", app.AppRoot)) {
+		source = filepath.Join("/System/Volumes/Data", app.AppRoot)
+	}
+	assert.Contains(stdout, ":"+dockerutil.MassageWindowsNFSMount(source))
 
 	// Create a host-side dir symlink; give a second for it to sync, make sure it can be used in container.
 	err = os.Symlink(".ddev", "nfslinked_.ddev")

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 
 	logOutput "github.com/sirupsen/logrus"
@@ -365,11 +366,16 @@ func TestRemoveVolume(t *testing.T) {
 	_ = RemoveVolume(testVolume)
 	pwd, err := os.Getwd()
 	assert.NoError(err)
+
+	source := pwd
+	if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", source)) {
+		source = filepath.Join("/System/Volumes/Data", source)
+	}
 	volume, err := CreateVolume(
 		testVolume,
 		"local",
 		map[string]string{"type": "nfs", "o": "addr=host.docker.internal,hard,nolock,rw",
-			"device": ":" + MassageWindowsNFSMount(pwd)},
+			"device": ":" + MassageWindowsNFSMount(source)},
 	)
 	assert.NoError(err)
 

--- a/scripts/macos_ddev_nfs_setup.sh
+++ b/scripts/macos_ddev_nfs_setup.sh
@@ -32,12 +32,17 @@ echo "
 echo "Stopping running ddev projects"
 echo ""
 
-ddev stop -a || true
+ddev poweroff || true
 
 echo "== Setting up nfs..."
 # Share /Users folder. If the projects are elsewhere the /etc/exports will need
 # to be adapted.
-LINE="${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost"
+# If Catalina or later, the share directory has to be /System/Volumes/Data/...
+SHAREDIR=${HOME}
+if [ -d /System/Volumes/Data${HOME} ] ; then
+    SHAREDIR=/System/Volumes/Data${HOME}
+fi
+LINE="${SHAREDIR} -alldirs -mapall=$(id -u):$(id -g) localhost"
 FILE=/etc/exports
 sudo bash -c "echo >> $FILE" || ( echo "Unable to edit /etc/exports, need Full Disk Access on Mojave and later" && exit 103 )
 grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )


### PR DESCRIPTION
## The Problem/Issue/Bug:

OP #1869 points out that nfs_mount_enabled is broken in macOS Catalina. 

## How this PR Solves The Problem:

- [x] Change the nfssource to /System/Volumes/Data/... in ddev
- [x] Change the scripts/macos_ddev_nfs_setup.sh to share the /System/Volumes/Data/... instead of sharing it raw
- [x] Add docs on troubleshooting as mentioned in #1869
- [x] Update at least one testbot to Catalina

## Manual Testing Instructions:

On fresh Catalina (and other macOS, but should be covered by automated testing)

* Read/review the [new docs](https://github.com/drud/ddev/blob/2c3fcb59d32d3c57b6a589cab00b5c4245147d93/docs/users/performance.md) about how to upgrade and debugging technique.
* On Catalina or pre-Catalina, run the [nfs setup script](https://raw.githubusercontent.com/drud/ddev/2c3fcb59d32d3c57b6a589cab00b5c4245147d93/scripts/macos_ddev_nfs_setup.sh)
* Use `showmount -e` to verify that the directory is now being shared.
* In a project directory, use `ddev debug nfsmount` to verify that it's successful and shows the mounted volume.
* In a project directory with `nfs_mount_enabled: true` do a `ddev start` and visit the site to make sure everything works.


## Automated Testing Overview:

Both of the macStadium testbots are being upgraded to Catalina.

## Related Issue Link(s):

OP #1869

## Release/Deployment notes:

