### PR TITLE
Add no_project_mount option to omit the web mount for app code (experiment with mutagen)

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -43,6 +43,9 @@ var (
 	// xdebugEnabledArg allows a user to enable XDebug from a command flag.
 	xdebugEnabledArg bool
 
+	// noProjectMountArg allows a user to skip the project mount from a command flag.
+	noProjectMountArg bool
+
 	// additionalHostnamesArg allows a user to provide a comma-delimited list of hostnames from a command flag.
 	additionalHostnamesArg string
 
@@ -230,6 +233,7 @@ func init() {
 	ConfigCommand.Flags().StringVar(&httpPortArg, "http-port", "", "The router HTTP port for this project")
 	ConfigCommand.Flags().StringVar(&httpsPortArg, "https-port", "", "The router HTTPS port for this project")
 	ConfigCommand.Flags().BoolVar(&xdebugEnabledArg, "xdebug-enabled", false, "Whether or not XDebug is enabled in the web container")
+	ConfigCommand.Flags().BoolVar(&noProjectMountArg, "no-project-mount", false, "Whether or not to skip mounting project code into the web container")
 	ConfigCommand.Flags().StringVar(&additionalHostnamesArg, "additional-hostnames", "", "A comma-delimited list of hostnames for the project")
 	ConfigCommand.Flags().StringVar(&additionalFQDNsArg, "additional-fqdns", "", "A comma-delimited list of FQDNs for the project")
 	ConfigCommand.Flags().StringVar(&omitContainersArg, "omit-containers", "", "A comma-delimited list of container types that should not be started when the project is started")
@@ -462,6 +466,11 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	// This bool flag is false by default, so only use the value if the flag was explicity set.
 	if cmd.Flag("xdebug-enabled").Changed {
 		app.XdebugEnabled = xdebugEnabledArg
+	}
+
+	// This bool flag is false by default, so only use the value if the flag was explicity set.
+	if cmd.Flag("no-project-mount").Changed {
+		app.NoProjectMount = noProjectMountArg
 	}
 
 	if cmd.Flag("phpmyadmin-port").Changed {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -148,6 +148,7 @@ func TestConfigSetValues(t *testing.T) {
 	hostWebserverPort := "60002"
 	hostHTTPSPort := "60003"
 	xdebugEnabled := true
+	noProjectMount := true
 	additionalHostnamesSlice := []string{"abc", "123", "xyz"}
 	additionalHostnames := strings.Join(additionalHostnamesSlice, ",")
 	additionalFQDNsSlice := []string{"abc.com", "123.pizza", "xyz.co.uk"}
@@ -182,6 +183,7 @@ func TestConfigSetValues(t *testing.T) {
 		"--http-port", httpPort,
 		"--https-port", httpsPort,
 		fmt.Sprintf("--xdebug-enabled=%t", xdebugEnabled),
+		fmt.Sprintf("--no-project-mount=%t", noProjectMount),
 		"--additional-hostnames", additionalHostnames,
 		"--additional-fqdns", additionalFQDNs,
 		"--upload-dir", uploadDir,
@@ -228,6 +230,7 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(hostWebserverPort, app.HostWebserverPort)
 	assert.Equal(hostDBPort, app.HostDBPort)
 	assert.Equal(xdebugEnabled, app.XdebugEnabled)
+	assert.Equal(noProjectMount, app.NoProjectMount)
 	assert.Equal(additionalHostnamesSlice, app.AdditionalHostnames)
 	assert.Equal(additionalFQDNsSlice, app.AdditionalFQDNs)
 	assert.Equal(uploadDir, app.UploadDir)

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -44,7 +44,7 @@ the .ddev/config.yaml is the primary configuration for the project.
 | disable_settings_management | defaults to false | If true, ddev will not create or update CMS-specific settings files |  |
 | provider| hosting provider for `ddev pull` | "pantheon" or "drud-aws" or "default" |
 | hooks | | See [Extending Commands](../extending-commands.md) for more information. |
-| omit_web_app_mount | Skip mounting code into the web container | If true, code will not be mounted by ddev into the web container. This is to enable experimentation with alternate file mounting strategies. Advanced users only!
+| no_project_mount | Skip mounting the project into the web container | If true, the project will not be mounted by ddev into the web container. This is to enable experimentation with alternate file mounting strategies. Advanced users only! |
 
 ## global_config.yaml Options
 

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -44,6 +44,7 @@ the .ddev/config.yaml is the primary configuration for the project.
 | disable_settings_management | defaults to false | If true, ddev will not create or update CMS-specific settings files |  |
 | provider| hosting provider for `ddev pull` | "pantheon" or "drud-aws" or "default" |
 | hooks | | See [Extending Commands](../extending-commands.md) for more information. |
+| omit_web_app_mount | Skip mounting code into the web container | If true, code will not be mounted by ddev into the web container. This is to enable experimentation with alternate file mounting strategies. Advanced users only!
 
 ## global_config.yaml Options
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -652,6 +652,7 @@ type composeYAMLVars struct {
 	NFSSource            string
 	DockerIP             string
 	IsWindowsFS          bool
+	OmitAppWebMount      bool
 	Hostnames            []string
 	Timezone             string
 	Username             string
@@ -698,6 +699,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		NFSMountEnabled:      app.NFSMountEnabled || app.NFSMountEnabledGlobal,
 		NFSSource:            "",
 		IsWindowsFS:          runtime.GOOS == "windows",
+		OmitAppWebMount:      app.OmitAppWebMount,
 		MountType:            "bind",
 		WebMount:             "../",
 		Hostnames:            app.GetHostnames(),

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -652,7 +652,7 @@ type composeYAMLVars struct {
 	NFSSource            string
 	DockerIP             string
 	IsWindowsFS          bool
-	OmitAppWebMount      bool
+	NoProjectMount       bool
 	Hostnames            []string
 	Timezone             string
 	Username             string
@@ -699,7 +699,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		NFSMountEnabled:      app.NFSMountEnabled || app.NFSMountEnabledGlobal,
 		NFSSource:            "",
 		IsWindowsFS:          runtime.GOOS == "windows",
-		OmitAppWebMount:      app.OmitAppWebMount,
+		NoProjectMount:       app.NoProjectMount,
 		MountType:            "bind",
 		WebMount:             "../",
 		Hostnames:            app.GetHostnames(),

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -73,7 +73,7 @@ type DdevApp struct {
 	RouterHTTPPort            string                 `yaml:"router_http_port"`
 	RouterHTTPSPort           string                 `yaml:"router_https_port"`
 	XdebugEnabled             bool                   `yaml:"xdebug_enabled"`
-	OmitAppWebMount           bool                   `yaml:"omit_app_web_mount,omitempty"`
+	NoProjectMount            bool                   `yaml:"no_project_mount,omitempty"`
 	AdditionalHostnames       []string               `yaml:"additional_hostnames"`
 	AdditionalFQDNs           []string               `yaml:"additional_fqdns"`
 	MariaDBVersion            string                 `yaml:"mariadb_version,omitempty"`

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -73,6 +73,7 @@ type DdevApp struct {
 	RouterHTTPPort            string                 `yaml:"router_http_port"`
 	RouterHTTPSPort           string                 `yaml:"router_https_port"`
 	XdebugEnabled             bool                   `yaml:"xdebug_enabled"`
+	OmitAppWebMount           bool                   `yaml:"omit_app_web_mount,omitempty"`
 	AdditionalHostnames       []string               `yaml:"additional_hostnames"`
 	AdditionalFQDNs           []string               `yaml:"additional_fqdns"`
 	MariaDBVersion            string                 `yaml:"mariadb_version,omitempty"`

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -628,6 +628,11 @@ func TestDdevNoProjectMount(t *testing.T) {
 	stdout, _, err := app.Exec(opts)
 	assert.NoError(err)
 	assert.Contains(stdout, "index.html")
+
+	// Clean up so the other tests don't fail.
+	app.NoProjectMount = false
+	err = app.WriteConfig()
+	assert.NoError(err)
 }
 
 // TestDdevXdebugEnabled tests running with xdebug_enabled = true, etc.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -621,13 +621,13 @@ func TestDdevNoProjectMount(t *testing.T) {
 
 	opts := &ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ls",
-		Dir:     "/var/www/html",
+		Cmd:     "df /var/www/html | awk '$1 != \"Filesystem\" {print $6}'",
+		Dir:     "/var/www",
 	}
 
 	stdout, _, err := app.Exec(opts)
 	assert.NoError(err)
-	assert.Contains(stdout, "index.html")
+	assert.NotContains(stdout, "/var/www/html")
 
 	// Clean up so the other tests don't fail.
 	app.NoProjectMount = false

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -578,8 +578,8 @@ func TestDdevStartUnmanagedSettings(t *testing.T) {
 
 }
 
-// TestDdevNoFileMount tests running without the app file mount.
-func TestDdevNoFileMount(t *testing.T) {
+// TestDdevNoProjectMount tests running without the app file mount.
+func TestDdevNoProjectMount(t *testing.T) {
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 
@@ -610,7 +610,7 @@ func TestDdevNoFileMount(t *testing.T) {
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 
-	app.OmitAppWebMount = true
+	app.NoProjectMount = true
 	err = app.WriteConfig()
 	assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3,8 +3,6 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
-	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/drud/ddev/pkg/version"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -19,6 +17,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/version"
+
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/stretchr/testify/require"
 
@@ -30,7 +31,7 @@ import (
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/google/uuid"
 	"github.com/lunixbochs/vtclean"
 	log "github.com/sirupsen/logrus"
@@ -625,7 +626,7 @@ func TestDdevNoFileMount(t *testing.T) {
 	}
 
 	stdout, _, err := app.Exec(opts)
-	assert.Error(err)
+	assert.NoError(err)
 	assert.Contains(stdout, "index.html")
 }
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -314,6 +314,12 @@ const ConfigInstructions = `
 # Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalSettings.php
 # In this case the user must provide all such settings.
 
+# no_project_mount: false
+# (Experimental) If true, ddev will not mount the project into the web container; 
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies. 
+# For advanced users only!
+
 # provider: default # Currently either "default" or "pantheon"
 #
 # Many ddev commands can be extended to run tasks before or after the

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -177,7 +177,7 @@ volumes:
   ddev-global-cache:
     name: ddev-global-cache
 
-  {{ if .NFSMountEnabled }}
+  {{ if and .NFSMountEnabled (not .NoProjectMount) }}
   nfsmount:
     driver: local
     driver_opts:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -64,7 +64,7 @@ services:
     cap_add:
       - SYS_PTRACE
     volumes:
-      {{ if not .OmitAppWebMount }}
+      {{ if not .NoProjectMount }}
       - type: {{ .MountType }}
         source: {{ .WebMount }}
         target: /var/www/html

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -64,6 +64,7 @@ services:
     cap_add:
       - SYS_PTRACE
     volumes:
+      {{ if not .OmitAppWebMount }}
       - type: {{ .MountType }}
         source: {{ .WebMount }}
         target: /var/www/html
@@ -73,6 +74,7 @@ services:
         {{ else }}
         consistency: cached
         {{ end }}
+      {{ end }}
       - ".:/mnt/ddev_config:ro"
       - ddev-global-cache:/mnt/ddev-global-cache
       {{ if not .OmitSSHAgent }}


### PR DESCRIPTION
## The Problem/Issue/Bug:

It is extremely difficult to experiment with new methods of getting files into the web container. docker-compose doesn't allow _removing_ things in the base docker-compose file, so any attempt to override the mount point, whether or not a volume is mounted at all, etc doesn't actually lead to success.

## How this PR Solves The Problem:

I added a new option to config.yml that lets people just opt out of the web mount in question. Since this is realistically the only mount people are going to care about getting rid of for testing new file sync methods, I didn't take it further than that.

## Manual Testing Instructions:

Add `no_project_mount: true` to a project config.yaml, then start the project. Inside the web container, you should see /var/www/phpstatus.php, /var/www/html/index.html, and /var/www/html/docroot/ which should contain the default php files from the container.

I've also been testing mutagen. The process for doing that is to install Mutagen (`brew install mutagen-io/mutagen/mutagen`), then run `mutagen daemon start`, and then `mutagen sync create . docker://ddev-[ddev project name]-web/var/www/html --sync-mode=two-way-resolved --name=[ddev project name]`. Wait for the initial sync to complete (somewhere on the order of 20 seconds depending on how large your project is -- you can view progress by running `mutagen sync list [ddev project name]`). Once it has synced, you don't need to do anything else. Mutagen will just handle things for you in the background.

## Automated Testing Overview:

I added a test to essentially perform the manual instructions above. Specifically, it's looking for /var/www/html/index.html, which is unlikely to exist on any of the PHP applications that ddev targets.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

