### PR TITLE
Fix some copy-pasta for the command help text.

### DIFF
--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -22,7 +22,7 @@ var ImportDBCmd = &cobra.Command{
 The database can be provided as a SQL dump in a .sql, .sql.gz, .mysql, .mysql.gz, .zip, .tgz, or .tar.gz
 format. For the zip and tar formats, the path to a .sql file within the archive
 can be provided if it is not located at the top level of the archive. An optional target database
-can also be provided; the default is the default database named "db". 
+can also be provided; the default is the default database named "db".
 Also note the related "ddev mysql" command`,
 	Example: `ddev import-db
 ddev import-db --src=.tarballs/junk.sql
@@ -66,7 +66,7 @@ gzip -dc db.sql.gz | ddev import-db`,
 func init() {
 	ImportDBCmd.Flags().StringVarP(&dbSource, "src", "f", "", "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format")
 	ImportDBCmd.Flags().StringVarP(&dbExtPath, "extract-path", "", "", "If provided asset is an archive, provide the path to extract within the archive.")
-	ImportDBCmd.Flags().StringVarP(&targetDB, "target-db", "d", "db", "If provided asset is an archive, provide the path to extract within the archive.")
+	ImportDBCmd.Flags().StringVarP(&targetDB, "target-db", "d", "db", "If provided, target-db is alternate database to import into")
 	ImportDBCmd.Flags().BoolVarP(&noDrop, "no-drop", "", false, "Set if you do NOT want to drop the db before importing")
 	ImportDBCmd.Flags().BoolVarP(&progressOption, "progress", "p", true, "Display a progress bar during import")
 	RootCmd.AddCommand(ImportDBCmd)


### PR DESCRIPTION
## The Problem/Issue/Bug:
The help text for the `target-db` argument in `import-db.go` was copied from the `extract-path` argument. It needed to be updated.

## How this PR Solves The Problem:

It updates the help text to mirror the help text used for the `target-db` argument on the `export-db` command.

## Manual Testing Instructions:

Run `ddev help import-db` and observe that the help text for `target-db` option is a copy of the different option `extract-path`. After using this MR it is appropriate documentation.

## Automated Testing Overview:
No new tests. Not sure if help text is tested?

## Related Issue Link(s):

## Release/Deployment notes:
n/a from my perspective.
