### PR TITLE
Remove file_scan_ignore_directories

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -149,11 +149,6 @@ ini_set('session.cookie_lifetime', 2000000);
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
-$settings['file_scan_ignore_directories'] = [
-  'node_modules',
-  'bower_components',
-];
-
 // This will prevent Drupal from setting read-only permissions on sites/default.
 $settings['skip_permissions_hardening'] = TRUE;
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

The setting for file_scan_ignore_directories is Drupal default settings.php. There is no need to override it in ddev.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

