### PR TITLE
NFS Installer on Windows breaks when spaces present

### DIFF
--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -19,7 +19,7 @@ if [ "${DOCKER_TOOLBOX_INSTALL_PATH:-}" != "" ] ; then
 fi
 
 mkdir -p ~/.ddev
-docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 101)
+docker run --rm -t -v "/$HOME/.ddev:/tmp/junker99" busybox:latest ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 101)
 
 
 status=uninstalled


### PR DESCRIPTION
## The Problem/Issue/Bug:
The NFS Installer on Windows errored out.

## How this PR Solves The Problem:
The $HOME variable isn't quoted and when a space is present in the profile it gets expanded into another parameter to the docker command.
This PR quotes the value to prevent unintended consequences.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

