### PR TITLE
Make solr/memcached name lookup refer exclusively to the right container

### DIFF
--- a/pkg/servicetest/testdata/services/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.beanstalkd.yaml
@@ -16,4 +16,7 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
     volumes:
     - ".:/mnt/ddev_config"
+  web:
+    links:
+    - beanstalk:beanstalk
 

--- a/pkg/servicetest/testdata/services/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.memcached.yaml
@@ -31,3 +31,6 @@ services:
 
     volumes:
     - ".:/mnt/ddev_config"
+  web:
+    links:
+    - memcached:memcached

--- a/pkg/servicetest/testdata/services/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/services/docker-compose.solr.yaml
@@ -65,7 +65,7 @@ services:
   # access the Solr service at sitename.ddev.site:8983.
   web:
     links:
-      - solr:$DDEV_HOSTNAME
+      - solr:solr
 volumes:
   # This creates a Docker volume that sticks around even if you remove or
   # rebuild the container


### PR DESCRIPTION

## The Problem/Issue/Bug:

There seems to be a docker bug or (misunderstanding?) about the correct use of a service lookup, as reported by @yanniboi in https://twitter.com/yanni_boi/status/1186941678885703682

If you do *not* add a "links:" stanza to the web service, then it may find "solr" at the wrong project. This was discovered about the "db" container in https://github.com/drud/ddev/issues/813 and so we used "links:" to make sure it was explicit. 

So currently, as was described by @yanniboi , if you have two projects with a solr container, and you `ddev ssh` into each, then `ping solr` you may get random results, sometimes referring to one project's solr container, sometimes referring to the other. 

## How this PR Solves The Problem:

Add explicit "links:" to the 3rd-party service definitions to prevent this.

## Manual Testing Instructions:

Start two projects that have solr (and memcached and beanstalk)
`ddev ssh` and `ping solr`. You should get the right name resolution and the right container.

## Automated Testing Overview:

## Related Issue Link(s):

#813 discusses this general problem but with the db container

## Release/Deployment notes:

This change is made here for the 3 services describe in the main repo, but the change should be made in the ddev-contrib repository as well.
