### PR TITLE
Add mariadb 10.5 support, fixes #2229

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -106,7 +106,7 @@ var (
 	// omitContainersArg allows user to determine value of omit_containers
 	omitContainersArg string
 
-	// mariadbVersionArg is mariadb version 5.5-10.4
+	// mariadbVersionArg is mariadb version 5.5-10.5
 	mariaDBVersionArg string
 
 	// nfsMountEnabled sets nfs_mount_enabled

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.10.5
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.10.5
@@ -1,0 +1,4 @@
+name: callme10.5
+type: php
+docroot: ""
+mariadb_version: "10.5"

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.5
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.5
@@ -1,0 +1,4 @@
+name: imagespec10.5
+type: php
+docroot: ""
+dbimage: somerandomdbimg-mariadb-10.5

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -87,11 +87,10 @@ test: container
 
 clean:
 	for item in $(MARIADB_VERSIONS); do \
-		@if docker image inspect $(DOCKER_REPO)-mariadb-4$item:$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO)-mariadb-4$item:$(VERSION); fi
+		if docker image inspect $(DOCKER_REPO)-mariadb-${item}:$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO)-mariadb-$${item}:$(VERSION); fi; \
 	done
 	for item in $(MYSQL_VERSIONS); do \
-		@if docker image inspect $(DOCKER_REPO)-myql-4$item:$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO)-mysql-4$item:$(VERSION); fi
+		if docker image inspect $(DOCKER_REPO)-mysql-${item}:$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO)-mysql-$${item}:$(VERSION); fi; \
 	done
-
 	@rm -rf .container-* .dockerfile* .push-* linux darwin windows container VERSION.txt .docker_image
 

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -83,7 +83,7 @@ push: container
 
 
 test: container
-	bash ./test/test_dbserver.sh # bash execution just for windows make
+	bash ./test/test_dbserver.sh $(VERSION) # bash execution just for windows make
 
 clean:
 	for item in $(MARIADB_VERSIONS); do \

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -46,7 +46,7 @@ build: container
 
 # The format here is majorversion:pinnedimageversion
 # This allows to pin the version (as currently required with 8.0.19
-MARIADB_VERSIONS=5.5:5.5 10.0:10.0 10.1:10.1 10.2:10.2 10.3:10.3 10.4:10.4
+MARIADB_VERSIONS=5.5:5.5 10.0:10.0 10.1:10.1 10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5
 MYSQL_VERSIONS=5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0.19
 
 container: mariadb_containers mysql_containers

--- a/containers/ddev-dbserver/test/basic_database.bats
+++ b/containers/ddev-dbserver/test/basic_database.bats
@@ -65,7 +65,7 @@ function containercheck {
     [ "${reported_version}" = ${DB_VERSION} ]
 }
 
-@test "look for utf8mb4 configured on ${DB_TYPE} ${DB_VERSION}" {
-    mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$HOSTPORT -e "SHOW GLOBAL VARIABLES like \"collation_server\";" | grep "utf8mb4_bin"
+@test "look for utf8mb4_general_ci configured on ${DB_TYPE} ${DB_VERSION}" {
+    mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$HOSTPORT -e "SHOW GLOBAL VARIABLES like \"collation_server\";" | grep "utf8mb4_general_ci"
 }
 

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -4,12 +4,15 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+if [ $# != "1" ]; then echo "Argument 'version' is required"; exit 1; fi
+VERSION=$1
+
 function cleanup {
     true
 }
 trap cleanup EXIT
 
-export tag=20191007_many_mariadb
+export tag=${VERSION}
 export DB_TYPE=mariadb
 for v in 5.5 10.0 10.0 10.1 10.2 10.3 10.4 10.5; do
     export IMAGE="drud/ddev-dbserver-$DB_TYPE-$v:$tag"

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -11,7 +11,7 @@ trap cleanup EXIT
 
 export tag=20191007_many_mariadb
 export DB_TYPE=mariadb
-for v in 5.5 10.0 10.0 10.1 10.2 10.3 10.4; do
+for v in 5.5 10.0 10.0 10.1 10.2 10.3 10.4 10.5; do
     export IMAGE="drud/ddev-dbserver-$DB_TYPE-$v:$tag"
     export DB_VERSION=$v
     # /usr/local/bin is added for git-bash, where it may not be in the $PATH.

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -16,7 +16,7 @@ the .ddev/config.yaml is the primary configuration for the project.
 | webimage | docker image to use for webserver | It is unusual to change the default and is not recommended, but the webimage can be overridden with a correctly crafted image, probably derived from drud/ddev-webserver |
 | dbimage | docker image to use for db server | It is unusual to change the default and is not recommended, but the dbimage can be overridden with a correctly crafted image, probably derived from drud/ddev-dbserver |
 | dbaimage | docker image to use for dba server (phpMyAdmin server) | It is unusual to change the default and is not recommended, but the dbimage can be overridden with a correctly crafted image, probably derived from drud/phpmyadmin |
-| mariadb_version | Version of MariaDB to be used |  Defaults to 10.2, but 5.5, 10.0, 10.1, 10.2, 10.3, 10.4 are available. Cannot be used with mysql_version. See [Database Server Types](database_types.md) for details and caveats. |
+| mariadb_version | Version of MariaDB to be used |  Defaults to 10.2, but 5.5, 10.0, 10.1, 10.2, 10.3, 10.4, 10.5 are available. Cannot be used with mysql_version. See [Database Server Types](database_types.md) for details and caveats. |
 | mysql_version | Version of Oracle MySQL to be used |  Defaults to empty (using MariaDB). 5.5, 5.6, 5.7, and 8.0 are available. Conflicts with mariadb_version. See [Database Server Types](database_types.md) for details and caveats. |
 | router_http_port | Port used by the router for http |  Defaults to port 80. This can be changed if there is a conflict on the host over port 80 |
 | router_https_port | Port used by the router for https |Defaults to 443, usually only changed if there is a conflicting process using port 443 |

--- a/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/dbimage-10.5/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/dbimage-10.5/.ddev/config.yaml
@@ -1,0 +1,1 @@
+dbimage: somedbimage:10.5

--- a/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/mariadb-version-10.5/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/mariadb-version-10.5/.ddev/config.yaml
@@ -1,0 +1,1 @@
+mariadb_version: 10.5

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -37,6 +37,7 @@ const (
 	MariaDB102 = "10.2"
 	MariaDB103 = "10.3"
 	MariaDB104 = "10.4"
+	MariaDB105 = "10.5"
 )
 
 // Oracle MySQL versions
@@ -83,6 +84,7 @@ var ValidMariaDBVersions = map[string]bool{
 	MariaDB102: true,
 	MariaDB103: true,
 	MariaDB104: true,
+	MariaDB105: true,
 }
 
 var ValidMySQLVersions = map[string]bool{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ var WebTag = "v1.14.2" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20200427_mysql_collation"
+var BaseDBTag = "20200501_mariadb_10.5"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Add MariaDB 10.5 support

## Manual Testing Instructions:

Configure for 10.5. Do something with the project.

## Automated Testing Overview:

All tests executed up through 10.4 are also executed against 10.5

