### PR TITLE
Fix missing commands (import-db, export-db) when outside project, fixes #1872

### DIFF
--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/drud/ddev/pkg/nodeps"
 	"os"
 
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -50,8 +49,5 @@ var ExportDBCmd = &cobra.Command{
 func init() {
 	ExportDBCmd.Flags().StringVarP(&outFileName, "file", "f", "", "Provide the path to output the dump")
 	ExportDBCmd.Flags().BoolVarP(&gzipOption, "gzip", "z", true, "If provided asset is an archive, provide the path to extract within the archive.")
-	app, err := ddevapp.GetActiveApp("")
-	if err == nil && app != nil && !nodeps.ArrayContainsString(app.OmitContainers, "db") {
-		RootCmd.AddCommand(ExportDBCmd)
-	}
+	RootCmd.AddCommand(ExportDBCmd)
 }

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/drud/ddev/pkg/nodeps"
 	"os"
 
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -61,8 +60,5 @@ func init() {
 	ImportDBCmd.Flags().StringVarP(&dbSource, "src", "", "", "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format")
 	ImportDBCmd.Flags().StringVarP(&dbExtPath, "extract-path", "", "", "If provided asset is an archive, provide the path to extract within the archive.")
 	ImportDBCmd.Flags().BoolVarP(&progressOption, "progress", "p", true, "Display a progress bar during import")
-	app, err := ddevapp.GetActiveApp("")
-	if err == nil && app != nil && !nodeps.ArrayContainsString(app.OmitContainers, "db") {
-		RootCmd.AddCommand(ImportDBCmd)
-	}
+	RootCmd.AddCommand(ImportDBCmd)
 }

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -34,8 +32,5 @@ var DdevSnapshotCommand = &cobra.Command{
 func init() {
 	DdevSnapshotCommand.Flags().BoolVarP(&snapshotAll, "all", "a", false, "Snapshot all running sites")
 	DdevSnapshotCommand.Flags().StringVarP(&snapshotName, "name", "n", "", "provide a name for the snapshot")
-	app, err := ddevapp.GetActiveApp("")
-	if err == nil && app != nil && !nodeps.ArrayContainsString(app.OmitContainers, "db") {
-		RootCmd.AddCommand(DdevSnapshotCommand)
-	}
+	RootCmd.AddCommand(DdevSnapshotCommand)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev import-db`, export-db, and snapshot were missing from autocomplete, and were not in the instructions of ddev help.

## How this PR Solves The Problem:

Put them back in,.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

