### PR TITLE
Increase timeout on ddev-router and ddev-webserver for slower machines, fixes #2120

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ include build-tools/makefile_components/base_build_go.mak
 
 TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
-TEST_TIMEOUT=120m
+TEST_TIMEOUT=150m
 BUILD_ARCH = $(shell go env GOARCH)
 ifeq ($(BUILD_OS),linux)
     DDEV_BINARY_FULLPATH=$(PWD)/$(GOTMP)/bin/ddev

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -129,8 +129,8 @@ services:
     {{ end }}
     healthcheck:
       interval: 1s
-      retries: 10
-      start_period: 10s
+      retries: 20
+      start_period: 20s
       timeout: 120s
 
 {{ if not .OmitDBA }}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -409,8 +409,8 @@ services:
     restart: "no"
     healthcheck:
       interval: 1s
-      retries: 10
-      start_period: 10s
+      retries: 20
+      start_period: 20s
       timeout: 120s
 
 networks:


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2120 reports that on a slower machine (2011 MBP) and probably a larger project, `ddev start` can report a timeout... but `ddev list` immediately shows it being OK. 

We've also seen this in a few situations with ddev-webserver

## How this PR Solves The Problem:

Loosen the timeout for ddev-router and ddev-webserver

## Manual Testing Instructions:

Currently I don't have a way to test this, but will ask @rpkoller to test. 

- [ ] Make sure it solves the problem at hand (`ddev start` should succeed predictably on slower machines)
- [ ] Make sure it doesn't change the start time for more recent machines (`ddev start` should take about the same amount of time as previously on recent machines.

## Automated Testing Overview:

I think existing tests will test for regressions just fine. Many, many ddev starts are done. 

## Related Issue Link(s):

OP #2120 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

