### PR TITLE
Add creation of .ddev/.gitignore to post-start actions on php project, fixes #2200

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -65,7 +65,7 @@ var appTypeMatrix map[string]AppTypeFuncs
 
 func init() {
 	appTypeMatrix = map[string]AppTypeFuncs{
-		nodeps.AppTypePHP: {},
+		nodeps.AppTypePHP: {postStartAction: phpPostStartAction},
 		nodeps.AppTypeDrupal6: {
 			settingsCreator: createDrupal6SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal6Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal6App, postImportDBAction: nil, configOverrideAction: drupal6ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal6PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},

--- a/pkg/ddevapp/php.go
+++ b/pkg/ddevapp/php.go
@@ -1,0 +1,14 @@
+package ddevapp
+
+import (
+	"fmt"
+)
+
+func phpPostStartAction(app *DdevApp) error {
+	if !app.DisableSettingsManagement {
+		if _, err := app.CreateSettingsFile(); err != nil {
+			return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# The Problem/Issue/Bug:

#2200 points out that with a  project of type 'php', the .ddev/.gitignore does not get created/managed on `ddev start`. It ought to update.

## How this PR Solves The Problem:

Add post-start hook for 'php' project type to update.

## Manual Testing Instructions:

1. Create a project of type 'php'
2. Edit the .ddev/.gitignore
3. `ddev start`

Your edits should be gone.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

