### PR TITLE
Move drush.yml into /drush from sites/all/drush

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -137,7 +137,7 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 			util.Warning("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteDdevSettingsFile), err)
 		}
 		if app.Type == nodeps.AppTypeDrupal8 {
-			drushDir := filepath.Join(filepath.Dir(app.SiteSettingsPath), "..", "all", "drush")
+			drushDir := filepath.Join(app.AppRoot, "drush")
 			if err = CreateGitIgnore(drushDir, "drush.yml"); err != nil {
 				util.Warning("Failed to write .gitignore in %s: %v", drushDir, err)
 			}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -980,7 +980,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 			assert.FileExists(filepath.Join(filepath.Dir(app.SiteSettingsPath), "drushrc.php"))
 		}
 		if app.Type == "drupal8" {
-			assert.FileExists(filepath.Join(filepath.Dir(app.SiteSettingsPath), "..", "all", "drush", "drush.yml"))
+			assert.FileExists(filepath.Join(app.AppRoot, "drush", "drush.yml"))
 		}
 
 		if site.DBTarURL != "" {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -514,13 +514,11 @@ func WriteDrushrc(app *DdevApp, filePath string) error {
 		}
 	}
 
-	uri := app.GetHTTPSURL()
-	if GetCAROOT() == "" {
-		uri = app.GetHTTPURL()
-	}
+	uri := app.GetPrimaryURL()
 	drushContents := []byte(`<?php
-/** ` + DdevFileSignature + `: Automatically generated drushrc.php file.
+/** ` + DdevFileSignature + `: Automatically generated drushrc.php file (for Drush 8)
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ Remove this comment if you don't want ddev to manage this file.'
  */
 $options['l'] = "` + uri + `";
 `)
@@ -560,13 +558,11 @@ func WriteDrushYML(app *DdevApp, filePath string) error {
 		}
 	}
 
-	uri := app.GetHTTPSURL()
-	if GetCAROOT() == "" {
-		uri = app.GetHTTPURL()
-	}
+	uri := app.GetPrimaryURL()
 	drushContents := []byte(`
 #` + DdevFileSignature + `: Automatically generated drush.yml file.
 # ddev manages this file and may delete or overwrite the file unless this comment is removed.
+# Remove the comment if you don't want ddev to manage this file.'
 
 options:
   uri: "` + uri + `"
@@ -687,7 +683,7 @@ func drupal8PostStartAction(app *DdevApp) error {
 	// Write both drush.yml and drushrc.php for Drupal 8, because we can't know
 	// what version of drush may be in use. drush8 is happy with drushrc.php
 	// drush9 wants drush.yml
-	err := WriteDrushYML(app, filepath.Join(filepath.Dir(app.SiteSettingsPath), "..", "all", "drush", "drush.yml"))
+	err := WriteDrushYML(app, filepath.Join(app.AppRoot, "drush", "drush.yml"))
 	if err != nil {
 		util.Warning("Failed to WriteDrushYML: %v", err)
 	}

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -119,7 +119,7 @@ func TestWriteDrushConfig(t *testing.T) {
 			assert.True(optionFound)
 
 			if app.Type == nodeps.AppTypeDrupal8 {
-				drushYMLFilePath := filepath.Join(filepath.Dir(app.SiteSettingsPath), "..", "all", "drush", "drush.yml")
+				drushYMLFilePath := filepath.Join(app.AppRoot, "drush", "drush.yml")
 				require.True(t, fileutil.FileExists(drushYMLFilePath))
 				optionFound, err := fileutil.FgrepStringInFile(drushYMLFilePath, "options")
 				assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Drupal 8 drush drush.yml has always been placed in <docroot>/sites/all/drush. However, community opinion seems to be that putting drush.yml in <projectroot>/drush. 

Both of these 
* Can break multisite in the same way by overriding the default uri
* Create a new drush.yml file that is annoying to people and they may have to take over. 

But this is a slightly better place, outside Drupal's docroot, etc.


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

