### PR TITLE
Increase timeout on create_base_db to avoid transient windows test failures (tests only)

### DIFF
--- a/containers/ddev-dbserver/files/create_base_db.sh
+++ b/containers/ddev-dbserver/files/create_base_db.sh
@@ -32,7 +32,7 @@ pid="$!"
 
 # Wait for the server to respond to mysqladmin ping, or fail if it never does,
 # or if the process dies.
-for i in {60..0}; do
+for i in {90..0}; do
 	if mysqladmin ping -uroot --socket=$SOCKET 2>/dev/null; then
 		break
 	fi
@@ -41,7 +41,6 @@ for i in {60..0}; do
 		echo "MariaDB initialization startup failed"
 		exit 3
 	fi
-#	echo "MariaDB initialization startup process in progress... Try# $i"
 	sleep 1
 done
 if [ "$i" -eq 0 ]; then

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ var WebTag = "20200613_global_homeadditions" // Note that this can be overridden
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20200501_mariadb_10.5"
+var BaseDBTag = "20200624_longer_mysql_timeout"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

There have been intermittent timeouts only on the Windows container build; this increases the timeout. 

