### PR TITLE
Improve settings.ddev.php handling of config_sync_directory

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -161,13 +161,12 @@ $settings['trusted_host_patterns'] = ['.*'];
 $settings['class_loader_auto_detect'] = FALSE;
 
 // This specifies the default configuration sync directory.
-// Both $config_directories (pre-Drupal 8.8) and
-// $settings['config_sync_directory'] are provided
+// $config_directories (pre-Drupal 8.8) and
+// $settings['config_sync_directory'] are supported
 // so it should work on any Drupal 8 or 9 version.
-if (empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
+if (defined('CONFIG_SYNC_DIRECTORY') && empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
   $config_directories[CONFIG_SYNC_DIRECTORY] = '{{ joinPath $config.SitePath $config.SyncDir }}';
-}
-if (empty($settings['config_sync_directory'])) {
+} else if (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = '{{ joinPath $config.SitePath $config.SyncDir }}';
 }
 `


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1994 switched settings.ddev.php to handle Drupal 8.8+ new method of managing config_sync_directory. However, it was a bit naive, and results in warnings about undefined CONFIG_SYNC_DIRECTORY on newer Drupal versions.

## How this PR Solves The Problem:

Drive the usage on existence of CONFIG_SYNC_DIRECTORY instead of setting both things.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

