### PR TITLE
Apache2 config: Enforce file types matching at end of filename only

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/apache2.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/apache2.conf
@@ -185,24 +185,6 @@ AccessFileName .htaccess
 </FilesMatch>
 
 
-# Security: Enforce file types matching at end of filename only
-# see https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/Security/GuidelinesAdministrators/Index.html#file-extension-handling
-# see https://httpd.apache.org/docs/2.4/mod/mod_mime.html#multipleext
-<IfModule mod_mime.c>
-	RemoveType .html .htm
-	<FilesMatch ".+\.html?$">
-		AddType text/html .html
-		AddType text/html .htm
-	</FilesMatch>
-
-	RemoveType .svg .svgz
-	<FilesMatch ".+\.svgz?$">
-		AddType image/svg+xml .svg
-		AddType image/svg+xml .svgz
-	</FilesMatch>
-</IfModule>
-
-
 #
 # The following directives define some format nicknames for use with
 # a CustomLog directive.
@@ -230,6 +212,23 @@ PassEnv IS_DDEV_PROJECT DDEV_PHP_VERSION DDEV_PROJECT_TYPE DDEV_ROUTER_HTTPS_POR
 
 # Include generic snippets of statements
 IncludeOptional conf-enabled/*.conf
+
+# Security: Enforce file types matching at end of filename only
+# see https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/Security/GuidelinesAdministrators/Index.html#file-extension-handling
+# see https://httpd.apache.org/docs/2.4/mod/mod_mime.html#multipleext
+<IfModule mod_mime.c>
+	RemoveType .html .htm
+	<FilesMatch ".+\.html?$">
+		AddType text/html .html
+		AddType text/html .htm
+	</FilesMatch>
+
+	RemoveType .svg .svgz
+	<FilesMatch ".+\.svgz?$">
+		AddType image/svg+xml .svg
+		AddType image/svg+xml .svgz
+	</FilesMatch>
+</IfModule>
 
 # Include the virtual host configurations:
 IncludeOptional sites-enabled/*.conf

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/apache2.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/apache2.conf
@@ -185,6 +185,24 @@ AccessFileName .htaccess
 </FilesMatch>
 
 
+# Security: Enforce file types matching at end of filename only
+# see https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/Security/GuidelinesAdministrators/Index.html#file-extension-handling
+# see https://httpd.apache.org/docs/2.4/mod/mod_mime.html#multipleext
+<IfModule mod_mime.c>
+	RemoveType .html .htm
+	<FilesMatch ".+\.html?$">
+		AddType text/html .html
+		AddType text/html .htm
+	</FilesMatch>
+
+	RemoveType .svg .svgz
+	<FilesMatch ".+\.svgz?$">
+		AddType image/svg+xml .svg
+		AddType image/svg+xml .svgz
+	</FilesMatch>
+</IfModule>
+
+
 #
 # The following directives define some format nicknames for use with
 # a CustomLog directive.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200601_inherit_php_from_ddev_images" // Note that this can be overridden by make
+var WebTag = "20200606_gilbertsoft_harden_apache" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
see https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/Security/GuidelinesAdministrators/Index.html#file-extension-handling
see https://httpd.apache.org/docs/2.4/mod/mod_mime.html#multipleext
