### PR TITLE
Fix nightly build - config.yaml left with unusable mariadb version, tests only

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1001,8 +1001,8 @@ func TestPkgConfigMariaDBVersion(t *testing.T) {
 	err := fileutil.CopyDir(filepath.Join(testDir, "testdata", "TestPkgConfigMariaDBVersion"), targetBase)
 	require.NoError(t, err)
 
-	mariaDBVersions := []string{"5.5", "10.0", "10.1", "10.2", "10.3", "10.4"}
-	for _, v := range mariaDBVersions {
+	mariaDBVersions := nodeps.ValidMariaDBVersions
+	for v := range mariaDBVersions {
 		for _, configType := range []string{"dbimage", "mariadb-version"} {
 			app := &DdevApp{}
 			appRoot := filepath.Join(targetBase, configType+"-"+v)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -743,7 +743,8 @@ func TestDdevAllDatabases(t *testing.T) {
 	//nolint: errcheck
 	defer func() {
 		_ = app.Stop(true, false)
-		app.MariaDBVersion = ""
+		// Make sure we leave the config.yaml in expected state
+		app.MariaDBVersion = version.MariaDBDefaultVersion
 		app.MySQLVersion = ""
 		_ = app.WriteConfig()
 	}()


### PR DESCRIPTION
## The Problem/Issue/Bug:

The [nightly build is broken](https://circleci.com/gh/drud/ddev/19578?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link). The problem shows up in TestDdevFullSiteSetup with "ERROR 1273 (HY000) at line 25: Unknown collation: 'utf8mb4_unicode_520_ci". This is a result of one of the other tests (I think TestDdevAllDatabases) leaving the Wordpress site in a state with mariadb_version or mysql_version with an old version.

## How this PR Solves The Problem:

Defer a cleanup of the mariadb_version and mysql_version.

