### PR TITLE
generate_artifacts needs to include phpmyadmin image in image tarball [skip ci][ci skip]

### DIFF
--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -36,7 +36,7 @@ esac
 
 if [ "${BUILD_IMAGE_TARBALLS}" = "true" ]; then
     # Make sure we have all our docker images, and save them in a tarball
-    $BUILTPATH/ddev version | awk '/drud\// {print $2;}' >/tmp/images.txt
+    $BUILTPATH/ddev version | awk '/(drud|phpmyadmin)\// {print $2;}' >/tmp/images.txt
     for item in $(cat /tmp/images.txt); do
       docker pull $item
     done


### PR DESCRIPTION
## The Problem/Issue/Bug:

As far as I know only Quickstart uses the image tarball, but it did not include the phpmyadmin image before this PR. 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

