### PR TITLE
Remove debug code about provider.Validate return value

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -191,7 +191,6 @@ func handleConfigRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		util.Failed("Failed to validate project %v: %v", app.Name, err)
 	}
-	util.Warning("provider.Validate() returned %v", err)
 
 	err = app.WriteConfig()
 	if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Testing for v1.13.0 revealed the bogus "Provider.Validate() returned nil" statement on ddev config. I couldn't find any reason that this existed except as printf debugging code.

## How this PR Solves The Problem:

## Manual Testing Instructions:

`ddev config`

When it goes through and does everything you should no longer see the "Provider.Validate() returned nil" warning message.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

