### PR TITLE
Subdirectories of .ddev/commands/* should not show up as custom commands

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -49,13 +49,15 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 		}
 
 		for _, commandName := range commandFiles {
-			if strings.HasSuffix(commandName, ".example") || strings.HasPrefix(commandName, "README") || strings.HasPrefix(commandName, ".") || fileutil.IsDirectory(commandName) {
-				continue
-			}
+
 			// Use path.Join() for the inContainerFullPath because it's about the path in the container, not on the
 			// host; a Windows path is not useful here.
 			inContainerFullPath := path.Join("/mnt/ddev_config/commands", service, commandName)
 			onHostFullPath := filepath.Join(topCommandPath, service, commandName)
+
+			if strings.HasSuffix(commandName, ".example") || strings.HasPrefix(commandName, "README") || strings.HasPrefix(commandName, ".") || fileutil.IsDirectory(onHostFullPath) {
+				continue
+			}
 
 			// Any command we find will want to be executable on Linux
 			_ = os.Chmod(onHostFullPath, 0755)


### PR DESCRIPTION
## The Problem/Issue/Bug:

https://github.com/drud/ddev/pull/2022 attempted to prevent *directories* in the .ddev/commands/* area from showing up as commands. Because they shouldn't. 

It failed. 

This fixes it. 

## How this PR Solves The Problem:

## Manual Testing Instructions:
```
mkdir .ddev/commands/host/junkhost .ddev/commands/web/junkweb .ddev/commands/db/junkdb
ddev | grep junk
```

You shouldn't see anything.


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

