### PR TITLE
Update version of mkcert, specified in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOLANGCI_LINT_ARGS ?= --out-format=line-number --disable-all --enable=gofmt --en
 WINDOWS_SUDO_VERSION=v0.0.1
 WINNFSD_VERSION=2.4.0
 NSSM_VERSION=2.24-101-g897c7ad
-MKCERT_VERSION=v1.3.0
+MKCERT_VERSION=v1.4.1
 
 GOTESTSUM_FORMAT ?= short-verbose
 TESTTMP=/tmp/testresults


### PR DESCRIPTION
## The Problem/Issue/Bug:

The Windows installer was providing version 1.3 of mkcert; this shouldn't really cause trouble, but 1.4.1 is current, and it has the --version command, which helps in so many ways.

## How this PR Solves The Problem:

Bump the version.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

