### PR TITLE
Put zsh completions in correct place in homebrew bottle, fixes #2317

### DIFF
--- a/.circleci/bump_homebrew.sh
+++ b/.circleci/bump_homebrew.sh
@@ -60,6 +60,7 @@ class Ddev < Formula
     end
     bash_completion.install ".gotmp/bin/ddev_bash_completion.sh" => "ddev"
     zsh_completion.install ".gotmp/bin/ddev_zsh_completion.sh" => "ddev"
+    fish_completion.install ".gotmp/bin/ddev_fish_completion.sh" => "ddev"
   end
 
   test do

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -85,9 +85,9 @@ for os in sierra x86_64_linux ; do
     NO_V_VERSION=${VERSION#v}
     rm -rf /tmp/bottle
     BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
-    mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh-completions}
+    mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh/site-functions}
     cp $BASE_DIR/.gotmp/bin/ddev_bash_completion.sh $BOTTLE_BASE/etc/bash_completion.d/ddev
-    cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh-completions/_ddev
+    cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh/site-functions/_ddev
 
     if [ "${os}" = "sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin ; fi
     if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/ddev $BOTTLE_BASE/bin ; fi

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -85,9 +85,10 @@ for os in sierra x86_64_linux ; do
     NO_V_VERSION=${VERSION#v}
     rm -rf /tmp/bottle
     BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
-    mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh/site-functions}
+    mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh/site-functions,share/fish/vendor_completions.d}
     cp $BASE_DIR/.gotmp/bin/ddev_bash_completion.sh $BOTTLE_BASE/etc/bash_completion.d/ddev
     cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh/site-functions/_ddev
+    cp $BASE_DIR/.gotmp/bin/ddev_fish_completion.sh $BOTTLE_BASE/share/fish/vendor_completions.d/ddev.fish
 
     if [ "${os}" = "sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin ; fi
     if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/ddev $BOTTLE_BASE/bin ; fi


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2317: Zsh and fish completions were not being placed properly in the homebrew bottle.

## How this PR Solves The Problem:

Put them in the correct place.

## Manual Testing Instructions:

* `brew uninstall ddev`
* Verify that the zsh completions are gone
* `brew install ddev`
* Verify that zsh and fish completions have been properly added to /usr/local/share/zsh/site-functions and that they work

It should say
```
zsh functions have been installed to:
  /usr/local/share/zsh/site-functions
```

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP #2317 

## Release/Deployment notes:

This needs to be tested after next alpha release
