### PR TITLE
Bump containers to v1.13.0-rc1 (and phpmyadmin to 5)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,29 +49,29 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200119_bump_backdrop" // Note that this can be overridden by make
+var WebTag = "v1.13.0-rc1" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20200122_fix_mysql_build"
+var BaseDBTag = "v1.13.0-rc1"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin/phpmyadmin"
 
 // DBATag defines the default phpmyadmin image tag used for applications.
-var DBATag = "4.9" // Note that this can be overridden by make
+var DBATag = "5" // Note that this can be overridden by make
 
 // RouterImage defines the image used for the router.
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.12.0" // Note that this can be overridden by make
+var RouterTag = "v1.13.0-rc1" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "20191126_debian_buster"
+var SSHAuthTag = "v1.13.0-rc1"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

New container versions for coming edge v1.13.0-rc1

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

