### PR TITLE
Added links to ddev-contrib for some extra services and old PHP

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -70,21 +70,12 @@ This recipe adds a [Beanstalk](https://beanstalkd.github.io/) container to a pro
 - The Beanstalk instance will listen on TCP port 11300 (the beanstalkd default).
 - Configure your application to access Beanstalk on the host:port `beanstalk:11300`.
 
-## MongoDB
+## Additional services in ddev-contrib (MongoDB, Blackfire, PostgresSQL, etc)
 
-[MongoDB support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/mongodb) as a [custom Docker compose file](custom-compose-files.md).
+The [ddev-contrib](https://github.com/drud/ddev-contrib) repository has a wealth of additional examples and instructions:
 
-## Blackfire.io (Performance testing and profiling)
-
-[Blackfire support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/blackfire) as a [custom Docker compose file](custom-compose-files.md).
-
-## PostgreSQL
-
-[PostgreSQL support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/postgres) as a [custom Docker compose file](custom-compose-files.md).
-
-## Elasticsearch
-
-[Elasticsearch support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/elasticsearch) as a [custom Docker compose file](custom-compose-files.md).
-
-## Oracle MySQL
-[Oracle MySQL support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/mysql) as a [custom Docker compose file](custom-compose-files.md).
+* **MongoDB**: See [MongoDB](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/mongodb).
+* **Blackfire.io for performance testing and profiling**: See [Blackfire.io](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/blackfire).
+* **PostgresSQL**: See [PostgresSQL](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/postgres).
+* **Elasticsearch**: See [Elasticsearch](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/elasticsearch).
+* **Oracle MySQL**: See [MySQL](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/mysql).

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -69,3 +69,22 @@ This recipe adds a [Beanstalk](https://beanstalkd.github.io/) container to a pro
 
 - The Beanstalk instance will listen on TCP port 11300 (the beanstalkd default).
 - Configure your application to access Beanstalk on the host:port `beanstalk:11300`.
+
+## MongoDB
+
+[MongoDB support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/mongodb) as a [custom Docker compose file](custom-compose-files.md).
+
+## Blackfire.io (Performance testing and profiling)
+
+[Blackfire support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/blackfire) as a [custom Docker compose file](custom-compose-files.md).
+
+## PostgreSQL
+
+[PostgreSQL support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/postgres) as a [custom Docker compose file](custom-compose-files.md).
+
+## Elasticsearch
+
+[Elasticsearch support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/elasticsearch) as a [custom Docker compose file](custom-compose-files.md).
+
+## Oracle MySQL
+[Oracle MySQL support is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/mysql) as a [custom Docker compose file](custom-compose-files.md).

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -4,6 +4,8 @@
 
 Much of ddev's customization ability and extensibility comes from leveraging features and functionality provided by [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/overview/). Some working knowledge of these tools is required in order to customize or extend the environment ddev provides.
 
+There are [many examples of custom Docker compose files](https://github.com/drud/ddev-contrib#additional-services-added-via-docker-composeserviceyaml) available on [ddev-contrib](https://github.com/drud/ddev-contrib).
+
 ## Background
 
 Under the hood, ddev uses docker-compose to define and run the multiple containers that make up the local environment for a project. docker-compose supports defining multiple compose files to facilitate [sharing Compose configurations between files and projects](https://docs.docker.com/compose/extends/), and ddev is designed to leverage this ability.

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -5,6 +5,10 @@ ddev provides several ways in which the environment for a project using ddev can
 
 The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to (currently) "5.6", "7.0", "7.1", "7.2", or "7.3". The current default is php 7.1.
 
+### Older versions of PHP
+
+[Support for older versions of PHP is available on ddev-contrib](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/old_php) via [custom Docker compose files](custom-compose-files.md).
+
 ## Changing webserver type
 
 DDEV-Local supports nginx with php-fpm by default ("nginx-fpm"), apache2 with php-fpm ("apache-fpm"), and apache2 with embedded php via cgi (apache-cgi). These can be changed using the "webserver_type" value in .ddev/config.yaml, for example `webserver_type: apache-fpm`. 


### PR DESCRIPTION
## The Problem/Issue/Bug:

As discussed on Slack, people don't always know to look at ddev-contrib for support of relatively common, but not built-in, services.

## How this PR Solves The Problem:

This PR updates three pages to add references to ddev-contrib recipes for things like Blackfire, MongoDB, and older versions of PHP.  It also links to ddev-contrib from the "defining additional services" page so people can use them as examples.

