### PR TITLE
Make package noninteractive install more likely to succeed, fixes #1947

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -749,7 +749,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
  `
 	if extraPackages != nil {
 		contents = contents + `
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 	return WriteImageDockerfile(fullpath, []byte(contents))
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1947 points out that in certain situations (major config file changes in upstream Debian packages) the `webimage_extra_packages` (or any apt-get install noninteractive) may fail. 

## How this PR Solves The Problem:

Per https://serverfault.com/a/279446/79810 a DEBIAN_NONINTERACTIVE can be more likely to succeed with `-o Dpkg::Options::="--force-confnew"`

## Manual Testing Instructions:

* Set `webimage: drud/ddev-webserver:v1.11.0` to recreate the starting point of #1947
* `webimage_extra_packages: [php-yaml, php7.3-ldap]`
* `ddev restart`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #1947

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

