### PR TITLE
Adds ddev-live as a default custom command

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/commands/web/live
+++ b/cmd/ddev/cmd/dotddev_assets/commands/web/live
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Run ddev-live inside the web container
+## Usage: live [flags] [args]
+## Example: "ddev live auth" or "ddev live list sites" or "ddev live --version"
+
+ddev-live $@


### PR DESCRIPTION
## The Problem/Issue/Bug:
Now that the ddev-live tool is in the web container we should ship a default custom command for `live`

## How this PR Solves The Problem:
* introduces `live` command resulting in commands `ddev live` 

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

