### PR TITLE
Add sqlite3 to web container

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -87,7 +87,8 @@ RUN apt-get -qq update && \
         libpcre3 \
         openssh-client \
         php-imagick \
-        php-uploadprogress && \
+        php-uploadprogress \
+        sqlite3 && \
     for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y  $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-pgsql $v-mbstring $v-opcache $v-soap $v-sqlite3 $v-readline $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
     # These are items not yet available in php7.4 \
     for v in php5.6 php7.0 php7.1 php7.2 php7.3; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-memcached $v-redis $v-xdebug ; done && \

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.11.0" // Note that this can be overridden by make
+var WebTag = "20191014_heddn_sqlite3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
Add sqlite3 to base webserver image.

## The Problem/Issue/Bug:

With the addition of build tests to drupal core, it would be nice to be able to run build tests that leverage sqlite and drush without needing to remember that sqlite3 isn't installed by default.

See https://www.drupal.org/project/drupal/issues/3082230

## How this PR Solves The Problem:
It installs the package.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Adds sqlite CLI for being able to test things leveraging sqlite inside of the docker instance.

