### PR TITLE
Minor docs changes to pacify readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,0 @@
-version: 2
-formats: all
-mkdocs:
-  configuration: mkdocs.yml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ extra_javascript:
   - assets/fix-search.js
 markdown_extensions:
   - markdown.extensions.toc
-nav:
+pages:
   - 'Home': 'index.md'
   - 'ddev Basics':
     - 'Using the CLI': 'users/cli-usage.md'


### PR DESCRIPTION
## The Problem/Issue/Bug:

readthedocs didn't like a couple of changes in a509531a82bb7cadde34595739d8bc5cd2ecc979 and the build failed; it uses an incomprehensibly old version of mkdocs.

## How this PR Solves The Problem:

Remove the offending changes

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

