### PR TITLE
Change default mysql collation to utf8mb4_general_ci

### DIFF
--- a/containers/ddev-dbserver/files/etc/my.cnf
+++ b/containers/ddev-dbserver/files/etc/my.cnf
@@ -37,7 +37,8 @@ expire-logs-days = 1
 log_bin_trust_function_creators=on
 
 character-set-server = utf8mb4
-collation-server = utf8mb4_bin
+collation-server = utf8mb4_general_ci
+init_connect='SET collation_connection = utf8mb4_unicode_ci'
 
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ var WebTag = "v1.14.1" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.14.1"
+var BaseDBTag = "20200427_mysql_collation"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

In [TYPO3 slack](https://typo3.slack.com/archives/C8TRNQ601/p1587817297004700) we studied extensively why a few collation variables weren't the utf8mb4_general_ci variables we expected. 


## How this PR Solves The Problem:

* change `collation-server`, which also results in the default database creation with the correct collation.
* add `init_connect='SET collation_connection = utf8mb4_unicode_ci'`, which auto-changes the client connection.

## Manual Testing Instructions:

* Delete your existing database or create a new project. `mkdir testcoll && cd testcol && ddev config --project-type=php && ddev start`
* `echo "SHOW VARIABLES LIKE 'coll%';" | ddev mysql`

You should see all collation variables being utf8mb4_general_ci

```
$ echo "SHOW VARIABLES LIKE 'coll%';" | ddev mysql
mysql: [Warning] Using a password on the command line interface can be insecure.
Variable_name	Value
collation_connection	utf8mb4_unicode_ci
collation_database	utf8mb4_general_ci
collation_server	utf8mb4_general_ci
```

You should see


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

