### PR TITLE
Minor improvement for reliability of TestDdevDescribeMissingDirectory on Windows (tests only)

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1995,9 +1995,11 @@ func TestDdevDescribeMissingDirectory(t *testing.T) {
 		assert.NoError(err)
 		t.Fatalf("app.StartAndWait failed err=%v logs from broken container: \n=======\n%s\n========\n", startErr, logs)
 	}
-	// Move the site directory to a temp location to mimick a missing directory.
+	// Move the site directory to a temp location to mimic a missing directory.
 	err = app.Stop(false, false)
 	assert.NoError(err)
+	// Docker seems not always to release resources already, so sleep a bit before rename
+	time.Sleep(2 * time.Second)
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

On Windows you can't just rename/mv/rm a directory that's in use, and TestDdevDescribeMissingDirectory has been haunted by occasional failures due to that. Even though the project is now shut down before the rename, it seems maybe a sleep is in order. This adds a sleep after the stop.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

