### PR TITLE
Use PHP7.3 as default PHP version

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -31,7 +31,7 @@ var (
 	// projectTypeArg is the ddev app type, like drupal7/drupal8/wordpress.
 	projectTypeArg string
 
-	// phpVersionArg overrides the default version of PHP to be used in the web container, like 5.6/7.0/7.1/7.2/7.3.
+	// phpVersionArg overrides the default version of PHP to be used in the web container, like 5.6/7.0/7.1/7.2/7.3/7.4.
 	phpVersionArg string
 
 	// httpPortArg overrides the default HTTP port (80).

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/minideb:buster
 
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4"
-ENV PHP_DEFAULT_VERSION="7.2"
+ENV PHP_DEFAULT_VERSION="7.3"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 
 ENV DRUSH_VERSION=8.3.2

--- a/containers/ddev-webserver/files/etc/php/7.4/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.4/fpm/php-fpm.conf
@@ -123,4 +123,4 @@ daemonize = no
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
-include = /etc/php/7.2/fpm/pool.d/*.conf
+include = /etc/php/7.4/fpm/pool.d/*.conf

--- a/containers/ddev-webserver/test/containertest.sh
+++ b/containers/ddev-webserver/test/containertest.sh
@@ -151,7 +151,7 @@ for project_type in drupal6 drupal7 drupal8 typo3 backdrop wordpress default; do
 done
 
 echo "--- testing use of custom nginx and php configs"
-docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DOCROOT=potato" -e "DDEV_PHP_VERSION=7.2" -v "/$PWD/test/testdata:/mnt/ddev_config:ro" -v ddev-global-cache:/mnt/ddev-global-cache -d --name $CONTAINER_NAME -d $DOCKER_IMAGE
+docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DOCROOT=potato" -e "DDEV_PHP_VERSION=7.3" -v "/$PWD/test/testdata:/mnt/ddev_config:ro" -v ddev-global-cache:/mnt/ddev-global-cache -d --name $CONTAINER_NAME -d $DOCKER_IMAGE
 if ! containercheck; then
     exit 109
 fi

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -12,7 +12,7 @@ the .ddev/config.yaml is the primary configuration for the project.
 | name  | Project name   | Must be unique on the host (no two projects can have the same name). It's best if this is the same as the directory name.   |
 | type | Project type | php/drupal6/drupal7/drupal8/backdrop/typo3wordpress. Project type "php" does not try to do any CMS configuration or settings file management, and can work with any project|
 | docroot | Relative path of the docroot (where index.php or index.html is) from the project root| |
-| php_version | 5.6/7.0/7.1/7.2/7.3 | It is only possible to provide the major version (like "7.3"), not a minor version like "7.3.2", and it is only possible to use the provided php versions. |
+| php_version | 5.6/7.0/7.1/7.2/7.3/7.4 | It is only possible to provide the major version (like "7.3"), not a minor version like "7.3.2", and it is only possible to use the provided php versions. |
 | webimage | docker image to use for webserver | It is unusual to change the default and is not recommended, but the webimage can be overridden with a correctly crafted image, probably derived from drud/ddev-webserver |
 | dbimage | docker image to use for db server | It is unusual to change the default and is not recommended, but the dbimage can be overridden with a correctly crafted image, probably derived from drud/ddev-dbserver |
 | dbaimage | docker image to use for dba server (phpMyAdmin server) | It is unusual to change the default and is not recommended, but the dbimage can be overridden with a correctly crafted image, probably derived from drud/phpmyadmin |

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -3,7 +3,7 @@ ddev provides several ways in which the environment for a project using ddev can
 
 ## Changing PHP version
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to (currently) "5.6", "7.0", "7.1", "7.2", or "7.3". The current default is php 7.1.
+The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to (currently) "5.6", "7.0", "7.1", "7.2",  "7.3", or "7.4". The current default is php 7.3.
 
 ### Older versions of PHP
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -69,7 +69,7 @@ func init() {
 			settingsCreator: createDrupal6SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal6Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal6App, postImportDBAction: nil, configOverrideAction: drupal6ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal6PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal7: {
-			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
+			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: drupal7ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal8: {
 			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -57,7 +57,7 @@ func TestPostConfigAction(t *testing.T) {
 
 	appTypes := map[string]string{
 		nodeps.AppTypeDrupal6:   nodeps.PHP56,
-		nodeps.AppTypeDrupal7:   nodeps.PHPDefault,
+		nodeps.AppTypeDrupal7:   nodeps.PHP72,
 		nodeps.AppTypeDrupal8:   nodeps.PHPDefault,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:  nodeps.PHPDefault,

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -187,7 +187,7 @@ func TestConfigCommand(t *testing.T) {
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {nodeps.AppTypeDrupal6, nodeps.PHP56},
 		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHP72},
-		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP72},
+		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP73},
 	}
 
 	for testName, testValues := range testMatrix {
@@ -268,7 +268,7 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {nodeps.AppTypeDrupal6, nodeps.PHP56},
 		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHP72},
-		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP72},
+		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP73},
 	}
 
 	for testName := range testMatrix {
@@ -314,7 +314,7 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {nodeps.AppTypeDrupal6, nodeps.PHP56},
 		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHP72},
-		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP72},
+		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP73},
 	}
 
 	for testName, testValues := range testMatrix {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -664,6 +664,13 @@ func drupal6ConfigOverrideAction(app *DdevApp) error {
 	return nil
 }
 
+// drupal7ConfigOverrideAction overrides php_version for D7,
+// since it is not yet compatible with php7.3
+func drupal7ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP72
+	return nil
+}
+
 // drupal8PostStartAction handles default post-start actions for D8 apps, like ensuring
 // useful permissions settings on sites/default.
 func drupal8PostStartAction(app *DdevApp) error {

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -232,7 +232,7 @@ const ConfigInstructions = `
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "7.2"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4"
+# php_version: "7.3"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4"
 
 # You can explicitly specify the webimage, dbimage, dbaimage lines but this
 # is not recommended, as the images are often closely tied to ddev's' behavior,

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -62,7 +62,7 @@ const (
 )
 
 // PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
-const PHPDefault = PHP72
+const PHPDefault = PHP73
 
 // ValidPHPVersions should be updated whenever PHP versions are added or removed, and should
 // be used to ensure user-supplied values are valid.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20191126_debian_buster" // Note that this can be overridden by make
+var WebTag = "20191126_php_7.3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

PHP7.2 active support ends on Nov 30, 2019 (in 3 days). Time to set PHP7.3 as default version

## How this PR Solves The Problem:

Use PHP7.3 as default both in container and in ddev and docs.

## Manual Testing Instructions:

* Configure a junk site
* Start it up
* php --version should show 7.3

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

