### PR TITLE
Add webp nginx configuration for TYPO3 projects

### DIFF
--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-typo3.conf
@@ -10,6 +10,11 @@ map $http_x_forwarded_proto $fcgi_https {
     https on;
 }
 
+map $http_accept $webp_suffix {
+    default   "";
+    "~*webp"  ".webp";
+}
+
 server {
     listen 80; ## listen for ipv4; this line is default and implied
 

--- a/containers/ddev-webserver/files/etc/nginx/nginx_typo3.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx_typo3.conf
@@ -38,10 +38,17 @@
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    location ~* \.(?:ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";
+    }
+
+    location ~* ^/fileadmin/.+\.(png|jpg|jpeg)$ {
+        expires 1M;
+        add_header Cache-Control "public";
+        add_header Vary "Accept";
+        try_files $uri$webp_suffix $uri =404;
     }
 
     # Prevent clients from accessing hidden files (starting with a dot)


### PR DESCRIPTION
## The Problem/Issue/Bug:
There is possibility to provide webp support out of box, also with fallback to original file
## How this PR Solves The Problem:
Nginx automatically matches .webp files if they exist and serves them instead of original file
## Manual Testing Instructions:
Create TYPO3 project, generate .webp files for existing processed images (there are extensions which can be used for generating those files)
## Release/Deployment notes:
This change is backward compatible. 

