### PR TITLE
Ngrok, nssm, mkcert should be a dependency of ddev, why not?

### DIFF
--- a/winpkg/chocolatey/ddev.nuspec
+++ b/winpkg/chocolatey/ddev.nuspec
@@ -20,9 +20,15 @@
     <summary>ddev is a local web development tool optimized for PHP projects and CMSs.</summary>
     <description>ddev allows developers to use both nginx and apache, and many versions of PHP, with no host configurations. It works for most web apps, but has a bias toward TYPO3 and Drupal and Wordpress.</description>
     <releaseNotes>See https://github.com/drud/ddev/releases/tag/vREPLACE_DDEV_VERSION</releaseNotes>
+  <dependencies>
+      <dependency id="ngrok" />
+      <dependency id="mkcert" />
+      <dependency id="nssm" />
+  </dependencies>
+
   </metadata>
   <files>
     <file src="tools/**" target="tools" />
-
   </files>
+
 </package>


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've been telling people complicated things to install ngrok. We *bundle* nssm and mkcert in the installer, but they should probably also be dependencies.  

Note that #1925 also proposes to add ngrok to the installer, which is appropriate.

## How this PR Solves The Problem:

Make those 3 things dependencies for ngrok.

## Manual Testing Instructions:

This will have to be tested with a real pre-release in choco.

## Related Issue Link(s):

#1925 proposes to bundle ngrok with the installer, which I still think is fine. 

## Release/Deployment notes:

I'm concerned about the lack of version requirements. My assumption is that chocolatey upgrades to current when you upgrade ddev.
