### PR TITLE
fix(nginx): Remove duplicated image location

### DIFF
--- a/containers/ddev-webserver/files/etc/nginx/nginx_drupal7.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx_drupal7.conf
@@ -82,10 +82,3 @@
         expires 30d;
         try_files $uri @rewrite;
     }
-
-    # Media: images, icons, video, audio, HTC
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-        try_files $uri @rewrite;
-        expires max;
-        log_not_found off;
-    }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200527_atomicptr_composer_bin_path" // Note that this can be overridden by make
+var WebTag = "20200515_klausi_remove_extra_nginx_stanza" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
The `location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {` entry is duplicated in the drupal7 nginx config.