### PR TITLE
Remove unneeded ipv6 listen from nginx config

### DIFF
--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-backdrop.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-backdrop.conf
@@ -16,7 +16,7 @@ server {
     root $WEBSERVER_DOCROOT;
 
     listen 80; ## listen for ipv4; this line is default and implied
-    listen [::]:80 default ipv6only=on; ## listen for ipv6
+
 
     include /etc/nginx/monitoring.conf;
 
@@ -31,7 +31,7 @@ server {
     root $WEBSERVER_DOCROOT;
 
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     ssl_certificate /etc/ssl/certs/master.crt;
     ssl_certificate_key /etc/ssl/certs/master.key;

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-default.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-default.conf
@@ -12,7 +12,7 @@ map $http_x_forwarded_proto $fcgi_https {
 
 server {
     listen 80;
-    listen [::]:80 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.
@@ -27,7 +27,7 @@ server {
 
 server {
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal6.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal6.conf
@@ -22,7 +22,7 @@ map $uri $no_slash_uri {
 
 server {
     listen 80; ## listen for ipv4; this line is default and implied
-    listen [::]:80 default ipv6only=on; ## listen for ipv6
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.
@@ -36,7 +36,7 @@ server {
 
 server {
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal7.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal7.conf
@@ -12,7 +12,7 @@ map $http_x_forwarded_proto $fcgi_https {
 
 server {
     listen 80; ## listen for ipv4; this line is default and implied
-    listen [::]:80 default ipv6only=on; ## listen for ipv6
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.
@@ -26,7 +26,7 @@ server {
 
 server {
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal8.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal8.conf
@@ -12,7 +12,7 @@ map $http_x_forwarded_proto $fcgi_https {
 
 server {
     listen 80; ## listen for ipv4; this line is default and implied
-    listen [::]:80 default ipv6only=on; ## listen for ipv6
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.
@@ -26,7 +26,7 @@ server {
 
 server {
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-magento.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-magento.conf
@@ -12,7 +12,7 @@ map $http_x_forwarded_proto $fcgi_https {
 
 server {
     listen 80;
-    listen [::]:80 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.
@@ -26,7 +26,7 @@ server {
 
 server {
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-magento2.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-magento2.conf
@@ -12,7 +12,7 @@ map $http_x_forwarded_proto $fcgi_https {
 
 server {
     listen 80;
-    listen [::]:80 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.
@@ -26,7 +26,7 @@ server {
 
 server {
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
@@ -12,7 +12,7 @@ map $http_x_forwarded_proto $fcgi_https {
 
 server {
     listen 80; ## listen for ipv4; this line is default and implied
-    listen [::]:80 default ipv6only=on; ## listen for ipv6
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.
@@ -26,7 +26,7 @@ server {
 
 server {
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-wordpress.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-wordpress.conf
@@ -15,7 +15,7 @@ map $http_x_forwarded_proto $fcgi_https {
 
 server {
     listen 80; ## listen for ipv4; this line is default and implied
-    listen [::]:80 default ipv6only=on; ## listen for ipv6
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.
@@ -29,7 +29,7 @@ server {
 
 server {
     listen 443 ssl;
-    listen [::]:443 default ipv6only=on;
+
 
     # The WEBSERVER_DOCROOT variable is substituted with
     # its value when the container is started.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1208,7 +1208,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
 		// Test dynamic php + database content.
 		rawurl := app.GetHTTPSURL() + site.DynamicURI.URI
-		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, 60)
+		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, 90)
 		assert.NoError(err, "GetLocalHTTPResponse returned err on project=%s rawurl %s, resp=%v: %v", site.Name, rawurl, resp, err)
 		if err != nil && strings.Contains(err.Error(), "container ") {
 			logs, err := ddevapp.GetErrLogsFromApp(app, err)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200301_leymannx_apache" // Note that this can be overridden by make
+var WebTag = "20200402_remove_ipv6" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Docker desktop 2.2.3.0 (both Windows and Mac) can't handle IPV6, see github.com/docker/for-win/issues/6206 and https://github.com/docker/for-mac/issues/4415

An untouched line in our nginx config binds nginx to ::80 and ::443, but it's completely unnecessary as far as I know. 

## How this PR Solves The Problem:

Remove the ipv6 bind lines.

## Manual Testing Instructions:

Try out ddev on windows or mac with docker 2.2.3.0

Note that you can use the image that works with `webimage: drud/ddev-webserver:20200402_remove_ipv6` in your project's config.yaml

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

