### PR TITLE
Actually select database when --target-db is provided to export-db

### DIFF
--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -37,7 +37,7 @@ ddev export-db someproject > ~/tmp/someproject.sql`,
 			util.Failed("ddev can't export-db until the project is started, please start it first.")
 		}
 
-		err = app.ExportDB(outFileName, gzipOption, targetDB)
+		err = app.ExportDB(outFileName, gzipOption, exportTargetDB)
 		if err != nil {
 			util.Failed("Failed to export database for %s: %v", app.GetName(), err)
 		}

--- a/cmd/ddev/cmd/export-db_test.go
+++ b/cmd/ddev/cmd/export-db_test.go
@@ -68,7 +68,6 @@ func TestCmdExportDB(t *testing.T) {
 	assert.FileExists(outputFileName)
 	assert.True(fileutil.FgrepStringInFile(outputFileName, "13751eca-19cf-41c2-90d4-9363f3a07c45"))
 
-
 	// Work with a non-default database named "nondefault"
 	// Read in a database
 	inputFileName = filepath.Join(testDir, "testdata", t.Name(), "nondefault.sql")
@@ -83,11 +82,11 @@ func TestCmdExportDB(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	outputFileName=filepath.Join(tmpDir, "nondefault_output.sql")
-	command = exec.Command(DdevBin, "export-db", site.Name, "-d=nondefault" , "-f="+outputFileName, "--gzip=false")
+	outputFileName = filepath.Join(tmpDir, "nondefault_output.sql")
+	command = exec.Command(DdevBin, "export-db", site.Name, "-d=nondefault", "-f="+outputFileName, "--gzip=false")
 	byteout, err = command.CombinedOutput()
 	assert.NoError(err, "export-db failure output=%s", string(byteout))
-	assert.Contains(string(byteout), fmt.Sprintf("Wrote database dump from %s database 'nondefault' to file %s in plain text format", site.Name,outputFileName ))
+	assert.Contains(string(byteout), fmt.Sprintf("Wrote database dump from %s database 'nondefault' to file %s in plain text format", site.Name, outputFileName))
 	assert.FileExists(outputFileName)
 	assert.True(fileutil.FgrepStringInFile(outputFileName, "INSERT INTO `nondefault_table` VALUES (0,'13751eca-19cf-41c2-90d4-9363f3a07c45','en'),"))
 
@@ -96,5 +95,4 @@ func TestCmdExportDB(t *testing.T) {
 		Cmd:     "mysql nondefault -e 'SELECT * FROM nondefault_table;'",
 	})
 	assert.NoError(err)
-
 }

--- a/cmd/ddev/cmd/testdata/TestCmdExportDB/nondefault.sql
+++ b/cmd/ddev/cmd/testdata/TestCmdExportDB/nondefault.sql
@@ -1,0 +1,55 @@
+-- MySQL dump 10.13  Distrib 5.5.54, for debian-linux-gnu (x86_64)
+--
+-- Host: db    Database: data
+-- ------------------------------------------------------
+-- Server version	5.7.17-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `nondefault_table`
+--
+
+DROP TABLE IF EXISTS `nondefault_table`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `nondefault_table` (
+  `uid` int(10) unsigned NOT NULL,
+  `uuid` varchar(128) CHARACTER SET ascii NOT NULL,
+  `langcode` varchar(12) CHARACTER SET ascii NOT NULL,
+  PRIMARY KEY (`uid`),
+  UNIQUE KEY `user_field__uuid__value` (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='The base table for user entities.';
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `nondefault_table`
+--
+
+LOCK TABLES `nondefault_table` WRITE;
+/*!40000 ALTER TABLE `nondefault_table` DISABLE KEYS */;
+set autocommit=0;
+INSERT INTO `nondefault_table` VALUES (0,'13751eca-19cf-41c2-90d4-9363f3a07c45','en'),(1,'186efa0a-8aa3-4eeb-90ce-6302fb9c4e07','en');
+/*!40000 ALTER TABLE `nondefault_table` ENABLE KEYS */;
+UNLOCK TABLES;
+commit;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2017-05-31 14:03:34


### PR DESCRIPTION
## The Problem/Issue/Bug:

Discovered in testing: Using the "-d" or "--target-db" option with `ddev export-db` didn't actually change the db. It always exported the database named "db".

This fixes it.

It adds tests for this scenario as well.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

