### PR TITLE
Fix typo phpmyadmin_http_url -> phpmyadmin_https_url

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -194,6 +194,17 @@ func (app *DdevApp) Describe() (map[string]interface{}, error) {
 	appDesc["httpsURLs"] = httpsURLs
 	appDesc["urls"] = allURLs
 
+	if app.MySQLVersion != "" {
+		appDesc["database_type"] = "mysql"
+		appDesc["mysql_version"] = app.MySQLVersion
+	} else {
+		appDesc["database_type"] = "mariadb" // default
+		appDesc["mariadb_version"] = app.MariaDBVersion
+		if app.MariaDBVersion == "" {
+			appDesc["mariadb_version"] = version.MariaDBDefaultVersion
+		}
+	}
+
 	// Only show extended status for running sites.
 	if app.SiteStatus() == SiteRunning {
 		if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -59,15 +59,13 @@ func (app *DdevApp) SetInstrumentationAppTags() {
 	ignoredProperties := []string{"approot", "hostname", "hostnames", "name", "router_status_log", "shortroot"}
 
 	describeTags, _ := app.Describe()
-
-	if globalconfig.DdevGlobalConfig.InstrumentationOptIn {
-		for key, val := range describeTags {
-			// Make sure none of the "URL" attributes or the ignoredProperties comes through
-			if strings.Contains(strings.ToLower(key), "url") || nodeps.ArrayContainsString(ignoredProperties, key) {
-				continue
-			}
-			nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
+	for key, val := range describeTags {
+		// Make sure none of the "URL" attributes or the ignoredProperties comes through
+		if strings.Contains(strings.ToLower(key), "url") || nodeps.ArrayContainsString(ignoredProperties, key) {
+			continue
 		}
+		nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
+	}
 	nodeps.InstrumentationTags["ProjectID"] = getProjectHash(app.Name)
 }
 

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -38,6 +38,13 @@ func SetInstrumentationBaseTags() {
 		isToolbox := nodeps.IsDockerToolbox()
 
 		nodeps.InstrumentationTags["OS"] = runtime.GOOS
+		if runtime.GOOS == "linux" {
+			wslDistro := os.Getenv("WSL_DISTRO_NAME")
+			if wslDistro != "" {
+				nodeps.InstrumentationTags["isWSL"] = "true"
+				nodeps.InstrumentationTags["wslDistro"] = wslDistro
+			}
+		}
 		nodeps.InstrumentationTags["dockerVersion"] = dockerVersion
 		nodeps.InstrumentationTags["dockerComposeVersion"] = composeVersion
 		nodeps.InstrumentationTags["dockerToolbox"] = strconv.FormatBool(isToolbox)

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -60,14 +60,13 @@ func (app *DdevApp) SetInstrumentationAppTags() {
 
 		describeTags, _ := app.Describe()
 		for key, val := range describeTags {
-			// Make sure none of the "URL" attributes comes through
-			if strings.Contains(strings.ToLower(key), "url") {
+			// Make sure none of the "URL" attributes or the ignoredProperties comes through
+			if strings.Contains(strings.ToLower(key), "url") || nodeps.ArrayContainsString(ignoredProperties, key) {
 				continue
 			}
-			if !nodeps.ArrayContainsString(ignoredProperties, key) {
-				nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
-			}
+			nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
 		}
+
 	nodeps.InstrumentationTags["ProjectID"] = getProjectHash(app.Name)
 }
 

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -58,7 +58,9 @@ func getProjectHash(projectName string) string {
 func (app *DdevApp) SetInstrumentationAppTags() {
 	ignoredProperties := []string{"approot", "hostname", "hostnames", "name", "router_status_log", "shortroot"}
 
-		describeTags, _ := app.Describe()
+	describeTags, _ := app.Describe()
+
+	if globalconfig.DdevGlobalConfig.InstrumentationOptIn {
 		for key, val := range describeTags {
 			// Make sure none of the "URL" attributes or the ignoredProperties comes through
 			if strings.Contains(strings.ToLower(key), "url") || nodeps.ArrayContainsString(ignoredProperties, key) {
@@ -66,7 +68,6 @@ func (app *DdevApp) SetInstrumentationAppTags() {
 			}
 			nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
 		}
-
 	nodeps.InstrumentationTags["ProjectID"] = getProjectHash(app.Name)
 }
 

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -55,14 +56,18 @@ func getProjectHash(projectName string) string {
 
 // SetInstrumentationAppTags creates app-specific tags for Segment
 func (app *DdevApp) SetInstrumentationAppTags() {
-	ignoredProperties := []string{"approot", "hostname", "hostnames", "httpurl", "httpsurl", "httpURLs", "httpsURLs", "primary_url", "mailhog_url", "mailhog_https_url", "name", "phpmyadmin_url", "phpmyadmin_https_url", "router_status_log", "shortroot", "urls"}
+	ignoredProperties := []string{"approot", "hostname", "hostnames", "name", "router_status_log", "shortroot"}
 
-	describeTags, _ := app.Describe()
-	for key, val := range describeTags {
-		if !nodeps.ArrayContainsString(ignoredProperties, key) {
-			nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
+		describeTags, _ := app.Describe()
+		for key, val := range describeTags {
+			// Make sure none of the "URL" attributes comes through
+			if strings.Contains(strings.ToLower(key), "url") {
+				continue
+			}
+			if !nodeps.ArrayContainsString(ignoredProperties, key) {
+				nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
+			}
 		}
-	}
 	nodeps.InstrumentationTags["ProjectID"] = getProjectHash(app.Name)
 }
 

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -55,7 +55,7 @@ func getProjectHash(projectName string) string {
 
 // SetInstrumentationAppTags creates app-specific tags for Segment
 func (app *DdevApp) SetInstrumentationAppTags() {
-	ignoredProperties := []string{"approot", "hostname", "hostnames", "httpurl", "httpsurl", "httpURLs", "httpsURLs", "primary_url", "mailhog_url", "mailhog_https_url", "name", "phpmyadmin_url", "phpmyadmin_http_url", "router_status_log", "shortroot", "urls"}
+	ignoredProperties := []string{"approot", "hostname", "hostnames", "httpurl", "httpsurl", "httpURLs", "httpsURLs", "primary_url", "mailhog_url", "mailhog_https_url", "name", "phpmyadmin_url", "phpmyadmin_https_url", "router_status_log", "shortroot", "urls"}
 
 	describeTags, _ := app.Describe()
 	for key, val := range describeTags {

--- a/pkg/ddevapp/instrumentation_test.go
+++ b/pkg/ddevapp/instrumentation_test.go
@@ -1,0 +1,40 @@
+package ddevapp_test
+
+import (
+	"fmt"
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
+	asrt "github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+//TestSetInstrumentationAppTags checks to see that tags are properly set
+//and tries to make sure no leakage happens with URLs or other
+//tags that we don't want to see.
+func TestSetInstrumentationAppTags(t *testing.T) {
+	assert := asrt.New(t)
+
+	site := TestSites[0]
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+
+	testcommon.ClearDockerEnv()
+	app := new(ddevapp.DdevApp)
+
+	err := app.Init(site.Dir)
+	assert.NoError(err)
+	t.Cleanup(func() {
+		_ = app.Stop(true, false)
+	})
+	app.SetInstrumentationAppTags()
+
+	// Make sure that none of the "url" items in app.desc are being reported
+	for k := range nodeps.InstrumentationTags {
+		assert.NotContains(strings.ToLower(k), "url")
+	}
+	assert.NotEmpty(nodeps.InstrumentationTags["ProjectID"])
+	runTime()
+}

--- a/pkg/ddevapp/instrumentation_test.go
+++ b/pkg/ddevapp/instrumentation_test.go
@@ -41,7 +41,7 @@ func TestSetInstrumentationAppTags(t *testing.T) {
 	}
 
 	// Make sure that expected attributes come through
-	for _, wanted := range []string{"dbimg", "dbaimg", "nfs_mount_enabled", "ProjectID", "php_version", "router_http_port", "router_https_port", "router_status", "ssh_agent_status", "status", "type", "webimg", "webserver_type"} {
+	for _, wanted := range []string{"database_type", "dbimg", "dbaimg", "nfs_mount_enabled", "ProjectID", "php_version", "router_http_port", "router_https_port", "router_status", "ssh_agent_status", "status", "type", "webimg", "webserver_type"} {
 		assert.NotEmpty(nodeps.InstrumentationTags[wanted], "tag '%s' was not found and it should have been", wanted)
 	}
 	runTime()

--- a/pkg/ddevapp/instrumentation_test.go
+++ b/pkg/ddevapp/instrumentation_test.go
@@ -35,6 +35,14 @@ func TestSetInstrumentationAppTags(t *testing.T) {
 	for k := range nodeps.InstrumentationTags {
 		assert.NotContains(strings.ToLower(k), "url")
 	}
-	assert.NotEmpty(nodeps.InstrumentationTags["ProjectID"])
+
+	for _, unwanted := range []string{"approot", "hostname", "hostnames", "name", "router_status_log", "shortroot"} {
+		assert.Empty(nodeps.InstrumentationTags[unwanted])
+	}
+
+	// Make sure that expected attributes come through
+	for _, wanted := range []string{"dbimg", "dbaimg", "nfs_mount_enabled", "ProjectID", "php_version", "router_http_port", "router_https_port", "router_status", "ssh_agent_status", "status", "type", "webimg", "webserver_type"} {
+		assert.NotEmpty(nodeps.InstrumentationTags[wanted], "tag '%s' was not found and it should have been", wanted)
+	}
 	runTime()
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

A one-character typo caused the phpmyadmin_https_url to be included in segment data, and that shouldn't be included. Thanks to @unn for noticing this.

## How this PR Solves The Problem:

* Fix it, don't send phpmyadmin_https_url
* Any app.Describe() tag with "url" in it doesn't get sent
* Add TestSetInstrumentationAppTags to ensure these things happen right

## Manual Testing Instructions:

Watching segment debug data, do something. Look at results. There should be no phpmyadmin_https_url (or any other URLs)

## Automated Testing Overview:

* Added TestSetInstrumentationAppTags and make sure that no URLs are included. Make sure that ignoredProperties is handled as expected. 

## Related Issue Link(s):

## Release/Deployment notes:

This is a candidate for v1.14.2 point release
