### PR TITLE
Add gnupg2 to container build to fix xtrabackup fail

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -11,7 +11,7 @@ ENV MYSQL_PASSWORD db
 ENV MYSQL_ROOT_PASSWORD root
 
 # Install extra packages
-RUN apt-get update && apt-get install -y tzdata sudo pv less vim wget
+RUN apt-get update && apt-get install -y tzdata sudo gnupg2 pv less vim wget
 
 RUN if ( ! command -v xtrabackup && ! command -v mariabackup ); then \
     apt-get install -y lsb-release; \

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -52,12 +52,14 @@ container: mariadb_containers mysql_containers
 mariadb_containers:
 	for item in $(MARIADB_VERSIONS); do \
 		set -euo pipefail ; \
+		printf "\n\n========== Building MariaDB $$item ==========\n"; \
 		docker build $(DOCKER_ARGS) --build-arg "DBVERSION=$${item}" --build-arg="DBTYPE=mariadb" -t "drud/ddev-dbserver-mariadb-$${item}:$(VERSION)" . ; \
 	done
 
 mysql_containers:
 	for item in $(MYSQL_VERSIONS) ; do \
 		set -euo pipefail ;\
+		printf "\n\n========== Building MySQL $$item ==========\n"; \
 		docker build $(DOCKER_ARGS) --build-arg "DBVERSION=$$item" --build-arg="DBTYPE=mysql" -t "drud/ddev-dbserver-mysql-$${item%%%.*}:$(VERSION)" . ; \
 	done
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -55,7 +55,7 @@ var WebTag = "20200120_bump_xdebug" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20191217_utf8mb4_connection"
+var BaseDBTag = "20200122_fix_mysql_build"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The mysql builds suddenly started failing because xtradb requires gnupg2 package. 

This adds it.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

