### PR TITLE
Remove the forced error if glob characters in project path

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -116,15 +116,6 @@ func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	}
 	app.SetInstrumentationAppTags()
 
-	// Make sure that not in a dir with glob pattern
-	hasGlob, err := regexp.Match(`[\[\]\{\}\*\?]`, []byte(appRoot))
-	if err != nil {
-		return app, err
-	}
-	if hasGlob {
-		return app, fmt.Errorf("Project directory contains a glob pattern, please use a directory that does not contain `{}[]*?`")
-	}
-
 	// Rendered yaml is not there until after ddev config or ddev start
 	if fileutil.FileExists(app.DockerComposeFullRenderedYAMLPath()) {
 		content, err := fileutil.ReadFileIntoString(app.DockerComposeFullRenderedYAMLPath())


### PR DESCRIPTION
## The Problem/Issue/Bug:

In an earlier architecture/code we couldn't handle a project directory which had glob characters in its path. That problem no longer exists, so this removes the error about it. 

## Manual Testing Instructions:

docker-compose.*.yaml with wildcard characters: Verify that the described failure case is resolved. (Create dir named ~/tmp/[Local]/j2 and try ddev config)

See https://github.com/drud/ddev/issues/2049#issuecomment-579255858

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

