### PR TITLE
Allow nfs_mount_enabled globally, fixes #1985, fixes #1456

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -112,7 +112,7 @@ ddev composer create --repository=https://repo.magento.com/ magento/project-comm
 		// If not NFSMountEnabled,
 		// we will move the contents of the temp installation
 		// using host-side manipulation, but can't do that with a cached filesystem.
-		if runtime.GOOS == "windows" && !app.NFSMountEnabled {
+		if runtime.GOOS == "windows" && !(app.NFSMountEnabled || app.NFSMountEnabledGlobal) {
 			// If traditional windows mount
 			err = filepath.Walk(hostInstallPath, func(path string, info os.FileInfo, err error) error {
 				// Skip the initial tmp install directory

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -46,7 +46,7 @@ func TestComposerCmd(t *testing.T) {
 	// These two often fail on Windows with NFS
 	// It appears to be something about composer itself?
 
-	if !(runtime.GOOS == "windows" && app.NFSMountEnabled) {
+	if !(runtime.GOOS == "windows" && (app.NFSMountEnabled || app.NFSMountEnabledGlobal)) {
 		// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
 		args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0"}
 		out, err = exec.RunCommand(DdevBin, args)

--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -40,12 +40,17 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 	if cmd.Flag("omit-containers").Changed {
 		omitContainers = strings.Replace(omitContainers, " ", "", -1)
 		if omitContainers == "" {
-			globalconfig.DdevGlobalConfig.OmitContainers = []string{}
+			globalconfig.DdevGlobalConfig.OmitContainersGlobal = []string{}
 		} else {
-			globalconfig.DdevGlobalConfig.OmitContainers = strings.Split(omitContainers, ",")
+			globalconfig.DdevGlobalConfig.OmitContainersGlobal = strings.Split(omitContainers, ",")
 		}
 		dirty = true
 	}
+	if cmd.Flag("nfs-mount-enabled").Changed {
+		globalconfig.DdevGlobalConfig.NFSMountEnabledGlobal, _ = cmd.Flags().GetBool("nfs-mount-enabled")
+		dirty = true
+	}
+
 	if cmd.Flag("router-bind-all-interfaces").Changed {
 		globalconfig.DdevGlobalConfig.RouterBindAllInterfaces, _ = cmd.Flags().GetBool("router-bind-all-interfaces")
 		dirty = true
@@ -63,12 +68,15 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 	}
 	util.Success("Global configuration:")
 	output.UserOut.Printf("instrumentation-opt-in=%v", globalconfig.DdevGlobalConfig.InstrumentationOptIn)
-	output.UserOut.Printf("omit-containers=[%s]", strings.Join(globalconfig.DdevGlobalConfig.OmitContainers, ","))
+	output.UserOut.Printf("omit-containers=[%s]", strings.Join(globalconfig.DdevGlobalConfig.OmitContainersGlobal, ","))
+	output.UserOut.Printf("nfs-mount-enabled=%v", globalconfig.DdevGlobalConfig.NFSMountEnabledGlobal)
+
 	output.UserOut.Printf("router-bind-all-interfaces=%v", globalconfig.DdevGlobalConfig.RouterBindAllInterfaces)
 }
 
 func init() {
 	configGlobalCommand.Flags().StringVarP(&omitContainers, "omit-containers", "", "", "For example, --omit-containers=dba,ddev-ssh-agent")
+	configGlobalCommand.Flags().Bool("nfs-mount-enabled", false, "Enable NFS mounting on all projects globally")
 	configGlobalCommand.Flags().BoolVarP(&instrumentationOptIn, "instrumentation-opt-in", "", false, "instrmentation-opt-in=true")
 	configGlobalCommand.Flags().Bool("router-bind-all-interfaces", false, "router-bind-all-interfaces=true")
 

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -45,23 +45,24 @@ func TestCmdGlobalConfig(t *testing.T) {
 	args := []string{"config", "global"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nrouter-bind-all-interfaces=false")
+	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nnfs-mount-enabled=false\nrouter-bind-all-interfaces=false")
 
 	// Update a config
-	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent", "--router-bind-all-interfaces=true"}
+	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent", "--nfs-mount-enabled=true", "--router-bind-all-interfaces=true"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]\nrouter-bind-all-interfaces=true")
+	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]\nnfs-mount-enabled=true\nrouter-bind-all-interfaces=true")
 
 	err = globalconfig.ReadGlobalConfig()
 	assert.NoError(err)
 	assert.False(globalconfig.DdevGlobalConfig.InstrumentationOptIn)
 	assert.Contains(globalconfig.DdevGlobalConfig.OmitContainersGlobal, "ddev-ssh-agent")
 	assert.Contains(globalconfig.DdevGlobalConfig.OmitContainersGlobal, "dba")
+	assert.True(globalconfig.DdevGlobalConfig.NFSMountEnabledGlobal)
 	assert.Len(globalconfig.DdevGlobalConfig.OmitContainersGlobal, 2)
 
 	// Even though the global config is going to be deleted, make sure it's sane before leaving
-	args = []string{"config", "global", "--omit-containers", ""}
+	args = []string{"config", "global", "--omit-containers", "", "--nfs-mount-enabled=true"}
 	globalconfig.DdevGlobalConfig.OmitContainersGlobal = nil
 	_, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -29,7 +29,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	// nolint: errcheck
 	defer func() {
 		globalconfig.DdevGlobalConfig = backupConfig
-		globalconfig.DdevGlobalConfig.OmitContainers = nil
+		globalconfig.DdevGlobalConfig.OmitContainersGlobal = nil
 
 		err := os.Remove(configFile)
 		if err != nil {
@@ -56,13 +56,13 @@ func TestCmdGlobalConfig(t *testing.T) {
 	err = globalconfig.ReadGlobalConfig()
 	assert.NoError(err)
 	assert.False(globalconfig.DdevGlobalConfig.InstrumentationOptIn)
-	assert.Contains(globalconfig.DdevGlobalConfig.OmitContainers, "ddev-ssh-agent")
-	assert.Contains(globalconfig.DdevGlobalConfig.OmitContainers, "dba")
-	assert.Len(globalconfig.DdevGlobalConfig.OmitContainers, 2)
+	assert.Contains(globalconfig.DdevGlobalConfig.OmitContainersGlobal, "ddev-ssh-agent")
+	assert.Contains(globalconfig.DdevGlobalConfig.OmitContainersGlobal, "dba")
+	assert.Len(globalconfig.DdevGlobalConfig.OmitContainersGlobal, 2)
 
 	// Even though the global config is going to be deleted, make sure it's sane before leaving
 	args = []string{"config", "global", "--omit-containers", ""}
-	globalconfig.DdevGlobalConfig.OmitContainers = nil
+	globalconfig.DdevGlobalConfig.OmitContainersGlobal = nil
 	_, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 }

--- a/cmd/ddev/cmd/sequelpro.go
+++ b/cmd/ddev/cmd/sequelpro.go
@@ -108,7 +108,7 @@ func init() {
 	switch {
 	case detectSequelpro():
 		app, err := ddevapp.GetActiveApp("")
-		if err == nil && app != nil && !nodeps.ArrayContainsString(app.OmitContainers, "db") {
+		if err == nil && app != nil && !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 			RootCmd.AddCommand(DdevSequelproCmd)
 		}
 	case runtime.GOOS == "darwin":

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -51,6 +51,7 @@ The $HOME/.ddev/global_config.yaml has a few key global config options.
 
 | Item  | Description   | Notes  |
 |---|---|---|
+| nfs_mount_enabled | Enables NFS mounting globally for all projects | Only a "true" value has any effect. If true, NFS will be used on all projects |
 | omit_containers | Allows the project to not load specified containers | For example, `omit_containers: [ "dba", "ddev-ssh-agent"]`. Currently only these containers are supported. Note that you cannot omit the "db" container in the global configuration, but you can in the per-project .ddev/config.yaml |
 | instrumentation_opt_in | Opt in or out of instrumentation reporting | If true, anonymous usage information is sent to ddev via [segment](https://segment.com) |
 | router_bind_all_interfaces | Bind on all network interfaces | If true, ddev-router will bind on all network interfaces instead of just localhost, exposing ddev projects to your local network. If you set this to true, you may consider `omit_containers: ["dba"]` so that the PHPMyAdmin port is not available.  |

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -36,7 +36,8 @@ type ProjectInfo struct {
 
 // GlobalConfig is the struct defining ddev's global config
 type GlobalConfig struct {
-	OmitContainers          []string                `yaml:"omit_containers,flow"`
+	OmitContainersGlobal    []string                `yaml:"omit_containers,flow"`
+	NFSMountEnabledGlobal   bool                    `yaml:"nfs_mount_enabled"`
 	InstrumentationOptIn    bool                    `yaml:"instrumentation_opt_in"`
 	RouterBindAllInterfaces bool                    `yaml:"router_bind_all_interfaces"`
 	DeveloperMode           bool                    `yaml:"developer_mode,omitempty"`
@@ -53,8 +54,8 @@ func GetGlobalConfigPath() string {
 
 // ValidateGlobalConfig validates global config
 func ValidateGlobalConfig() error {
-	if !IsValidOmitContainers(DdevGlobalConfig.OmitContainers) {
-		return fmt.Errorf("Invalid omit_containers: %s, must contain only %s", strings.Join(DdevGlobalConfig.OmitContainers, ","), strings.Join(GetValidOmitContainers(), ",")).(InvalidOmitContainers)
+	if !IsValidOmitContainers(DdevGlobalConfig.OmitContainersGlobal) {
+		return fmt.Errorf("Invalid omit_containers: %s, must contain only %s", strings.Join(DdevGlobalConfig.OmitContainersGlobal, ","), strings.Join(GetValidOmitContainers(), ",")).(InvalidOmitContainers)
 	}
 
 	return nil
@@ -131,6 +132,9 @@ func WriteGlobalConfig(config GlobalConfig) error {
 # and you can opt in or out of sending instrumentation the ddev developers with
 # instrumentation_opt_in: true # or false
 #
+# You can enable nfs mounting for all projects with
+# nfs_mount_enabled: true
+
 # instrumentation_user: <your_username> # can be used to give ddev specific info about who you are
 # developer_mode: true # (defaults to false) is not used widely at this time.
 # router_bind_all_interfaces: false  # (defaults to false)


### PR DESCRIPTION
## The Problem/Issue/Bug:

People want to set nfs_mount_enabled globally, not per project. Most people like it that way.

## How this PR Solves The Problem:

* Enabled nfs_mount_enabled in global_config.yaml
* This also fixes a longstanding problem with global value of omit_containers leaking into per-project config.yaml, #1456 

## Manual Testing Instructions:

- [ ]  Enable nfs_mount_enabled with `ddev config global --nfs_mount_enabled`
- [ ]  Start a project
- [ ]  Use `ddev describe` to verify that nfs is enabled.
- [ ] `ddev config` and verify that it does not get introduced into project config. Same with omit_containers

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

