### PR TITLE
Use debian existing package conf, not new conf, fixes #2092

### DIFF
--- a/docs/users/extend/customizing-images.md
+++ b/docs/users/extend/customizing-images.md
@@ -37,5 +37,5 @@ ADD README.txt /
 Note that if a Dockerfile is provided, any config.yaml `webimage_extra_packages` or `dbimage_extra_packages` will be ignored. If you need to add packages as well as other custom configuration, add them to your Dockerfile with a line like
 
 ```
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests php-yaml php7.3-ldap
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests php-yaml php7.3-ldap
 ```

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -789,7 +789,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
  `
 	if extraPackages != nil {
 		contents = contents + `
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 	return WriteImageDockerfile(fullpath, []byte(contents))
 }

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -758,7 +758,7 @@ func TestExtraPackages(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestExtraPackages", site.Name))
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -770,13 +770,11 @@ func TestExtraPackages(t *testing.T) {
 	_, err = exec.RunCommand("bash", []string{"-c", command})
 	assert.NoError(err)
 
-	oldPHPVersion := app.PHPVersion
-	app.PHPVersion = "7.3"
 	defer func() {
 		_ = app.Stop(true, false)
 		app.WebImageExtraPackages = nil
 		app.DBImageExtraPackages = nil
-		app.PHPVersion = oldPHPVersion
+		app.PHPVersion = nodeps.PHPDefault
 		_ = app.WriteConfig()
 		_ = fileutil.RemoveContents(app.GetConfigPath("web-build"))
 		_ = fileutil.RemoveContents(app.GetConfigPath("db-build"))
@@ -788,13 +786,7 @@ func TestExtraPackages(t *testing.T) {
 	err = app.Start()
 	assert.NoError(err)
 
-	_, _, err = app.Exec(&ExecOpts{
-		Service: "web",
-		Cmd:     "dpkg -s php7.3-gmp",
-	})
-	assert.Error(err)
-	assert.Contains(err.Error(), "exit status 1")
-
+	// Test db container to make sure no ncdu in there at beginning
 	_, _, err = app.Exec(&ExecOpts{
 		Service: "db",
 		Cmd:     "command -v ncdu",
@@ -802,25 +794,42 @@ func TestExtraPackages(t *testing.T) {
 	assert.Error(err)
 	assert.Contains(err.Error(), "exit status 1")
 
-	// Now add the packages and start again, they should be in there
-	app.WebImageExtraPackages = []string{"php7.3-gmp"}
-	app.DBImageExtraPackages = []string{"ncdu"}
-	err = app.Start()
-	assert.NoError(err)
+	for _, v := range nodeps.GetValidPHPVersions() {
+		t.Log("Testing extra packages with PHP" + v)
+		app.PHPVersion = v
 
-	stdout, stderr, err := app.Exec(&ExecOpts{
-		Service: "web",
-		Cmd:     "dpkg -s php7.3-gmp",
-	})
-	assert.NoError(err, "dpkg -s php7.3-gmp failed", stdout, stderr)
+		// Start and make sure that the packages don't exist already
+		err = app.Start()
+		assert.NoError(err)
 
-	stdout, stderr, err = app.Exec(&ExecOpts{
-		Service: "web",
-		Cmd:     "php -i | grep 'gmp support =. enabled'",
-	})
-	assert.NoError(err, "failed to grep for gmp support, stdout=%s, stderr=%s", stdout, stderr)
+		_, _, err = app.Exec(&ExecOpts{
+			Service: "web",
+			Cmd:     "dpkg -s php" + v + "-ldap",
+		})
+		assert.Error(err)
+		assert.Contains(err.Error(), "exit status 1")
 
-	stdout, _, err = app.Exec(&ExecOpts{
+		// Now add the packages and start again, they should be in there
+		app.WebImageExtraPackages = []string{"php" + v + "-ldap"}
+		app.DBImageExtraPackages = []string{"ncdu"}
+		err = app.Start()
+		assert.NoError(err)
+
+		stdout, stderr, err := app.Exec(&ExecOpts{
+			Service: "web",
+			Cmd:     "dpkg -s php" + v + "-ldap",
+		})
+		assert.NoError(err, "dpkg -s php"+v+"-ldap failed", stdout, stderr)
+
+		stdout, stderr, err = app.Exec(&ExecOpts{
+			Service: "web",
+			Cmd:     "php -i | grep 'LDAP Support =. enabled'",
+		})
+		assert.NoError(err, "failed to grep for ldap support, stdout=%s, stderr=%s", stdout, stderr)
+
+	}
+
+	stdout, _, err := app.Exec(&ExecOpts{
 		Service: "db",
 		Cmd:     "command -v ncdu",
 	})

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -1,5 +1,7 @@
 package nodeps
 
+import "sort"
+
 // Providers
 const (
 	ProviderDrudS3   = "drud-s3"
@@ -186,7 +188,7 @@ func GetValidPHPVersions() []string {
 	for p := range ValidPHPVersions {
 		s = append(s, p)
 	}
-
+	sort.Strings(s)
 	return s
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2092 points out that once again, upstream configuration changes broke use of `webimage_extra_packages`. In this case it was PHP 7.4.5 that did it, and it shipped with a new configuration.

The basic problem though was that ddev was automatically accepting new config, when it should be using existing config.

## How this PR Solves The Problem:

Use configold not confignew

## Manual Testing Instructions:

Create a php7.4 project
Add `webimage_extra_packages: [php7.4-ldap]` to the config.yaml
ddev start

If it succeeds, it's working

## Automated Testing Overview:

- [x] Improve TestExtraPackages to use webimage_extra_packages with all PHP versions

## Related Issue Link(s):

OP #2092

## Release/Deployment notes:

This has to be backported to v1.13.1 as well.
