### PR TITLE
Skip tests that are too difficult for Windows Docker (tests only)

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/stretchr/testify/require"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -219,6 +220,11 @@ func unmarshalJSONLogs(in string) ([]log.Fields, error) {
 func TestCmdDescribeMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping because unreliable on Windows")
+	}
+
 	assert := asrt.New(t)
 
 	projDir, _ := os.Getwd()

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/stretchr/testify/require"
 	"os"
+	"runtime"
 	"testing"
 
 	"path/filepath"
@@ -64,6 +65,11 @@ func TestCmdPauseContainers(t *testing.T) {
 func TestCmdPauseContainersMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping because unreliable on Windows")
+	}
+
 	assert := asrt.New(t)
 
 	projDir, _ := os.Getwd()

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/stretchr/testify/require"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"os"
@@ -62,6 +63,11 @@ func TestCmdStart(t *testing.T) {
 func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping because unreliable on Windows")
+	}
+
 	assert := asrt.New(t)
 
 	projDir, _ := os.Getwd()

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -65,6 +65,11 @@ func TestCmdStop(t *testing.T) {
 func TestCmdStopMissingProjectDirectory(t *testing.T) {
 	var err error
 	var out string
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping because unreliable on Windows")
+	}
+
 	assert := asrt.New(t)
 	projDir, _ := os.Getwd()
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1948,6 +1948,10 @@ func TestDdevPause(t *testing.T) {
 
 // TestDdevStopMissingDirectory tests that the 'ddev stop' command works properly on sites with missing directories or ddev configs.
 func TestDdevStopMissingDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping because unreliable on Windows")
+	}
+
 	assert := asrt.New(t)
 
 	site := TestSites[0]
@@ -2050,6 +2054,10 @@ func TestDdevDescribe(t *testing.T) {
 
 // TestDdevDescribeMissingDirectory tests that the describe command works properly on sites with missing directories or ddev configs.
 func TestDdevDescribeMissingDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping because unreliable on Windows")
+	}
+
 	assert := asrt.New(t)
 	site := TestSites[0]
 	tempPath := testcommon.CreateTmpDir("site-copy")
@@ -2266,6 +2274,9 @@ func TestRouterNotRunning(t *testing.T) {
 // TestListWithoutDir prevents regression where ddev list panics if one of the
 // sites found is missing a directory
 func TestListWithoutDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping because unreliable on Windows")
+	}
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 	testcommon.ClearDockerEnv()


### PR DESCRIPTION
## The Problem/Issue/Bug:

Due to apparent problems with cache flushing on Docker Desktop For Windows, we have some tests are intermittently fail there.

The Docker for Windows issue is https://github.com/docker/for-win/issues/6512 (probably). 

Basically, even though a container with a bind mount gets shut down, it does not give up control of the host-side directory, causing these tests to fail. Probably a longer sleep would make it work, but it's hard to tell how much longer.  

## How this PR Solves The Problem:

Skip these tests on Windows. There's nothing particularly valuable in executing these on Windows I don't think.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

