### PR TITLE
Improve util.Failed() handling and export-db, fixes #2281

### DIFF
--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -34,7 +34,9 @@ ddev export-db someproject > ~/tmp/someproject.sql`,
 		app := projects[0]
 
 		if app.SiteStatus() != ddevapp.SiteRunning {
-			util.Failed("ddev can't export-db until the project is started, please start it first.")
+			if err = app.Start(); err != nil {
+				util.Failed("Failed to start %s: %v", app.Name, err)
+			}
 		}
 
 		err = app.ExportDB(outFileName, gzipOption, exportTargetDB)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -675,30 +675,31 @@ func TestConfigOverrideDetection(t *testing.T) {
 		assert.NoError(err, "unable to invalidate docker cache")
 	})
 
-	restoreOutput := util.CaptureUserOut()
+	stdoutFunc, err := util.CaptureOutputToFile()
+	assert.NoError(err)
 	startErr := app.StartAndWait(2)
-	out := restoreOutput()
+	stdout := stdoutFunc()
 
 	var logs string
 	if startErr != nil {
 		logs, _ = GetErrLogsFromApp(app, startErr)
 	}
 
-	require.NoError(t, startErr, "app.StartAndWait() did not succeed: output:\n=====\n%s\n===== logs:\n========= logs =======\n%s\n========\n", out, logs)
+	require.NoError(t, startErr, "app.StartAndWait() did not succeed: output:\n=====\n%s\n===== logs:\n========= logs =======\n%s\n========\n", stdout, logs)
 
-	assert.Contains(out, "utf.cnf")
-	assert.Contains(out, "my-php.ini")
+	assert.Contains(stdout, "utf.cnf")
+	assert.Contains(stdout, "my-php.ini")
 
 	switch app.WebserverType {
 	case nodeps.WebserverNginxFPM:
-		assert.Contains(out, "nginx-site.conf")
-		assert.NotContains(out, "apache-site.conf")
-		assert.Contains(out, "junker99.conf")
+		assert.Contains(stdout, "nginx-site.conf")
+		assert.NotContains(stdout, "apache-site.conf")
+		assert.Contains(stdout, "junker99.conf")
 	default:
-		assert.Contains(out, "apache-site.conf")
-		assert.NotContains(out, "nginx-site.conf")
+		assert.Contains(stdout, "apache-site.conf")
+		assert.NotContains(stdout, "nginx-site.conf")
 	}
-	assert.Contains(out, "Custom configuration takes effect")
+	assert.Contains(stdout, "Custom configuration takes effect")
 	runTime()
 }
 

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -1,15 +1,15 @@
 package output
 
 import (
-	"os"
-
 	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
+	"os"
 )
 
 var (
 	// UserOut is the customized logrus log used for direct user output
 	UserOut = log.New()
+	UserErr = log.New()
 	// UserOutFormatter is the specialized formatter for UserOut
 	UserOutFormatter = new(TextFormatter)
 	// JSONOutput is a bool telling whether we're outputting in json. Set by command-line args.
@@ -19,13 +19,16 @@ var (
 // LogSetUp sets up UserOut and log loggers as needed by ddev
 func LogSetUp() {
 	// Use color.Output instead of stderr for all user output
-	log.SetOutput(color.Output)
 	UserOut.Out = color.Output
+	UserErr.Out = os.Stderr
+	UserErr.SetOutput(&ErrorWriter{})
 
 	if !JSONOutput {
 		UserOut.Formatter = UserOutFormatter
+		UserErr.Formatter = UserOutFormatter
 	} else {
 		UserOut.Formatter = &JSONFormatter{}
+		UserErr.Formatter = &JSONFormatter{}
 	}
 
 	UserOutFormatter.DisableTimestamp = true
@@ -39,4 +42,12 @@ func LogSetUp() {
 		logLevel = log.DebugLevel
 	}
 	log.SetLevel(logLevel)
+}
+
+// Splitting to stderr approach from
+// https://huynvk.dev/blog/4-tips-for-logging-on-gcp-using-golang-and-logrus
+type ErrorWriter struct{}
+
+func (w *ErrorWriter) Write(p []byte) (n int, err error) {
+	return os.Stderr.Write(p)
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -23,27 +23,30 @@ func init() {
 // Failed will print a red error message and exit with failure.
 func Failed(format string, a ...interface{}) {
 	if a != nil {
-		output.UserOut.Fatalf(format, a...)
+		//output.UserOut.Fatalf(format, a...)
+		output.UserErr.Fatalf(format, a...)
+		//output.UserOut.WithField("level", "fatal").Fatalf(format, a...)
 	} else {
-		output.UserOut.Fatal(format)
+		output.UserErr.Fatal(format)
+		//output.UserOut.WithField("level", "fatal").Fatal(format)
 	}
 }
 
 // Error will print an red error message but will not exit.
 func Error(format string, a ...interface{}) {
 	if a != nil {
-		output.UserOut.Errorf(format, a...)
+		output.UserErr.Errorf(format, a...)
 	} else {
-		output.UserOut.Error(format)
+		output.UserErr.Error(format)
 	}
 }
 
 // Warning will present the user with warning text.
 func Warning(format string, a ...interface{}) {
 	if a != nil {
-		output.UserOut.Warnf(format, a...)
+		output.UserErr.Warnf(format, a...)
 	} else {
-		output.UserOut.Warn(format)
+		output.UserErr.Warn(format)
 	}
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev export-db >something.sql` could output an error message to something.sql

All error messages were going to stdout

## How this PR Solves The Problem:

* Improve export-db in general by starting if not started
* Improve all calls to util.Failed and friends to go to stderr

## Manual Testing Instructions:

* `ddev stop`
* `ddev export-db >junk.sql.gz`

It should now start and succeed.

But create an error with 

`ddev start somethingthatdoesntexist >/tmp/junk.out`

and you should see the error on the screen

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

