### PR TITLE
Simplify TYPO3 composer example

### DIFF
--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -158,7 +158,7 @@ hooks:
 ```
 hooks:
     post-start:
-      - exec: composer install -d /var/www/html/
+      - composer: install
 ```
 
 ## Adding Additional Debian Packages (PHP Modules) Example


### PR DESCRIPTION
I think this came from a version when the `composer` command was not yet available. Also the `-d` pointed to the default directory.

## The Problem/Issue/Bug:

The example does not use an available ddev command which would make the docs more consistent.
