### PR TITLE
Add utf8mb4 client collation to my.cnf in containers

### DIFF
--- a/containers/ddev-dbserver/files/etc/my.cnf
+++ b/containers/ddev-dbserver/files/etc/my.cnf
@@ -2,6 +2,7 @@
 # CLIENT #
 port                           = 3306
 socket                         = /var/tmp/mysql.sock
+default-character-set = utf8mb4
 
 [mysqld]
 

--- a/containers/ddev-webserver/files/home/.my.cnf
+++ b/containers/ddev-webserver/files/home/.my.cnf
@@ -2,6 +2,7 @@
 user=db
 password=db
 host=db
+default-character-set = utf8mb4
 
 [mysql]
 database=db

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,13 +49,13 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190911_terminus_pantheon" // Note that this can be overridden by make
+var WebTag = "20191217_utf8mb4_connection" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.12.0"
+var BaseDBTag = "20191217_utf8mb4_connection"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

mysql import-db and mysql are affected by client config which lacks utf8mb4 (defaults to latin1). 

## How this PR Solves The Problem:

Add client config to set connection to utf8mb4

## Manual Testing Instructions:

Example is coming from @RobertLang, who ran into trouble with imported dbs because of this.

## Automated Testing Overview:

We need to add a test to the mysql container to make sure that everything works properly, should be easy enough.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

