### PR TITLE
New location to define sync directory

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -161,6 +161,12 @@ $settings['trusted_host_patterns'] = ['.*'];
 $settings['class_loader_auto_detect'] = FALSE;
 
 // This specifies the default configuration sync directory.
+// Both $config_directories (pre-Drupal 8.8) and
+// $settings['config_sync_directory'] are provided
+// so it should work on any Drupal 8 or 9 version.
+if (empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
+  $config_directories[CONFIG_SYNC_DIRECTORY] = '{{ joinPath $config.SitePath $config.SyncDir }}';
+}
 if (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = '{{ joinPath $config.SitePath $config.SyncDir }}';
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -161,8 +161,8 @@ $settings['trusted_host_patterns'] = ['.*'];
 $settings['class_loader_auto_detect'] = FALSE;
 
 // This specifies the default configuration sync directory.
-if (empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
-  $config_directories[CONFIG_SYNC_DIRECTORY] = '{{ joinPath $config.SitePath $config.SyncDir }}';
+if (empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = '{{ joinPath $config.SitePath $config.SyncDir }}';
 }
 `
 )


### PR DESCRIPTION
## The Problem/Issue/Bug:

Drupal 8.8 changed where the sync directory is defined
(https://www.drupal.org/node/3018145)

## How this PR Solves The Problem:

Changing the code to use $settings rather than $config_directories.
