### PR TITLE
Set cgi.fix_pathinfo=1 in php-fpm php.ini files, fixes #2083

### DIFF
--- a/containers/ddev-webserver/files/etc/php/5.6/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/5.6/fpm/php.ini
@@ -49,7 +49,7 @@ default_charset = "UTF-8"
 doc_root =
 user_dir =
 enable_dl = Off
-cgi.fix_pathinfo=0
+cgi.fix_pathinfo=1
 ; File Uploads ;
 file_uploads = On
 upload_max_filesize = 100M

--- a/containers/ddev-webserver/files/etc/php/7.0/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.0/fpm/php.ini
@@ -49,7 +49,7 @@ default_charset = "UTF-8"
 doc_root =
 user_dir =
 enable_dl = Off
-cgi.fix_pathinfo=0
+cgi.fix_pathinfo=1
 ; File Uploads ;
 file_uploads = On
 upload_max_filesize = 100M

--- a/containers/ddev-webserver/files/etc/php/7.1/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.1/fpm/php.ini
@@ -48,7 +48,7 @@ default_charset = "UTF-8"
 doc_root =
 user_dir =
 enable_dl = Off
-cgi.fix_pathinfo=0
+cgi.fix_pathinfo=1
 ; File Uploads ;
 file_uploads = On
 upload_max_filesize = 100M

--- a/containers/ddev-webserver/files/etc/php/7.2/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.2/fpm/php.ini
@@ -48,7 +48,7 @@ default_charset = "UTF-8"
 doc_root =
 user_dir =
 enable_dl = Off
-cgi.fix_pathinfo=0
+cgi.fix_pathinfo=1
 ; File Uploads ;
 file_uploads = On
 upload_max_filesize = 100M

--- a/containers/ddev-webserver/files/etc/php/7.3/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.3/fpm/php.ini
@@ -48,7 +48,7 @@ default_charset = "UTF-8"
 doc_root =
 user_dir =
 enable_dl = Off
-cgi.fix_pathinfo=0
+cgi.fix_pathinfo=1
 ; File Uploads ;
 file_uploads = On
 upload_max_filesize = 100M

--- a/containers/ddev-webserver/files/etc/php/7.4/fpm/php.ini
+++ b/containers/ddev-webserver/files/etc/php/7.4/fpm/php.ini
@@ -48,7 +48,7 @@ default_charset = "UTF-8"
 doc_root =
 user_dir =
 enable_dl = Off
-cgi.fix_pathinfo=0
+cgi.fix_pathinfo=1
 ; File Uploads ;
 file_uploads = On
 upload_max_filesize = 100M

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200228_fix_run_pidfile" // Note that this can be overridden by make
+var WebTag = "20200301_leymannx_apache" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

This fixes #2083 when with an `apache-fpm` web server in a Drupal project accessing /update.php/selection returns the following error:

> No input file specified.

## How this PR Solves The Problem:

`cgi.fix_pathinfo=1` lets CGI interpret the path correctly. See [`PATH_INFO`](https://tools.ietf.org/html/rfc3875#section-4.1.5) in the CGI specs.

## Manual Testing Instructions:

Same as in the opening post to #2083  

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

Should there be tests for this issue?

## Related Issue Link(s):

Probably worth to mention that setting `cgi.fix_pathinfo=1` may come with security implications. But I don't know how relevant these implications are in a local setup.

* [Turned on cgi.fix_pathinfo still “dangerous” in Nginx?](https://security.stackexchange.com/q/177354/150906)
* [Is the PHP option 'cgi.fix_pathinfo' really dangerous with Nginx + PHP-FPM?](https://serverfault.com/q/627903/291405)

## Release/Deployment notes:

<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

I wonder if all php.ini files should have `cgi.fix_pathinfo=1` or if it's good to let this affect just the /etc/php/*/fpm.php.ini files.