### PR TITLE
Don't allow export-db if project not started, fixes #1892

### DIFF
--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -34,10 +34,7 @@ var ExportDBCmd = &cobra.Command{
 		}
 
 		if app.SiteStatus() != ddevapp.SiteRunning {
-			err = app.Start()
-			if err != nil {
-				util.Failed("Failed to start app %s to export-db: %v", app.Name, err)
-			}
+			util.Failed("ddev can't export-db until the project is started, please start it first.")
 		}
 
 		err = app.ExportDB(outFileName, gzipOption)


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev export-db ` was willing to start the project for people... But the output of starting the project came out in the file, making it invalid. #1892 

## How this PR Solves The Problem:

Don't allow export-db when project isn't started

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

