### PR TITLE
Tests only: Get mysql client working right in High Sierra

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,14 +73,14 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v14
+        - homebrew-macoshighsierra-v15
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - save_cache:
-        key: homebrew-macoshighsierra-v14
+        key: homebrew-macoshighsierra-v15
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -105,7 +105,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v14
+        - homebrew-macoshighsierra-v15
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -118,7 +118,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macoshighsierra-v14
+        key: homebrew-macoshighsierra-v15
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -137,13 +137,13 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v14
+        - homebrew-macoshighsierra-v15
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macoshighsierra-v14
+        key: homebrew-macoshighsierra-v15
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -311,12 +311,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v14
+        - homebrew-macoshighsierra-v15
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macoshighsierra-v14
+        key: homebrew-macoshighsierra-v15
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -408,12 +408,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v14
+        - homebrew-macoshighsierra-v15
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: RELEASE BUILD Circle VM setup
     - save_cache:
-        key: homebrew-macoshighsierra-v14
+        key: homebrew-macoshighsierra-v15
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,14 +73,14 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macoshighsierra-v14
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macoshighsierra-v14
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -105,7 +105,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macoshighsierra-v14
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -118,7 +118,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macoshighsierra-v14
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -137,13 +137,13 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macoshighsierra-v14
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macoshighsierra-v14
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -311,12 +311,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macoshighsierra-v14
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macoshighsierra-v14
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -408,12 +408,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macoshighsierra-v14
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: RELEASE BUILD Circle VM setup
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macoshighsierra-v14
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -19,11 +19,8 @@ nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 
 brew tap drud/ddev
 
-# Some CircleCI images seem to have root-owned /usr/local
-sudo chown -R distiller /usr/local/*
 brew install mariadb zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
 brew link mariadb zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
-brew reinstall openssl@1.1
 
 # homebrew sometimes removes /usr/local/etc/my.cnf.d
 mkdir -p /usr/local/etc/my.cnf.d

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -19,10 +19,11 @@ nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 
 brew tap drud/ddev
 
-brew install mysql-client zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
-brew link mysql-client zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
-
-brew link --force mysql-client
+# Some CircleCI images seem to have root-owned /usr/local
+sudo chown -R distiller /usr/local/*
+brew install mariadb zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
+brew link mariadb zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
+brew reinstall openssl@1.1
 
 # homebrew sometimes removes /usr/local/etc/my.cnf.d
 mkdir -p /usr/local/etc/my.cnf.d

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -19,8 +19,8 @@ nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 
 brew tap drud/ddev
 
-brew install mariadb zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
-brew link mariadb zip nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
+brew install mariadb openssl@1.1 nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
+brew link mariadb nsis jq expect coreutils golang ddev mkcert osslsigncode ghr
 
 # homebrew sometimes removes /usr/local/etc/my.cnf.d
 mkdir -p /usr/local/etc/my.cnf.d


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1973 rolled the CircleCI macOS install back to High Sierra. 

Although that one passed the macOS test, when merged there were still problems with the mysql command on some at least one build. 

This attempts to use the mariadb package instead of mysql-client. We'll see how it goes.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

