### PR TITLE
Use nsis from linuxbrew (3.04) instead of from apt-get (ancient)

### DIFF
--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -23,6 +23,9 @@ for item in osslsigncode golang mkcert ddev makensis; do
     brew install $item || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item
 done
 
+# Get the Stubs and Plugins for makensis; the linux makensis build doesn't do this.
+wget https://sourceforge.net/projects/nsis/files/NSIS%203/3.04/nsis-3.04.zip/download && sudo unzip -d /usr/local/share download && sudo mv /usr/local/share/nsis-3.04 /usr/local/share/nsis
+
 # Temporarily overwrite the brew-loaded broken-on-Ubuntu1604 mkcert
 brew unlink mkcert
 sudo curl -sSL -o /usr/local/bin/mkcert -O https://github.com/rfay/mkcert/releases/download/v1.4.1-alpha1/mkcert-v1.4.1-alpha1-linux-amd64 && sudo chmod +x /usr/local/bin/mkcert

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -6,7 +6,7 @@ set -x
 # Basic tools
 
 sudo apt-get update -qq
-sudo apt-get install -qq mysql-client realpath zip nsis jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
+sudo apt-get install -qq mysql-client realpath zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
 
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && sudo unzip -d /usr/local/bin /tmp/ngrok.zip
 
@@ -19,7 +19,7 @@ echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 . ~/.bashrc
 
 brew update && brew tap drud/ddev
-for item in osslsigncode golang mkcert ddev; do
+for item in osslsigncode golang mkcert ddev makensis; do
     brew install $item || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item
 done
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

In https://github.com/drud/ddev/pull/1880 @gilbertsoft noted that the Circleci/Linux makensis we're using is really old. It seems we were getting it from apt-get (and those testbots are Ubuntu 16.04, a few years old). 

## How this PR Solves The Problem:

* Use homebrew to build makensis
* Unzip the standard 3.04 nsis tarball into /usr/local/share/nsis so that we get Stubs

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

