### PR TITLE
[Tests only] Remove macOS nfsd setup as not working on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,14 +73,14 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macoshighsierra-v13
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macoshighsierra-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -105,7 +105,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macoshighsierra-v13
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -118,7 +118,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macoshighsierra-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -137,13 +137,13 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macoshighsierra-v13
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macoshighsierra-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -311,12 +311,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macoshighsierra-v13
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macoshighsierra-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -408,12 +408,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macoshighsierra-v13
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: RELEASE BUILD Circle VM setup
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macoshighsierra-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
   mac_nginx_fpm_test:
     macos:
-      xcode: "11.0.0"
+      xcode: "10.1"
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
@@ -94,7 +94,7 @@ jobs:
 
   mac_apache_fpm_test:
     macos:
-      xcode: "11.0.0"
+      xcode: "10.1"
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
@@ -126,7 +126,7 @@ jobs:
 
   mac_nfsmount_test:
     macos:
-      xcode: "11.0.0"
+      xcode: "10.1"
     working_directory: ~/ddev
     environment:
       DDEV_TEST_USE_NFSMOUNT: "true"
@@ -305,7 +305,7 @@ jobs:
 
   mac_container_test:
     macos:
-      xcode: "11.0.0"
+      xcode: "10.1"
     working_directory: ~/ddev
     steps:
     - checkout
@@ -399,7 +399,7 @@ jobs:
   # 'release_build' is used to push a full release; it's triggered by api call
   release_build:
     macos:
-      xcode: "11.0.0"
+      xcode: "10.1"
     working_directory: ~/ddev
     environment:
       DDEV_DEBUG: "true"

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -35,18 +35,16 @@ curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/rel
 GOTESTSUM_VERSION=0.3.2
 curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
 
-# As of 2019-11-23, the macOS build on CircleCI seems to not allow writing
-# /etc/exports, probably as a result of the "full disk access" stuff.
-#sudo bash -c "cat <<EOF >/etc/exports
-#${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost
-#/private/var -alldirs -mapall=$(id -u):$(id -g) localhost
-#EOF"
-#
-#LINE="nfs.server.mount.require_resv_port = 0"
-#FILE=/etc/nfs.conf
-#grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )
-#
-#sudo nfsd enable && sudo nfsd restart
+sudo bash -c "cat <<EOF >/etc/exports
+${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost
+/private/var -alldirs -mapall=$(id -u):$(id -g) localhost
+EOF"
+
+LINE="nfs.server.mount.require_resv_port = 0"
+FILE=/etc/nfs.conf
+grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )
+
+sudo nfsd enable && sudo nfsd restart
 
 
 while ! docker ps 2>/dev/null ; do

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -35,16 +35,18 @@ curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/rel
 GOTESTSUM_VERSION=0.3.2
 curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
 
-sudo bash -c "cat <<EOF >/etc/exports
-${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost
-/private/var -alldirs -mapall=$(id -u):$(id -g) localhost
-EOF"
-
-LINE="nfs.server.mount.require_resv_port = 0"
-FILE=/etc/nfs.conf
-grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )
-
-sudo nfsd enable && sudo nfsd restart
+# As of 2019-11-23, the macOS build on CircleCI seems to not allow writing
+# /etc/exports, probably as a result of the "full disk access" stuff.
+#sudo bash -c "cat <<EOF >/etc/exports
+#${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost
+#/private/var -alldirs -mapall=$(id -u):$(id -g) localhost
+#EOF"
+#
+#LINE="nfs.server.mount.require_resv_port = 0"
+#FILE=/etc/nfs.conf
+#grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )
+#
+#sudo nfsd enable && sudo nfsd restart
 
 
 while ! docker ps 2>/dev/null ; do


### PR DESCRIPTION
## The Problem/Issue/Bug:

It seems CircleCI has changed the macOS image and we can't write
/etc/exports any more. It's not worth chasing this at this moment
because we don't use NFS on macOS currently.

Commenting out the NFS setup.
