### PR TITLE
Add ProjectHash to segment reporting, fixes #2193

### DIFF
--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -48,8 +48,8 @@ func SetInstrumentationBaseTags() {
 // getProjectHash combines the machine ID and project name and then
 // hashes the result, so we can end up with a unique project id
 func getProjectHash(projectName string) string {
-	ph := hmac.New(sha256.New, []byte(GetInstrumentationUser() + projectName))
-	ph.Write([]byte("phash"))
+	ph := hmac.New(sha256.New, []byte(GetInstrumentationUser()+projectName))
+	_, _ = ph.Write([]byte("phash"))
 	return hex.EncodeToString(ph.Sum(nil))
 }
 

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -1,6 +1,9 @@
 package ddevapp
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"github.com/denisbrodbeck/machineid"
 	"github.com/drud/ddev/pkg/globalconfig"
@@ -42,6 +45,14 @@ func SetInstrumentationBaseTags() {
 	}
 }
 
+// getProjectHash combines the machine ID and project name and then
+// hashes the result, so we can end up with a unique project id
+func getProjectHash(projectName string) string {
+	ph := hmac.New(sha256.New, []byte(GetInstrumentationUser() + projectName))
+	ph.Write([]byte("phash"))
+	return hex.EncodeToString(ph.Sum(nil))
+}
+
 // SetInstrumentationAppTags creates app-specific tags for Segment
 func (app *DdevApp) SetInstrumentationAppTags() {
 	ignoredProperties := []string{"approot", "hostname", "hostnames", "httpurl", "httpsurl", "httpURLs", "httpsURLs", "primary_url", "mailhog_url", "mailhog_https_url", "name", "phpmyadmin_url", "phpmyadmin_http_url", "router_status_log", "shortroot", "urls"}
@@ -54,6 +65,7 @@ func (app *DdevApp) SetInstrumentationAppTags() {
 			}
 		}
 	}
+	nodeps.InstrumentationTags["ProjectID"] = getProjectHash(app.Name)
 }
 
 // SegmentUser does the enqueue of the Identify action, identifying the user


### PR DESCRIPTION
## The Problem/Issue/Bug:

It would be nice to detect unique project IDs in segment. This adds a hashed project ID (server ID + project name) to the reporting

## How this PR Solves The Problem:

## Manual Testing Instructions:

Do an action. Watch segment for the event. Look at the ProjectID hash.

![image](https://user-images.githubusercontent.com/112444/79608745-c40de380-80b2-11ea-8bde-11444d61d7ba.png)


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

