### PR TITLE
Make TestTimezoneConfig more robust for summertime CEST

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -868,15 +869,15 @@ func TestTimezoneConfig(t *testing.T) {
 		Cmd:     "printf \"timezone=$(date +%Z)\n\" && php -r 'print \"phptz=\" . date_default_timezone_get();'",
 	})
 	assert.NoError(err)
-	assert.Equal("timezone=CET\nphptz=Europe/Paris", stdout)
+	assert.Regexp(regexp.MustCompile("timezone=CES?T\nphptz=Europe/Paris"), stdout)
 
-	// Make sure db container is also working with Dublin time/IST
+	// Make sure db container is also working with CET
 	stdout, _, err = app.Exec(&ExecOpts{
 		Service: "db",
 		Cmd:     "echo -n timezone=$(date +%Z)",
 	})
 	assert.NoError(err)
-	assert.Equal("timezone=CET", stdout)
+	assert.Regexp(regexp.MustCompile("timezone=CES?T"), stdout)
 
 	runTime()
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

TestTimezoneConfig had a naive assumption about CET vs CEST, and now that CEST has arrived, the test fails. 

## How this PR Solves The Problem:

Allow the test response to be either CET or CEST. 

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

