### PR TITLE
Improve output from ddev delete to show volume deletion, etc.

### DIFF
--- a/cmd/ddev/cmd/delete.go
+++ b/cmd/ddev/cmd/delete.go
@@ -60,8 +60,6 @@ ddev delete --all`,
 			if err := project.Stop(true, !omitSnapshot); err != nil {
 				util.Failed("Failed to remove project %s: \n%v", project.GetName(), err)
 			}
-
-			util.Success("Project %s has been deleted.", project.GetName())
 		}
 	},
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -735,10 +735,11 @@ func GetHostDockerInternalIP() (string, error) {
 // RemoveImage removes an image
 func RemoveImage(tag string) error {
 	client := GetDockerClient()
-	util.Warning("Removing image: %s", tag)
 	err := client.RemoveImage(tag)
-	if err != nil {
-		util.Warning("Failed to remove %s: %v", tag, err)
+	if err == nil {
+		util.Success("Deleting docker image %s", tag)
+	} else {
+		util.Warning("Failed to delete %s: %v", tag, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

In testing v1.14 I noticed that the volume deletion of persistent third-party volumes is done, but there's no info to the user about this.

## How this PR Solves The Problem:

Add the info to the user
Improves some other output at delete time.

## Manual Testing Instructions:

1. Create a project with some docker-compose stuff (use solr)
2. start it
3. Stop it. View output. You should see explicit info about volumes being deleted

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

