### PR TITLE
Improve docker-compose.y*ml parse: Prevent using glob inappropriately

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -57,25 +57,18 @@ func init() {
 }
 
 // NewApp creates a new DdevApp struct with defaults set and overridden by any existing config.yml.
-func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, error) {
+func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, error) {
 	// Set defaults.
 	app := &DdevApp{}
 
 	homeDir, _ := homedir.Dir()
-	if AppRoot == filepath.Dir(globalconfig.GetGlobalDdevDir()) || app.AppRoot == homeDir {
+	if appRoot == filepath.Dir(globalconfig.GetGlobalDdevDir()) || app.AppRoot == homeDir {
 		return nil, fmt.Errorf("ddev config is not useful in home directory (%s)", homeDir)
 	}
-	hasGlob, err := regexp.Match(`[\[\]\{\}\*\?]`, []byte(AppRoot))
-	if err != nil {
-		return nil, err
-	}
-	if hasGlob {
-		return nil, fmt.Errorf("Current directory contains a glob pattern, please use a directory that does not contain `{}[]*?`")
-	}
 
-	app.AppRoot = AppRoot
-	if !fileutil.FileExists(AppRoot) {
-		return app, fmt.Errorf("project root %s does not exist", AppRoot)
+	app.AppRoot = appRoot
+	if !fileutil.FileExists(appRoot) {
+		return app, fmt.Errorf("project root %s does not exist", appRoot)
 	}
 	app.ConfigPath = app.GetConfigPath("config.yaml")
 	app.APIVersion = version.DdevVersion
@@ -119,6 +112,16 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 		return app, fmt.Errorf("provider '%s' is not implemented", provider)
 	}
 	app.SetInstrumentationAppTags()
+
+	// Make sure that not in a dir with glob pattern
+	hasGlob, err := regexp.Match(`[\[\]\{\}\*\?]`, []byte(appRoot))
+	if err != nil {
+		return app, err
+	}
+	if hasGlob {
+		return app, fmt.Errorf("Project directory contains a glob pattern, please use a directory that does not contain `{}[]*?`")
+	}
+
 	return app, nil
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -65,6 +65,13 @@ func NewApp(AppRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	if AppRoot == filepath.Dir(globalconfig.GetGlobalDdevDir()) || app.AppRoot == homeDir {
 		return nil, fmt.Errorf("ddev config is not useful in home directory (%s)", homeDir)
 	}
+	hasGlob, err := regexp.Match(`[\[\]\{\}\*\?]`, []byte(AppRoot))
+	if err != nil {
+		return nil, err
+	}
+	if hasGlob {
+		return nil, fmt.Errorf("Current directory contains a glob pattern, please use a directory that does not contain `{}[]*?`")
+	}
 
 	app.AppRoot = AppRoot
 	if !fileutil.FileExists(AppRoot) {

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -346,6 +346,7 @@ func GetProjects(activeOnly bool) ([]*DdevApp, error) {
 
 		app, err := NewApp(info.AppRoot, true, nodeps.ProviderDefault)
 		if err != nil {
+			util.Warning("unable to create project at project root %s: %v", info.AppRoot, err)
 			app.Name = name
 		}
 		if !activeOnly || (app.SiteStatus() != SiteStopped && app.SiteStatus() != SiteConfigMissing && app.SiteStatus() != SiteDirMissing) {


### PR DESCRIPTION
## The Problem/Issue/Bug:

This follows on https://github.com/drud/ddev/pull/2052

and attempts to discover the problems shown in #2049 

Essentially, there are times that `ddev start` or other commands (`ddev ssh`?) result in "Failed to start <project>: failed to load any docker-compose.*y*l files". We know one occasion, and it's when there are glob characters in the full path to the project.

There may be other causes.

This PR should *not* be merged into v1.13.0, but go on the back burner to be included in v1.14 or whatever. It may involve some risk that I'd rather not take.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

