### PR TITLE
auth pantheon missing the dash

### DIFF
--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -12,7 +12,7 @@ If you have ddev installed, and have an active Pantheon account with an active W
 
     a. Login to your Pantheon Dashboard, and [Generate a Machine Token](https://pantheon.io/docs/machine-tokens/) for ddev to use.
 
-    b. Run `ddev auth pantheon <YOUR TOKEN>` (This is a one-time operation, and configures ddev to work with all the sites on your account.)
+    b. Run `ddev auth-pantheon <YOUR TOKEN>` (This is a one-time operation, and configures ddev to work with all the sites on your account.)
 
 2. Choose a Pantheon site and environment you want to use with ddev.
 


### PR DESCRIPTION
I was running through our setup documentation before on boarding a new dev. I was still running v1.10.2 and thought this may have changed in the current version, but after updating to v1.12.1 I was still running into an issue trying to configuration this using `ddev auth pantheon`. I'm not sure if this changed at some point and needs to be broken out by version, but `ddev auth-pantheon <YOUR TOKEN>` is required now.

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

