### PR TITLE
Unlink python2 since it can't be used any more

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v8
+        - homebrew-linux-v9
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v8
+        key: homebrew-linux-v9
         paths:
         - /home/linuxbrew
 
@@ -42,13 +42,13 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v8
+        - homebrew-linux-v9
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v8
+        key: homebrew-linux-v9
         paths:
         - /home/linuxbrew
 
@@ -73,14 +73,14 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macos-v13
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macos-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -105,7 +105,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macos-v13
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -118,7 +118,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macos-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -137,13 +137,13 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macos-v13
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macos-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -168,14 +168,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v8
+        - homebrew-linux-v9
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v8
+        key: homebrew-linux-v9
         paths:
         - /home/linuxbrew
 
@@ -201,14 +201,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v8
+        - homebrew-linux-v9
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v8
+        key: homebrew-linux-v9
         paths:
         - /home/linuxbrew
     - run:
@@ -231,14 +231,14 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v8
+        - homebrew-linux-v9
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v8
+        key: homebrew-linux-v9
         paths:
         - /home/linuxbrew
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
@@ -261,12 +261,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v8
+        - homebrew-linux-v9
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v8
+        key: homebrew-linux-v9
         paths:
         - /home/linuxbrew
     - run:
@@ -282,12 +282,12 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v8
+        - homebrew-linux-v9
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-linux-v8
+        key: homebrew-linux-v9
         paths:
         - /home/linuxbrew
     - run:
@@ -311,12 +311,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macos-v13
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: macOS Circle VM setup - tools, docker, golang
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macos-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar
@@ -343,7 +343,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v8
+        - homebrew-linux-v9
     - attach_workspace:
         at: ~/
     - run:
@@ -351,7 +351,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: homebrew-linux-v8
+        key: homebrew-linux-v9
         paths:
         - /home/linuxbrew
     - store_artifacts:
@@ -371,12 +371,12 @@ jobs:
       - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
       - restore_cache:
           keys:
-          - homebrew-linux-v8
+          - homebrew-linux-v9
       - run:
           command: ./.circleci/linux_circle_vm_setup.sh
           name: TAG BUILD Circle VM setup - tools, docker, golang
       - save_cache:
-          key: homebrew-linux-v8
+          key: homebrew-linux-v9
           paths:
           - /home/linuxbrew
 
@@ -408,12 +408,12 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - homebrew-macos-v12
+        - homebrew-macos-v13
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
         name: RELEASE BUILD Circle VM setup
     - save_cache:
-        key: homebrew-macos-v12
+        key: homebrew-macos-v13
         paths:
         - /usr/local/Homebrew
         - /usr/local/Cellar

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -18,6 +18,7 @@ sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unatt
 nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 
 brew tap drud/ddev
+brew unlink python@2 || true
 
 brew install mysql-client zip makensis jq expect coreutils golang ddev mkcert osslsigncode ghr
 brew link mysql-client zip makensis jq expect coreutils golang ddev mkcert osslsigncode ghr


### PR DESCRIPTION
## The Problem/Issue/Bug:

Apparently homebrew has phased out python2 now in one of the recipes and switched to python3. Anyway, we have to unlink python2.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

