### PR TITLE
Fix incorrect .gitignore contents, fixes #2180

### DIFF
--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -665,3 +665,39 @@ func TestConfigMySQLVersion(t *testing.T) {
 		}
 	}
 }
+
+//TestConfigGitignore checks that our gitignore is ignoring the right things.
+func TestConfigGitignore(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Create a temporary directory and switch to it.
+	tmpDir := testcommon.CreateTmpDir(t.Name())
+	defer testcommon.CleanupDir(tmpDir)
+	defer testcommon.Chdir(tmpDir)()
+
+	_, err := exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
+	assert.Error(err)
+	defer func() {
+		_, err = exec.RunCommand(DdevBin, []string{"delete", "-Oy"})
+		assert.NoError(err)
+	}()
+
+	_, err = exec.RunCommand("git", []string{"init"})
+	assert.NoError(err)
+	_, err = exec.RunCommand("git", []string{"add", "."})
+	assert.NoError(err)
+	out, err := exec.RunCommand("git", []string{"status"})
+	assert.NoError(err)
+
+	// git status should have one new file, config.yaml
+	assert.Contains(out, "new file:   .ddev/config.yaml")
+	// .ddev/config.yaml should be the only new file, remove it and check
+	out = strings.ReplaceAll(out, "new file:   .ddev/config.yaml", "")
+	assert.NotContains(out, "new file:")
+	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	assert.NoError(err)
+	statusOut, err := exec.RunCommand("bash", []string{"-c", "git status"})
+	assert.NoError(err)
+	out, err = exec.RunCommand("bash", []string{"-c", "git status | grep 'Untracked files'"})
+	assert.Error(err, "Untracked files were found were we didn't expect them: %s", statusOut)
+}

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -676,7 +676,7 @@ func TestConfigGitignore(t *testing.T) {
 	defer testcommon.Chdir(tmpDir)()
 
 	_, err := exec.RunCommand(DdevBin, []string{"config", "--project-type=php"})
-	assert.Error(err)
+	assert.NoError(err)
 	defer func() {
 		_, err = exec.RunCommand(DdevBin, []string{"delete", "-Oy"})
 		assert.NoError(err)
@@ -698,6 +698,6 @@ func TestConfigGitignore(t *testing.T) {
 	assert.NoError(err)
 	statusOut, err := exec.RunCommand("bash", []string{"-c", "git status"})
 	assert.NoError(err)
-	out, err = exec.RunCommand("bash", []string{"-c", "git status | grep 'Untracked files'"})
+	_, err = exec.RunCommand("bash", []string{"-c", "git status | grep 'Untracked files'"})
 	assert.Error(err, "Untracked files were found were we didn't expect them: %s", statusOut)
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -958,7 +958,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "commands/*/*.example", "commands/*/README.txt", "commands/host/launch", "commands/host/xdebug", "commands/db/mysql", "homeadditions/*.example", "homeadditions/README.txt", ".gitignore", "import.yaml", ".ddev-docker-compose-base.yaml", ".ddev-docker-compose-full.yaml", "db_snapshots", "sequelpro.spf", "import-db", "config.*.y*ml", ".webimageBuild", ".dbimageBuild", ".sshimageBuild", ".webimageExtra", ".dbimageExtra", "*-build/Dockerfile.example")
+	err := CreateGitIgnore(dir, "commands/*/*.example", "commands/*/README.txt", "commands/host/launch", "commands/web/xdebug", "commands/db/mysql", "homeadditions/*.example", "homeadditions/README.txt", ".gitignore", "import.yaml", ".ddev-docker-compose-base.yaml", ".ddev-docker-compose-full.yaml", "db_snapshots", "sequelpro.spf", "import-db", "config.*.y*ml", ".webimageBuild", ".dbimageBuild", ".sshimageBuild", ".webimageExtra", ".dbimageExtra", "*-build/Dockerfile.example")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -512,11 +512,11 @@ func (app *DdevApp) GetHostnames() []string {
 	return nameListArray
 }
 
-// WriteDockerComposeYAML writes a .docker-compose-base.yaml and related to the .ddev directory.
+// WriteDockerComposeYAML writes a .ddev-docker-compose-base.yaml and related to the .ddev directory.
 func (app *DdevApp) WriteDockerComposeYAML() error {
 	var err error
 
-	// Because of move from docker-compose.yaml as base file to .docker-compose-base.yaml
+	// Because of move from docker-compose.yaml as base file to .ddev-docker-compose-base.yaml
 	// remove old ddev-managed docker-compose.yaml
 	oldDockerCompose := filepath.Join(app.AppConfDir(), "docker-compose.yaml")
 	if fileutil.FileExists(oldDockerCompose) {
@@ -651,7 +651,7 @@ type composeYAMLVars struct {
 	GID                  string
 }
 
-// RenderComposeYAML renders the contents of .ddev/.docker-compose*.
+// RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.
 func (app *DdevApp) RenderComposeYAML() (string, error) {
 	var doc bytes.Buffer
 	var err error
@@ -958,7 +958,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "commands/*/*.example", "commands/*/README.txt", "commands/host/launch", "commands/host/xdebug", "commands/db/mysql", "homeadditions/*.example", "homeadditions/README.txt", ".gitignore", "import.yaml", ".docker-compose-base.yaml", ".docker-compose-full.yaml", "db_snapshots", "sequelpro.spf", "import-db", "config.*.y*ml", ".webimageBuild", ".dbimageBuild", ".sshimageBuild", ".webimageExtra", ".dbimageExtra", "*-build/Dockerfile.example")
+	err := CreateGitIgnore(dir, "commands/*/*.example", "commands/*/README.txt", "commands/host/launch", "commands/host/xdebug", "commands/db/mysql", "homeadditions/*.example", "homeadditions/README.txt", ".gitignore", "import.yaml", ".ddev-docker-compose-base.yaml", ".ddev-docker-compose-full.yaml", "db_snapshots", "sequelpro.spf", "import-db", "config.*.y*ml", ".webimageBuild", ".dbimageBuild", ".sshimageBuild", ".webimageExtra", ".dbimageExtra", "*-build/Dockerfile.example")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2180 points out that the generated .ddev/.gitignore has the wrong files gitignored in .ddev (.ddev-docker-compose-*)

## How this PR Solves The Problem:

Make it right.

## Manual Testing Instructions:


Follow pattern in https://github.com/drud/ddev/pull/2182#issuecomment-614796590 and make sure it works right.

## Automated Testing Overview:

Adds TestConfigGitignore, which discovered another problem here.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

