### PR TITLE
Subdirectories in commands dirs should not show up as commands

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -49,7 +49,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 		}
 
 		for _, commandName := range commandFiles {
-			if strings.HasSuffix(commandName, ".example") || strings.HasPrefix(commandName, "README") || strings.HasPrefix(commandName, ".") {
+			if strings.HasSuffix(commandName, ".example") || strings.HasPrefix(commandName, "README") || strings.HasPrefix(commandName, ".") || fileutil.IsDirectory(commandName) {
 				continue
 			}
 			// Use path.Join() for the inContainerFullPath because it's about the path in the container, not on the


### PR DESCRIPTION
## The Problem/Issue/Bug:

In testing @jonaseberle 's excellent and very fancy dump-db commands (https://github.com/drud/ddev-contrib/pull/30) I noted that the .ddev/commands/web/target subdirectory showed up as a "target" command.

This checks to make sure that items in custom command directories are not directories, removing them in that case.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

