### PR TITLE
Give more info on "Failed to start <project>: failed to load any docker-compose.*y*l files"  for #2049

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -620,7 +620,7 @@ func (app *DdevApp) ImportFiles(importPath string, extPath string) error {
 func (app *DdevApp) ComposeFiles() ([]string, error) {
 	files, err := filepath.Glob(filepath.Join(app.AppConfDir(), "docker-compose*.y*l"))
 	if err != nil || len(files) == 0 {
-		return []string{}, fmt.Errorf("failed to load any docker-compose.*y*l files: %v", err)
+		return []string{}, fmt.Errorf("failed to load any docker-compose.*y*l files in %s: err=%v", app.AppConfDir(), err)
 	}
 
 	mainfiles, err := filepath.Glob(filepath.Join(app.AppConfDir(), "docker-compose.y*l"))


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've had a few questions like #2049 where people see errors like "Failed to start my-project: failed to load any docker-compose.*y*l files:"

So far it's not been easy to track them down. 

You can start a project, remove .ddev/docker-compose.yaml, then `ddev exec ls` and you'll get it. But most of the time we don't understand.

This PR:
* Tells the directory in which it's looking for docker-compose.yaml.

A future PR will prevent `ddev config` or `ddev start` in directories that have glob patterns in them. That seems too risky for near-release of v1.13.0, and this doesn't happen that often.

The simple change of the output should help us with debugging and learning new instances of this problem.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

