### PR TITLE
Provide explicit Drupal9 nginx configuration

### DIFF
--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal9.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal9.conf
@@ -1,4 +1,4 @@
-# ddev drupal8 config
+# ddev drupal9 config
 
 # You can override ddev's configuration by placing an edited copy
 # of this config (or one of the other ones) in .ddev/nginx-site.conf

--- a/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal9.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx-site-drupal9.conf
@@ -1,0 +1,42 @@
+# ddev drupal8 config
+
+# You can override ddev's configuration by placing an edited copy
+# of this config (or one of the other ones) in .ddev/nginx-site.conf
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+
+# Set https to 'on' if x-forwarded-proto is https
+map $http_x_forwarded_proto $fcgi_https {
+    default off;
+    https on;
+}
+
+server {
+    listen 80; ## listen for ipv4; this line is default and implied
+
+
+    # The WEBSERVER_DOCROOT variable is substituted with
+    # its value when the container is started.
+    root $WEBSERVER_DOCROOT;
+
+    include /etc/nginx/monitoring.conf;
+
+    include /etc/nginx/nginx_drupal9.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}
+
+server {
+    listen 443 ssl;
+
+
+    # The WEBSERVER_DOCROOT variable is substituted with
+    # its value when the container is started.
+    root $WEBSERVER_DOCROOT;
+
+    ssl_certificate /etc/ssl/certs/master.crt;
+    ssl_certificate_key /etc/ssl/certs/master.key;
+
+    include /etc/nginx/monitoring.conf;
+
+    include /etc/nginx/nginx_drupal9.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}

--- a/containers/ddev-webserver/files/etc/nginx/nginx_drupal9.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx_drupal9.conf
@@ -1,0 +1,80 @@
+    index index.php index.htm index.html;
+
+    # Make site accessible from http://localhost/
+    server_name _;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    location / {
+        absolute_redirect off;
+        try_files $uri /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location @rewrite {
+        # For D7 and above:
+        # Clean URLs are handled in drupal_environment_initialize().
+        rewrite ^ /index.php;
+    }
+
+    # Handle image styles for Drupal 7+
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on socket
+    location ~ '\.php$|^/update.php' {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors off;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 10m;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+    }
+
+    # Expire rules for static content
+    # Feed
+    location ~* \.(?:rss|atom)$ {
+        expires 1h;
+    }
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    ## Regular private file serving (i.e. handled by Drupal).
+    location ^~ /system/files/ {
+        ## For not signaling a 404 in the error log whenever the
+        ## system/files directory is accessed add the line below.
+        ## Note that the 404 is the intended behavior.
+        log_not_found off;
+        access_log off;
+        expires 30d;
+        try_files $uri @rewrite;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
+    }

--- a/containers/ddev-webserver/test/containertest.sh
+++ b/containers/ddev-webserver/test/containertest.sh
@@ -119,8 +119,8 @@ for v in 5.6 7.0 7.1 7.2 7.3 7.4; do
 done
 
 # Run various project_types and check behavior.
-for project_type in drupal6 drupal7 drupal8 typo3 backdrop wordpress default; do
-	PHP_VERSION="7.1"
+for project_type in drupal6 drupal7 drupal8 drupal9 typo3 backdrop wordpress default; do
+	PHP_VERSION="7.3"
 
 	if [ "$project_type" == "drupal6" ]; then
 	  PHP_VERSION="5.6"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.14.1" // Note that this can be overridden by make
+var WebTag = "20200504_add_drupal9_nginx_config" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The drupal9 configuration in ddev-webserver was left out in v1.14; as a result, the default configuration was in use. It seemed to work for everything, but it needs its own configuration. 

The explicit test in the container was also left out, and that's how this was discovered, when working on https://github.com/drud/ddev-images/pull/3

## How this PR Solves The Problem:

Add the Drupal9 explicit nginx config (just a copy of drupal8)

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

This probably requires a release v1.14.2
