### PR TITLE
Fix curl recognition of system CA path (testing only)

### DIFF
--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -16,6 +16,9 @@ fi
 
 echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 
+# Without this .curlrc CircleCI linux image doesn't respect mkcert certs
+echo "capath=/etc/ssl/certs/" >>~/.curlrc
+
 . ~/.bashrc
 
 export HOMEBREW_NO_AUTO_UPDATE=1


### PR DESCRIPTION
## The Problem/Issue/Bug:

CircleCI did something that broke curl's respect for the system CA path. This adds a .curlrc to fix that and make ddev-router tests work again.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

