### PR TITLE
Diagnose/improve execution speed on macOS Catalina, for #1881

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ jobs:
       image: ubuntu-1604:201903-01
     working_directory: ~/ddev
     environment:
-      DRUD_DEBUG: "true"
+      DDEV_DEBUG: "true"
       ARTIFACTS: /artifacts
     steps:
       - checkout
@@ -402,7 +402,7 @@ jobs:
       xcode: "11.0.0"
     working_directory: ~/ddev
     environment:
-      DRUD_DEBUG: "true"
+      DDEV_DEBUG: "true"
       ARTIFACTS: /artifacts
     steps:
     - checkout

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "host": "127.0.0.1",
             "program": "${workspaceRoot}/cmd/ddev",
             "cwd": "$HOME/sites/drupal8",
-            "env": {"DRUD_DEBUG": true},
+            "env": {"DDEV_DEBUG": true},
             "args": [],
             "showLog": true
         },
@@ -24,7 +24,7 @@
             "port": 2345,
             "host": "127.0.0.1",
             "program": "${workspaceRoot}/pkg/plugins/platform",
-            "env": {"DRUD_DEBUG": true},
+            "env": {"DDEV_DEBUG": true},
             "args": [],
             "showLog": true
         }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 {
     "go.testTimeout": "360s",
     "go.testEnvVars": {
-        "DRUD_DEBUG": "true",
+        "DDEV_DEBUG": "true",
         "GOTEST_SHORT": "true"
     }
 }

--- a/docs/developers/building-contributing.md
+++ b/docs/developers/building-contributing.md
@@ -21,7 +21,7 @@ The binaries are built into .gotmp/bin; although normal command-line `go build` 
 ## Testing
 Normal test invocation is just `make test`. Run a single test with an invocation like `go test -v -run TestDevAddSites ./pkg/...` or `make testpkg TESTARGS="-run TestDevAddSites"`.
 
-To see which ddev commands the tests are executing, set the environment variable DRUD_DEBUG=true.
+To see which ddev commands the tests are executing, set the environment variable DDEV_DEBUG=true.
 
 Use GOTEST_SHORT=true to run just one CMS in each test.
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -642,7 +642,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ConfigOverrideDetection", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s ConfigOverrideDetection", site.Name))
 
 	// Copy test overrides into the project .ddev directory
 	for _, item := range []string{"nginx", "apache", "php", "mysql"} {
@@ -701,7 +701,7 @@ func TestPHPOverrides(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	// Copy test overrides into the project .ddev directory
 	err := fileutil.CopyDir(filepath.Join(testDir, "testdata/TestPHPOverrides/.ddev/php"), filepath.Join(site.Dir, ".ddev/php"))
@@ -748,7 +748,7 @@ func TestExtraPackages(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s TestExtraPackages", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestExtraPackages", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -817,7 +817,7 @@ func TestTimezoneConfig(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s %s", t.Name(), site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", t.Name(), site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -878,7 +878,7 @@ func TestCustomBuildDockerfiles(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s TestCustomBuildDockerfiles", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestCustomBuildDockerfiles", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)

--- a/pkg/ddevapp/container_test.go
+++ b/pkg/ddevapp/container_test.go
@@ -3,7 +3,6 @@ package ddevapp_test
 import (
 	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"os"
@@ -27,7 +26,7 @@ func TestUserProvisioningInContainer(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 	defer runTime()
 
 	err := app.Init(site.Dir)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -123,6 +123,9 @@ func (app *DdevApp) GetType() string {
 // Init populates DdevApp config based on the current working directory.
 // It does not start the containers.
 func (app *DdevApp) Init(basePath string) error {
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("app.Init(%s)", basePath))
+	defer runTime()
+
 	newApp, err := NewApp(basePath, true, "")
 	if err != nil {
 		return err

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -239,7 +239,7 @@ func TestDdevStart(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStart", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStart", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -358,7 +358,7 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 
 	for _, site := range TestSites {
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStartMultipleHostnames", site.Name))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStartMultipleHostnames", site.Name))
 		testcommon.ClearDockerEnv()
 
 		err := app.Init(site.Dir)
@@ -430,7 +430,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	testcommon.ClearDockerEnv()
 
 	site := TestSites[0]
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevXdebugEnabled", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevXdebugEnabled", site.Name))
 
 	phpVersions := nodeps.ValidPHPVersions
 	err := app.Init(site.Dir)
@@ -513,7 +513,7 @@ func TestDdevMysqlWorks(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 
 	site := TestSites[0]
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevMysqlWorks", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevMysqlWorks", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -628,7 +628,7 @@ func TestDdevImportDB(t *testing.T) {
 
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevImportDB", site.Name))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevImportDB", site.Name))
 
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
@@ -754,7 +754,7 @@ func TestDdevAllDatabases(t *testing.T) {
 	site := TestSites[0]
 	switchDir := site.Chdir()
 	defer switchDir()
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -872,7 +872,7 @@ func TestDdevExportDB(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevExportDB", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevExportDB", site.Name))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -936,7 +936,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
 		defer switchDir()
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevFullSiteSetup", site.Name))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevFullSiteSetup", site.Name))
 		t.Logf("=== BEGIN TestDdevFullSiteSetup for %s\n", site.Name)
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
@@ -1019,7 +1019,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	testDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
 
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("TestDdevRestoreSnapshot"))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("TestDdevRestoreSnapshot"))
 
 	d7testerTest1Dump, err := filepath.Abs(filepath.Join("testdata", t.Name(), "restore_snapshot", "d7tester_test_1.sql.gz"))
 	assert.NoError(err)
@@ -1150,7 +1150,7 @@ func TestWriteableFilesDirectory(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s TestWritableFilesDirectory", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestWritableFilesDirectory", site.Name))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -1284,7 +1284,7 @@ func TestDdevImportFilesDir(t *testing.T) {
 
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 		testcommon.ClearDockerEnv()
 		err = app.Init(site.Dir)
@@ -1320,7 +1320,7 @@ func TestDdevImportFiles(t *testing.T) {
 
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
@@ -1366,7 +1366,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
@@ -1426,7 +1426,7 @@ func TestDdevExec(t *testing.T) {
 
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevExec", site.Name))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevExec", site.Name))
 
 		err := app.Init(site.Dir)
 		assert.NoError(err)
@@ -1520,7 +1520,7 @@ func TestDdevLogs(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevLogs", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevLogs", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -1578,7 +1578,7 @@ func TestProcessHooks(t *testing.T) {
 	}
 
 	cleanup := site.Chdir()
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s ProcessHooks", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s ProcessHooks", site.Name))
 
 	testcommon.ClearDockerEnv()
 	app, err := ddevapp.NewApp(site.Dir, true, nodeps.ProviderDefault)
@@ -1634,7 +1634,7 @@ func TestDdevPause(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStop", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStop", site.Name))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -2206,7 +2206,7 @@ func TestGetAllURLs(t *testing.T) {
 	assert := asrt.New(t)
 
 	site := TestSites[0]
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s GetAllURLs", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s GetAllURLs", site.Name))
 
 	testcommon.ClearDockerEnv()
 	app := new(ddevapp.DdevApp)
@@ -2267,7 +2267,7 @@ func TestWebserverType(t *testing.T) {
 	assert := asrt.New(t)
 
 	for _, site := range TestSites {
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s TestWebserverType", site.Name))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestWebserverType", site.Name))
 
 		app := new(ddevapp.DdevApp)
 
@@ -2326,7 +2326,7 @@ func TestWebserverType(t *testing.T) {
 func TestInternalAndExternalAccessToURL(t *testing.T) {
 	assert := asrt.New(t)
 
-	runTime := testcommon.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrack(time.Now(), t.Name())
 
 	site := TestSites[0]
 	app := new(ddevapp.DdevApp)
@@ -2416,7 +2416,7 @@ func TestCaptureLogs(t *testing.T) {
 	assert := asrt.New(t)
 
 	site := TestSites[0]
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s CaptureLogs", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s CaptureLogs", site.Name))
 
 	app := ddevapp.DdevApp{}
 
@@ -2449,7 +2449,7 @@ func TestNFSMount(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s TestNFSMount", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestNFSMount", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -2535,7 +2535,7 @@ func TestWebcache(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s TestWebcache", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestWebcache", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -2584,7 +2584,7 @@ func TestWebcache(t *testing.T) {
 // TestHostDBPort tests to make sure that the host_db_port specification has the intended effect
 func TestHostDBPort(t *testing.T) {
 	assert := asrt.New(t)
-	runTime := testcommon.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrack(time.Now(), t.Name())
 	defer runTime()
 	testDir, _ := os.Getwd()
 
@@ -2649,7 +2649,7 @@ func TestHostDBPort(t *testing.T) {
 // ports used by another
 func TestPortSpecifications(t *testing.T) {
 	assert := asrt.New(t)
-	runTime := testcommon.TimeTrack(time.Now(), fmt.Sprint("TestPortSpecifications"))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprint("TestPortSpecifications"))
 	defer runTime()
 	testDir, _ := os.Getwd()
 

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -2,6 +2,7 @@ package ddevapp_test
 
 import (
 	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/util"
 	"path/filepath"
 	"testing"
 
@@ -90,7 +91,7 @@ func TestWriteDrushConfig(t *testing.T) {
 
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
-		runTime := testcommon.TimeTrack(time.Now(), fmt.Sprintf("%s WriteDrushrc", site.Name))
+		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s WriteDrushrc", site.Name))
 
 		testcommon.ClearDockerEnv()
 

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -28,7 +28,7 @@ func TestSSHAuth(t *testing.T) {
 	testDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
 
-	runTime := testcommon.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrack(time.Now(), t.Name())
 
 	//  Add a docker-compose service that has ssh server and mounted authorized_keys
 	site := TestSites[0]

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	exec2 "github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -403,8 +404,10 @@ func CheckDockerVersion(versionConstraint string) error {
 // CheckDockerCompose determines if docker-compose is present and executable on the host system. This
 // relies on docker-compose being somewhere in the user's $PATH.
 func CheckDockerCompose(versionConstraint string) error {
-	runTime := util.TimeTrack(time.Now(), "CheckDockerComposeVersion()")
-	defer runTime()
+	if globalconfig.DdevDebug {
+		runTime := util.TimeTrack(time.Now(), "CheckDockerComposeVersion()")
+		defer runTime()
+	}
 
 	version, err := version.GetDockerComposeVersion()
 	if err != nil {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	exec2 "github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"io"
 	"log"
@@ -367,6 +368,9 @@ func GetContainerEnv(key string, container docker.APIContainers) string {
 // constraints. See https://godoc.org/github.com/Masterminds/semver#hdr-Checking_Version_Constraints
 // for examples defining version constraints.
 func CheckDockerVersion(versionConstraint string) error {
+	runTime := util.TimeTrack(time.Now(), "CheckDockerVersion()")
+	defer runTime()
+
 	currentVersion, err := version.GetDockerVersion()
 	if err != nil {
 		return fmt.Errorf("no docker")
@@ -399,6 +403,9 @@ func CheckDockerVersion(versionConstraint string) error {
 // CheckDockerCompose determines if docker-compose is present and executable on the host system. This
 // relies on docker-compose being somewhere in the user's $PATH.
 func CheckDockerCompose(versionConstraint string) error {
+	runTime := util.TimeTrack(time.Now(), "CheckDockerComposeVersion()")
+	defer runTime()
+
 	version, err := version.GetDockerComposeVersion()
 	if err != nil {
 		return err

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -14,3 +14,4 @@ var ValidOmitContainers = map[string]bool{
 }
 
 var DdevNoInstrumentation = os.Getenv("DDEV_NO_INSTRUMENTATION") == "true"
+var DdevDebug = (os.Getenv("DDEV_DEBUG") == "true")

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -15,3 +15,4 @@ var ValidOmitContainers = map[string]bool{
 
 var DdevNoInstrumentation = os.Getenv("DDEV_NO_INSTRUMENTATION") == "true"
 var DdevDebug = (os.Getenv("DDEV_DEBUG") == "true")
+var DdevVerbose = (os.Getenv("DDEV_VERBOSE") == "true")

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -50,9 +50,9 @@ func LogSetUp() {
 	// Always use log.DebugLevel for UserOut
 	UserOut.Level = log.DebugLevel // UserOut will by default always output
 
-	// But we use custom DRUD_DEBUG-settable loglevel for log
+	// But we use custom DDEV_DEBUG-settable loglevel for log
 	logLevel := log.InfoLevel
-	drudDebug := os.Getenv("DRUD_DEBUG")
+	drudDebug := os.Getenv("DDEV_DEBUG")
 	if drudDebug != "" {
 		logLevel = log.DebugLevel
 	}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -251,15 +251,6 @@ func ContainerCheck(checkName string, checkState string) (bool, error) {
 	return false, errors.New("unable to find container " + checkName)
 }
 
-// TimeTrack determines the amount of time a function takes to return. Timing starts when it is called.
-// It returns an anonymous function that, when called, will print the elapsed run time.
-func TimeTrack(start time.Time, name string) func() {
-	return func() {
-		elapsed := time.Since(start)
-		log.Printf("PERF: %s took %s", name, elapsed)
-	}
-}
-
 // GetCachedArchive returns a directory populated with the contents of the specified archive, either from cache or
 // from downloading and creating cache.
 // siteName is the site.Name used for storage

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/sirupsen/logrus"
 	"math/rand"
 	osexec "os/exec"
 	"os/user"
@@ -161,4 +162,13 @@ func FindWindowsBashPath() string {
 		}
 	}
 	return windowsBashPath
+}
+
+// TimeTrack determines the amount of time a function takes to return. Timing starts when it is called.
+// It returns an anonymous function that, when called, will print the elapsed run time.
+func TimeTrack(start time.Time, name string) func() {
+	return func() {
+		elapsed := time.Since(start)
+		logrus.Printf("PERF: %s took %s", name, elapsed)
+	}
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -167,12 +167,12 @@ func FindWindowsBashPath() string {
 
 // TimeTrack determines the amount of time a function takes to return. Timing starts when it is called.
 // It returns an anonymous function that, when called, will print the elapsed run time.
-// It tracks if DDEV_DEBUG is set
+// It tracks if DDEV_VERBOSE is set
 func TimeTrack(start time.Time, name string) func() {
-	if globalconfig.DdevDebug {
+	if globalconfig.DdevVerbose {
 		logrus.Printf("starting %s at %v\n", name, start.Format("15:04:05"))
 		return func() {
-			if globalconfig.DdevDebug {
+			if globalconfig.DdevVerbose {
 				elapsed := time.Since(start)
 				logrus.Printf("PERF: %s took %.2fs", name, elapsed.Seconds())
 			}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -170,17 +170,14 @@ func FindWindowsBashPath() string {
 // It tracks if DDEV_DEBUG is set
 func TimeTrack(start time.Time, name string) func() {
 	if globalconfig.DdevDebug {
+		logrus.Printf("starting %s at %v\n", name, start.Format("15:04:05"))
 		return func() {
-
-			logrus.Printf("starting %s at %v\n", name, start.Format("15:04:05"))
-
 			if globalconfig.DdevDebug {
 				elapsed := time.Since(start)
 				logrus.Printf("PERF: %s took %.2fs", name, elapsed.Seconds())
 			}
 		}
-	} else {
-		return func() {
-		}
+	}
+	return func() {
 	}
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/sirupsen/logrus"
 	"math/rand"
@@ -166,9 +167,20 @@ func FindWindowsBashPath() string {
 
 // TimeTrack determines the amount of time a function takes to return. Timing starts when it is called.
 // It returns an anonymous function that, when called, will print the elapsed run time.
+// It tracks if DDEV_DEBUG is set
 func TimeTrack(start time.Time, name string) func() {
-	return func() {
-		elapsed := time.Since(start)
-		logrus.Printf("PERF: %s took %s", name, elapsed)
+	if globalconfig.DdevDebug {
+		return func() {
+
+			logrus.Printf("starting %s at %v\n", name, start.Format("15:04:05"))
+
+			if globalconfig.DdevDebug {
+				elapsed := time.Since(start)
+				logrus.Printf("PERF: %s took %.2fs", name, elapsed.Seconds())
+			}
+		}
+	} else {
+		return func() {
+		}
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -159,6 +159,7 @@ func GetRouterImage() string {
 
 // GetDockerComposeVersion runs docker-compose -v to get the current version
 func GetDockerComposeVersion() (string, error) {
+
 	if DockerComposeVersion != "" {
 		return DockerComposeVersion, nil
 	}
@@ -168,6 +169,14 @@ func GetDockerComposeVersion() (string, error) {
 	path, err := exec.LookPath(executableName)
 	if err != nil {
 		return "", fmt.Errorf("no docker-compose")
+	}
+
+	// Temporarily fake the docker-compose check on macOS because of
+	// the slow docker-compose problem in https://github.com/docker/compose/issues/6956
+	// This can be removed when that's resolved.
+	if runtime.GOOS != "darwin" {
+		DockerComposeVersion = "1.25.0-rc4"
+		return DockerComposeVersion, nil
 	}
 
 	out, err := exec.Command(path, "version", "--short").Output()

--- a/testing/ddev-perf-test.sh
+++ b/testing/ddev-perf-test.sh
@@ -10,7 +10,7 @@ command -v $TIMECMD >/dev/null 2>&1 || { echo >&2 "please install gnu time with 
 TIMEFMT='-f %e'
 TIMEIT="$TIMECMD $TIMEFMT -o time.out"
 CURLIT='curl  -o /dev/null --fail -sfL -w %{time_total}'
-unset DRUD_DEBUG
+unset DDEV_DEBUG
 
 PROFILE=standard
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1881: MacOS Catalina really slow execution.

This is mostly due to docker-compose problems as described in https://github.com/docker/compose/issues/6956#issuecomment-555623639 and potentially fixed by https://github.com/docker/compose/pull/7010

## How this PR Solves The Problem:

* Adds more debugging capability than anything else.
* On macOS temporarily skip the docker-compose version check

## Manual Testing Instructions:

`ddev list` on macOS should return in a couple of seconds or less. 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

#1905 (fixed by #1916) was also a problem here, not just for Catalina, but for everybody that had a Pantheon project active.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

