### PR TITLE
Debian buster is now the mainline distribution, use it instead of stretch, fixes #2009

### DIFF
--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -42,7 +42,7 @@ func TestComposerCmd(t *testing.T) {
 	defer app.Stop(true, false)
 
 	// Test create-project
-	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0
+	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
 	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
@@ -50,9 +50,9 @@ func TestComposerCmd(t *testing.T) {
 	ddevapp.WaitForSync(app, 2)
 	assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
 
-	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	err = app.StartAndWaitForSync(5)
 	assert.NoError(err)
-	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0 --no-install
+	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0 --no-install
 	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0", "--no-install"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -50,6 +50,8 @@ func TestComposerCmd(t *testing.T) {
 	ddevapp.WaitForSync(app, 2)
 	assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
 
+	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	assert.NoError(err)
 	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log 1.1.0 --no-install
 	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0", "--no-install"}
 	out, err = exec.RunCommand(DdevBin, args)

--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb:stretch
+FROM bitnami/minideb:buster
 
 RUN apt-get update && apt-get install -y bash expect file openssh-client socat sudo psmisc && sudo apt autoclean
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb:stretch
+FROM bitnami/minideb:buster
 
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4"
 ENV PHP_DEFAULT_VERSION="7.2"
@@ -47,22 +47,23 @@ RUN apt-get -qq update && \
         bzip2 \
         ghostscript \
         gnupg \
-        locales-all && \
+        locales-all \
+        lsb-release && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
-    echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list && \
+    echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add - && \
     echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list && \
     wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
     apt-key add /tmp/nginx_signing.key && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    echo "deb http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list && \
+    echo "deb http://nginx.org/packages/debian/ $(lsb_release -sc) nginx" >> /etc/apt/sources.list && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get -qq update && \
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
         less \
         git \
-        mysql-client \
+        mariadb-client \
         nginx \
         apache2 \
         nodejs \

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -48,7 +48,7 @@ func TestComposer(t *testing.T) {
 		_ = app.Stop(true, false)
 	}()
 	err = app.Start()
-	assert.NoError(err)
+	require.NoError(t, err)
 	_, _, err = app.Composer([]string{"install"})
 	assert.NoError(err)
 	assert.FileExists("hello-pre-composer-" + app.Name)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1242,7 +1242,7 @@ func (app *DdevApp) StartAndWaitForSync(extraSleep int) error {
 		if extraSleep > 0 {
 			time.Sleep(time.Duration(extraSleep) * time.Second)
 		}
-	} else if nodeps.IsDockerToolbox() {
+	} else if nodeps.IsDockerToolbox() || app.NFSMountEnabled {
 		// Docker Toolbox seems not to get the router properly
 		// updated with certs as fast as we expect, use the extraSleep for that.
 		if extraSleep > 0 {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20191212_truls_drush" // Note that this can be overridden by make
+var WebTag = "20191126_debian_buster" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
@@ -77,7 +77,7 @@ var RouterTag = "v1.12.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.12.0"
+var SSHAuthTag = "20191126_debian_buster"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Debian buster is now the mainline distribution, use it instead of stretch in both ddev-webserver and ddev-ssh-agent

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

