### PR TITLE
Hook output streamed as it occurs, fixes #2214

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -170,7 +170,11 @@ func handleConfigRun(cmd *cobra.Command, args []string) {
 		util.Failed(err.Error())
 	}
 
-	_, _, err = app.ProcessHooks("pre-config")
+	err = app.ProcessHooks("pre-config")
+	if err != nil {
+		util.Failed(err.Error())
+	}
+
 	if err != nil {
 		util.Failed("Failed to process hook 'pre-config'")
 	}
@@ -216,7 +220,7 @@ func handleConfigRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		util.Failed("Failed to write provider config: %v", err)
 	}
-	_, _, err = app.ProcessHooks("post-config")
+	err = app.ProcessHooks("post-config")
 	if err != nil {
 		util.Failed("Failed to process hook 'post-config'")
 	}

--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -12,7 +12,7 @@ import (
 
 // Composer runs composer commands in the web container, managing pre- and post- hooks
 func (app *DdevApp) Composer(args []string) (string, string, error) {
-	_, _, err := app.ProcessHooks("pre-composer")
+	err := app.ProcessHooks("pre-composer")
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to process pre-composer hooks: %v", err)
 	}
@@ -30,7 +30,7 @@ func (app *DdevApp) Composer(args []string) (string, string, error) {
 	if runtime.GOOS == "windows" && !nodeps.IsDockerToolbox() {
 		fileutil.ReplaceSimulatedLinks(app.AppRoot)
 	}
-	_, _, err = app.ProcessHooks("post-composer")
+	err = app.ProcessHooks("post-composer")
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to process post-composer hooks: %v", err)
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -389,13 +389,16 @@ func TestDdevStart(t *testing.T) {
 	app.Hooks = map[string][]ddevapp.YAMLTask{"post-start": {{"exec": "echo hello"}}}
 
 	assert.NoError(err)
-	stdout := util.CaptureUserOut()
+	stdoutFunc, err := util.CaptureOutputToFile()
+	assert.NoError(err)
+	promptOutFunc := util.CaptureUserOut()
 	err = app.Start()
 	assert.NoError(err)
 	//nolint: errcheck
 	defer app.Stop(true, false)
-	out := stdout()
-	assert.Contains(out, "Running task: Exec command 'echo hello' in container/service 'web'")
+	out := stdoutFunc()
+	UOut := promptOutFunc()
+	assert.Contains(UOut, "Running task: Exec command 'echo hello' in container/service 'web'")
 	assert.Contains(out, "hello\n")
 
 	// try to start a site of same name at different path

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -80,6 +81,28 @@ func TestCaptureStdOut(t *testing.T) {
 	out := restoreOutput()
 
 	assert.Contains(out, text)
+}
+
+// TestCaptureOutputToFile tests CaptureOutputToFile.
+func TestCaptureOutputToFile(t *testing.T) {
+	assert := asrt.New(t)
+	restoreOutput, err := util.CaptureOutputToFile()
+	assert.NoError(err)
+	text := util.RandString(128)
+	fmt.Println("randstring-println=" + text)
+	c := exec.Command("sh", "-c", fmt.Sprintf("echo randstring-stdout=%s; echo 1>&2 randstring-stderr=%s", text, text))
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	err = c.Start()
+	assert.NoError(err)
+	err = c.Wait()
+	assert.NoError(err)
+
+	out := restoreOutput()
+
+	assert.Contains(out, "randstring-println="+text)
+	assert.Contains(out, "randstring-stdout="+text)
+	assert.Contains(out, "randstring-stderr="+text)
 }
 
 // TestConfirm ensures that the confirmation prompt works as expected.


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2214: Hook output has been saved up and then output at completion, but users want to see it as it happens, especially on long-running items.

## How this PR Solves The Problem:

Output directly as things happen.

## Manual Testing Instructions:

Add a post-start hook like this:

```
hooks:
  post-start:
  - exec: echo hi there && sleep 1 && date && sleep 1 && date
```
and then `ddev start`

You should see the output as it happens.

## Automated Testing Overview:

Existing hook tests were updated. 

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

