### PR TITLE
Make sure that Exec() runs commands with bash error checking, especially pipefail

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -977,7 +977,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, opts.Service) {
 		shell = "sh"
 	}
-	exec = append(exec, shell, "-c", "set -eu -o pipefail; "+opts.Cmd)
+	exec = append(exec, shell, "-c", "set -eu -o pipefail && ( "+opts.Cmd+")")
 
 	files, err := app.ComposeFiles()
 	if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -977,7 +977,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, opts.Service) {
 		shell = "sh"
 	}
-	exec = append(exec, shell, "-c", opts.Cmd)
+	exec = append(exec, shell, "-c", "set -eu -o pipefail; "+opts.Cmd)
 
 	files, err := app.ComposeFiles()
 	if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

@edysmp pointed out in https://github.com/drud/ddev/issues/2278#issuecomment-636215134 that `ddev import-db` was failing in the tested Mutagen edge version of Docker, but reporting success. 

The reason this was happening was that in app.Exec bash was being invoked without the `pipefail` option, so a failure in the pipe wasn't caught, and the ddev import-db uses a pipe with pv. 

## How this PR Solves The Problem:

Make sure that `set -o pipefail` is set

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

This change needs to be mentioned in release notes, as some people might be counting on failures not being reported.
