### PR TITLE
Use php-xdebug that should work with php7.4 xdebug

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -88,9 +88,8 @@ RUN apt-get -qq update && \
         openssh-client \
         php-imagick \
         php-uploadprogress \
-        php-xdebug \
         sqlite3 && \
-    for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y  $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-pgsql $v-mbstring $v-opcache $v-soap $v-sqlite3 $v-readline $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
+    for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y  $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-pgsql $v-mbstring $v-opcache $v-soap $v-sqlite3 $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
     # These are items not yet available in php7.4 \
     for v in php5.6 php7.0 php7.1 php7.2 php7.3; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-memcached $v-redis ; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -88,10 +88,11 @@ RUN apt-get -qq update && \
         openssh-client \
         php-imagick \
         php-uploadprogress \
+        php-xdebug \
         sqlite3 && \
     for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y  $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-pgsql $v-mbstring $v-opcache $v-soap $v-sqlite3 $v-readline $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
     # These are items not yet available in php7.4 \
-    for v in php5.6 php7.0 php7.1 php7.2 php7.3; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-memcached $v-redis $v-xdebug ; done && \
+    for v in php5.6 php7.0 php7.1 php7.2 php7.3; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-memcached $v-redis ; done && \
     for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
     apt-get install blackfire-php -y --allow-unauthenticated && \
     apt-get -qq autoremove -y && \

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -433,8 +433,11 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevXdebugEnabled", site.Name))
 
 	phpVersions := nodeps.ValidPHPVersions
+	phpVersions = map[string]bool{"7.4": true}
 	err := app.Init(site.Dir)
 	assert.NoError(err)
+	//nolint: errcheck
+	defer app.Stop(true, false)
 
 	for v := range phpVersions {
 		app.PHPVersion = v
@@ -443,10 +446,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 		app.XdebugEnabled = false
 		assert.NoError(err)
 		err = app.Start()
-
-		//nolint: errcheck
-		defer app.Stop(true, false)
-		require.NoError(t, err)
+		assert.NoError(err)
 
 		opts := &ddevapp.ExecOpts{
 			Service: "web",
@@ -510,9 +510,6 @@ func TestDdevXdebugEnabled(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			fmt.Println("Timed out waiting for accept/listen")
 		}
-
-		err = app.Stop(true, false)
-		assert.NoError(err)
 	}
 	runTime()
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -427,61 +427,93 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 func TestDdevXdebugEnabled(t *testing.T) {
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
+	testcommon.ClearDockerEnv()
 
 	site := TestSites[0]
 	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevXdebugEnabled", site.Name))
 
+	phpVersions := nodeps.ValidPHPVersions
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 
-	// Run with xdebug_enabled: false
-	testcommon.ClearDockerEnv()
-	app.XdebugEnabled = false
-	err = app.WriteConfig()
-	assert.NoError(err)
-	err = app.StartAndWaitForSync(0)
-	//nolint: errcheck
-	defer app.Stop(true, false)
-	require.NoError(t, err)
+	for v := range phpVersions {
+		app.PHPVersion = v
+		t.Logf("Attempting XDebug checks with XDebug %s\n", v)
+		fmt.Printf("Attempting XDebug checks with XDebug %s\n", v)
+		app.XdebugEnabled = false
+		assert.NoError(err)
+		err = app.Start()
 
-	opts := &ddevapp.ExecOpts{
-		Service: "web",
-		Cmd:     "php --ri xdebug",
+		//nolint: errcheck
+		defer app.Stop(true, false)
+		require.NoError(t, err)
+
+		opts := &ddevapp.ExecOpts{
+			Service: "web",
+			Cmd:     "php --ri xdebug",
+		}
+		fmt.Printf("Attempting exec php --ri xdebug with xdebug disabled, XDebug version=%s\n", v)
+
+		stdout, _, err := app.Exec(opts)
+		assert.Error(err)
+		assert.Contains(stdout, "Extension 'xdebug' not present")
+
+		// Run with xdebug_enabled: true
+		testcommon.ClearDockerEnv()
+		app.XdebugEnabled = true
+		err = app.Start()
+		assert.NoError(err)
+		//nolint: errcheck
+		defer app.Stop(true, false)
+
+		stdout, _, err = app.Exec(opts)
+		fmt.Printf("Attempting exec php --ri xdebug with xdebug enabled XDebug version=%s\n", v)
+
+		assert.NoError(err)
+		assert.Contains(stdout, "xdebug support => enabled")
+		assert.Contains(stdout, "xdebug.remote_host => host.docker.internal => host.docker.internal")
+
+		// Start a listener on port 9000 of localhost (where PHPStorm or whatever would listen)
+		listener, err := net.Listen("tcp", ":9000")
+		assert.NoError(err)
+
+		// Curl to the project's index.php or anything else
+		_, _, _ = testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL(), 1)
+
+		fmt.Printf("Attempting accept of port 9000 with xdebug enabled, XDebug version=%s\n", v)
+
+		// Accept is blocking, no way to timeout, so use
+		// goroutine instead.
+		acceptListenDone := make(chan bool, 1)
+		defer close(acceptListenDone)
+
+		go func() {
+			conn, err := listener.Accept()
+			assert.NoError(err)
+			fmt.Printf("Completed accept of port 9000 with xdebug enabled, XDebug version=%s\n", v)
+
+			err = conn.SetDeadline(time.Now().Add(5 * time.Second))
+			assert.NoError(err)
+
+			// Grab the Xdebug connection start and look in it for "Xdebug"
+			bufReader := bufio.NewReader(conn)
+			assert.NoError(err)
+			lineString, err := bufReader.ReadString('\n')
+			assert.NoError(err)
+			assert.Contains(lineString, "Xdebug")
+			acceptListenDone <- true
+		}()
+
+		select {
+		case <-acceptListenDone:
+			fmt.Println("Read from acceptListenDone")
+		case <-time.After(5 * time.Second):
+			fmt.Println("Timed out waiting for accept/listen")
+		}
+
+		err = app.Stop(true, false)
+		assert.NoError(err)
 	}
-	stdout, _, err := app.Exec(opts)
-	assert.Error(err)
-	assert.Contains(stdout, "Extension 'xdebug' not present")
-
-	// Run with xdebug_enabled: true
-	testcommon.ClearDockerEnv()
-	app.XdebugEnabled = true
-	err = app.WriteConfig()
-	assert.NoError(err)
-	err = app.Start()
-	assert.NoError(err)
-	//nolint: errcheck
-	defer app.Stop(true, false)
-
-	stdout, _, err = app.Exec(opts)
-	assert.NoError(err)
-	assert.Contains(stdout, "xdebug support => enabled")
-	assert.Contains(stdout, "xdebug.remote_host => host.docker.internal => host.docker.internal")
-
-	// Start a listener on port 9000 of localhost (where PHPStorm or whatever would listen)
-	ln, err := net.Listen("tcp", ":9000")
-	assert.NoError(err)
-	// Curl to the project's index.php or anything else
-	_, _, _ = testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL(), 1)
-
-	conn, err := ln.Accept()
-	assert.NoError(err)
-
-	// Grab the Xdebug connection start and look in it for "Xdebug"
-	b := make([]byte, 650)
-	_, err = bufio.NewReader(conn).Read(b)
-	require.NoError(t, err)
-	lineString := string(b)
-	assert.Contains(lineString, "Xdebug")
 	runTime()
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20191117_symlink_wp" // Note that this can be overridden by make
+var WebTag = "20191117_xdebug_2_8" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

xdebug 2.8 (works with php7.4) is now part of deb.sury.org, distribution, try to get it working.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

