### PR TITLE
Add WP_HOME to bedrock instructions [skip ci][ci skip]

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -71,6 +71,7 @@ Now, since [bedrock](https://roots.io/bedrock/) uses a configuration technique w
   DB_USER=db
   DB_PASSWORD=db
   DB_HOST=db
+  WP_HOME=https://my-wp-bedrock-site.ddev.site
   ```
   For more details see [bedrock installation](https://roots.io/bedrock/docs/installing-bedrock/)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
@lopezs points out in https://github.com/drud/ddev/pull/1918#issuecomment-554344217 that the WordPress bedrock instructions need to mention WP_HOME. This docs-only PR does that. 

