### PR TITLE
Image maintenance and deprecation warnings, for #2284 and #2286

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,9 +3,10 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod (for DDEV-Live)
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v0.3 as ddev-webserver-base
+FROM drud/ddev-php-base:v0.3.1 as ddev-webserver-base
+
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4"
-ENV BACKDROP_DRUSH_VERSION=1.3.1
+ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.1
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -40,13 +41,13 @@ ADD ddev-webserver-base-scripts /
 ### ---------------------------ddev-webserver-prod--------------------------------------
 ### Build ddev-webserver-prod, the hardened version of ddev-webserver-base
 ### (Withut dev features, single layer)
-FROM scratch as ddev-webserver-prod
-ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
-ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
-ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
-ENV DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
-
-COPY --from=ddev-webserver-base / /
+#FROM scratch as ddev-webserver-prod
+#ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
+#ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
+#ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
+#ENV DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
+#
+#COPY --from=ddev-webserver-base / /
 # END ddev-webserver-prod
 
 ### ---------------------------ddev-webserver-dev-base--------------------------------------
@@ -97,7 +98,7 @@ RUN curl -sSL https://raw.githubusercontent.com/netz98/n98-magerun2/${MAGERUN2_V
 
 RUN curl -sSL "https://drupalconsole.com/installer" -L -o /usr/local/bin/drupal && chmod +x /usr/local/bin/drupal
 
-RUN curl -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/drush.zip -o /tmp/backdrop_drush.zip && unzip -o /tmp/backdrop_drush.zip -d /var/tmp/backdrop_drush_commands
+RUN curl -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands
 
 RUN mkdir -p /etc/nginx/sites-enabled /var/log/apache2 /var/run/apache2 /var/lib/apache2/module/enabled_by_admin /var/lib/apache2/module/disabled_by_admin && \
     touch /var/log/php-fpm.log && \

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -32,9 +32,9 @@ VERSION := $(shell git describe --tags --always --dirty)
 # include. That way the base components can easily be updated as our general needs
 # change.
 #include ../build-tools/makefile_components/base_build_go.mak
-include ../../build-tools/makefile_components/base_build_python-docker.mak
+#include ../../build-tools/makefile_components/base_build_python-docker.mak
 include ../../build-tools/makefile_components/base_container.mak
-include ../../build-tools/makefile_components/base_push.mak
+#include ../../build-tools/makefile_components/base_push.mak
 #include build-tools/makefile_components/base_test_go.mak
 #include build-tools/makefile_components/base_test_python.mak
 

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -51,7 +51,7 @@ push: images
 		echo "pushed $(DOCKER_ORG)/$$item"; \
 	done
 
-ddev-webserver d:
+ddev-webserver:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 test: images

--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -14,7 +14,7 @@ __Please note that you *must* share your local drives in the "settings" after in
 
 ## Windows Installation: Docker Toolbox
 
-Docker Toolbox is only recommended for systems that absolutely won't run Docker Desktop for Windows (Windows 10 Home, etc.)
+Docker Toolbox support is deprecated and support will be removed in the next DDEV-Local support cycle. Please use Docker Desktop, which now runs fine on Windows 10 Home.
 
 [Download and install docker toolbox](https://download.docker.com/win/stable/DockerToolbox.exe).
 

--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -21,7 +21,7 @@ the .ddev/config.yaml is the primary configuration for the project.
 | router_http_port | Port used by the router for http |  Defaults to port 80. This can be changed if there is a conflict on the host over port 80 |
 | router_https_port | Port used by the router for https |Defaults to 443, usually only changed if there is a conflicting process using port 443 |
 | xdebug_enabled | "true" enables xdebug | Most people use `ddev xdebug` and `ddev xdebug off` instead of configuring this, because xdebug has a significant performance impact. |
-| webserver_type | nginx-fpm or apache-fpm or apache-cgi | The default is nginx-fpm, and it works best for many projects |
+| webserver_type | nginx-fpm or apache-fpm or apache-cgi | The default is nginx-fpm, and it works best for many projects. apache-cgi is deprecated and will be removed in the next release cycle. |
 | timezone | timezone to use in container and in PHP configuration | It can be set to any valid timezone, see [timezone list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). For example "Europe/Dublin" or "MST7MDT". The default is UTC. |
 | additional_hostnames | array of extra hostnames | `additional_hostnames: ["somename", "someothername"]` would provide http and https URLs for "somename.ddev.site" and "someothername.ddev.site". |
 | additional_fqdns | extra fully-qualified domain names | `additional_fqdns: ["example.com", "sub1.example.com"]` would provide http and https URLs for "example.com" and "sub1.example.com". Please take care with this because it can cause great confusion and adds extraneous items to your /etc/hosts file. |

--- a/docs/users/extend/custom-commands.md
+++ b/docs/users/extend/custom-commands.md
@@ -74,7 +74,7 @@ A number of environment variables are provided to the script. Useful variables f
 * DDEV_ROUTER_HTTP_PORT: Router port for http
 * DDEV_ROUTER_HTTPS_PORT: Router port for https
 * DDEV_SITENAME: Project name, like "d8composer". Same as $DDEV_PROJECT inside container
-* DDEV_WEBSERVER_TYPE: nginx-fpm, apache-fpm, apache-cgi
+* DDEV_WEBSERVER_TYPE: nginx-fpm, apache-fpm
 
 Useful variables for container scripts are:
 
@@ -85,7 +85,7 @@ Useful variables for container scripts are:
 * DDEV_PROJECT_TYPE: drupal8, typo3, backdrop, wordpress, etc.
 * DDEV_ROUTER_HTTP_PORT: Router port for http
 * DDEV_ROUTER_HTTPS_PORT: Router port for https
-* DDEV_WEBSERVER_TYPE: nginx-fpm, apache-fpm, apache-cgi
+* DDEV_WEBSERVER_TYPE: nginx-fpm, apache-fpm
 
 ### Known Windows OS issues
 

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -12,7 +12,7 @@ The project's `.ddev/config.yaml` file defines the PHP version to use. This can 
 
 ### Changing webserver type
 
-DDEV-Local supports nginx with php-fpm by default ("nginx-fpm"), apache2 with php-fpm ("apache-fpm"), and apache2 with embedded php via cgi (apache-cgi). These can be changed using the "webserver_type" value in .ddev/config.yaml, for example `webserver_type: apache-fpm`.
+DDEV-Local supports nginx with php-fpm by default ("nginx-fpm"), apache2 with php-fpm ("apache-fpm"), and apache2 with embedded php via cgi (apache-cgi). These can be changed using the "webserver_type" value in .ddev/config.yaml, for example `webserver_type: apache-fpm`. Note that `apache-cgi` is deprecated and will be removed in the next release cycle.
 
 ### Adding services to a project
 
@@ -66,7 +66,7 @@ To add an nginx snippet to the default config, add an nginx config file as `.dde
 
 ### Providing custom apache configuration
 
-If you're using `webserver_type: apache-fpm` or `webserver_type: apache-cgi` in your .ddev/config.yaml, you can override the default site configuration by editing or replacing the ddev-provided `.ddev/apache/apache-site.conf` configuration.
+If you're using `webserver_type: apache-fpm` in your .ddev/config.yaml, you can override the default site configuration by editing or replacing the ddev-provided `.ddev/apache/apache-site.conf` configuration.
 
 * Edit the `.ddev/apache/apache-site.conf`.
 * Add your configuration changes.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -627,6 +627,17 @@ func (app *DdevApp) CheckCustomConfig() {
 
 }
 
+// CheckDeprecations warns the user if anything in use is deprecated.
+func (app *DdevApp) CheckDeprecations() {
+
+	if app.WebserverType == nodeps.WebserverApacheCGI {
+		util.Warning("The apache-cgi webserver_type is deprecated and will be removed from the next ddev release. Please use apache-fpm")
+	}
+	if nodeps.IsDockerToolbox() {
+		util.Warning("Docker Toolbox is deprecated and support will be removed from the next ddev release. Please upgrade to latest Windows 10 Home (2004) and migrate to Docker Desktop, which now works great on Windows 10 Home.")
+	}
+}
+
 type composeYAMLVars struct {
 	Name                 string
 	Plugin               string

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -775,8 +775,7 @@ func TestExtraPackages(t *testing.T) {
 
 	// Make sure no "-built" items are still hanging around
 	command := fmt.Sprintf("docker rmi -f %s-%s-built %s-%s-built", app.WebImage, app.Name, app.GetDBImage(), app.Name)
-	_, err = exec.RunCommand("bash", []string{"-c", command})
-	assert.NoError(err)
+	_, _ = exec.RunCommand("bash", []string{"-c", command})
 
 	defer func() {
 		_ = app.Stop(true, false)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -864,6 +864,9 @@ func (app *DdevApp) Start() error {
 	// Warn the user if there is any custom configuration in use.
 	app.CheckCustomConfig()
 
+	// Warn user if there are deprecated items used in the config
+	app.CheckDeprecations()
+
 	caRoot := globalconfig.GetCAROOT()
 	if caRoot == "" {
 		util.Warning("mkcert may not be properly installed, we suggest installing it for trusted https support, `brew install mkcert nss`, `choco install -y mkcert`, etc. and then `mkcert -install`")

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -372,12 +372,11 @@ func TestDdevStart(t *testing.T) {
 	assert.NoError(err)
 
 	// Make sure the -built docker images do not exist after stop with removeData
-	exists, err = dockerutil.ImageExistsLocally(webBuilt)
-	assert.NoError(err)
-	assert.False(exists)
-	exists, err = dockerutil.ImageExistsLocally(dbBuilt)
-	assert.NoError(err)
-	assert.False(exists)
+	for _, imageName := range []string{webBuilt, dbBuilt} {
+		exists, err = dockerutil.ImageExistsLocally(imageName)
+		assert.NoError(err)
+		assert.False(exists, "image %s should not have existed but still exists (while testing %s)", app.Name)
+	}
 
 	runTime()
 	switchDir()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200610_nginx_mount" // Note that this can be overridden by make
+var WebTag = "20200617_image_maintenance" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Minor ddev-webserver image maintenance
* Add deprecation warnings for docker toolbox and apache-cgi

#2284: Deprecate docker-toolbox
#2286: Deprecate apache-cgi

## Manual Testing Instructions:

* Normal testing
- [x] Normal testing
- [x] Try starting on Docker Toolbox machine, should work but with deprecation warning
- [x] Try starting with apache-cgi, should work, but with deprecation warning.


