### PR TITLE
Move event initialization to right before reporting, fixes #2065

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -125,6 +125,7 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 		}
 
 		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && version.SegmentKey != "" && nodeps.IsInternetActive() && len(fullCommand) > 1 {
+			ddevapp.SetInstrumentationBaseTags()
 			ddevapp.SendInstrumentationEvents(event)
 		}
 	},
@@ -159,15 +160,6 @@ func init() {
 	// We really don't want ~/.ddev to have root ownership, breaks things.
 	if os.Geteuid() == 0 && len(os.Args) > 1 && os.Args[1] != "hostname" {
 		output.UserOut.Fatal("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
-	}
-
-	err = globalconfig.ReadGlobalConfig()
-	if err != nil {
-		util.Failed("Failed to read global config file %s: %v", globalconfig.GetGlobalConfigPath(), err)
-	}
-
-	if !globalconfig.DdevNoInstrumentation && globalconfig.DdevGlobalConfig.InstrumentationOptIn {
-		ddevapp.SetInstrumentationBaseTags()
 	}
 
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2065 reports that most (all?) of the event description in Segment/Amplitude is missing. It was reported as just being the "type" field, but really everything is missing. 

## How this PR Solves The Problem:

As  in another bug, #1882, the codebase has a long history of depending on init() for lots of things, and init() is a lousy cheater, with poorly-defined execution order. 

The actual population of the event struct should happen right before the event is to be sent, and that should do the job (assuming the correct analysis of the problem)

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

