### PR TITLE
Bump to build-tools 2.4.0, golang 1.14

### DIFF
--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -21,6 +21,7 @@ DOCKERTESTCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)               
           	    -v "$(S)$(PWD):/workdir$(DOCKERMOUNTFLAG)"                              \
           	    -e GOPATH="//workdir/$(GOTMP)" \
           	    -e GOCACHE="//workdir/$(GOTMP)/.cache" \
+          	    -e GOLANGCI_LINT_CACHE="//workdir/$(GOTMP)/.golanci-lint-cache" \
           	    -e GOFLAGS="$(USEMODVENDOR)" \
           	    -w //workdir              \
           	    $(BUILD_IMAGE)
@@ -34,7 +35,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.13.0
+BUILD_IMAGE ?= drud/golang-build-container:v1.14.0
 
 BUILD_BASE_DIR ?= $(PWD)
 

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -235,7 +235,10 @@ func TestCmdDescribeMissingProjectDirectory(t *testing.T) {
 
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
 	//nolint: errcheck
-	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
+	defer exec.RunCommand(DdevBin, []string{"delete", "-Oy", projectName})
+	assert.NoError(err)
+
+	_, err = exec.RunCommand(DdevBin, []string{"stop"})
 	assert.NoError(err)
 
 	err = os.Chdir(projDir)

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -84,6 +84,9 @@ func TestCmdPauseContainersMissingProjectDirectory(t *testing.T) {
 	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"stop", "-RO", projectName})
 
+	_, err = exec.RunCommand(DdevBin, []string{"pause", projectName})
+	assert.NoError(err)
+
 	err = os.Chdir(projDir)
 	assert.NoError(err)
 

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -81,6 +81,9 @@ func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
 	assert.NoError(err)
 
+	_, err = exec.RunCommand(DdevBin, []string{"stop"})
+	assert.NoError(err)
+
 	err = os.Chdir(projDir)
 	assert.NoError(err)
 

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -84,17 +84,20 @@ func TestCmdStopMissingProjectDirectory(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
 	assert.NoError(err)
 
+	_, err = exec.RunCommand(DdevBin, []string{"stop", projectName})
+	assert.NoError(err)
+
 	err = os.Chdir(projDir)
 	assert.NoError(err)
 
 	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
 	err = os.Rename(tmpDir, copyDir)
 	assert.NoError(err)
+	//nolint: errcheck
+	defer os.Rename(copyDir, tmpDir)
 
 	out, err = exec.RunCommand(DdevBin, []string{"stop", projectName})
 	assert.NoError(err)
 	assert.Contains(out, "has been stopped")
 
-	err = os.Rename(copyDir, tmpDir)
-	assert.NoError(err)
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1884,6 +1884,7 @@ func TestDdevStopMissingDirectory(t *testing.T) {
 	siteCopyDest := filepath.Join(tempPath, "site")
 	defer removeAllErrCheck(tempPath, assert)
 
+	_ = app.Stop(false, false)
 	// Move the site directory to a temp location to mimic a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
@@ -1978,6 +1979,8 @@ func TestDdevDescribeMissingDirectory(t *testing.T) {
 		t.Fatalf("app.StartAndWait failed err=%v logs from broken container: \n=======\n%s\n========\n", startErr, logs)
 	}
 	// Move the site directory to a temp location to mimick a missing directory.
+	err = app.Stop(false, false)
+	assert.NoError(err)
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1888,14 +1888,16 @@ func TestDdevStopMissingDirectory(t *testing.T) {
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
 
+	//nolint: errcheck
+	defer os.Rename(siteCopyDest, site.Dir)
+
 	// ddev stop (in cmd) actually does the check for missing project files,
 	// so we imitate that here.
 	err = ddevapp.CheckForMissingProjectFiles(app)
 	assert.Error(err)
-	assert.Contains(err.Error(), "If you would like to continue using ddev to manage this project please restore your files to that directory.")
-	// Move the site directory back to its original location.
-	err = os.Rename(siteCopyDest, site.Dir)
-	assert.NoError(err)
+	if err != nil {
+		assert.Contains(err.Error(), "If you would like to continue using ddev to manage this project please restore your files to that directory.")
+	}
 }
 
 // TestDdevDescribe tests that the describe command works properly on a running


### PR DESCRIPTION
## The Problem/Issue/Bug:

Bumps tools, golang to 1.14

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

