### PR TITLE
Set provider in app after config read, fixes #2243

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -103,17 +103,6 @@ func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	}
 	app.SetApptypeSettingsPaths()
 
-	// Allow override with provider.
-	// Otherwise we accept whatever might have been in config file if there was anything.
-	if provider == "" && app.Provider != "" {
-		// Do nothing. This is the case where the config has a provider and no override is provided. Config wins.
-	} else if provider == nodeps.ProviderPantheon || provider == nodeps.ProviderDrudS3 || provider == nodeps.ProviderDefault {
-		app.Provider = provider // Use the provider passed-in. Function argument wins.
-	} else if provider == "" && app.Provider == "" {
-		app.Provider = nodeps.ProviderDefault // Nothing passed in, nothing configured. Set c.Provider to default
-	} else {
-		return app, fmt.Errorf("provider '%s' is not implemented", provider)
-	}
 	app.SetInstrumentationAppTags()
 
 	// Rendered yaml is not there until after ddev config or ddev start
@@ -133,6 +122,17 @@ func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, e
 		}
 	}
 
+	// Allow override with provider.
+	// Otherwise we accept whatever might have been in config file if there was anything.
+	if provider == "" && app.Provider != "" {
+		// Do nothing. This is the case where the config has a provider and no override is provided. Config wins.
+	} else if provider == nodeps.ProviderPantheon || provider == nodeps.ProviderDrudS3 || provider == nodeps.ProviderDefault {
+		app.Provider = provider // Use the provider passed-in. Function argument wins.
+	} else if provider == "" && app.Provider == "" {
+		app.Provider = nodeps.ProviderDefault // Nothing passed in, nothing configured. Set c.Provider to default
+	} else {
+		return app, fmt.Errorf("provider '%s' is not implemented", provider)
+	}
 	return app, nil
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2243 pointed out that if a project is already configured with "default" provider, you can't do a `ddev config pantheon`.

## How this PR Solves The Problem:

Set the provider after reading the config.

## Manual Testing Instructions:

In a pantheon project, `ddev config` (to get default provider)
Then try `ddev config pantheon`. It should work

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

