### PR TITLE
Fix enable_xdebug / disable_xdebug not fully working for apache-cgi

### DIFF
--- a/containers/ddev-webserver/files/usr/local/bin/disable_xdebug
+++ b/containers/ddev-webserver/files/usr/local/bin/disable_xdebug
@@ -2,4 +2,7 @@
 export PATH=$PATH:/usr/sbin:/sbin
 phpdismod xdebug
 killall -HUP php-fpm 2>/dev/null || true
+if [[ $DDEV_WEBSERVER_TYPE == "apache-cgi" ]]; then
+  /etc/init.d/apache2 reload >/dev/null || true
+fi
 echo "Disabled xdebug"

--- a/containers/ddev-webserver/files/usr/local/bin/enable_xdebug
+++ b/containers/ddev-webserver/files/usr/local/bin/enable_xdebug
@@ -2,4 +2,7 @@
 export PATH=$PATH:/usr/sbin:/sbin
 phpenmod xdebug
 killall -HUP php-fpm 2>/dev/null || true
+if [[ $DDEV_WEBSERVER_TYPE == "apache-cgi" ]]; then
+  /etc/init.d/apache2 reload >/dev/null || true
+fi
 echo "Enabled xdebug"

--- a/containers/ddev-webserver/files/var/www/html/docroot/test/xdebug.php
+++ b/containers/ddev-webserver/files/var/www/html/docroot/test/xdebug.php
@@ -1,0 +1,6 @@
+<?php
+if (extension_loaded('xdebug')) {
+    echo 'Xdebug is enabled';
+} else {
+    echo 'Xdebug is disabled';
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20191216_sudo_cp_webserver" // Note that this can be overridden by make
+var WebTag = "20191126_carstendietrich_enable_xdebug" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:
Due to the nature of apache-cgi we need an config reload to make php config changes work. Therefore running `ddev exec enable_xdebug` with `apache-cgi` as webserver turns on Xdebug only for the CLI and not for normal webserver requests.

## How this PR Solves The Problem:
This adds an apache2 reload to the enable_xdebug and disable_xdebug bash scripts in case the current webserver is apache-cgi.

## Manual Testing Instructions:
Use the containertest.sh which now checks if both the CLI and the webserver have Xdebug enabled/disabled after using the commands.


