### PR TITLE
Increase the upload limit for PHPMyAdmin

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -312,6 +312,8 @@ ddev import-db --src=dumpfile.sql.gz
 
 ```
 
+It is also possible to use PHPMyAdmin for database imports, but that approach is much slower. Also, the web and db containers container the `mysql` client, which can be used for imports, and the `ddev mysql` command can be used in the same way you might use `mysql` on a server.
+
 **Note for Backdrop users:** In addition to importing a Backdrop database, you will need to extract a copy of your Backdrop project's configuration into the local `active` directory. The location for this directory can vary depending on the contents of your Backdrop `settings.php` file, but the default location is `[docroot]/files/config_[random letters and numbers]/active`. Please refer to the Backdrop documentation for more information on [moving your Backdrop site](https://backdropcms.org/user-guide/moving-backdrop-site) into the `ddev` environment.
 
 ## Getting Started

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -152,6 +152,7 @@ services:
       - PMA_USER=db
       - PMA_PASSWORD=db
       - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - UPLOAD_LIMIT=1024M
       - TZ={{ .Timezone }}
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       - HTTP_EXPOSE=${DDEV_PHPMYADMIN_PORT}:{{ .DBAPort }}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Javierv pointed out in [TYPO3 slack](https://typo3.slack.com/archives/C8TRNQ601/p1589667761211100) that the upload size of a database in PHPMyAdmin was limited to 2MB, mighty small. 

## How this PR Solves The Problem:

Increase the max upload to 1024MB. With PHPMyAdmin a database this large will *time* out, but the other limits won't prevent success. 

## Manual Testing Instructions:

Upload a large database using PHPMyAdmin

<img width="685" alt="satirtraining_ddev_site_8037___db___db___phpMyAdmin_5_0_2" src="https://user-images.githubusercontent.com/112444/82340190-2b69cc80-99ac-11ea-8dd1-f18f117c2f7c.png">


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

