### PR TITLE
WordPress: Fix bug with complaints about config.php not set up, fixes #1736, fixes #1928

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -27,7 +27,7 @@ In addition to the *commands* listed above, there are loads and loads of tools i
 
 ## Quickstart Guides
 
-These are quickstart instructions for generic PHP, WordPress, Drupal 6, Drupal 7, Drupal 8, TYPO3, and Backdrop.
+Here are quickstart instructions for generic PHP, WordPress, Drupal 6, Drupal 7, Drupal 8, TYPO3, and Backdrop.
 
 **Prerequisites:** Before you start, follow the [installation instructions](../index.md#installation). Make sure to [check the system requirements](../index.md#system-requirements), you will need *docker* and *docker-compose* to use ddev.
 
@@ -48,23 +48,31 @@ DDEV works happily with most any PHP or static HTML project, although it has spe
 
 ### WordPress Quickstart
 
-**Composer Setup Example**
+**Composer Setup Example Using roots/bedrock**
 
 ```
-mkdir my-wordpress-site
-cd my-wordpress-site
+mkdir my-wp-bedrock-site
+cd my-wp-bedrock-site
 ddev config --project-type=php
-ddev composer create wordpress/skeleton --no-interaction --prefer-dist
-ddev config --docroot=wp --project-type=wordpress
+ddev composer create roots/bedrock
+ddev config
 ddev restart
 ```
-
-When `ddev start` runs, it outputs status messages to indicate the project environment is starting. When the startup is complete, ddev outputs a message like the one below with a link to access your project in a browser.
-
 ```
 Successfully started my-wordpress-site
 Your application can be reached at: http://my-wordpress-site.ddev.site
 ```
+
+Now, since [bedrock](https://roots.io/bedrock/) uses a configuration technique which is unusual for WordPress:
+
+* Edit the .env file which has been created in the project root, and set 
+    ```
+  DB_NAME=db
+  DB_USER=db
+  DB_PASSWORD=db
+  DB_HOST=db
+  ```
+  For more details see [bedrock installation](https://roots.io/bedrock/docs/installing-bedrock/)
 
 **Git Clone Example**
 
@@ -81,23 +89,66 @@ From here we can start setting up ddev. Inside your project's working directory,
 ddev config
 ```
 
-_Note: ddev config will prompt you for a project name, docroot, and project type._
+You'll see a message like:
+```
+An existing user-managed wp-config.php file has been detected!
+Project ddev settings have been written to:
 
-After `ddev config`, you're ready to start running your project. Run ddev using:
+/Users/rfay/workspace/bedrock/web/wp-config-ddev.php
+
+Please comment out any database connection settings in your wp-config.php and
+add the following snippet to your wp-config.php, near the bottom of the file
+and before the include of wp-settings.php:
+
+// Include for ddev-managed settings in wp-config-ddev.php.
+$ddev_settings = dirname(__FILE__) . '/wp-config-ddev.php';
+if (is_readable($ddev_settings) && !defined('DB_USER')) {
+  require_once($ddev_settings);
+}
+
+If you don't care about those settings, or config is managed in a .env
+file, etc, then you can eliminate this message by putting a line that says
+// wp-config-ddev.php not needed
+in your wp-config.php
+```
+
+So just add the suggested include into your wp-config.php, or take the workaround shown.
+
+Now start your project with `ddev start`
+
+Quickstart instructions regarding database imports can be found under [Database Imports](#database-imports).
+
+### Drupal 8 Quickstart
+
+Get started with Drupal 8 projects on ddev either using a new or existing composer project or by cloning a git repository.
+
+**Composer Setup Example**
 
 ```
-ddev start
+mkdir my-drupal8-site
+cd my-drupal8-site
+ddev config --project-type php
+ddev composer create drupal-composer/drupal-project:8.x-dev --prefer-dist
+ddev config --project-type drupal8
+ddev restart
 ```
 
 When `ddev start` runs, it outputs status messages to indicate the project environment is starting. When the startup is complete, ddev outputs a message like the one below with a link to access your project in a browser.
 
 ```
-Successfully started example-site
-Your project can be reached at: http://example-site.ddev.site and https://example-site.ddev.site
+Successfully started my-drupal8-site
+Your project can be reached at: http://my-drupal8-site.ddev.site
 ```
 
-Quickstart instructions regarding database imports can be found under [Database Imports](#database-imports).
+**Git Clone Example**
 
+Note that the git URL shown below is an example only, you'll need to use your own project.
+
+```
+git clone https://github.com/example/example-site
+cd example-site
+ddev composer install
+```
 
 ### Drupal 6/7 Quickstart
 
@@ -133,38 +184,6 @@ If you want to run the Drupal install script, the next step is to hit "/install.
 
 Quickstart instructions for database imports can be found under [Database Imports](#database-imports).
 
-### Drupal 8 Quickstart
-
-Get started with Drupal 8 projects on ddev either using a new or existing composer project or by cloning a git repository.
-
-**Composer Setup Example**
-
-```
-mkdir my-drupal8-site
-cd my-drupal8-site
-ddev config --project-type php
-ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev --no-interaction --prefer-dist
-ddev config --project-type drupal8
-ddev restart
-```
-
-When `ddev start` runs, it outputs status messages to indicate the project environment is starting. When the startup is complete, ddev outputs a message like the one below with a link to access your project in a browser.
-
-```
-Successfully started my-drupal8-site
-Your project can be reached at: http://my-drupal8-site.ddev.site
-```
-
-**Git Clone Example**
-
-Note that the git URL shown below is an example only, you'll need to use your own project.
-
-```
-git clone https://github.com/example/example-site
-cd example-site
-ddev composer install
-```
-
 ### TYPO3 Quickstart
 
 **Composer Setup Example**
@@ -173,7 +192,7 @@ ddev composer install
 mkdir my-typo3-site
 cd my-typo3-site
 ddev config --project-type php
-ddev composer create "typo3/cms-base-distribution:^9" --no-interaction --prefer-dist
+ddev composer create "typo3/cms-base-distribution:^9" --prefer-dist
 ddev config --project-type typo3
 ddev restart
 ```
@@ -251,7 +270,7 @@ Check out the git repository for the project you want to work on. `cd` into the 
 $ mkdir drupal8
 $ cd drupal8
 $ ddev config --project-type php
-$ ddev composer create drupal-composer/drupal-project:8.x-dev --stability dev --no-interaction
+$ ddev composer create drupal-composer/drupal-project:8.x-dev  
 $ ddev config --project-type drupal8
 ```
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -131,7 +131,7 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	if appFuncs, ok := appTypeMatrix[app.GetType()]; ok && appFuncs.settingsCreator != nil {
 		settingsPath, err := appFuncs.settingsCreator(app)
 		if err != nil {
-			util.Warning("Unable to create settings file: %v", err)
+			util.Warning("Unable to create settings file '%s': %v", app.SiteSettingsPath, err)
 		}
 		if err = CreateGitIgnore(filepath.Dir(app.SiteSettingsPath), filepath.Base(app.SiteDdevSettingsFile), "drushrc.php"); err != nil {
 			util.Warning("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteDdevSettingsFile), err)

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -42,7 +42,7 @@ func TestWriteSettings(t *testing.T) {
 		nodeps.AppTypeDrupal6:   "sites/default/settings.ddev.php",
 		nodeps.AppTypeDrupal7:   "sites/default/settings.ddev.php",
 		nodeps.AppTypeDrupal8:   "sites/default/settings.ddev.php",
-		nodeps.AppTypeWordPress: "local-config.php",
+		nodeps.AppTypeWordPress: "wp-config-ddev.php",
 		nodeps.AppTypeTYPO3:     "typo3conf/AdditionalConfiguration.php",
 	}
 	dir := testcommon.CreateTmpDir(t.Name())

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -42,7 +42,7 @@ func TestWriteSettings(t *testing.T) {
 		nodeps.AppTypeDrupal6:   "sites/default/settings.ddev.php",
 		nodeps.AppTypeDrupal7:   "sites/default/settings.ddev.php",
 		nodeps.AppTypeDrupal8:   "sites/default/settings.ddev.php",
-		nodeps.AppTypeWordPress: "wp-config-ddev.php",
+		nodeps.AppTypeWordPress: "local-config.php",
 		nodeps.AppTypeTYPO3:     "typo3conf/AdditionalConfiguration.php",
 	}
 	dir := testcommon.CreateTmpDir(t.Name())

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -290,8 +290,7 @@ func writeWordpressDdevSettingsFile(config *WordpressConfig, filePath string) er
 func setWordpressSiteSettingsPaths(app *DdevApp) {
 	config := NewWordpressConfig(app, "")
 
-	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
-	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, config.SiteSettings)
+	settingsFileBasePath := app.AppRoot
 	app.SiteDdevSettingsFile = filepath.Join(settingsFileBasePath, config.SiteSettingsDdev)
 }
 
@@ -390,7 +389,6 @@ func wordpressGetRelativeAbsPath(app *DdevApp) (string, error) {
 }
 
 // wordpressPostStartAction handles post-start actions
-
 func wordpressPostStartAction(app *DdevApp) error {
 	if _, err := app.CreateSettingsFile(); err != nil {
 		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -59,7 +59,7 @@ func NewWordpressConfig(app *DdevApp, absPath string) *WordpressConfig {
 		SecureAuthSalt:   util.RandString(64),
 		Signature:        DdevFileSignature,
 		SiteSettings:     "wp-config.php",
-		SiteSettingsDdev: "wp-config-ddev.php",
+		SiteSettingsDdev: "local-config.php",
 		AbsPath:          absPath,
 	}
 }
@@ -198,7 +198,7 @@ func createWordpressSettingsFile(app *DdevApp) (string, error) {
 		} else {
 			// Settings file exists and is not ddev-managed, alert the user to the location
 			// of the generated ddev settings file
-			util.Failed(wordpressConfigInstructions, app.SiteDdevSettingsFile)
+			util.Warning(wordpressConfigInstructions, app.SiteDdevSettingsFile)
 		}
 	} else {
 		// If settings file does not exist, write basic settings file including it

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -163,7 +163,13 @@ and before the include of wp-settings.php:
 $ddev_settings = dirname(__FILE__) . '/wp-config-ddev.php';
 if (is_readable($ddev_settings) && !defined('DB_USER')) {
   require_once($ddev_settings);
-}`
+}
+
+If you don't care about those settings, or config is managed in a .env
+file, etc, then you can eliminate this message by putting a line that says
+// wp-config-ddev.php not needed
+in your wp-config.php
+`
 
 // createWordpressSettingsFile creates a Wordpress settings file from a
 // template. Returns full path to location of file + err
@@ -204,7 +210,7 @@ func createWordpressSettingsFile(app *DdevApp) (string, error) {
 			}
 
 			if includeExists {
-				util.Success("Include of wp-config-ddev.php found in %s", app.SiteDdevSettingsFile, app.SiteSettingsPath)
+				util.Success("Include of %s found in %s", app.SiteDdevSettingsFile, app.SiteSettingsPath)
 			} else {
 				util.Warning(wordpressConfigInstructions, app.SiteDdevSettingsFile)
 			}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1736 (ddev pull fails on Wordpress site) is just one description of the problem here. It seems to affect almost all current WordPress-type sites. 

```
An existing user-managed wp-config.php file has been detected!
Project ddev settings have been written to:

/Users/rfay/workspace/ddevwptest/wp-config-ddev.php

Please comment out any database connection settings in your wp-config.php and
add the following snippet to your wp-config.php, near the bottom of the file
and before the include of wp-settings.php:

// Include for ddev-managed settings in wp-config-ddev.php.
$ddev_settings = dirname(__FILE__) . '/wp-config-ddev.php';
if (is_readable($ddev_settings) && !defined('DB_USER')) {
  require_once($ddev_settings);
```

There are a number of open issues for WordPress, and this problem is at the root of most.

## How this PR Solves The Problem:

* Not finding the include in wp-config.php is no longer an error, just a warning.
* The warning can be quieted by just adding a comment in wp-config.php, as explained by the warning.
* The docs switch to roots/bedrock as the demonstration WordPress Quickstart.

## Manual Testing Instructions:

* Current artifacts for testing at https://circleci.com/gh/drud/ddev/19890#artifacts/containers/0 
* New WP quickstart instructions are at https://github.com/drud/ddev/blob/cd8371fdbdd5f568fea92751fb785a0e62124d63/docs/users/cli-usage.md - please review them and use them.
* Use `ddev config` and `ddev start` on your WP or fresh WP build. 
* Review usage in light of #1736 and #1928, and it should work on Bedrock

## Automated Testing Overview:

* No changes at this point.

## Related Issue Link(s):

#1736 (ddev pull failing on Pantheon sites) was a result of the error thrown if nothing found in wp-config.php. It's now just a warning.
#1928 was about Bedrock not working. For the same reason it works now.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

