### PR TITLE
Change silent uninstaller to not showing messages

### DIFF
--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -1001,7 +1001,7 @@ Function un.onInit
   ; Load language
   !insertmacro MUI_UNGETLANGUAGE
 
-  MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "Are you sure you want to completely remove $(^Name) and all of its components?" IDYES DoUninstall
+  MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "Are you sure you want to completely remove $(^Name) and all of its components?" /SD IDYES IDYES DoUninstall
   Abort
 
 DoUninstall:
@@ -1015,7 +1015,7 @@ FunctionEnd
  */
 Function un.onUninstSuccess
   HideWindow
-  MessageBox MB_ICONINFORMATION|MB_OK "$(^Name) was successfully removed from your computer."
+  MessageBox MB_ICONINFORMATION|MB_OK "$(^Name) was successfully removed from your computer." /SD IDOK
 FunctionEnd
 
 /**
@@ -1032,7 +1032,7 @@ Function un.mkcertUninstall
     ; Check if setup has done
     ${If} $0 == 1
       ; Get user confirmation
-      MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "mkcert was found in this installation. Do you like to remove the mkcert configuration?" IDYES +2
+      MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "mkcert was found in this installation. Do you like to remove the mkcert configuration?" /SD IDNO IDYES +2
       Goto Skip
 
       MessageBox MB_ICONINFORMATION|MB_OK "Now running mkcert to disable trusted https. Please accept the mkcert dialog box that may follow."


### PR DESCRIPTION

## The Problem/Issue/Bug:
Message boxes are shown during the uninstall.
## How this PR Solves The Problem:
This patch changes the behavior of the uninstaller to not to show message boxes during the process. The only exception is the message if the install directory could not be removed.
## Manual Testing Instructions:
Run the uninstaller with the parameter /S or with chocolatey uninstall
## Automated Testing Overview:

## Related Issue Link(s):

## Release/Deployment notes:
