### PR TITLE
Do app.Start() after `ddev composer create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ ddev is an open source tool that makes it simple to get local PHP development en
     * [WordPress Quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage#wordpress-quickstart)
     * [Drupal 6 and 7 Quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage#drupal-6/7-quickstart)
     * [Drupal 8 Quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage#drupal-8-quickstart)
+    * [Drupal 9 Quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage#drupal-9-quickstart)
     * [Backdrop Quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage/#backdrop-quickstart)
     * [TYPO3 Quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage#typo3-quickstart)
     * [Magento 1 Quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage#magento-1-quickstart)

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -154,7 +154,11 @@ ddev composer create --repository=https://repo.magento.com/ magento/project-comm
 		if runtime.GOOS == "windows" && !nodeps.IsDockerToolbox() {
 			fileutil.ReplaceSimulatedLinks(app.AppRoot)
 		}
-
+		// Do a spare start, which will create any needed settings files
+		err = app.Start()
+		if err != nil {
+			util.Failed("Failed to start project after composer create: %v", err)
+		}
 	},
 }
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -17,6 +17,7 @@ Each of these commands has full help. For example, `ddev start -h` or `ddev help
 * `ddev share` works with [ngrok](https://ngrok.com/) (and requires ngrok) so you can let someone in the next office or on the other side of the planet see your project and what you're working on. `ddev share -h` gives more info about how to set up ngrok (it's easy).
 * `ddev launch` or `ddev launch some/uri` will launch a browser with the current project's URL (or a full URL to `/some/uri`). And `ddev launch -p` will launch the PHPMyAdminUI, and `ddev launch -m` will launch the MailHogUI.
 * `ddev delete` is the same as `ddev stop --remove-data` and will delete a project's database and ddev's record of the project's existence. It doesn't touch your project or code. `ddev delete -O` will omit the snapshot creation step that would otherwise take place, and `ddev delete images` gets rid of spare Docker images you may have on your machine.
+* `ddev xdebug` enables xdebug, `ddev xdebug off` disables it, `ddev xdebug status` shows status
 
 ## Partial Bundled Tools List
 
@@ -59,7 +60,6 @@ cd my-wp-bedrock-site
 ddev config --project-type=wordpress --docroot=web --create-docroot=true
 ddev start
 ddev composer create roots/bedrock
-ddev start
 ```
 
 ```
@@ -141,7 +141,6 @@ ddev start
 ddev composer create drupal/recommended-project:^8
 ddev composer remove drupal/core-project-message
 ddev composer require drush/drush
-ddev start
 ddev launch
 ```
 
@@ -176,7 +175,6 @@ ddev start
 ddev composer create drupal/recommended-project:9.0.x-dev
 ddev composer remove drupal/core-project-message
 ddev composer require drush/drush
-ddev start
 ddev launch
 ```
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -219,7 +219,7 @@ cd my-typo3-site
 ddev config --project-type=typo3 --docroot=public --create-docroot=true
 ddev start
 ddev composer create "typo3/cms-base-distribution:^9" --prefer-dist
-ddev start
+ddev launch
 ```
 
 **On TYPO3 versions < 9 an install may fail if you use the https URL to install because the allowed proxy is not configured yet ("Trusted hosts pattern mismatch"). Please use "http" instead of "https" for the URL while doing the install.**

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -15,7 +15,7 @@ Each of these commands has full help. For example, `ddev start -h` or `ddev help
 * `ddev snapshot` makes a very fast snapshot of your database that can be easily and quickly restored with `ddev restore-snapshot`.
 * `ddev ssh` opens a bash session in the web container (or other container).
 * `ddev share` works with [ngrok](https://ngrok.com/) (and requires ngrok) so you can let someone in the next office or on the other side of the planet see your project and what you're working on. `ddev share -h` gives more info about how to set up ngrok (it's easy).
-* `ddev launch` or `ddev launch some/uri` will launch a browser with the current project's URL (or a full URL to `/some/uri`). And `ddev launch -p` will launch the PHPMyAdminUI, and `ddev launch -m` will launch the MailHogUI.
+* `ddev launch` or `ddev launch some/uri` will launch a browser with the current project's URL (or a full URL to `/some/uri`). `ddev launch -p` will launch the PHPMyAdmin UI, and `ddev launch -m` will launch the MailHog UI.
 * `ddev delete` is the same as `ddev stop --remove-data` and will delete a project's database and ddev's record of the project's existence. It doesn't touch your project or code. `ddev delete -O` will omit the snapshot creation step that would otherwise take place, and `ddev delete images` gets rid of spare Docker images you may have on your machine.
 * `ddev xdebug` enables xdebug, `ddev xdebug off` disables it, `ddev xdebug status` shows status
 
@@ -24,7 +24,7 @@ Each of these commands has full help. For example, `ddev start -h` or `ddev help
 In addition to the *commands* listed above, there are loads and loads of tools included inside the containers:
 
 * `ddev describe` tells how to access **mailhog**, which captures email in your development environment.
-* `ddev describe` tells how to use the built-in **PHPMyAdmin**.
+* `ddev describe` tells how to use the built-in **PHPMyAdmin** and `ddev launch -p` gives direct access to it.
 * Composer, git, node, npm, and dozens of other tools are installed in the web container, and you can access them via `ddev ssh` or `ddev exec`.
 * `ddev logs` gets you webserver logs; `ddev logs -s db` gets dbserver logs.
 * sqlite3 and the mysql client are inside the web container (and mysql client is also in the db container).
@@ -139,7 +139,6 @@ cd my-drupal8-site
 ddev config --project-type=drupal8 --docroot=web --create-docroot
 ddev start
 ddev composer create drupal/recommended-project:^8
-ddev composer remove drupal/core-project-message
 ddev composer require drush/drush
 ddev launch
 ```
@@ -173,7 +172,6 @@ cd my-drupal9-site
 ddev config --project-type=drupal9 --docroot=web --create-docroot
 ddev start
 ddev composer create drupal/recommended-project:9.0.x-dev
-ddev composer remove drupal/core-project-message
 ddev composer require drush/drush
 ddev launch
 ```


### PR DESCRIPTION
## The Problem/Issue/Bug:

This is inspired by and replaces @alesrebec's #2175 - Thanks for stimulating the thinking @alesrebec!

An eccentricity of `ddev composer create` has been the need to run an extra `ddev start` after it finishes. This is because the create-project has just created an entirely new code structure, and ddev hasn't had the chance to create settings files. (ddev creates settings files on start and config)

## How this PR Solves The Problem:

* Run app.Start() at the end of the `ddev composer create` process to get the settings files created.
* Change the docs to have just one start (it's actually unnecessary but instructional)
* Other minor docs changes. 

## Manual Testing Instructions:

* Run through the Drupal 8 and Drupal 9 Quickstarts and verify.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

