### PR TITLE
`make staticrequired` shouldn't require all kinds of local installs, fixes #2253

### DIFF
--- a/.githooks/pre-push.allchecks
+++ b/.githooks/pre-push.allchecks
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-# markdownlint
-markdownlint -o /tmp/mdlint.out *.md docs
-if [ "$?" != "0" ]; then
-    echo "Markdownlint failed on these files:"
-    awk -F: '{ print $1 }' < "/tmp/mdlint.out" | sort -u
-    exit 1
-fi
-set -o errexit
-
 # Look for uncommitted files, http://stackoverflow.com/a/2659808/215713
 git diff-index --quiet HEAD || (echo "There are uncommitted files" && exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,13 @@ packr2:
 staticrequired: setup golangci-lint markdownlint mkdocs
 
 markdownlint:
-	markdownlint *.md docs >/dev/null
+	@echo "markdownlint: "
+	@$(DOCKERTESTCMD) \
+		bash -c "markdownlint *.md docs >/dev/null 2>&1"
 mkdocs:
-	mkdocs build -d /tmp/mkdocsbuild >/dev/null 2>&1
+	@echo "mkdocs: "
+	@$(DOCKERTESTCMD) \
+		bash -c "mkdocs build -d /tmp/mkdocsbuld >/dev/null 2>&1"
 
 darwin_signed: darwin
 	@if [ -z "$(DDEV_MACOS_SIGNING_PASSWORD)" ] ; then echo "Skipping signing ddev for macOS, no DDEV_MACOS_SIGNING_PASSWORD provided"; else echo "Signing macOS ddev..."; \

--- a/build-tools/build_update.sh
+++ b/build-tools/build_update.sh
@@ -4,11 +4,14 @@
 
 set -e
 
-base_url=$(curl -s -I https://github.com/drud/build-tools/releases/latest | awk '/^Location/ {gsub(/[\n\r]/,"",$2);  printf "%s", $2}')
-tag=${base_url##*/}
+LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/drud/build-tools/releases/latest)
+# The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
+LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+URL="https://github.com/drud/build-tools/releases/download/$LATEST_VERSION"
+tag=${LATEST_VERSION}
 
 tarball_url="https://github.com/drud/build-tools/archive/$tag.tar.gz"
-internal_name=build-tools-$tag
+internal_name=build-tools-${tag#v}
 local_file=/tmp/$internal_name.tgz
 
 # If there is a current build-tools, get permission and remove

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -35,7 +35,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.14.0
+BUILD_IMAGE ?= drud/golang-build-container:v1.14.2
 
 BUILD_BASE_DIR ?= $(PWD)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2253 points out that `make staticrequired` requires lots of workstation-installed software, and it shouldn't be like that. 

## How this PR Solves The Problem:

* Update golang via build-tools and golang-build-container
* mkdocs and markdownlint-cli are now in the golang-build-container
* Change the githooks and `make staticrequired` to just use `make staticrequired` 

## Manual Testing Instructions:

`make staticrequired` - no local installs required beyond go and docker.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

