### PR TITLE
Don't check host lookup if not IsInternetActive()

### DIFF
--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -10,8 +10,8 @@ import (
 	asrt "github.com/stretchr/testify/assert"
 )
 
-// TestDevRestart runs `ddev restart` on the test apps
-func TestDevRestart(t *testing.T) {
+// TestCmdRestart runs `ddev restart` on the test apps
+func TestCmdRestart(t *testing.T) {
 	assert := asrt.New(t)
 	site := TestSites[0]
 	cleanup := site.Chdir()
@@ -29,8 +29,8 @@ func TestDevRestart(t *testing.T) {
 	cleanup()
 }
 
-// TestDevRestartJSON runs `ddev restart -j` on the test apps and harvests and checks the output
-func TestDevRestartJSON(t *testing.T) {
+// TestCmdRestartJSON runs `ddev restart -j` on the test apps and harvests and checks the output
+func TestCmdRestartJSON(t *testing.T) {
 	assert := asrt.New(t)
 	site := TestSites[0]
 	cleanup := site.Chdir()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1623,7 +1623,7 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 	}
 
 	for _, name := range app.GetHostnames() {
-		if app.UseDNSWhenPossible {
+		if app.UseDNSWhenPossible && nodeps.IsInternetActive() {
 			hostIPs, err := net.LookupHost(name)
 			// If we had successful lookup and dockerIP matches
 			// (which won't happen on Docker Toolbox) then don't bother

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -2,7 +2,7 @@ package nodeps
 
 import (
 	"context"
-	"fmt"
+	"github.com/drud/ddev/pkg/output"
 	"math/rand"
 	"net"
 	"os"
@@ -66,10 +66,10 @@ func IsInternetActive() bool {
 	// Internet is active (active == true) if both err and ctx.Err() were nil
 	active := err == nil && ctx.Err() == nil
 	if os.Getenv("DDEV_DEBUG") != "" {
-		fmt.Printf("IsInternetActive DEBUG: err=%v ctx.Err()=%v addrs=%v IsInternetactive==%v, randomURL=%v\n", err, ctx.Err(), addrs, active, randomURL)
+		output.UserOut.Printf("IsInternetActive DEBUG: err=%v ctx.Err()=%v addrs=%v IsInternetactive==%v, randomURL=%v\n", err, ctx.Err(), addrs, active, randomURL)
 	}
 	if active == false {
-		fmt.Println("Internet connection not detected")
+		output.UserOut.Println("Internet connection not detected")
 	}
 
 	// remember the result to not call this twice


### PR DESCRIPTION
## The Problem/Issue/Bug:

Testing in https://github.com/drud/ddev/issues/2174 showed that although IsInternetActive() is working correctly with flaky internet, hostnames might not be added to /etc/hosts in that situation, and we'd think they'd want to be.

## How this PR Solves The Problem:

If !IsInternetActive(), we'll go ahead and add the hostnames.

## Manual Testing Instructions:

I tested this by setting a network conditioner on Parallels Windows 10 instance with a 1000ms delay on incoming. With the delay, it now adds hostnames rather than relying on net.Lookup.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

