### PR TITLE
Use drupal/recommended-project template now that Drupal 8.8 is here (docs only), fixes #1920

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -135,10 +135,9 @@ Get started with Drupal 8 projects on ddev either using a new or existing compos
 ```
 mkdir my-drupal8-site
 cd my-drupal8-site
-ddev config --project-type php
-ddev composer create drupal-composer/drupal-project:8.x-dev --prefer-dist
-ddev config --project-type drupal8
-ddev restart
+ddev config --project-type=drupal8 --docroot=web --create-docroot=true
+ddev start
+ddev composer create drupal/recommended-project:~8.8.0
 ```
 
 When `ddev start` runs, it outputs status messages to indicate the project environment is starting. When the startup is complete, ddev outputs a message like the one below with a link to access your project in a browser.

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -26,7 +26,7 @@ In addition to the *commands* listed above, there are loads and loads of tools i
 * `ddev describe` tells how to use the built-in **PHPMyAdmin**.
 * Composer, git, node, npm, and dozens of other tools are installed in the web container, and you can access them via `ddev ssh` or `ddev exec`.
 * `ddev logs` gets you webserver logs; `ddev logs -s db` gets dbserver logs.
-*  sqlite3 and the mysql client are inside the web container (and mysql client is also in the db container).
+* sqlite3 and the mysql client are inside the web container (and mysql client is also in the db container).
 
 ## Quickstart Guides
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -139,6 +139,7 @@ cd my-drupal8-site
 ddev config --project-type=drupal8 --docroot=web --create-docroot=true
 ddev start
 ddev composer create drupal/recommended-project
+ddev composer remove drupal/core-project-message
 ddev composer require drush/drush
 ddev start
 ```

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -138,7 +138,8 @@ mkdir my-drupal8-site
 cd my-drupal8-site
 ddev config --project-type=drupal8 --docroot=web --create-docroot=true
 ddev start
-ddev composer create drupal/recommended-project:~8.8.0
+ddev composer create drupal/recommended-project
+ddev composer require drush/drush
 ddev start
 ```
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -18,7 +18,7 @@ Each of these commands has full help. For example, `ddev start -h` or `ddev help
 * `ddev launch` or `ddev launch some/uri` will launch a browser with the current project's URL (or a full URL to `/some/uri`)
 * `ddev delete` is the same as `ddev stop --remove-data` and will delete a project's database and ddev's record of the project's existence. It doesn't touch your project or code. `ddev delete -O` will omit the snapshot creation step that would otherwise take place, and `ddev delete images` gets rid of spare Docker images you may have on your machine.
 
-## Bundled Tools List
+## Partial Bundled Tools List
 
 In addition to the *commands* listed above, there are loads and loads of tools included inside the containers:
 
@@ -26,6 +26,7 @@ In addition to the *commands* listed above, there are loads and loads of tools i
 * `ddev describe` tells how to use the built-in **PHPMyAdmin**.
 * Composer, git, node, npm, and dozens of other tools are installed in the web container, and you can access them via `ddev ssh` or `ddev exec`.
 * `ddev logs` gets you webserver logs; `ddev logs -s db` gets dbserver logs.
+*  sqlite3 and the mysql client are inside the web container (and mysql client is also in the db container).
 
 ## Quickstart Guides
 
@@ -55,10 +56,10 @@ DDEV works happily with most any PHP or static HTML project, although it has spe
 ```
 mkdir my-wp-bedrock-site
 cd my-wp-bedrock-site
-ddev config --project-type=php
+ddev config --project-type=wordpress --docroot=web --create-docroot=true
+ddev start
 ddev composer create roots/bedrock
-ddev config
-ddev restart
+ddev start
 ```
 
 ```
@@ -138,6 +139,7 @@ cd my-drupal8-site
 ddev config --project-type=drupal8 --docroot=web --create-docroot=true
 ddev start
 ddev composer create drupal/recommended-project:~8.8.0
+ddev start
 ```
 
 When `ddev start` runs, it outputs status messages to indicate the project environment is starting. When the startup is complete, ddev outputs a message like the one below with a link to access your project in a browser.
@@ -198,20 +200,13 @@ Quickstart instructions for database imports can be found under [Database Import
 ```
 mkdir my-typo3-site
 cd my-typo3-site
-ddev config --project-type php
+ddev config --project-type=typo3 --docroot=public --create-docroot=true
+ddev start
 ddev composer create "typo3/cms-base-distribution:^9" --prefer-dist
-ddev config --project-type typo3
-ddev restart
+ddev start
 ```
 
-When the startup is complete, ddev outputs a message like the one below with a link to access your project in a browser.
-
-```
-Successfully started example-typo3-site
-Your application can be reached at: https://example-typo3-site.ddev.site
-```
-
-**A Some versions of TYPO3 an install may fail if you use the https URL ("Trusted hosts pattern mismatch"). Please use "http" instead of "https" for the URL while doing the install.**
+**A Some versions of TYPO3 an install may fail if you use the https URL to install ("Trusted hosts pattern mismatch"). Please use "http" instead of "https" for the URL while doing the install.**
 
 If doing a basic TYPO3 install, you can then `touch public/FIRST_INSTALL` and hit the http URL top begin an installation.
 
@@ -309,16 +304,6 @@ ddev import-db --src=dumpfile.sql.gz
 
 Check out the git repository for the project you want to work on. `cd` into the directory, run `ddev config`, and follow the prompts.
 
-```
-
-mkdir drupal8
-cd drupal8
-ddev config --project-type php
-ddev composer create drupal-composer/drupal-project:8.x-dev  
-ddev config --project-type drupal8
-
-```
-
 Configuration files have now been created for your project. Take a look at the project's .ddev/config.yaml file.
 
 Now that the configuration files have been created, you can start your project with `ddev start` (still from within the project working directory):
@@ -336,7 +321,7 @@ Your project can be reached at: <http://drupal8.ddev.site>
 
 ```
 
-And you can now visit your working project. Enjoy!
+And you can now visit your working project by URL or just give the command `ddev launch`. Enjoy!
 
 ### Configuration files
 
@@ -378,7 +363,7 @@ How do you know if DDEV manages a settings file? You will see the following comm
 
 ## Listing project information
 
-To see a list of your projects you can use `ddev list`; `ddev list --active-only` will show only projects currently running or paused.
+`ddev list` or `ddev list --active-only` current projects.
 
 ```
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

This is just a re-open of #1993 

* Drupal 8.8 now has its own composer template, drupal/recommended-project, so we no longer need to use the traditional template. See [Drupal.org docs](https://www.drupal.org/docs/develop/using-composer/starting-a-site-using-drupal-composer-project-templates)
* I updated the bedrock/WordPress and TYPO3 quickstarts to not require switching the project type.

Notes in #1993 point out 
* trouble on Windows with unzipping. This seems to be a Docker problem when WSL2 is enabled.
* Drush is not installed by recommended-project. So we need to mention that and add it to this one.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->


