### PR TITLE
Minor docs fixes, fixes #2203 [skip ci][ci skip]

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -138,7 +138,7 @@ mkdir my-drupal8-site
 cd my-drupal8-site
 ddev config --project-type=drupal8 --docroot=web --create-docroot
 ddev start
-ddev composer create drupal/recommended-project:^8
+ddev composer create "drupal/recommended-project:^8"
 ddev composer require drush/drush
 ddev launch
 ```
@@ -171,7 +171,7 @@ mkdir my-drupal9-site
 cd my-drupal9-site
 ddev config --project-type=drupal9 --docroot=web --create-docroot
 ddev start
-ddev composer create drupal/recommended-project:9.0.x-dev
+ddev composer create "drupal/recommended-project:9.0.x-dev"
 ddev composer require drush/drush
 ddev launch
 ```

--- a/docs/users/extending-commands.md
+++ b/docs/users/extending-commands.md
@@ -5,7 +5,7 @@ To define command tasks in your configuration, specify the desired command hook 
 
 Example:
 
-```
+```yaml
 hooks:
   post-start:
     - exec: "simple command expression"
@@ -39,7 +39,7 @@ Value: string providing the command to run. Commands requiring user interaction 
 
 Example: _Use drush to clear the Drupal cache and get a user login link after database import_
 
-```
+```yaml
 hooks:
   post-import-db:
     - exec: drush cr
@@ -50,7 +50,7 @@ hooks:
 
 Example: _Use wp-cli to replace the production URL with development URL in the database of a WordPress project_
 
-```
+```yaml
 hooks:
   post-import-db:
     - exec: wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.site
@@ -58,7 +58,7 @@ hooks:
 
 Example: _Add an extra database before import-db, executing in db container_
 
-```
+```yaml
 hooks:
   pre-import-db:
     - exec: mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS some_new_database;"
@@ -68,7 +68,7 @@ hooks:
 
 Example: _Add the common "ll" alias into the web container .bashrc file_
 
-```
+```yaml
 hooks:
   post-start:
   - exec: sudo echo alias ll=\"ls -lhA\" >> ~/.bashrc
@@ -82,7 +82,7 @@ Value: string providing the command to run. Commands requiring user interaction 
 
 Example: Run "composer install" from your system before starting the project (composer must already be installed on the host workstation):
 
-```
+```yaml
 hooks:
   pre-start:
     - exec-host: "composer install"
@@ -94,7 +94,7 @@ Value: string providing the composer command to run.
 
 Example:
 
-```
+```yaml
 hooks:
   post-start:
     - composer: config discard-changes true
@@ -102,7 +102,7 @@ hooks:
 
 ## WordPress Example
 
-```
+```yaml
 hooks:
   post-start:
     # Install WordPress after start
@@ -115,7 +115,7 @@ hooks:
 
 ## Drupal 7 Example
 
-```
+```yaml
 hooks:
   post-start:
     # Install Drupal after start if not installed already
@@ -133,7 +133,7 @@ hooks:
 
 ## Drupal 8 Example
 
-```
+```yaml
 hooks:
   pre-start:
     # Install composer dependencies using composer on host system
@@ -154,7 +154,7 @@ hooks:
 
 ## TYPO3 Example
 
-```
+```yaml
 hooks:
     post-start:
       - composer: install
@@ -162,7 +162,7 @@ hooks:
 
 ## Adding Additional Debian Packages (PHP Modules) Example
 
-```
+```yaml
 webimage_extra_packages: ["php7.2-ldap", "php7.2-tidy"]
 dbimage_extra_packages: ["vim"]
 ```


### PR DESCRIPTION
## The Problem/Issue/Bug:

A couple of late entries for 1.14 docs:

* Add quotes around `ddev composer create` examples that use "^", since that's a reserved character on cmd in Windows
* Improve yaml presentation by using ` ```yaml` as the yaml type on a few problematic stanzas, fixing #2203 

## How this PR Solves The Problem:

<img width="774" alt="ddev_Hooks_-_DDEV-Local_Documentation" src="https://user-images.githubusercontent.com/112444/79793661-2f9fbd00-830e-11ea-8429-0f86e35700ed.png">

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

