### PR TITLE
Update php nginx config to be more compatible with modern PHP applications

### DIFF
--- a/containers/ddev-webserver/files/etc/nginx/nginx_default.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx_default.conf
@@ -11,7 +11,7 @@
 
     location / {
         absolute_redirect off;
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri /index.php?$query_string;
     }
 
     location @rewrite {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20191014_heddn_sqlite3" // Note that this can be overridden by make
+var WebTag = "20191025_cweagans_nginx_config" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Running Drupal 8 + the redirect module with the php config results in an endless redirect. More generally, other modern PHP applications don't expect `?q=` to designate what the path is.

## How this PR Solves The Problem:

Just re-use the D8 rewrite for the php app type.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

