### PR TITLE
Add .markdownlintrc defining markdown, especially for readthedocs

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,28 @@
+{
+
+  // These rules mostly come from mkdocs rules
+  // https://github.com/mkdocs/mkdocs/blob/master/.markdownlintrc
+
+  // Enable all markdownlint rules
+  "default": true,
+
+  // Fine with long lines, editor can wrap
+  "line-length": false,
+
+  "MD004": { "style": "consistent" },
+
+  // Set Ordered list item prefix to "ordered" (use 1. 2. 3. not 1. 1. 1.)
+  "MD029": { "style": "ordered" },
+
+  // Set list indent level to 4 which Python-Markdown requires
+  "MD007": { "indent": 4 },
+
+  // Embedded html allowed; often used for named anchors with mkdocs/readthedocs
+  "no-inline-html": false,
+
+  // Fenced code blocks do not need language spec
+  "MD040": false,
+
+  // Exclude code block style
+  "MD046": false
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

@gilbertsoft pointed out github.com/DavidAnson/markdownlint and https://github.com/igorshubovych/markdownlint-cli - these can be used to specify consistent markdown in our docs. Since readthedocs/mkdocs is particularly susceptible to markdown style, this will be great for fixing up our markdown in the docs.

Markdown will either be updated later bit by bit or with a mass update like https://github.com/drud/ddev/pull/1980, or perhaps that one will be updated to meet the requirements of this markdownlintrc

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

