### PR TITLE
Only use //c on Docker Toolbox, not Docker Desktop for Windows

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -650,7 +650,11 @@ func MassageWindowsHostMountpoint(mountPoint string) string {
 	if string(mountPoint[1]) == ":" {
 		pathPortion := strings.Replace(mountPoint[2:], `\`, "/", -1)
 		drive := strings.ToLower(string(mountPoint[0]))
-		mountPoint = "//" + drive + pathPortion
+		mountPoint = "/" + drive + pathPortion
+
+		if nodeps.IsDockerToolbox() {
+			mountPoint = "//" + drive + pathPortion
+		}
 	}
 	return mountPoint
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

For Docker Toolbox we had a path massaging function that changed C:\Users\rfay\workspace to //c/Users/rfay/workspace. This // really helped toolbox work.

But now in Docker 2.3.0.1 (edge) and 2.3.0.2 (released today as stable) it doesn't work any more on Docker Desktop for Windows.

## How this PR Solves The Problem:

Only add the extra slash on the front when running Docker Toolbox.

## Manual Testing Instructions:

`ddev auth ssh` with Docker Desktop for Windows 2.3.0.2

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

