### PR TITLE
Improved Node install docs

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -70,6 +70,14 @@ This recipe adds a [Beanstalk](https://beanstalkd.github.io/) container to a pro
 - The Beanstalk instance will listen on TCP port 11300 (the beanstalkd default).
 - Configure your application to access Beanstalk on the host:port `beanstalk:11300`.
 
+## Node
+This recipe adds a [Node](https://github.com/nodejs/docker-node) container to a project.
+
+**Installation:**
+
+- Copy [docker-compose.node.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/services/docker-compose.node.yaml) to the .ddev folder for your project.
+- Run `ddev start`.
+
 ## Additional services in ddev-contrib (MongoDB, Blackfire, PostgresSQL, etc)
 
 The [ddev-contrib](https://github.com/drud/ddev-contrib) repository has a wealth of additional examples and instructions:

--- a/pkg/servicetest/testdata/services/docker-compose.node.yml
+++ b/pkg/servicetest/testdata/services/docker-compose.node.yml
@@ -1,0 +1,33 @@
+# DDev Node recipe file.
+#
+# To use this in your own project:
+# 1. Copy this file to your project's ".ddev" directory.
+# 2. Launch "ddev start".
+
+version: '3.6'
+
+services:
+  # This is the service name used when running ddev commands accepting the
+  # --service flag.
+  node:
+    # This is the name of the container. It is recommended to follow the same
+    # name convention used in the main docker-compose.yml file.
+    container_name: ddev-${DDEV_SITENAME}-node
+    working_dir: /var/www/html/path/to/theme
+    image: node
+    # Node is available at this port inside the container.
+    ports:
+      - 3000
+    # These labels ensure this service is discoverable by ddev.
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=3000
+    volumes:
+      - ../:/var/www/html
+    command: sh -c 'yarn install && yarn run start'
+  web:
+    links:
+      - node:node


### PR DESCRIPTION
## The Problem/Issue/Bug:

- Setting up a Local dev environment with Browsersync (a Node.js application that watches your files for changes then refreshes your browser window or injects new CSS into the page.), require exposing additional port (e.g.: 3000). `web` service wont let us alter `HTTP_EXPOSE` to expose additionals ports to serve for container.

## How this PR Solves The Problem:

- This recipe adds a Node container to a project. It will set run an arbitrary command specified in the package’s (custom Drupal theme) "start" property of its "scripts" object.

## Manual Testing Instructions:

- Create a custom Drupal theme, add a `package.json` to the theme with a "start" property in its "scripts" object.

## Automated Testing Overview:

- Test require creating a custom Drupal theme

## Related Issue Link(s):

## Release/Deployment notes:

- No, this is only an improved installation docs.

