### PR TITLE
Revert "[Tests only] Temporarily Use macOS High Sierra for CircleCI testing (#1973)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
   mac_nginx_fpm_test:
     macos:
-      xcode: "10.1"
+      xcode: "11.0.0"
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
@@ -73,14 +73,14 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macos-v12
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macos-v12
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -94,7 +94,7 @@ jobs:
 
   mac_apache_fpm_test:
     macos:
-      xcode: "10.1"
+      xcode: "11.0.0"
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
@@ -105,7 +105,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macos-v12
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -118,7 +118,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macos-v12
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -126,7 +126,7 @@ jobs:
 
   mac_nfsmount_test:
     macos:
-      xcode: "10.1"
+      xcode: "11.0.0"
     working_directory: ~/ddev
     environment:
       DDEV_TEST_USE_NFSMOUNT: "true"
@@ -137,13 +137,13 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macos-v12
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macos-v12
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -305,18 +305,18 @@ jobs:
 
   mac_container_test:
     macos:
-      xcode: "10.1"
+      xcode: "11.0.0"
     working_directory: ~/ddev
     steps:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macos-v12
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macos-v12
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -399,7 +399,7 @@ jobs:
   # 'release_build' is used to push a full release; it's triggered by api call
   release_build:
     macos:
-      xcode: "10.1"
+      xcode: "11.0.0"
     working_directory: ~/ddev
     environment:
       DDEV_DEBUG: "true"
@@ -408,12 +408,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macoshighsierra-v13
+        - homebrew-macos-v12
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: RELEASE BUILD Circle VM setup
     - save_cache:
-        key: homebrew-macoshighsierra-v13
+        key: homebrew-macos-v12
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar


### PR DESCRIPTION
This reverts commit 5023ee9384cbe9456ad51ca89c19c36efedce0d7.

CircleCI has fixed their regression and claim that this will work now.

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

