### PR TITLE
More robust initial cert for ddev-router

### DIFF
--- a/containers/ddev-router/docker-entrypoint.sh
+++ b/containers/ddev-router/docker-entrypoint.sh
@@ -32,7 +32,7 @@ mkcert -install
 
 # It's unknown what docker event causes an attempt to use these certs/.crt files, but they might as well exist
 # to prevent it.
-mkcert -cert-file /etc/nginx/certs/.crt -key-file /etc/nginx/certs/.key "*.ddev.local" 127.0.0.1 localhost ddev-router ddev-router.ddev_default
+mkcert -cert-file /etc/nginx/certs/.crt -key-file /etc/nginx/certs/.key "*.ddev.local" "*.ddev.site" 127.0.0.1 localhost ddev-router ddev-router.ddev_default
 
 if [ ! -f /etc/nginx/certs/master.crt ]; then
   mkcert -cert-file /etc/nginx/certs/master.crt -key-file /etc/nginx/certs/master.key "*.ddev.local" "*.ddev.site" "ddev-router" "ddev-router.ddev_default" 127.0.0.1 localhost

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -73,7 +73,7 @@ var BgsyncTag = "v1.11.0" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.11.0" // Note that this can be overridden by make
+var RouterTag = "20191008_router_cert" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

There was one cert in the router that did not have "*.ddev.site". It really only showed up on https://127.0.0.1, so probably didn't matter.

## How this PR Solves The Problem:

Add "*.ddev.site" to that one situation.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

