### PR TITLE
Improve handling of duplicate project in same directory, closes #1933

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -165,6 +165,11 @@ func handleConfigRun(cmd *cobra.Command, args []string) {
 		util.Failed("Please do not use `ddev config` in your home directory")
 	}
 
+	err = app.CheckExistingAppInApproot()
+	if err != nil {
+		util.Failed(err.Error())
+	}
+
 	_, _, err = app.ProcessHooks("pre-config")
 	if err != nil {
 		util.Failed("Failed to process hook 'pre-config'")

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -339,6 +339,12 @@ func TestConfigInvalidProjectname(t *testing.T) {
 		assert.NoError(err)
 		assert.NotContains(out, "is not a valid project name")
 		assert.Contains(out, "You may now run 'ddev start'")
+		args = []string{
+			"stop",
+			"--unlist", projName,
+		}
+		_, _ = exec.RunCommand(DdevBin, args)
+
 		_ = os.Remove(filepath.Join(tmpdir, ".ddev", "config.yaml"))
 	}
 
@@ -444,7 +450,7 @@ func TestConfigMariaDBVersion(t *testing.T) {
 	// it should end up with default mariadb version dbimage
 	_ = os.RemoveAll(filepath.Join(tmpDir, ".ddev"))
 	_ = os.MkdirAll(filepath.Join(tmpDir, ".ddev"), 0777)
-	err := fileutil.CopyFile(filepath.Join(testDir, "testdata/TestConfigMariaDBVersion", "config.yaml.empty"), filepath.Join(tmpDir, ".ddev", "config.yaml"))
+	err := fileutil.CopyFile(filepath.Join(testDir, "testdata", t.Name(), "config.yaml.empty"), filepath.Join(tmpDir, ".ddev", "config.yaml"))
 	assert.NoError(err)
 	app, err := ddevapp.NewApp(tmpDir, false, "")
 	//nolint: errcheck
@@ -487,6 +493,7 @@ func TestConfigMariaDBVersion(t *testing.T) {
 		_, err = app.ReadConfig(false)
 		assert.NoError(err)
 		assert.Equal(cmdMariaDBVersion, app.MariaDBVersion)
+		_ = app.Stop(true, false)
 	}
 
 	// If we start with a config.yaml specifying basically anything for mariadb_version
@@ -519,6 +526,7 @@ func TestConfigMariaDBVersion(t *testing.T) {
 			_, err = app.ReadConfig(false)
 			assert.NoError(err)
 			assert.Equal(cmdMariaDBVersion, app.MariaDBVersion)
+			_ = app.Stop(true, false)
 		}
 	}
 
@@ -579,7 +587,7 @@ func TestConfigMariaDBVersion(t *testing.T) {
 			// First test the bare explicit values found in the config.yaml,
 			// without the NewApp adjustments
 			app := &ddevapp.DdevApp{}
-			assert.NoError(err)
+			//assert.NoError(err)
 			err = app.LoadConfigYamlFile(filepath.Join(tmpDir, ".ddev", "config.yaml"))
 			assert.NoError(err)
 			assert.Equal(cmdMariaDBVersion, app.MariaDBVersion)
@@ -607,6 +615,7 @@ func TestConfigMariaDBVersion(t *testing.T) {
 			} else {
 				assert.EqualValues(app.DBImage, version.GetDBImage(nodeps.MariaDB, cmdDBImageVersion))
 			}
+			_ = app.Stop(true, false)
 		}
 	}
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -286,7 +286,7 @@ func SetProjectAppRoot(projectName string, appRoot string) error {
 		return fmt.Errorf("project %s project root %s does not exist", projectName, appRoot)
 	}
 	if DdevGlobalConfig.ProjectList[projectName].AppRoot != "" && DdevGlobalConfig.ProjectList[projectName].AppRoot != appRoot {
-		return fmt.Errorf("project %s project root is already set to %s, refusing to change it to %s; you can `ddev rm --unlist` and start again if the listed project root is in error", projectName, DdevGlobalConfig.ProjectList[projectName].AppRoot, appRoot)
+		return fmt.Errorf("project %s project root is already set to %s, refusing to change it to %s; you can `ddev stop --unlist %s` and start again if the listed project root is in error", projectName, DdevGlobalConfig.ProjectList[projectName].AppRoot, appRoot, projectName)
 	}
 	DdevGlobalConfig.ProjectList[projectName].AppRoot = appRoot
 	err := WriteGlobalConfig(DdevGlobalConfig)


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1933 points out that a lot of nasty things happen when people change the name of a project in a directory.

This attempts to mitigate most of those. 

## How this PR Solves The Problem:

* When `ddev start` or `ddev config`, look to see if the global_config.yaml already has a project in that directory. If so, error out. 
* Improve error messages in this case
* Improve the error message where the directory has been deleted.


## Manual Testing Instructions:

Manual testing is so important on this one.

Change the name in a project when it's already started. Use `ddev config` or edit the config.yaml. Verify that you get fails when needed.

Change the name in a project when it's *not* running. Same checks.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

