### PR TITLE
Add timeout to docker startup in macos circleci

### DIFF
--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -51,8 +51,7 @@ grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/nu
 
 sudo nfsd enable && sudo nfsd restart
 
-
-while ! docker ps 2>/dev/null ; do
+timeout -v 10m bash -c 'while ! docker ps 2>/dev/null ; do
   sleep 5
   echo "Waiting for docker to come up: $(date)"
-done
+done'


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've been occasionally seeing docker not starting up in CircleCI macOS instances. But the loop is infinite, so the test runs until circle stops it. Kill it in a shorter amount of time.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

