### PR TITLE
Bump web tag for xdebug 2.9.1 fixes #1996

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,13 +135,13 @@ mkdocs:
 
 darwin_signed: darwin
 	@if [ -z "$(DDEV_MACOS_SIGNING_PASSWORD)" ] ; then echo "Skipping signing ddev for macOS, no DDEV_MACOS_SIGNING_PASSWORD provided"; else echo "Signing macOS ddev..."; \
-		set -o errexit pipefail; \
+		set -o errexit -o pipefail; \
 		curl -s https://raw.githubusercontent.com/drud/signing_tools/master/macos_sign.sh | bash -s -  --signing-password="$(DDEV_MACOS_SIGNING_PASSWORD)" --cert-file=certfiles/ddev_developer_id_cert.p12 --cert-name="Developer ID Application: DRUD Technology, LLC (3BAN66AG5M)" --target-binary="$(GOTMP)/bin/darwin_amd64/ddev" ; \
 	fi
 
 darwin_notarized: darwin_signed
 	@if [ -z "$(DDEV_MACOS_APP_PASSWORD)" ]; then echo "Skipping notarizing ddev for macOS, no DDEV_MACOS_APP_PASSWORD provided"; else \
-		set -o errexit pipefail; \
+		set -o errexit -o pipefail; \
 		echo "Notarizing macOS ddev..." ; \
 		curl -s https://raw.githubusercontent.com/drud/signing_tools/master/macos_notarize.sh | bash -s -  --app-specific-password=${DDEV_MACOS_APP_PASSWORD} --apple-id=accounts@drud.com --primary-bundle-id=com.ddev.ddev --target-binary="$(PWD)/$(GOTMP)/bin/darwin_amd64/ddev" ; \
 	fi

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -38,7 +38,7 @@ ENV CAROOT /mnt/ddev-global-cache/mkcert
 
 RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime && dpkg-reconfigure --frontend noninteractive tzdata
 
-RUN apt-get -qq update && \
+RUN set -o errexit && apt-get -qq update && \
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
         procps \
         curl \
@@ -93,8 +93,8 @@ RUN apt-get -qq update && \
         php-imagick \
         php-uploadprogress \
         sqlite3 && \
-    for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y  $v-apcu $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-memcached $v-mysql $v-pgsql $v-mbstring $v-opcache $v-soap $v-redis $v-sqlite3 $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip libapache2-mod-$v ; done && \
-    for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
+    for v in $PHP_VERSIONS; do apt-get -qq install --no-install-recommends --no-install-suggests -y  $v-apcu $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-memcached $v-mysql $v-pgsql $v-mbstring $v-opcache $v-soap $v-redis $v-sqlite3 $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip libapache2-mod-$v || exit $?; done && \
+    for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt || exit $?; done && \
     apt-get install blackfire-php -y --allow-unauthenticated && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
@@ -152,7 +152,7 @@ RUN chmod 644 /home/.my.cnf
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
   chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
-RUN for v in $PHP_VERSIONS; do a2dismod $v; done
+RUN for v in $PHP_VERSIONS; do a2dismod $v || exit $?; done
 RUN a2dismod mpm_event
 RUN a2enmod ssl headers expires
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -472,9 +472,6 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevXdebugEnabled", site.Name))
 
 	phpVersions := nodeps.ValidPHPVersions
-	// Temporarily delete 7.0 from test because sury didn't package php7.0-xdebug in latest
-	// See https://github.com/oerdnj/deb.sury.org/issues/1316
-	delete(phpVersions, "7.0")
 	phpKeys := make([]string, 0, len(phpVersions))
 	for k := range phpVersions {
 		phpKeys = append(phpKeys, k)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -471,19 +472,28 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevXdebugEnabled", site.Name))
 
 	phpVersions := nodeps.ValidPHPVersions
+	// Temporarily delete 7.0 from test because sury didn't package php7.0-xdebug in latest
+	// See https://github.com/oerdnj/deb.sury.org/issues/1316
+	delete(phpVersions, "7.0")
+	phpKeys := make([]string, 0, len(phpVersions))
+	for k := range phpVersions {
+		phpKeys = append(phpKeys, k)
+	}
+	sort.Strings(phpKeys)
+
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 	//nolint: errcheck
 	defer app.Stop(true, false)
 
-	for v := range phpVersions {
+	for _, v := range phpKeys {
 		app.PHPVersion = v
 		t.Logf("Attempting XDebug checks with XDebug %s\n", v)
 		fmt.Printf("Attempting XDebug checks with XDebug %s\n", v)
 		app.XdebugEnabled = false
 		assert.NoError(err)
 		err = app.Start()
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		opts := &ddevapp.ExecOpts{
 			Service: "web",
@@ -498,17 +508,17 @@ func TestDdevXdebugEnabled(t *testing.T) {
 		testcommon.ClearDockerEnv()
 		app.XdebugEnabled = true
 		err = app.Start()
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		stdout, _, err = app.Exec(opts)
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		assert.Contains(stdout, "xdebug support => enabled")
 		assert.Contains(stdout, "xdebug.remote_host => host.docker.internal => host.docker.internal")
 
 		// Start a listener on port 9000 of localhost (where PHPStorm or whatever would listen)
 		listener, err := net.Listen("tcp", ":9000")
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		// Curl to the project's index.php or anything else
 		_, _, _ = testcommon.GetLocalHTTPResponse(t, app.GetHTTPURL(), 1)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20190827_magento" // Note that this can be overridden by make
+var WebTag = "20200120_bump_xdebug" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

xdebug has been fixed upstream, fixing #1996. This applies the change to the master branch; a patch fix for v1.12.2 is in the 20200106_notarize_v1.12.1 branch.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

