### PR TITLE
Use proper IS_DDEV_PROJECT, not IS_DRUSH_PROJECT

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -519,7 +519,7 @@ func WriteDrushrc(app *DdevApp, filePath string) error {
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
  Remove this comment if you don't want ddev to manage this file.'
  */
-if (getenv('IS_DRUSH_PROJECT') == 'true') {
+if (getenv('IS_DDEV_PROJECT') == 'true') {
   $options['l'] = "` + uri + `";
 }
 `)


### PR DESCRIPTION
## The Problem/Issue/Bug:

In https://github.com/drud/ddev/pull/1856 the environment variable IS_DDEV_PROJECT was introduced and used to wrap things like settings.ddev.php

However, in final testing for v1.13.0 it was noted that there was a TYPO in drushrc.php, which had IS_DRUSH_PROJECT instead of IS_DDEV_PROJECT. As a result, when drush was used on the host on a D7 project the URL wasn't set correctly.

## How this PR Solves The Problem:

## Manual Testing Instructions:

With a Drupal 7 project:
```
ddev config && ddev start
drush uli
```
You should see the URL generated properly. 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

