### PR TITLE
Put php-fpm pidfile in new location for upstream, fixes #2092

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -140,7 +140,7 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/log/apache2 /var/run/apache2 /var/lib
 RUN chmod -R 777 /var/log
 
 # /home is a prototype for the actual user dir, but leave it writable
-RUN mkdir -p /home/.composer /home/.drush/commands /home/.drush/aliases /mnt/ddev-global-cache/mkcert && chmod -R ugo+rw /home /mnt/ddev-global-cache/
+RUN mkdir -p /home/.composer /home/.drush/commands /home/.drush/aliases /mnt/ddev-global-cache/mkcert /run/php && chmod -R ugo+rw /home /mnt/ddev-global-cache/
 
 RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php /etc/apache2 /var/log/apache2/ /var/run/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
 

--- a/containers/ddev-webserver/files/etc/php/5.6/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/5.6/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php5.6-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.0/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.0/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.0-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.1/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.1/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.1-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.2/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.2/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.2-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.3/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.3/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.3-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.4/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.4/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php/php7.3-fpm.pid
+pid = /run/php/php7.4-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.4/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.4/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.3-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.13.0" // Note that this can be overridden by make
+var WebTag = "20200228_fix_run_pidfile" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Upstream php-fpm packaging suddenly changed where the php-fpm pid is stored, causing usage of extra packages (or custom Dockerfile) to fail. Reported in #2092 

## How this PR Solves The Problem:

* Create the new directory
* Change all fpm configs to use the standard directory
* Add a test to make sure that extra_packages works so we catch stuff like this in nightly build in the future.

## Manual Testing Instructions:

* Add webimage_extra_packages: [php7.3-ldap]
* `ddev start`
* Should work

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

