### PR TITLE
Fix up ddev-dbserver tests to work with docker 2.3.0.1+ - tests only

### DIFF
--- a/containers/ddev-dbserver/test/basic_database.bats
+++ b/containers/ddev-dbserver/test/basic_database.bats
@@ -14,7 +14,7 @@ function setup {
     export MOUNTGID=98
 
     # Homebrew mysql client realy really wants /usr/local/etc/my.cnf.d
-    if [ "${OS}" != "Windows_NT" ] && [ ! -d /usr/local/etc/my.cnf.d ]; then
+    if [ "${OS:-$(uname)}" != "Windows_NT" ] && [ ! -d /usr/local/etc/my.cnf.d ]; then
         mkdir -p /usr/local/etc/my.cnf.d || sudo mkdir -p /usr/local/etc/my.cnf.d
     fi
     docker rm -f ${CONTAINER_NAME} 2>/dev/null || true

--- a/containers/ddev-dbserver/test/basic_database.bats
+++ b/containers/ddev-dbserver/test/basic_database.bats
@@ -13,7 +13,10 @@ function setup {
     export MOUNTUID=98
     export MOUNTGID=98
 
-    mkdir -p /usr/local/etc/my.cnf.d || sudo mkdir -p /usr/local/etc/my.cnf.d
+    # Homebrew mysql client realy really wants /usr/local/etc/my.cnf.d
+    if [ "${OS}" != "Windows_NT" ] && [ ! -d /usr/local/etc/my.cnf.d ]; then
+        mkdir -p /usr/local/etc/my.cnf.d || sudo mkdir -p /usr/local/etc/my.cnf.d
+    fi
     docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
 
     echo "# Starting image with database image $IMAGE"

--- a/containers/ddev-dbserver/test/custom_config.bats
+++ b/containers/ddev-dbserver/test/custom_config.bats
@@ -13,11 +13,14 @@ function setup {
     export MOUNTUID=98
     export MOUNTGID=98
 
-    mkdir -p /usr/local/etc/my.cnf.d || sudo mkdir -p /usr/local/etc/my.cnf.d
+    # Homebrew mysql client realy really wants /usr/local/etc/my.cnf.d
+    if [ "${OS}" != "Windows_NT" ] && [ ! -d /usr/local/etc/my.cnf.d ]; then
+        mkdir -p /usr/local/etc/my.cnf.d || sudo mkdir -p /usr/local/etc/my.cnf.d
+    fi
     docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
 
     echo "# Starting image with database image $IMAGE"
-docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql -v "/$PWD/test/testdata:/mnt/ddev_config:ro" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+    docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
     containercheck
 }
 
@@ -47,7 +50,7 @@ function containercheck {
 }
 
 @test "test with mysql/utf.cnf override ${DB_TYPE} ${DB_VERSION}" {
-    docker exec -t $CONTAINER_NAME grep "collation-server" //mnt/ddev_config/mysql/utf.cnf
+    docker exec $CONTAINER_NAME sh -c 'grep collation-server /mnt/ddev_config/mysql/utf.cnf'
     mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$HOSTPORT -e "SHOW GLOBAL VARIABLES like \"collation_server\";" | grep "utf8_general_ci"
 }
 

--- a/containers/ddev-dbserver/test/custom_config.bats
+++ b/containers/ddev-dbserver/test/custom_config.bats
@@ -14,7 +14,7 @@ function setup {
     export MOUNTGID=98
 
     # Homebrew mysql client realy really wants /usr/local/etc/my.cnf.d
-    if [ "${OS}" != "Windows_NT" ] && [ ! -d /usr/local/etc/my.cnf.d ]; then
+    if [ "${OS:-$(uname)}" != "Windows_NT" ] && [ ! -d /usr/local/etc/my.cnf.d ]; then
         mkdir -p /usr/local/etc/my.cnf.d || sudo mkdir -p /usr/local/etc/my.cnf.d
     fi
     docker rm -f ${CONTAINER_NAME} 2>/dev/null || true

--- a/containers/ddev-router/test/containertest.sh
+++ b/containers/ddev-router/test/containertest.sh
@@ -5,6 +5,9 @@ set -o pipefail
 set -o nounset
 set -x
 
+# As of Docker 2.3.0.2 May 2020, the mount of /var/run/docker.sock doesn't seem to be possible any more.
+if [ "$OS" = "Windows_NT" ]; then exit; fi
+
 DOCKER_IMAGE=$(awk '{print $1}' .docker_image)
 CONTAINER_NAME=ddev-router-test
 
@@ -38,7 +41,7 @@ mkcert -install
 docker run -t --rm  -v "$(mkcert -CAROOT):/mnt/mkcert" -v ddev-global-cache:/mnt/ddev-global-cache busybox sh -c "mkdir -p /mnt/ddev-global-cache/mkcert && chmod -R ugo+w /mnt/ddev-global-cache/* && cp -R /mnt/mkcert /mnt/ddev-global-cache"
 
 # Run the router alone
-docker run --rm --name $CONTAINER_NAME -p 8080:80 -p 8443:443 -v //var/run/docker.sock:/tmp/docker.sock:ro -v ddev-global-cache:/mnt/ddev-global-cache --name ddev-router-test -d $DOCKER_IMAGE
+docker run --rm --name $CONTAINER_NAME -p 8080:80 -p 8443:443 --mount "type=bind,src=/var/run/docker.sock,target=/tmp/docker.sock" -v ddev-global-cache:/mnt/ddev-global-cache --name ddev-router-test -d $DOCKER_IMAGE
 
 CONTAINER_NAME=ddev-router-test
 

--- a/containers/ddev-router/test/containertest.sh
+++ b/containers/ddev-router/test/containertest.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -x
 
 # As of Docker 2.3.0.2 May 2020, the mount of /var/run/docker.sock doesn't seem to be possible any more.
-if [ "$OS" = "Windows_NT" ]; then exit; fi
+if [ "${OS:-$(uname)}" = "Windows_NT" ]; then exit; fi
 
 DOCKER_IMAGE=$(awk '{print $1}' .docker_image)
 CONTAINER_NAME=ddev-router-test

--- a/containers/ddev-webserver/test/containertest.sh
+++ b/containers/ddev-webserver/test/containertest.sh
@@ -162,11 +162,11 @@ for project_type in drupal6 drupal7 drupal8 drupal9 typo3 backdrop wordpress def
 done
 
 echo "--- testing use of custom nginx and php configs"
-docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DOCROOT=potato" -e "DDEV_PHP_VERSION=7.3" -v "/$PWD/test/testdata:/mnt/ddev_config:ro" -v ddev-global-cache:/mnt/ddev-global-cache -d --name $CONTAINER_NAME -d $DOCKER_IMAGE
+docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DOCROOT=potato" -e "DDEV_PHP_VERSION=7.3" --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache -d --name $CONTAINER_NAME -d $DOCKER_IMAGE
 if ! containercheck; then
     exit 109
 fi
-docker exec -t $CONTAINER_NAME grep "docroot is /var/www/html/potato in custom conf" //etc/nginx/sites-enabled/nginx-site.conf
+docker exec -t $CONTAINER_NAME bash -c 'grep "docroot is /var/www/html/potato in custom conf" /etc/nginx/sites-enabled/nginx-site.conf'
 
 # Verify that the custom php configuration in ddev_config/php is activated.
 echo "--- Verify that /mnt/ddev_config is mounted and we have php overrides there."


### PR DESCRIPTION
## The Problem/Issue/Bug:

Docker Desktop for Windows 2.3.0.1+ stopped accepting the classic path workaround //c/...

This meant that git-bash and all its friends would rewrite /c to C:\Program...

Which meant that nothing worked. 

Work around all this mess in a new way.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

