### PR TITLE
Allow docker-compose.*.yml as well as docker-compose.*.yaml, fixes #2217

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -699,7 +699,7 @@ func (app *DdevApp) ImportFiles(importPath string, extPath string) error {
 }
 
 // ComposeFiles returns a list of compose files for a project.
-// It has to put the .ddev/docker-compose-*.yaml first
+// It has to put the .ddev/docker-compose.*.y*ml first
 // It has to put the docker-compose.override.y*l last
 func (app *DdevApp) ComposeFiles() ([]string, error) {
 	dir, _ := os.Getwd()
@@ -709,9 +709,9 @@ func (app *DdevApp) ComposeFiles() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	files, err := filepath.Glob("docker-compose.*.yaml")
+	files, err := filepath.Glob("docker-compose.*.y*ml")
 	if err != nil {
-		return []string{}, fmt.Errorf("unable to glob docker-compose.*.yaml in %s: err=%v", app.AppConfDir(), err)
+		return []string{}, fmt.Errorf("unable to glob docker-compose.*.y*ml in %s: err=%v", app.AppConfDir(), err)
 	}
 
 	mainfile := app.DockerComposeYAMLPath()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -719,7 +719,7 @@ func (app *DdevApp) ComposeFiles() ([]string, error) {
 		return nil, fmt.Errorf("failed to find %s", mainfile)
 	}
 
-	overrides, err := filepath.Glob("docker-compose.override.yaml")
+	overrides, err := filepath.Glob("docker-compose.override.y*ml")
 	util.CheckErr(err)
 
 	orderedFiles := make([]string, 1)


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2217 pointed out that v1.14.0 (deliberately) disallowed docker-compose add-ons of the format docker-compose.*.yml. This seems unnecessary. 

## How this PR Solves The Problem:

Put it back to allow docker-compose.*.yml

## Manual Testing Instructions:

* Test add-on 3rd party services with `docker-compose.*.yml` as well as `docker-compose.*.yaml`
* Verify that a mixture of yaml and yml files works out OK.
* Verify that no additional files are picked up with this glob pattern
* Review the code to make sure it does what's expected
* What happens when there is a docker-compose.override.yaml and also a docker-compose.override.yml ?

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

