### PR TITLE
Check for docker on ddev config, fixes #2222

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -49,7 +49,7 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 		err := dockerutil.CheckDockerVersion(version.DockerVersionConstraint)
 		if err != nil {
 			if err.Error() == "no docker" {
-				if os.Args[1] != "version" && os.Args[1] != "config" {
+				if os.Args[1] != "version" {
 					util.Failed("Could not connect to docker. Please ensure Docker is installed and running.")
 				}
 			} else {


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2222 points out that life would be a lot easier for new users if `ddev config` checked for docker before doing things. 

## How this PR Solves The Problem:

Don't skip the docker check for `ddev config`

## Manual Testing Instructions:

Try `ddev config` without docker running.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

