### PR TITLE
remove { on phpmyadmin_https_port

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -280,7 +280,7 @@ const ConfigInstructions = `
 # unless explicitly specified.
 
 # phpmyadmin_port: "8036"
-# phpmyadmin_https_port: "8037{"
+# phpmyadmin_https_port: "8037"
 # The PHPMyAdmin ports can be changed from the default 8036 and 8037
 
 # mailhog_port: "8025"


### PR DESCRIPTION
fixes a small typo

## The Problem/Issue/Bug:
there is an extra { on the port for "phpmyadmin_https_port" in the config.yaml
## How this PR Solves The Problem:
remove the the extra "{"

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

