### PR TITLE
Add support for XDEBUG_HOST_IP to override all other ways of figuring it out

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -705,6 +705,11 @@ func CreateVolume(volumeName string, driver string, driverOpts map[string]string
 func GetHostDockerInternalIP() (string, error) {
 	hostDockerInternal := ""
 
+	// Allow user to override the host.docker.internal, for example PHPStorm running on Windows host
+	xdebugHostIP := os.Getenv("XDEBUG_HOST_IP")
+	if xdebugHostIP != "" {
+		return xdebugHostIP, nil
+	}
 	// Docker 18.09 on linux and docker-toolbox don't define host.docker.internal
 	// so we need to go get the ip address of docker0
 	// We would hope to be able to remove this when


### PR DESCRIPTION
## The Problem/Issue/Bug:

There are times (like running PHPStorm on the Windows host but using ddev inside WSL2 environment) when it's useful to override host.docker.internal, the *normal* way you figure out where the xdebug-listening IDE may be.

This adds support for an environment variable that ddev will respect, XDEBUG_HOST_IP.

It should be set with `export XDEBUG_HOST_IP=<ip addr>`. On WSL2 with PHPStorm on the host, `export XDEBUG_HOST_IP=$(awk '/^nameserver/ {print $2; exit;}' </etc/resolv.conf)` will normally do the job

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

