### PR TITLE
Improve error message when ddev auth pantheon has not been run, fixes #2241

### DIFF
--- a/pkg/ddevapp/providerPantheon.go
+++ b/pkg/ddevapp/providerPantheon.go
@@ -276,7 +276,7 @@ func (p *PantheonProvider) GetEnvironments() ([]string, error) {
 	_, envs, err := dockerutil.RunSimpleContainer(version.GetWebImage(), "", []string{"bash", "-c", cmd}, nil, []string{"HOME=/tmp"}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, uid, true)
 
 	if err != nil {
-		return []string{}, fmt.Errorf("unable to get Pantheon environments for project %s - does the ddev project name match the pantheon project name? ('%v' failed)", p.Sitename, cmd)
+		return []string{}, fmt.Errorf("unable to get Pantheon environments for project %s - Have you authenticated with `ddev auth pantheon`? Does the ddev project name match the pantheon project name? ('%v' failed)", p.Sitename, cmd)
 	}
 
 	envs = strings.Trim(envs, "\n\r ")


### PR DESCRIPTION
# The Problem/Issue/Bug:

#2241 points out the common problem that if people haven't done a `ddev auth pantheon` then they get a cryptic message on `ddev config pantheon` and `ddev pull` that doesn't say "hey, do a `ddev auth pantheon`"

## How this PR Solves The Problem:

Improves that message to "unable to get Pantheon environments for project %s - Have you authenticated with `ddev auth pantheon`? Does the ddev project name match the pantheon project name?"

## Manual Testing Instructions:

Start a pantheon project without doing a `ddev auth pantheon`. If you need to kill off the existing authentication, `ddev exec rm -r /mnt/ddev-global-cache/terminus/cache/*`

`ddev config pantheon` and see the error message.
`ddev auth pantheon` and then try `ddev config pantheon` again to see it work.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

