### PR TITLE
Fix segment events without app data, fixes #2065 (again)

### DIFF
--- a/cmd/ddev/cmd/a.go
+++ b/cmd/ddev/cmd/a.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
+	"os"
 )
 
 // This file is a.go because global config must be loaded before anybody else
@@ -10,6 +12,12 @@ import (
 // uninitialized data
 
 func init() {
+	// Prevent running as root for most cases
+	// We really don't want ~/.ddev to have root ownership, breaks things.
+	if os.Geteuid() == 0 && len(os.Args) > 1 && os.Args[1] != "hostname" {
+		output.UserOut.Fatal("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
+	}
+
 	err := globalconfig.ReadGlobalConfig()
 	if err != nil {
 		util.Failed("unable to read global config: %v", err)

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -156,12 +156,6 @@ func init() {
 		util.Warning("Adding custom commands failed: %v", err)
 	}
 
-	// Prevent running as root for most cases
-	// We really don't want ~/.ddev to have root ownership, breaks things.
-	if os.Geteuid() == 0 && len(os.Args) > 1 && os.Args[1] != "hostname" {
-		output.UserOut.Fatal("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
-	}
-
 }
 
 func instrumentationNotSetUpWarning() {

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -168,7 +168,7 @@ func instrumentationNotSetUpWarning() {
 // from the last saved version. If it is, prompt to request anon ddev usage stats
 // and update the info.
 func checkDdevVersionAndOptInInstrumentation() error {
-	if !output.JSONOutput && semver.Compare(version.COMMIT, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoInstrumentation {
+	if !output.JSONOutput && semver.Compare(version.VERSION, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoInstrumentation {
 		allowStats := util.Confirm("It looks like you have a new ddev release.\nMay we send anonymous ddev usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/stable/users/cli-usage/#opt-in-usage-information\nPermission to beam up?")
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -26,15 +26,16 @@ any directory by running 'ddev start projectname [projectname ...]'`,
 		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+
+		// Look for version change and opt-in to instrumentation if it has changed.
+		err := checkDdevVersionAndOptInInstrumentation()
+		if err != nil {
+			util.Failed(err.Error())
+		}
+
 		projects, err := getRequestedProjects(args, startAll)
 		if err != nil {
 			util.Failed("Failed to get project(s): %v", err)
-		}
-
-		// Look for version change and opt-in to instrumentation if it has changed.
-		err = checkDdevVersionAndOptInInstrumentation()
-		if err != nil {
-			util.Failed(err.Error())
 		}
 
 		for _, project := range projects {

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -57,12 +57,10 @@ func getProjectHash(projectName string) string {
 func (app *DdevApp) SetInstrumentationAppTags() {
 	ignoredProperties := []string{"approot", "hostname", "hostnames", "httpurl", "httpsurl", "httpURLs", "httpsURLs", "primary_url", "mailhog_url", "mailhog_https_url", "name", "phpmyadmin_url", "phpmyadmin_http_url", "router_status_log", "shortroot", "urls"}
 
-	if globalconfig.DdevGlobalConfig.InstrumentationOptIn {
-		describeTags, _ := app.Describe()
-		for key, val := range describeTags {
-			if !nodeps.ArrayContainsString(ignoredProperties, key) {
-				nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
-			}
+	describeTags, _ := app.Describe()
+	for key, val := range describeTags {
+		if !nodeps.ArrayContainsString(ignoredProperties, key) {
+			nodeps.InstrumentationTags[key] = fmt.Sprintf("%v", val)
 		}
 	}
 	nodeps.InstrumentationTags["ProjectID"] = getProjectHash(app.Name)

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -3,7 +3,6 @@ package globalconfig
 import (
 	"fmt"
 	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/drud/ddev/pkg/version"
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -64,11 +63,6 @@ func ValidateGlobalConfig() error {
 // ReadGlobalConfig() reads the global config file into DdevGlobalConfig
 func ReadGlobalConfig() error {
 	globalConfigFile := GetGlobalConfigPath()
-	// This is added just so we can see it in global; not checked.
-	// Make sure that LastStartedVersion always has a valid value
-	if DdevGlobalConfig.LastStartedVersion == "" {
-		DdevGlobalConfig.LastStartedVersion = version.DdevVersion
-	}
 
 	// Can't use fileutil.FileExists() here because of import cycle.
 	if _, err := os.Stat(globalConfigFile); err != nil {
@@ -104,6 +98,11 @@ func ReadGlobalConfig() error {
 	}
 	if DdevGlobalConfig.MkcertCARoot == "" {
 		DdevGlobalConfig.MkcertCARoot = readCAROOT()
+	}
+	// This is added just so we can see it in global; not checked.
+	// Make sure that LastStartedVersion always has a valid value
+	if DdevGlobalConfig.LastStartedVersion == "" {
+		DdevGlobalConfig.LastStartedVersion = "v0.0"
 	}
 
 	err = ValidateGlobalConfig()


### PR DESCRIPTION
## The Problem/Issue/Bug:

At least one recreation scenario for #2065  is described in https://github.com/drud/ddev/issues/2065#issuecomment-624437369 - the opt-in request was made *after* the app data was collected, so at the time of collection, the opt-in flag was false. 

In addition, SetInstrumentationAppTags() was not setting the tags if InstrumentationOptIn was false, which was unnecessary.

## How this PR Solves The Problem:

* Collect the app/tag information regardless of the setting (of course we don't send it if it's turned off)
* Do the opt-in earlier than the app creation
* This also moves a failsafe to prevent superuser execution to an earlier and more appropriate spot. 

## Manual Testing Instructions:

* Delete the `instrumentation_opt_in` and `last_started_version` lines in ~/.ddev/global_config.yaml
* `ddev start`
* Accept the opt-in
* Review what's sent to segment. It should be decent information with the app tags like project type and php version.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

This may be a candidate for release v1.14.2
