### PR TITLE
Add mariadb 10.3 image to docker tarball, fixes #2118

### DIFF
--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -36,6 +36,8 @@ esac
 if [ "${BUILD_IMAGE_TARBALLS}" = "true" ]; then
     # Make sure we have all our docker images, and save them in a tarball
     $BUILTPATH/ddev version | awk '/(drud|phpmyadmin)\// {print $2;}' >/tmp/images.txt
+    # Quicksprint is the only known consumer of this tarball, and Drupal 9 needs non-default mariadb 10.3
+    $BUILTPATH/ddev version | awk ' $1 == "db" { sub(/mariadb-10.2/, "mariadb-10.3"); print $2 }' >>/tmp/images.txt
     for item in $(cat /tmp/images.txt); do
       docker pull $item
     done


### PR DESCRIPTION
## The Problem/Issue/Bug:

Quicksprint needs MariaDB 10.3 for Drupal 9. It should be added to the images tarball.

## How this PR Solves The Problem:

## Manual Testing Instructions:

After CircleCI build, ssh into build and run the generate_artifacts.sh script with BUILD_IMAGE_TARBALLS=true. (Otherwise, this won't be run that way until full release)

Verify that the 10.3 docker image is bundled in the tarball.

## Automated Testing Overview:

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

