### PR TITLE
Revert "Temporarily use a custom-built mkcert that works on Ubuntu 16.04"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v7
+        - homebrew-linux-v8
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v7
+        key: homebrew-linux-v8
         paths:
         - /home/linuxbrew
 
@@ -42,13 +42,13 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v7
+        - homebrew-linux-v8
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v7
+        key: homebrew-linux-v8
         paths:
         - /home/linuxbrew
 
@@ -168,14 +168,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v7
+        - homebrew-linux-v8
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v7
+        key: homebrew-linux-v8
         paths:
         - /home/linuxbrew
 
@@ -201,14 +201,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v7
+        - homebrew-linux-v8
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v7
+        key: homebrew-linux-v8
         paths:
         - /home/linuxbrew
     - run:
@@ -231,14 +231,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v7
+        - homebrew-linux-v8
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v7
+        key: homebrew-linux-v8
         paths:
         - /home/linuxbrew
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
@@ -261,12 +261,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v7
+        - homebrew-linux-v8
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v7
+        key: homebrew-linux-v8
         paths:
         - /home/linuxbrew
     - run:
@@ -282,12 +282,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v7
+        - homebrew-linux-v8
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v7
+        key: homebrew-linux-v8
         paths:
         - /home/linuxbrew
     - run:
@@ -343,7 +343,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v7
+        - homebrew-linux-v8
     - attach_workspace:
         at: ~/
     - run:
@@ -351,7 +351,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: homebrew-linux-v7
+        key: homebrew-linux-v8
         paths:
         - /home/linuxbrew
     - store_artifacts:
@@ -371,12 +371,12 @@ jobs:
       - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
       - restore_cache:
           keys:
-          - homebrew-linux-v7
+          - homebrew-linux-v8
       - run:
           command: ./.circleci/linux_circle_vm_setup.sh
           name: TAG BUILD Circle VM setup - tools, docker, golang
       - save_cache:
-          key: homebrew-linux-v7
+          key: homebrew-linux-v8
           paths:
           - /home/linuxbrew
 

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -26,10 +26,6 @@ done
 # Get the Stubs and Plugins for makensis; the linux makensis build doesn't do this.
 wget https://sourceforge.net/projects/nsis/files/NSIS%203/3.04/nsis-3.04.zip/download && sudo unzip -d /usr/local/share download && sudo mv /usr/local/share/nsis-3.04 /usr/local/share/nsis
 
-# Temporarily overwrite the brew-loaded broken-on-Ubuntu1604 mkcert
-brew unlink mkcert
-sudo curl -sSL -o /usr/local/bin/mkcert -O https://github.com/rfay/mkcert/releases/download/v1.4.1-alpha1/mkcert-v1.4.1-alpha1-linux-amd64 && sudo chmod +x /usr/local/bin/mkcert
-
 mkcert -install
 
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')


### PR DESCRIPTION
## The Problem/Issue/Bug:

In #1805 we had to go to a custom-made mkcert because v1.4 did not work right on Ubuntu 16.04 (which is what runs our CircleCI tests)

This reverts commit 95ab5532f1d35246a6d1433cfb7bf46135012a65.

Note that mkcert v1.4.1 has been released, which works OK with Ubuntu 16.04

## How this PR Solves The Problem:

## Manual Testing Instructions:

This should be OK if CircleCI tests pass.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

