### PR TITLE
Better example on drupal7/8 config

### DIFF
--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -123,8 +123,8 @@ hooks:
 ```
 hooks:
   post-start:
-    # Install Drupal after start
-    - exec: "drush site-install -y --db-url=db:db@db/db"
+    # Install Drupal after start if not installed already
+    - exec: "(drush status bootstrap | grep -q Successful) || drush site-install -y --db-url=db:db@db/db"
     # Generate a one-time login link for the admin account.
     - exec: "drush uli 1"
   post-import-db:
@@ -144,8 +144,8 @@ hooks:
     # Install composer dependencies using composer on host system
     - exec-host: "composer install"
   post-start:
-    # Install Drupal after start
-    - exec: "drush site-install -y --db-url=mysql://db:db@db/db"
+    # Install Drupal after start if not installed already
+    - exec: "(drush status bootstrap | grep -q Successful) || drush site-install -y --db-url=mysql://db:db@db/db"
     # Generate a one-time login link for the admin account.
     - exec: "drush uli 1"
   post-import-db:


### PR DESCRIPTION
## The Problem/Issue/Bug:

The issue is that the documentation suggests that it's the best practice to reinstall the site at every `ddev start`, but it's not so efficient, basically it loses all the benefits of database persistence. After stopping a container, using the example, you cannot continue using your existing site.

## How this PR Solves The Problem:

It makes the installation step conditional.

## Manual Testing Instructions:

Apply the config, start it, stop it, start it, let's make sure that the 2nd start is much faster, as no installation is involved, but the site is still usable.

## Automated Testing Overview:
Not applicable, only documentation.

## Release/Deployment notes:
Not applicable, only documentation.