### PR TITLE
Correctly detect when to build image tarballs [skip ci][ci skip] (Build only)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           make -s clean linux darwin windows_install EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: Build the ddev executables
     - run:
-        command: ./.circleci/generate_artifacts.sh ~/artifacts ${BUILD_IMAGE_TARBALLS:false}
+        command: ./.circleci/generate_artifacts.sh ~/artifacts
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - store_artifacts:
@@ -344,7 +344,7 @@ jobs:
     - attach_workspace:
         at: ~/
     - run:
-        command: ./.circleci/generate_artifacts.sh ~/artifacts ${BUILD_IMAGE_TARBALLS:false}
+        command: ./.circleci/generate_artifacts.sh ~/artifacts
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
@@ -417,7 +417,7 @@ jobs:
 
     # We only build the xz version of the docker images on tag build.
     - run:
-        command: ./.circleci/generate_artifacts.sh ~/artifacts ${BUILD_IMAGE_TARBALLS:true}
+        command: ./.circleci/generate_artifacts.sh ~/artifacts
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
 

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # This script builds ddev artifacts and their sha256 hashes.
 # First arg is the artifact directory
-# Optional second arg is whether to build ddev_docker_images.tar
 
 set -o errexit
 set -o pipefail

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -18,7 +18,7 @@ export VERSION=$(git describe --tags --always --dirty)
 
 # If the version does not have a dash in it, it's not prerelease,
 # so build image tarballs
-if [ -z ${VERSION##-*} ]; then
+if [ "${VERSION}" = "${VERSION%%-*}" ]; then
     BUILD_IMAGE_TARBALLS=true
 fi
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

The part of the script that determins when to build image tarballs
hadn't been tested, and they didn't get built in v1.13.0,
so have to be built manually.

This fix should solve the problem.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

