### PR TITLE
Stop providing default to BASE_IMAGE arg in Dockerfile.example, fixes #2155

### DIFF
--- a/docs/users/extend/customizing-images.md
+++ b/docs/users/extend/customizing-images.md
@@ -28,7 +28,7 @@ You can use the .ddev/*-build/ directory as the Docker "context" directory as we
 An example web image `.ddev/web-build/Dockerfile` might be:
 
 ```
-ARG BASE_IMAGE=drud/ddev-webserver:20190422_blackfire_io
+ARG BASE_IMAGE
 FROM $BASE_IMAGE
 RUN npm install --global gulp-cli
 ADD README.txt /

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -249,7 +249,7 @@ func (app *DdevApp) WriteConfig() error {
 	contents := []byte(`
 # You can copy this Dockerfile.example to Dockerfile to add configuration
 # or packages or anything else to your webimage
-ARG BASE_IMAGE=` + app.WebImage + `
+ARG BASE_IMAGE
 FROM $BASE_IMAGE
 RUN npm install --global gulp-cli
 `)
@@ -261,7 +261,7 @@ RUN npm install --global gulp-cli
 	contents = []byte(`
 # You can copy this Dockerfile.example to Dockerfile to add configuration
 # or packages or anything else to your dbimage
-ARG BASE_IMAGE=` + app.GetDBImage() + `
+ARG BASE_IMAGE
 FROM $BASE_IMAGE
 RUN echo "Built from ` + app.GetDBImage() + `" >/var/tmp/built-from.txt
 `)


### PR DESCRIPTION
## The Problem/Issue/Bug:

The inclusion of `ARG BASE_IMAGE=...` was confusing to people. ddev always provides the BASE_IMAGE arg, so it does not need a default (and the default does not need to be maintained)

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

