### PR TITLE
Prepare v1.13.1 point release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           make -s clean linux darwin windows_install EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: Build the ddev executables
     - run:
-        command: ./.circleci/generate_artifacts.sh ~/artifacts ${BUILD_IMAGE_TARBALLS:false}
+        command: ./.circleci/generate_artifacts.sh ~/artifacts
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - store_artifacts:
@@ -344,7 +344,7 @@ jobs:
     - attach_workspace:
         at: ~/
     - run:
-        command: ./.circleci/generate_artifacts.sh ~/artifacts ${BUILD_IMAGE_TARBALLS:false}
+        command: ./.circleci/generate_artifacts.sh ~/artifacts
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
@@ -417,7 +417,7 @@ jobs:
 
     # We only build the xz version of the docker images on tag build.
     - run:
-        command: ./.circleci/generate_artifacts.sh ~/artifacts ${BUILD_IMAGE_TARBALLS:true}
+        command: ./.circleci/generate_artifacts.sh ~/artifacts
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
 

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # This script builds ddev artifacts and their sha256 hashes.
 # First arg is the artifact directory
-# Optional second arg is whether to build ddev_docker_images.tar
 
 set -o errexit
 set -o pipefail
@@ -18,7 +17,7 @@ export VERSION=$(git describe --tags --always --dirty)
 
 # If the version does not have a dash in it, it's not prerelease,
 # so build image tarballs
-if [ -z ${VERSION##-*} ]; then
+if [ "${VERSION}" = "${VERSION%%-*}" ]; then
     BUILD_IMAGE_TARBALLS=true
 fi
 

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -16,6 +16,9 @@ fi
 
 echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 
+# Without this .curlrc CircleCI linux image doesn't respect mkcert certs
+echo "capath=/etc/ssl/certs/" >>~/.curlrc
+
 . ~/.bashrc
 
 export HOMEBREW_NO_AUTO_UPDATE=1

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -140,7 +140,7 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/log/apache2 /var/run/apache2 /var/lib
 RUN chmod -R 777 /var/log
 
 # /home is a prototype for the actual user dir, but leave it writable
-RUN mkdir -p /home/.composer /home/.drush/commands /home/.drush/aliases /mnt/ddev-global-cache/mkcert && chmod -R ugo+rw /home /mnt/ddev-global-cache/
+RUN mkdir -p /home/.composer /home/.drush/commands /home/.drush/aliases /mnt/ddev-global-cache/mkcert /run/php && chmod -R ugo+rw /home /mnt/ddev-global-cache/
 
 RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php /etc/apache2 /var/log/apache2/ /var/run/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
 

--- a/containers/ddev-webserver/files/etc/php/5.6/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/5.6/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php5.6-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.0/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.0/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.0-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.1/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.1/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.1-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.2/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.2/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.2-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.3/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.3/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.3-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/containers/ddev-webserver/files/etc/php/7.4/fpm/php-fpm.conf
+++ b/containers/ddev-webserver/files/etc/php/7.4/fpm/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php-fpm.pid
+pid = /run/php/php7.4-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
+	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/require"
@@ -755,13 +756,24 @@ func TestExtraPackages(t *testing.T) {
 	err = app.Stop(true, false)
 	assert.NoError(err)
 
+	// Make sure no "-built" items are still hanging around
+	command := fmt.Sprintf("docker rmi -f %s-%s-built %s-%s-built", app.WebImage, app.Name, app.GetDBImage(), app.Name)
+	_, err = exec.RunCommand("bash", []string{"-c", command})
+	assert.NoError(err)
+
+	oldPHPVersion := app.PHPVersion
+	app.PHPVersion = "7.3"
 	defer func() {
+		_ = app.Stop(true, false)
 		app.WebImageExtraPackages = nil
 		app.DBImageExtraPackages = nil
+		app.PHPVersion = oldPHPVersion
 		_ = app.WriteConfig()
 		_ = fileutil.RemoveContents(app.GetConfigPath("web-build"))
 		_ = fileutil.RemoveContents(app.GetConfigPath("db-build"))
 		_ = app.Stop(true, false)
+		command := fmt.Sprintf("docker rmi -f %s-%s-built %s-%s-built", app.WebImage, app.Name, app.GetDBImage(), app.Name)
+		_, _ = exec.RunCommand("bash", []string{"-c", command})
 	}()
 
 	// Start and make sure that the packages don't exist already
@@ -770,7 +782,7 @@ func TestExtraPackages(t *testing.T) {
 
 	_, _, err = app.Exec(&ExecOpts{
 		Service: "web",
-		Cmd:     "command -v zsh",
+		Cmd:     "dpkg -s php7.3-gmp",
 	})
 	assert.Error(err)
 	assert.Contains(err.Error(), "exit status 1")
@@ -783,17 +795,22 @@ func TestExtraPackages(t *testing.T) {
 	assert.Contains(err.Error(), "exit status 1")
 
 	// Now add the packages and start again, they should be in there
-	app.WebImageExtraPackages = []string{"zsh"}
+	app.WebImageExtraPackages = []string{"php7.3-gmp"}
 	app.DBImageExtraPackages = []string{"ncdu"}
 	err = app.Start()
 	assert.NoError(err)
 
-	stdout, _, err := app.Exec(&ExecOpts{
+	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "web",
-		Cmd:     "command -v zsh",
+		Cmd:     "dpkg -s php7.3-gmp",
 	})
-	assert.NoError(err)
-	assert.Equal("/usr/bin/zsh", strings.Trim(stdout, "\n"))
+	assert.NoError(err, "dpkg -s php7.3-gmp failed", stdout, stderr)
+
+	stdout, stderr, err = app.Exec(&ExecOpts{
+		Service: "web",
+		Cmd:     "php -i | grep 'gmp support =. enabled'",
+	})
+	assert.NoError(err, "failed to grep for gmp support, stdout=%s, stderr=%s", stdout, stderr)
 
 	stdout, _, err = app.Exec(&ExecOpts{
 		Service: "db",
@@ -801,10 +818,6 @@ func TestExtraPackages(t *testing.T) {
 	})
 	assert.NoError(err)
 	assert.Equal("/usr/bin/ncdu", strings.Trim(stdout, "\n"))
-
-	err = app.Stop(true, false)
-	assert.NoError(err)
-
 	runTime()
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200228_fix_run_pidfile" // Note that this can be overridden by make
+var WebTag = "v1.13.1" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.13.0" // Note that this can be overridden by make
+var WebTag = "20200228_fix_run_pidfile" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

A point release v1.13.1 is required because of upstream changes, see #2099 

Essentially upstream PHP packaging changed, #2099 fixes it, but it's on master, and we need to backport it to a v1.13.1

This should be *merged* not *squashed*

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

