### PR TITLE
[docs only] Catalina ~/Documents problem [skip ci][ci skip]

### DIFF
--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -82,7 +82,12 @@ Remember to use `ddev debug nfsmount` to verify
 * If nothing is showing, use `nfsd checkexports` and read carefully for errors
 * Use `ps -ef | grep nfsd` to make sure nfsd is running
 * Restart nfsd with `sudo nfsd restart`
-* Run Console.app and put "nfsd" in the search box at the top. `sudo nfsd restart` and read the messages carefully.
+* Add the following to your /etc/nfsd.conf:
+  ```
+  nfs.server.mount.require_resv_port = 0
+  nfs.server.verbose = 3
+  ```
+* Run Console.app and put "nfs" in the search box at the top. `sudo nfsd restart` and read the messages carefully. Attempt to `ddev debug nfsmount` the problematic project directory.
 
 ### Windows-specific NFS debugging
 

--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -18,6 +18,8 @@ __macOS Mojave (and later) warning:__ You'll need to give your terminal "Full di
 
 Download, inspect, and run the macos_ddev_nfs_setup.sh script  from [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/macos_ddev_nfs_setup.sh)). This stops running ddev projects, adds your home directory to the /etc/exports config file that nfsd uses, and enabled nfsd to run on your computer. This is one-time setup. Note that this shares the /Users directory via NFS to any client, so it's critical to consider security issues and verify that your firewall is enabled and configured. If your DDEV-Local projects are set up outside /Users, you'll need to edit /etc/exports for the correct values.
 
+Note: If you're on macOS Catalina and above, and your projects are in a subdirectory of the ~/Documents directory, you must grant "Full Disk Access" privilege to /sbin/nfsd in the Privacy settings in the System Control Panel. 
+
 ### Windows NFS Setup
 
 The executable components required for Windows NFS (winnfsd and nssm) are packaged with the ddev_windows_installer in each release, so if you've used the windows installer, they're available already. To enable winnfsd as a service, please download, inspect and run the script "windows_ddev_nfs_setup.sh" installed by the installer (or download from [windows_ddev_nfs_setup.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/windows_ddev_nfs_setup.sh)) in a git-bash session on windows. If your DDEV-Local projects are set up outside your home directory, you'll need to edit the ~/.ddev/nfs_exports.sh created by the script and then restart the service with `sudo nssm restart nfsd`.


### PR DESCRIPTION
## The Problem/Issue/Bug:

It turns out you have to explicitly allow /sbin/nfsd "Full Disk Access" on macOS Catalina if you want to work inside ~/Documents.

https://twitter.com/randyfay/status/1194303593559425024

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

