### PR TITLE
Improve a few tests to prevent transient failures (tests only)

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -240,6 +241,9 @@ func TestCmdDescribeMissingProjectDirectory(t *testing.T) {
 
 	_, err = exec.RunCommand(DdevBin, []string{"stop"})
 	assert.NoError(err)
+
+	// Docker seems not always to release resources already, so sleep a bit before rename
+	time.Sleep(2 * time.Second)
 
 	err = os.Chdir(projDir)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -86,6 +87,9 @@ func TestCmdPauseContainersMissingProjectDirectory(t *testing.T) {
 
 	_, err = exec.RunCommand(DdevBin, []string{"pause", projectName})
 	assert.NoError(err)
+
+	// Docker seems not always to release resources already, so sleep a bit before rename
+	time.Sleep(2 * time.Second)
 
 	err = os.Chdir(projDir)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -78,11 +79,14 @@ func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
 
 	//nolint: errcheck
-	defer exec.RunCommand(DdevBin, []string{"remove", "-RO", projectName})
+	defer exec.RunCommand(DdevBin, []string{"stop", "-RO", projectName})
 	assert.NoError(err)
 
 	_, err = exec.RunCommand(DdevBin, []string{"stop"})
 	assert.NoError(err)
+
+	// Docker seems not always to release resources already, so sleep a bit before rename
+	time.Sleep(2 * time.Second)
 
 	err = os.Chdir(projDir)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -86,6 +87,9 @@ func TestCmdStopMissingProjectDirectory(t *testing.T) {
 
 	_, err = exec.RunCommand(DdevBin, []string{"stop", projectName})
 	assert.NoError(err)
+
+	// Docker seems not always to release resources already, so sleep a bit before rename
+	time.Sleep(2 * time.Second)
 
 	err = os.Chdir(projDir)
 	assert.NoError(err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1902,6 +1902,9 @@ func TestDdevStopMissingDirectory(t *testing.T) {
 	defer removeAllErrCheck(tempPath, assert)
 
 	_ = app.Stop(false, false)
+	// Docker seems not always to release resources already, so sleep a bit before rename
+	time.Sleep(2 * time.Second)
+
 	// Move the site directory to a temp location to mimic a missing directory.
 	err = os.Rename(site.Dir, siteCopyDest)
 	assert.NoError(err)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -302,7 +302,7 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 // hits the local docker for it, returns result
 // Returns error (with the body) if not 200 status code.
 func GetLocalHTTPResponse(t *testing.T, rawurl string, timeoutSecsAry ...int) (string, *http.Response, error) {
-	var timeoutSecs = 20
+	var timeoutSecs = 30
 	if len(timeoutSecsAry) > 0 {
 		timeoutSecs = timeoutSecsAry[0]
 	}
@@ -368,7 +368,7 @@ func GetLocalHTTPResponse(t *testing.T, rawurl string, timeoutSecsAry ...int) (s
 
 // EnsureLocalHTTPContent will verify a URL responds with a 200 and expected content string
 func EnsureLocalHTTPContent(t *testing.T, rawurl string, expectedContent string, timeoutSeconds ...int) (*http.Response, error) {
-	var httpTimeout = 20
+	var httpTimeout = 30
 	if len(timeoutSeconds) > 0 {
 		httpTimeout = timeoutSeconds[0]
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* A few timeouts in TestDdevFullSiteSetup
* A few failures on Test*MissingDirectory that weren't fixed in #2139 

## How this PR Solves The Problem:

Increase timeouts, wait after stopping project

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

