### PR TITLE
Remove -built image when deleting project, fixes #2134

### DIFF
--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -60,30 +60,30 @@ var DeleteImagesCmd = &cobra.Command{
 			for _, tag := range image.RepoTags {
 				// If a webimage, but doesn't match our webimage, delete it
 				if strings.HasPrefix(tag, version.WebImg) && !strings.HasPrefix(tag, webimg) && !strings.HasPrefix(tag, webimg+"-built") {
-					if err = removeImage(client, tag); err != nil {
+					if err = dockerutil.RemoveImage(tag); err != nil {
 						util.Warning("Failed to remove %s: %v", tag, err)
 					}
 				}
 				if strings.HasPrefix(tag, "drud/ddev-dbserver") && !strings.HasSuffix(tag, keepDBImageTag) && !strings.HasSuffix(tag, keepDBImageTag+"-built") {
-					if err = removeImage(client, tag); err != nil {
+					if err = dockerutil.RemoveImage(tag); err != nil {
 						util.Warning("Unable to remove %s: %v", tag, err)
 					}
 				}
 				// If a dbaimage, but doesn't match our dbaimage, delete it
 				if strings.HasPrefix(tag, version.DBAImg) && !strings.HasPrefix(tag, dbaimage) {
-					if err = removeImage(client, tag); err != nil {
+					if err = dockerutil.RemoveImage(tag); err != nil {
 						util.Warning("Failed to remove %s: %v", tag, err)
 					}
 				}
 				// If a routerImage, but doesn't match our routerimage, delete it
 				if strings.HasPrefix(tag, version.RouterImage) && !strings.HasPrefix(tag, routerimage) {
-					if err = removeImage(client, tag); err != nil {
+					if err = dockerutil.RemoveImage(tag); err != nil {
 						util.Warning("Failed to remove %s: %v", tag, err)
 					}
 				}
 				// If a sshAgentImage, but doesn't match our sshAgentImage, delete it
 				if strings.HasPrefix(tag, version.SSHAuthImage) && !strings.HasPrefix(tag, sshimage) && !strings.HasPrefix(tag, sshimage+"-built") {
-					if err = removeImage(client, tag); err != nil {
+					if err = dockerutil.RemoveImage(tag); err != nil {
 						util.Warning("Failed to remove %s: %v", tag, err)
 					}
 				}
@@ -95,13 +95,4 @@ var DeleteImagesCmd = &cobra.Command{
 
 func init() {
 	DeleteCmd.AddCommand(DeleteImagesCmd)
-}
-
-func removeImage(client *docker.Client, tag string) error {
-	util.Warning("Removing container: %s", tag)
-	err := client.RemoveImage(tag)
-	if err != nil {
-		util.Failed("Failed to remove %s: %v", tag, err)
-	}
-	return nil
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1454,6 +1454,12 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 				util.Warning("could not remove volume %s: %v", volName, err)
 			}
 		}
+		dbBuilt := app.GetDBImage() + "-" + app.Name + "-built"
+		_ = dockerutil.RemoveImage(dbBuilt)
+
+		webBuilt := version.GetWebImage() + "-" + app.Name + "-built"
+		_ = dockerutil.RemoveImage(webBuilt)
+
 		util.Success("Project data/database removed from docker volume for project %s", app.Name)
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -304,6 +304,13 @@ func TestDdevStart(t *testing.T) {
 	err = app.Start()
 	assert.NoError(err)
 
+	// Make sure the -built docker image exists before stop
+	webBuilt := version.GetWebImage() + "-" + site.Name + "-built"
+	dbBuilt := version.GetWebImage() + "-" + site.Name + "-built"
+	exists, err := dockerutil.ImageExistsLocally(webBuilt)
+	assert.NoError(err)
+	assert.True(exists)
+
 	// After start, we haven't changed default version, the dbimage
 	// should now be set and should be the default
 	assert.EqualValues(app.DBImage, version.GetDBImage(nodeps.MariaDB))
@@ -337,6 +344,15 @@ func TestDdevStart(t *testing.T) {
 
 	err = app.Stop(true, false)
 	assert.NoError(err)
+
+	// Make sure the -built docker images do not exist after stop with removeData
+	exists, err = dockerutil.ImageExistsLocally(webBuilt)
+	assert.NoError(err)
+	assert.False(exists)
+	exists, err = dockerutil.ImageExistsLocally(dbBuilt)
+	assert.NoError(err)
+	assert.False(exists)
+
 	runTime()
 	switchDir()
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -731,3 +731,14 @@ func GetHostDockerInternalIP() (string, error) {
 	}
 	return hostDockerInternal, nil
 }
+
+// RemoveImage removes an image
+func RemoveImage(tag string) error {
+	client := GetDockerClient()
+	util.Warning("Removing image: %s", tag)
+	err := client.RemoveImage(tag)
+	if err != nil {
+		util.Warning("Failed to remove %s: %v", tag, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

As per #2134, we need to make sure that -built images (<imagebase>-<projectname>-built) get deleted on ddev stop --remove-data and elsewhere

## How this PR Solves The Problem:

Delete them. 

## Manual Testing Instructions:

`ddev delete` a project make make sure it's -built image is gone. `docker images | grep built` will show remaining -built images.

## Automated Testing Overview:

Tests are improved to check this.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

