### PR TITLE
Use sudo to copy dotfiles into user dir on start

### DIFF
--- a/containers/ddev-webserver/scripts/start.sh
+++ b/containers/ddev-webserver/scripts/start.sh
@@ -102,7 +102,7 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
 # /home/.* is a prototype for the created user's homedir; copy it in.
-cp -r /home/{.ssh*,.drush,.gitconfig,.my.cnf} ~/
+sudo cp -r /home/{.ssh*,.drush,.gitconfig,.my.cnf} ~/
 sudo mkdir -p /mnt/ddev-global-cache/bashhistory/${HOSTNAME}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ ~/{.ssh*,.drush,.gitconfig,.my.cnf}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20191216_unzip_dash_o" // Note that this can be overridden by make
+var WebTag = "20191216_sudo_cp_webserver" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

A user had a problem where the ddev-webserver would fail to start on *any* project with this in the logs:
```
cp: cannot open '/home/.ssh-agent/known_hosts' for reading: Permission denied 
```

/home/.ssh-agent is actually mounted from a docker volume, ddev-ssh-agent_socket_dir. And in this case, when we inspected the actual contents, we found that /home/.ssh-agent/known_hosts actually was owned by root, which it shouldn't have been. We have no idea how it got that way.

The problem was resolved by running the webserver container with `docker run -it --rm -u $(id -u) -v ddev-ssh-agent_socket_dir:/home/.ssh-agent  drud/ddev-webserver:v1.11.0-built bash` so that we could inspect things. At that point, we found the known_hosts owned by root and `sudo rm /home/.ssh-agent/known_hosts` solved the problem.

## How this PR Solves The Problem:

Inspection of the failure mode suggested that changing the copy command as in this PR would have prevented this problem.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

