### PR TITLE
Pantheon should not authenticate when just initing app, fixes #1905

### DIFF
--- a/cmd/ddev/cmd/config_pantheon.go
+++ b/cmd/ddev/cmd/config_pantheon.go
@@ -37,7 +37,10 @@ func handlePantheonFlags(cmd *cobra.Command, args []string, app *ddevapp.DdevApp
 		return fmt.Errorf("failed to GetProvider: %v", err)
 	}
 	pantheonProvider := provider.(*ddevapp.PantheonProvider)
-	pantheonProvider.SetSiteNameAndEnv(pantheonEnvironmentName)
+	err = pantheonProvider.SetSiteNameAndEnv(pantheonEnvironmentName)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -3,7 +3,7 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
-	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/output"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,6 +91,7 @@ func TestPantheonConfigCommand(t *testing.T) {
 	assert.Equal("docroot", app.Docroot)
 	err = PrepDdevDirectory(testDir)
 	assert.NoError(err)
+	output.UserOut.Print("")
 }
 
 // TestPantheonBackupLinks ensures we can get backups from pantheon for a configured environment.
@@ -128,6 +129,7 @@ func TestPantheonBackupLinks(t *testing.T) {
 	assert.Equal(importPath, "")
 	assert.Contains(backupLink, "database.sql.gz")
 	assert.NoError(err)
+	output.UserOut.Print("")
 }
 
 // TestPantheonPull ensures we can pull backups from pantheon for a configured environment.
@@ -188,4 +190,5 @@ func TestPantheonPull(t *testing.T) {
 	_ = app.WriteConfig()
 	err = app.Stop(true, false)
 	assert.NoError(err)
+	output.UserOut.Print("")
 }

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/output"
 	"os"
 	"path/filepath"

--- a/pkg/ddevapp/pantheon_test.go
+++ b/pkg/ddevapp/pantheon_test.go
@@ -29,6 +29,7 @@ const pantheonTestEnvName = "bbowman"
 
 // TestConfigCommand tests the interactive config options.
 func TestPantheonConfigCommand(t *testing.T) {
+	t.Skip("Removing TestPantheonConfigCommand for now because it requires config-time project validation, which is being removed")
 	if os.Getenv("DDEV_PANTHEON_API_TOKEN") == "" {
 		t.Skip("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping Pantheon specific test.")
 	}

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -52,23 +52,32 @@ func (p *PantheonProvider) ValidateField(field, value string) error {
 }
 
 // SetSiteNameAndEnv sets the environment of the provider (dev/test/live)
-func (p *PantheonProvider) SetSiteNameAndEnv(environment string) {
+func (p *PantheonProvider) SetSiteNameAndEnv(environment string) error {
+	_, err := findPantheonSite(p.app.Name)
+	if err != nil {
+		return fmt.Errorf("unable to find siteName %s on Pantheon: %v", p.app.Name, err)
+	}
 	p.Sitename = p.app.Name
 	p.EnvironmentName = environment
+	return nil
 }
 
 // PromptForConfig provides interactive configuration prompts when running `ddev config pantheon`
 func (p *PantheonProvider) PromptForConfig() error {
 	for {
-		p.SetSiteNameAndEnv("dev")
-		err := p.environmentPrompt()
-
-		if err == nil {
-			return nil
+		err := p.SetSiteNameAndEnv("dev")
+		if err != nil {
+			output.UserOut.Errorf("%v\n", err)
+			continue
 		}
-
-		output.UserOut.Errorf("%v\n", err)
+		err = p.environmentPrompt()
+		if err != nil {
+			output.UserOut.Errorf("%v\n", err)
+			continue
+		}
+		break
 	}
+	return nil
 }
 
 // GetBackup will download the most recent backup specified by backupType in the given environment. If no environment
@@ -179,7 +188,7 @@ func (p *PantheonProvider) environmentPrompt() error {
 		keys = append(keys, k)
 	}
 	fmt.Println("\n\t- " + strings.Join(keys, "\n\t- ") + "\n")
-	var environmentPrompt = "Type the name to select an environment to import from"
+	var environmentPrompt = "Type the name to select an environment to pull from"
 	if p.EnvironmentName != "" {
 		environmentPrompt = fmt.Sprintf("%s (%s)", environmentPrompt, p.EnvironmentName)
 	}
@@ -192,7 +201,10 @@ func (p *PantheonProvider) environmentPrompt() error {
 	if !ok {
 		return fmt.Errorf("could not find an environment named '%s'", envName)
 	}
-	p.SetSiteNameAndEnv(envName)
+	err = p.SetSiteNameAndEnv(envName)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -48,14 +48,6 @@ func (p *PantheonProvider) Init(app *DdevApp) error {
 // allows provider plugins to have additional validation for top level config
 // settings.
 func (p *PantheonProvider) ValidateField(field, value string) error {
-	switch field {
-	case "Name":
-		_, err := findPantheonSite(value)
-		if err != nil {
-			p.Sitename = value
-		}
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

An app.Init() is done for most operations.. but if it's a pantheon provider, that means it was phoning home to verify the name of the project. Shouldn't do that. #1905.

## How this PR Solves The Problem:

Stop validating on app.Init()

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

