### PR TITLE
Remove APIVersion from global config and project config, fixes #2116, fixes #1713

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ brew upgrade ddev
 
 * A windows installer is provided in each [ddev release](https://github.com/drud/ddev/releases) (`ddev_windows_installer.<version>.exe`). Run that and it will do the full installation for you.  Open a new terminal or cmd window and start using ddev.
 * If you use [chocolatey](https://chocolatey.org/) (highly recommended), then you can just `choco install ddev` from an administrative-privileged shell. Upgrades are just `choco upgrade ddev`.
-* (Optional) As a one-time initialization, run `mkcert -install`
+* As a one-time initialization, run `mkcert -install`
 * Most people interact with ddev on Windows using git-bash, part of the [Windows git suite](https://git-scm.com/download/win). Although ddev does work with cmd and PowerShell, it's more at home in bash. You can install it with chocolatey using `choco install -y git`.
 
 ### Installation/Upgrade Script - Linux and macOS

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -71,7 +71,6 @@ func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, e
 		return app, fmt.Errorf("project root %s does not exist", appRoot)
 	}
 	app.ConfigPath = app.GetConfigPath("config.yaml")
-	app.APIVersion = version.DdevVersion
 	app.Type = nodeps.AppTypePHP
 	app.PHPVersion = nodeps.PHPDefault
 	app.WebserverType = nodeps.WebserverDefault
@@ -155,8 +154,6 @@ func (app *DdevApp) WriteConfig() error {
 
 	// Work against a copy of the DdevApp, since we don't want to actually change it.
 	appcopy := *app
-	// Update the "APIVersion" to be the ddev version.
-	appcopy.APIVersion = version.DdevVersion
 
 	// Only set the images on write if non-default values have been specified.
 	if appcopy.WebImage == version.GetWebImage() {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -40,7 +40,6 @@ func TestNewConfig(t *testing.T) {
 	assert.NoError(err)
 
 	// Ensure the config uses specified defaults.
-	assert.Equal(app.APIVersion, version.DdevVersion)
 	assert.Equal(app.GetDBImage(), version.GetDBImage(nodeps.MariaDB))
 	assert.Equal(app.WebImage, version.GetWebImage())
 	assert.Equal(app.DBAImage, version.GetDBAImage())
@@ -476,7 +475,6 @@ func TestReadConfig(t *testing.T) {
 
 	// This closely resembles the values one would have from NewApp()
 	app := &DdevApp{
-		APIVersion: version.DdevVersion,
 		ConfigPath: filepath.Join("testdata", "config.yaml"),
 		AppRoot:    "testdata",
 		Name:       "TestRead",
@@ -490,7 +488,6 @@ func TestReadConfig(t *testing.T) {
 
 	// Values not defined in file, we should still have default values
 	assert.Equal(app.Name, "TestRead")
-	assert.Equal(app.APIVersion, version.DdevVersion)
 
 	// Values defined in file, we should have values from file
 	assert.Equal(app.Type, nodeps.AppTypeDrupal8)
@@ -505,7 +502,6 @@ func TestReadConfigCRLF(t *testing.T) {
 
 	// This closely resembles the values one would have from NewApp()
 	app := &DdevApp{
-		APIVersion: version.DdevVersion,
 		ConfigPath: filepath.Join("testdata", t.Name(), ".ddev", "config.yaml"),
 		AppRoot:    filepath.Join("testdata", t.Name()),
 		Name:       t.Name(),
@@ -519,7 +515,6 @@ func TestReadConfigCRLF(t *testing.T) {
 
 	// Values not defined in file, we should still have default values
 	assert.Equal(app.Name, t.Name())
-	assert.Equal(app.APIVersion, version.DdevVersion)
 
 	// Values defined in file, we should have values from file
 	assert.Equal(app.Docroot, "public")
@@ -621,21 +616,21 @@ func TestWriteConfig(t *testing.T) {
 
 	// The default NewApp read should read config overrides, so we should have "config.extra.yaml"
 	// as the APIVersion
-	assert.Equal("config.extra.yaml", app.APIVersion)
+	assert.Equal("drupal9", app.Type)
 
-	// However, if we ReadConfig() without includeOverrides, we should get "config.yaml" as the APIVersion
+	// However, if we ReadConfig() without includeOverrides, we should get "php" as the type
 	_, err = app.ReadConfig(false)
 	assert.NoError(err)
-	assert.Equal("config.yaml", app.APIVersion)
+	assert.Equal("php", app.Type)
 
 	err = app.WriteConfig()
 	assert.NoError(err)
 
-	// Now read the config we just wrote; it should have config.yaml because ignored overrides.
+	// Now read the config we just wrote; it should have type php because ignored overrides.
 	_, err = app.ReadConfig(false)
 	assert.NoError(err)
 	// app.WriteConfig() writes the version.DdevVersion to the updated config.yaml
-	assert.Equal(version.DdevVersion, app.APIVersion)
+	assert.Equal("php", app.Type)
 }
 
 // TestConfigOverrideDetection tests to make sure we tell them about config overrides.
@@ -958,7 +953,7 @@ func TestConfigLoadingOrder(t *testing.T) {
 	assert.NoError(err)
 	_, err = app.ReadConfig(true)
 	assert.NoError(err)
-	assert.Equal("config.yaml", app.APIVersion)
+	assert.Equal("config.yaml", app.WebImage)
 
 	matches, err := filepath.Glob(filepath.Join(projDir, ".ddev/linkedconfigs/config.*.y*ml"))
 	assert.NoError(err)
@@ -971,7 +966,7 @@ func TestConfigLoadingOrder(t *testing.T) {
 		assert.NoError(err)
 		_, err = app.ReadConfig(true)
 		assert.NoError(err)
-		assert.Equal(filepath.Base(item), app.APIVersion)
+		assert.Equal(filepath.Base(item), app.WebImage)
 		err = os.Remove(linkedMatch)
 		assert.NoError(err)
 	}
@@ -987,14 +982,14 @@ func TestConfigLoadingOrder(t *testing.T) {
 		err = os.Symlink(item, linkedMatch)
 		assert.NoError(err)
 		_, err = app.ReadConfig(true)
-		assert.Equal(filepath.Base(item), app.APIVersion)
+		assert.Equal(filepath.Base(item), app.WebImage)
 	}
 
 	// Now we still have all those linked overrides, but do a ReadConfig() without allowing them
 	// and verify that they don't get loaded
 	_, err = app.ReadConfig(false)
 	assert.NoError(err)
-	assert.Equal("config.yaml", app.APIVersion)
+	assert.Equal("config.yaml", app.WebImage)
 
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -22,7 +22,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/drud/ddev/pkg/appimport"
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/ddevhosts"
@@ -63,7 +62,6 @@ const DdevFileSignature = "#ddev-generated"
 // DdevApp is the struct that represents a ddev app, mostly its config
 // from config.yaml.
 type DdevApp struct {
-	APIVersion                string                 `yaml:"APIVersion"`
 	Name                      string                 `yaml:"name"`
 	Type                      string                 `yaml:"type"`
 	Docroot                   string                 `yaml:"docroot"`
@@ -795,24 +793,6 @@ func (app *DdevApp) Start() error {
 	app.DockerEnv()
 
 	app.DBImage = app.GetDBImage()
-
-	APIVersion, err := semver.NewVersion(app.APIVersion)
-	if err != nil {
-		return err
-	}
-	DdevVersion, err := semver.NewVersion(version.DdevVersion)
-	if err != nil {
-		return err
-	}
-
-	// It returns -1, 0, or 1 if the version smaller, equal, or larger than the other version.
-	compareResult := APIVersion.Compare(DdevVersion)
-
-	if compareResult == -1 {
-		util.Warning("Your %s version is %s, but ddev is (newer) version %s. \nPlease run 'ddev config' to update your config.yaml. \nddev may not operate correctly until you do.", app.ConfigPath, app.APIVersion, version.DdevVersion)
-	} else if compareResult == 1 {
-		util.Warning("Your %s version is %s, but ddev is (older) version %s. \nPlease update ddev, see https://ddev.readthedocs.io/en/stable/.\nddev may not operate correctly until you do.", app.ConfigPath, app.APIVersion, version.DdevVersion)
-	}
 
 	// Make sure that any ports allocated are available.
 	// and of course add to global project list as well

--- a/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/config.yaml
@@ -1,1 +1,1 @@
-APIVersion: config.yaml
+webimage: config.yaml

--- a/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.----.yaml
+++ b/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.----.yaml
@@ -1,1 +1,1 @@
-APIVersion: config.----.yaml
+webimage: config.----.yaml

--- a/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.0.yaml
+++ b/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.0.yaml
@@ -1,1 +1,1 @@
-APIVersion: config.0.yaml
+webimage: config.0.yaml

--- a/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.0.yml
+++ b/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.0.yml
@@ -1,1 +1,1 @@
-APIVersion: config.0.yml
+webimage: config.0.yml

--- a/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.1.yaml
+++ b/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.1.yaml
@@ -1,1 +1,1 @@
-APIVersion: config.1.yaml
+webimage: config.1.yaml

--- a/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.a.yaml
+++ b/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.a.yaml
@@ -1,1 +1,1 @@
-APIVersion: config.a.yaml
+webimage: config.a.yaml

--- a/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.b.yaml
+++ b/pkg/ddevapp/testdata/TestConfigLoadingOrder/.ddev/linkedconfigs/config.b.yaml
@@ -1,1 +1,1 @@
-APIVersion: config.b.yaml
+webimage: config.b.yaml

--- a/pkg/ddevapp/testdata/TestWriteConfig/.ddev/config.extra.yaml
+++ b/pkg/ddevapp/testdata/TestWriteConfig/.ddev/config.extra.yaml
@@ -1,1 +1,1 @@
-APIVersion: config.extra.yaml
+type: drupal9

--- a/pkg/ddevapp/testdata/TestWriteConfig/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestWriteConfig/.ddev/config.yaml
@@ -1,3 +1,2 @@
-APIVersion: config.yaml
 name: "TestWriteConfig"
 type: "php"

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -36,7 +36,6 @@ type ProjectInfo struct {
 
 // GlobalConfig is the struct defining ddev's global config
 type GlobalConfig struct {
-	APIVersion              string                  `yaml:"APIVersion"`
 	OmitContainers          []string                `yaml:"omit_containers,flow"`
 	InstrumentationOptIn    bool                    `yaml:"instrumentation_opt_in"`
 	RouterBindAllInterfaces bool                    `yaml:"router_bind_all_interfaces"`
@@ -65,7 +64,6 @@ func ValidateGlobalConfig() error {
 func ReadGlobalConfig() error {
 	globalConfigFile := GetGlobalConfigPath()
 	// This is added just so we can see it in global; not checked.
-	DdevGlobalConfig.APIVersion = version.DdevVersion
 	// Make sure that LastStartedVersion always has a valid value
 	if DdevGlobalConfig.LastStartedVersion == "" {
 		DdevGlobalConfig.LastStartedVersion = version.DdevVersion
@@ -116,7 +114,6 @@ func ReadGlobalConfig() error {
 
 // WriteGlobalConfig writes the global config into ~/.ddev.
 func WriteGlobalConfig(config GlobalConfig) error {
-	config.APIVersion = version.VERSION
 	err := ValidateGlobalConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
# The Problem/Issue/Bug:

We have never, ever used the APIVersion in config.yaml or global_config.yaml
The version check annoys people and doesn't help in any way.

## How this PR Solves The Problem:

Remove the APIVersion and related version check from config.yaml and global_config.yaml

## Manual Testing Instructions:

- [x] `ddev config` on an existing, earlier version, should work OK. APIVersion should have disappeared.
- [x] Make sure that the pester for instrumentation still happens with global config when new version used.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

