### PR TITLE
#2196: Attempt twice to create the drush.yml file

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -695,7 +695,10 @@ func drupal8PostStartAction(app *DdevApp) error {
 		// drush9 wants drush.yml
 		err := WriteDrushYML(app, filepath.Join(app.AppRoot, "drush", "drush.yml"))
 		if err != nil {
-			util.Warning("Failed to WriteDrushYML: %v", err)
+			err := WriteDrushYML(app, filepath.Join(filepath.Dir(app.SiteSettingsPath), "..", "all", "drush", "drush.yml"))
+			if err != nil {
+				util.Warning("Failed to WriteDrushYML: %v", err)
+			}
 		}
 
 		err = WriteDrushrc(app, filepath.Join(filepath.Dir(app.SiteSettingsPath), "drushrc.php"))


### PR DESCRIPTION
## The Problem/Issue/Bug:
Since #2025 was merged , ddev tries to create the drush/drush.yml file instead of web/sites/all/drush.yml.

Because of this change, projects that already had a drush/drush.yml file no longer get a ddev-generated file with the correct site URL, and, as a result, drush uli returns http://default as ddev's base path.

## How this PR Solves The Problem:
This PR restores the previous behaviour of ddev <1.13, as a a fallback in case the new behaviour fails.

## Manual Testing Instructions:
Run ddev start on a project with an existing drush/drush.yml. Verify that it creates the web/sites/all/drush/drush.yml file.

## Automated Testing Overview:
Haven't created any automated test.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/2196