### PR TITLE
fix(nginx): Fix rewrite location for Drupal 7 to make subfolder setups work

### DIFF
--- a/containers/ddev-webserver/files/etc/nginx/nginx_drupal7.conf
+++ b/containers/ddev-webserver/files/etc/nginx/nginx_drupal7.conf
@@ -18,8 +18,8 @@
 
     location @rewrite {
         # For D7 and above:
-        # Clean URLs are handled in drupal_environment_initialize().
-        rewrite ^ /index.php;
+        # Directly rewrite to $_GET['q'] so that subfolder setup rewrites work as well.
+        rewrite ^ /index.php?q=$uri&$args;
     }
 
     # Handle image styles for Drupal 7+

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200518_add_ddev_live" // Note that this can be overridden by make
+var WebTag = "20200527_klausi_drupal7_subfolder" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
The `@rewrite` location does not forward requests correctly to Drupal if it is configured to run in a subfolder. We should just use the same rewrite line as we do in the `/` location, then everything works in both normal and subfolder setups.