### PR TITLE
Update link to Docker Desktop

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 ## System Requirements
 
-* [Docker](https://www.docker.com/community-edition) version 18.06 or higher. Linux users make sure you upgrade docker-compose and do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
+* [Docker](https://www.docker.com/products/docker-desktop) version 18.06 or higher. Linux users make sure you upgrade docker-compose and do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
 
 * docker-compose 1.21.0 and higher (bundled with Docker in Docker Desktop for Mac and Docker Desktop for Windows)
 * OS Support


### PR DESCRIPTION
## The Problem/Issue/Bug:
The link to Docker in the intro to the DDEV-Local docs no longer linked users to the appropriate tool
## How this PR Solves The Problem:
Updated the link to point to Docker desktop.
## Manual Testing Instructions:
Click the link for Docker at the top of system requirements. Should result in the Docker Desktop download side.
## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Nope, just docs.

