### PR TITLE
Add composer bin directory to PATH in ddev-webserver

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -25,6 +25,9 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_CACHE_DIR /mnt/ddev-global-cache/composer
 # Windows, especially Win10 Home/Docker toolbox, can take forever on composer build.
 ENV COMPOSER_PROCESS_TIMEOUT 2000
+# add composer bin dir to PATH
+ENV COMPOSER_BIN_DIR $WEBSERVER_DOCROOT/vendor/bin
+ENV PATH "$COMPOSER_BIN_DIR:$PATH"
 
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
 
@@ -54,7 +57,7 @@ RUN set -o errexit && apt-get -qq update && \
         gnupg \
         jq \
         locales-all \
-		lsb-release && \
+        lsb-release && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add - && \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -39,6 +39,11 @@ ENV DDEV_LIVE_DOWNLOAD_URL https://downloads.ddev.com/ddev-live-cli/latest/linux
 ENV DDEV_LIVE_CONFIG_FILE_PATH /mnt/ddev-global-cache/ddev-live/cli-config.json
 ENV DDEV_LIVE_NO_VERSION_PROMPT true
 
+# From "man bash":
+#    When bash is started non-interactively, to run a shell script, for example,
+#    it looks for the variable BASH_ENV in the environment, expands its value
+#    if it appears there, and uses the expanded value as the name of a file to read and execute.
+ENV BASH_ENV /etc/bash.nointeractive.bashrc
 
 RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime && dpkg-reconfigure --frontend noninteractive tzdata
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -25,9 +25,6 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_CACHE_DIR /mnt/ddev-global-cache/composer
 # Windows, especially Win10 Home/Docker toolbox, can take forever on composer build.
 ENV COMPOSER_PROCESS_TIMEOUT 2000
-# add composer bin dir to PATH
-ENV COMPOSER_BIN_DIR $WEBSERVER_DOCROOT/vendor/bin
-ENV PATH "$COMPOSER_BIN_DIR:$PATH"
 
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
 
@@ -41,6 +38,7 @@ ENV CAROOT /mnt/ddev-global-cache/mkcert
 ENV DDEV_LIVE_DOWNLOAD_URL https://downloads.ddev.com/ddev-live-cli/latest/linux/ddev-live.zip
 ENV DDEV_LIVE_CONFIG_FILE_PATH /mnt/ddev-global-cache/ddev-live/cli-config.json
 ENV DDEV_LIVE_NO_VERSION_PROMPT true
+
 
 RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime && dpkg-reconfigure --frontend noninteractive tzdata
 
@@ -57,7 +55,7 @@ RUN set -o errexit && apt-get -qq update && \
         gnupg \
         jq \
         locales-all \
-        lsb-release && \
+		lsb-release && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add - && \

--- a/containers/ddev-webserver/files/etc/bash.nointeractive.bashrc
+++ b/containers/ddev-webserver/files/etc/bash.nointeractive.bashrc
@@ -1,0 +1,2 @@
+# This file is loaded in non-interactive bash shells through $BASH_ENV
+source /etc/bashrc/*.bashrc

--- a/containers/ddev-webserver/files/etc/bashrc/composer-bin-dir-in-path.bashrc
+++ b/containers/ddev-webserver/files/etc/bashrc/composer-bin-dir-in-path.bashrc
@@ -1,0 +1,9 @@
+# Extends PATH to include the composer bin directory.
+
+# set COMPOSER_BIN_DIR to $WEBSERVER_DOCROOT/vendor/bin if unset
+if [[ ! -v $COMPOSER_BIN_DIR ]]; then
+    export COMPOSER_BIN_DIR="$WEBSERVER_DOCROOT/vendor/bin"
+fi
+
+# add composer bin dir to PATH
+export PATH="$PATH:$COMPOSER_BIN_DIR"

--- a/containers/ddev-webserver/files/etc/skel/.bashrc
+++ b/containers/ddev-webserver/files/etc/skel/.bashrc
@@ -111,3 +111,11 @@ if ! shopt -oq posix; then
     . /etc/bash_completion
   fi
 fi
+
+# set COMPOSER_BIN_DIR to $WEBSERVER_DOCROOT/vendor/bin if unset
+if [[ ! -v $COMPOSER_BIN_DIR ]]; then
+    export COMPOSER_BIN_DIR="$WEBSERVER_DOCROOT/vendor/bin"
+fi
+
+# add composer bin dir to PATH
+export PATH="$COMPOSER_BIN_DIR:$PATH"

--- a/containers/ddev-webserver/files/etc/skel/.bashrc
+++ b/containers/ddev-webserver/files/etc/skel/.bashrc
@@ -112,10 +112,4 @@ if ! shopt -oq posix; then
   fi
 fi
 
-# set COMPOSER_BIN_DIR to $WEBSERVER_DOCROOT/vendor/bin if unset
-if [[ ! -v $COMPOSER_BIN_DIR ]]; then
-    export COMPOSER_BIN_DIR="$WEBSERVER_DOCROOT/vendor/bin"
-fi
-
-# add composer bin dir to PATH
-export PATH="$COMPOSER_BIN_DIR:$PATH"
+source /etc/bashrc/*.bashrc

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -977,7 +977,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, opts.Service) {
 		shell = "sh"
 	}
-	exec = append(exec, shell, "-ic", opts.Cmd)
+	exec = append(exec, shell, "-c", opts.Cmd)
 
 	files, err := app.ComposeFiles()
 	if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -977,7 +977,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, opts.Service) {
 		shell = "sh"
 	}
-	exec = append(exec, shell, "-ci", opts.Cmd)
+	exec = append(exec, shell, "-ic", opts.Cmd)
 
 	files, err := app.ComposeFiles()
 	if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -977,7 +977,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, opts.Service) {
 		shell = "sh"
 	}
-	exec = append(exec, shell, "-c", opts.Cmd)
+	exec = append(exec, shell, "-ci", opts.Cmd)
 
 	files, err := app.ComposeFiles()
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200518_add_ddev_live" // Note that this can be overridden by make
+var WebTag = "20200527_atomicptr_composer_bin_path" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Most ddev projects probably use composer and many will have tools installed with composer. Sadly right now in order to execute them you have to do something like this:

```bash
$ ddev exec ./vendor/bin/tool --parameter
```

## How this PR Solves The Problem:

By adding the vendor/bin directory to the container PATH you can access the script directly

```bash
$ ddev exec tool --parameter
```

## Manual Testing Instructions:

Steps to test if this works (assuming you're using a built of ddev/containers from my PR)

```bash
$ mkdir test-this-change
$ cd test-this-change
$ composer req typo3/minimal helhum/typo3-console
# ... wait a moment
$ ddev config
# all the defaults
# now you'd need to add the modified container to .ddev/config.yml
# webimage: local-build-of-ddev-webserver
$ ddev start
# ... wait a moment
$ ddev exec typo3cms cache:flush
Flushed all file caches.
```

I couldn't think of a better example :).

## Release/Deployment notes:

This won't affect non composer projects at all, because directories that don't exist don't cause any issues when inside the PATH variable. If for some reason the composer bin directory is somewhere else you can apply that to the project by adding an environment variable COMPOSER_BIN_DIR ( which is also an option in composer https://getcomposer.org/doc/articles/vendor-binaries.md#can-vendor-binaries-be-installed-somewhere-other-than-vendor-bin- ) to the ddev configuration.

