### PR TITLE
Always add restore-snapshot command into list, fixes #2031

### DIFF
--- a/cmd/ddev/cmd/restore_snapshot.go
+++ b/cmd/ddev/cmd/restore_snapshot.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 	"os"
@@ -35,8 +34,5 @@ Example: "ddev restore-snapshot d8git_20180717203845"`,
 }
 
 func init() {
-	app, err := ddevapp.GetActiveApp("")
-	if err == nil && app != nil && !nodeps.ArrayContainsString(app.OmitContainers, "db") {
-		RootCmd.AddCommand(DdevRestoreSnapshotCommand)
-	}
+	RootCmd.AddCommand(DdevRestoreSnapshotCommand)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2031 points out that `restore-snapshot` doesn't happen in bash completions.

It's a result of trying to make the command not show up if omit_containers[db] is set, but it's probably not a good idea.

Bash completions are generated with no context (no project config'd or running) and so this wouldn't show up. In the future, we might consider changing the generation to be done in the context of a configured project. I think that's the basic flaw of this approach.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

