### PR TITLE
Panic: Handle numeric 3rd party service use of HTTP_EXPOSE or HTTPS_EXPOSE, fixes #2266

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -278,7 +278,8 @@ func (app *DdevApp) Describe() (map[string]interface{}, error) {
 					// Extract HTTP_EXPOSE and HTTPS_EXPOSE for additional info
 					for envName, envVal := range env {
 						if envName == "HTTP_EXPOSE" || envName == "HTTPS_EXPOSE" {
-							portSpecs := strings.Split(envVal.(string), ",")
+							envValStr := fmt.Sprintf("%s", envVal)
+							portSpecs := strings.Split(envValStr, ",")
 							// There might be more than one exposed UI port, but this only handles the first listed,
 							// most often there's only one.
 							if len(portSpecs) > 0 {


### PR DESCRIPTION
## The Problem/Issue/Bug:

It is possible to use a numeric value for HTTP_EXPOSE or HTTPS_EXPOSE environment variables in a 3rd-party service. 

The code assumes that it will be a string, and crashes with 
```
panic: interface conversion: interface {} is int, not string
goroutine 1 [running]:
github.com/drud/ddev/pkg/ddevapp.(*DdevApp).Describe(0xc00013adc0, 0xc0001c86c0, 0x8, 0x8)
        /workdir/pkg/ddevapp/ddevapp.go:270 +0x31a4
github.com/drud/ddev/cmd/ddev/cmd.glob..func25(0x219d1c0, 0x21d7d90, 0x0, 0x0)
        /workdir/cmd/ddev/cmd/list.go:41 +0x268
github.com/spf13/cobra.(*Command).execute(0x219d1c0, 0x21d7d90, 0x0, 0x0, 0x219d1c0, 0x21d7d90)
        /workdir/vendor/github.com/spf13/cobra/command.go:830 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0x219e340, 0x0, 0x0, 0x0)
        /workdir/vendor/github.com/spf13/cobra/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
        /workdir/vendor/github.com/spf13/cobra/command.go:864
github.com/drud/ddev/cmd/ddev/cmd.Execute()
        /workdir/cmd/ddev/cmd/root.go:140 +0x3c
main.main()
        /workdir/cmd/ddev/main.go:8 +0x20
```

This was reported in TYPO3 slack by Elias Häußler, thanks!, https://typo3.slack.com/archives/C8TRNQ601/p1589356915138500

The docker-compose.selenium.yaml that caused this problem is posted at https://gist.github.com/eliashaeussler/df4d277a6c390094436ce2e34783fc3f

## How this PR Solves The Problem:

Make sure the environment variable value is a string before using it.

## Manual Testing Instructions:

* Install the [docker-compose.selenium.yaml](https://gist.github.com/eliashaeussler/df4d277a6c390094436ce2e34783fc3f) above
* `ddev start`
* `ddev describe` should work correctly
* `ddev list` should behave correctly

## Workaround for affected users

Just change the affected HTTP_EXPOSE line to 
```
- HTTP_EXPOSE=4444
```
for example, instead of `- HTTP_EXPOSE: 4444`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

