### PR TITLE
Fix Magento 2 quickstart default url

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -272,12 +272,12 @@ Note that Magento 1 is a huge codebase and using `nfs_mount_enabled: true` is re
 Normal details of a composer build for Magento 2 are on [Magento 2 site](https://devdocs.magento.com/guides/v2.3/install-gde/composer.html) You must have a public and private key to install from Magento's repository; when prompted for "username" and "password" in the composer create it's asking for your public and private keys.
 
 ```
-ddev config --project-type=magento2 --docroot=pub --create-docroot=true
+ddev config --project-type=magento2 --docroot=pub --create-docroot=true --project-name=magento2
 ddev start
 ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition
 ddev ssh
 bin/magento setup:install  --db-host=db --db-name=db --db-user=db --db-password=db  --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com  --admin-user=admin --admin-password=admin123 --language=en_US
-bin/magento setup:store-config:set --base-url="https://magento2-ddev.ddev.site/"
+bin/magento setup:store-config:set --base-url="https://magento2.ddev.site/"
 bin/magento cache:clean
 bin/magento deploy:mode:set developer
 ```

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -277,7 +277,7 @@ ddev start
 ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition
 ddev ssh
 bin/magento setup:install  --db-host=db --db-name=db --db-user=db --db-password=db  --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com  --admin-user=admin --admin-password=admin123 --language=en_US
-bin/magento setup:store-config:set --base-url="https://magento2.ddev.site/"
+bin/magento setup:store-config:set --base-url="https://magento2-ddev.ddev.site/"
 bin/magento cache:clean
 bin/magento deploy:mode:set developer
 ```

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -272,17 +272,18 @@ Note that Magento 1 is a huge codebase and using `nfs_mount_enabled: true` is re
 Normal details of a composer build for Magento 2 are on [Magento 2 site](https://devdocs.magento.com/guides/v2.3/install-gde/composer.html) You must have a public and private key to install from Magento's repository; when prompted for "username" and "password" in the composer create it's asking for your public and private keys.
 
 ```
-ddev config --project-type=magento2 --docroot=pub --create-docroot=true --project-name=magento2
+mkdir ddev-magento2 && cd ddev-magento2
+ddev config --project-type=magento2 --docroot=pub --create-docroot=true
 ddev start
 ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition
 ddev ssh
 bin/magento setup:install  --db-host=db --db-name=db --db-user=db --db-password=db  --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com  --admin-user=admin --admin-password=admin123 --language=en_US
-bin/magento setup:store-config:set --base-url="https://magento2.ddev.site/"
+bin/magento setup:store-config:set --base-url="https://ddev-magento2.ddev.site/"
 bin/magento cache:clean
 bin/magento deploy:mode:set developer
 ```
 
-Of course, change the admin name and related information is needed.
+Of course, change the admin name and related information is needed. The project name here is derived from the directory name (ddev-magento2 in this example). Your project name (and thus the `setup:store-config:set --base-url`) will almost certainly be different.
 
 You may want to add the [Magento 2 Sample Data](https://devdocs.magento.com/guides/v2.3/install-gde/install/sample-data-after-composer.html).
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
Install clean 1.13 ddev. 
Install Magento 2 using the quickstart tutorial.
Accessing https://magento2.ddev.site/ gives an error page with message "There is no back-end webserver at the url you specified".
## How this PR Solves The Problem:
Use correct url in quickstart

## Release/Deployment notes:
No

