### PR TITLE
Remove ini_set() from settings.ddev.php

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -102,11 +102,6 @@ $database_prefix = '{{ $config.DatabasePrefix }}';
 $settings['update_free_access'] = FALSE;
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 $settings['backdrop_drupal_compatibility'] = TRUE;
-
-ini_set('session.gc_probability', 1);
-ini_set('session.gc_divisor', 100);
-ini_set('session.gc_maxlifetime', 200000);
-ini_set('session.cookie_lifetime', 2000000);
 `
 
 // createBackdropSettingsFile manages creation and modification of settings.php and settings.ddev.php.

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -142,11 +142,6 @@ $databases['default']['default'] = array(
   'prefix' => "{{ $config.DatabasePrefix }}",
 );
 
-ini_set('session.gc_probability', 1);
-ini_set('session.gc_divisor', 100);
-ini_set('session.gc_maxlifetime', 200000);
-ini_set('session.cookie_lifetime', 2000000);
-
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.
@@ -166,7 +161,8 @@ $settings['class_loader_auto_detect'] = FALSE;
 // so it should work on any Drupal 8 or 9 version.
 if (defined('CONFIG_SYNC_DIRECTORY') && empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
   $config_directories[CONFIG_SYNC_DIRECTORY] = '{{ joinPath $config.SitePath $config.SyncDir }}';
-} else if (empty($settings['config_sync_directory'])) {
+}
+elseif (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = '{{ joinPath $config.SitePath $config.SyncDir }}';
 }
 `
@@ -202,11 +198,6 @@ $databases['default']['default'] = array(
   'prefix' => "{{ $config.DatabasePrefix }}",
 );
 
-ini_set('session.gc_probability', 1);
-ini_set('session.gc_divisor', 100);
-ini_set('session.gc_maxlifetime', 200000);
-ini_set('session.cookie_lifetime', 2000000);
-
 $drupal_hash_salt = '{{ $config.HashSalt }}';
 `
 )
@@ -231,11 +222,6 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
 } 
 
 $db_url = "{{ $config.DatabaseDriver }}://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@$host:$port/{{ $config.DatabaseName }}";
-
-ini_set('session.gc_probability', 1);
-ini_set('session.gc_divisor', 100);
-ini_set('session.gc_maxlifetime', 200000);
-ini_set('session.cookie_lifetime', 2000000);
 `
 )
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

`settings.ddev.php` defined a few `ini_set`. Those `ini_set` are not part of the `default.settings.php` that comes with a vanilla Drupal.

The problem of having those `ini_set` is that it can result with `ini_set(): Headers already sent. You cannot change the session module's ini settings at this time` (witnessed for example in PHPunit tests).

One option would be to prefix it with `@` (e.g. `@ini_set('session.gc_probability', 1);`), however as this doesn't appear in the `default.settings.php`, it's likely a better idea to completely drop it.

## How this PR Solves The Problem:

Removes `ini_set`.
