### PR TITLE
Interpret exec-host in bash context, fixes #1946

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
-	osexec "os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -42,7 +41,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 			return err
 		}
 		if runtime.GOOS == "windows" {
-			windowsBashPath := findWindowsBashPath()
+			windowsBashPath := util.FindWindowsBashPath()
 			if windowsBashPath == "" {
 				fmt.Println("Unable to find bash.exe in PATH, not loading custom commands")
 				return nil
@@ -95,7 +94,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string) func(*cobra.Command, []string) {
 	var windowsBashPath = ""
 	if runtime.GOOS == "windows" {
-		windowsBashPath = findWindowsBashPath()
+		windowsBashPath = util.FindWindowsBashPath()
 	}
 
 	return func(cmd *cobra.Command, cobraArgs []string) {
@@ -217,19 +216,4 @@ func populateExamplesAndCommands() error {
 		}
 	}
 	return nil
-}
-
-// On Windows we'll need the path to bash to execute anything.
-// Returns empty string if not found, path if found
-func findWindowsBashPath() string {
-	windowsBashPath, err := osexec.LookPath(`C:\Program Files\Git\bin\bash.exe`)
-	if err != nil {
-		// This one could come back with the WSL bash, in which case we may have some trouble.
-		windowsBashPath, err = osexec.LookPath("bash.exe")
-		if err != nil {
-			fmt.Println("Not loading custom commands; bash is not in PATH")
-			return ""
-		}
-	}
-	return windowsBashPath
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"github.com/drud/ddev/pkg/nodeps"
 	"math/rand"
 	osexec "os/exec"
@@ -145,4 +146,19 @@ func IsCommandAvailable(cmdName string) bool {
 func GetFirstWord(s string) string {
 	arr := strings.Split(s, " ")
 	return arr[0]
+}
+
+// On Windows we'll need the path to bash to execute anything.
+// Returns empty string if not found, path if found
+func FindWindowsBashPath() string {
+	windowsBashPath, err := osexec.LookPath(`C:\Program Files\Git\bin\bash.exe`)
+	if err != nil {
+		// This one could come back with the WSL bash, in which case we may have some trouble.
+		windowsBashPath, err = osexec.LookPath("bash.exe")
+		if err != nil {
+			fmt.Println("Not loading custom commands; bash is not in PATH")
+			return ""
+		}
+	}
+	return windowsBashPath
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1946 points out that the exec-host task is not interpreted in the context of a shell, which people would expect (and the exec task - in a container - is interpreted in bash context). 

## How this PR Solves The Problem:

Use "bash -c" to interpret the item

## Manual Testing Instructions:

Add a pre-start hook like:
```
hooks:
  pre-start:
  - exec-host: echo $HOME
```
and then `ddev start`. You should see the interpreted $HOME, not '$HOME'

Also test this on Windows. Requires git-bash.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #1946 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

