### PR TITLE
Make internet connection timeout configurable, fixes #2302

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -37,3 +37,6 @@ esac
 # Remove any -built images, as we want to make sure tests do the building.
 docker rmi -f $(docker images --filter "dangling=true" -q --no-trunc) >/dev/null || true
 docker rmi -f $(docker images | awk '/drud.*-built/ {print $3}' ) >/dev/null || true
+
+# Make sure the global internet detection timeout is not set to 0 (broken)
+perl -pi -e 's/^internet_detection_timeout_ms:.*$/internet_detection_timeout_ms: 750/g' ~/.ddev/global_config.yaml

--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -72,6 +72,7 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 	output.UserOut.Printf("nfs-mount-enabled=%v", globalconfig.DdevGlobalConfig.NFSMountEnabledGlobal)
 
 	output.UserOut.Printf("router-bind-all-interfaces=%v", globalconfig.DdevGlobalConfig.RouterBindAllInterfaces)
+	output.UserOut.Printf("internet-detection-timeout-ms=%v", globalconfig.DdevGlobalConfig.InternetDetectionTimeout)
 }
 
 func init() {

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/updatecheck"
 	"github.com/drud/ddev/pkg/util"
@@ -76,7 +75,7 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 			util.Warning("Could not perform update check: %v", err)
 		}
 
-		if timeToCheckForUpdates && nodeps.IsInternetActive() {
+		if timeToCheckForUpdates && globalconfig.IsInternetActive() {
 			// Recreate the updatefile with current time so we won't do this again soon.
 			err = updatecheck.ResetUpdateTime(updateFile)
 			if err != nil {
@@ -126,7 +125,7 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 			event = fullCommand[1]
 		}
 
-		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && version.SegmentKey != "" && nodeps.IsInternetActive() && len(fullCommand) > 1 {
+		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && version.SegmentKey != "" && globalconfig.IsInternetActive() && len(fullCommand) > 1 {
 			ddevapp.SetInstrumentationBaseTags()
 			ddevapp.SendInstrumentationEvents(event)
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1726,7 +1726,7 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 	}
 
 	for _, name := range app.GetHostnames() {
-		if app.UseDNSWhenPossible && nodeps.IsInternetActive() {
+		if app.UseDNSWhenPossible && globalconfig.IsInternetActive() {
 			hostIPs, err := net.LookupHost(name)
 			// If we had successful lookup and dockerIP matches
 			// (which won't happen on Docker Toolbox) then don't bother

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -120,7 +120,7 @@ func SegmentEvent(client analytics.Client, hashedID string, event string) error 
 // SendInstrumentationEvents does the actual send to segment
 func SendInstrumentationEvents(event string) {
 
-	if globalconfig.DdevGlobalConfig.InstrumentationOptIn && nodeps.IsInternetActive() {
+	if globalconfig.DdevGlobalConfig.InstrumentationOptIn && globalconfig.IsInternetActive() {
 		client := analytics.New(version.SegmentKey)
 
 		err := SegmentUser(client, GetInstrumentationUser())

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -92,7 +92,7 @@ func ReadGlobalConfig() error {
 	}
 
 	// ReadConfig config values from file.
-	DdevGlobalConfig = GlobalConfig{InternetDetectionTimeout: 750}
+	DdevGlobalConfig = GlobalConfig{InternetDetectionTimeout: nodeps.InternetDetectionTimeoutDefault}
 	err = yaml.Unmarshal(source, &DdevGlobalConfig)
 	if err != nil {
 		return err

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -1,8 +1,10 @@
 package globalconfig
 
 import (
+	"context"
 	"fmt"
 	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -14,6 +16,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // DdevGlobalConfigName is the name of the global config file.
@@ -35,15 +38,16 @@ type ProjectInfo struct {
 
 // GlobalConfig is the struct defining ddev's global config
 type GlobalConfig struct {
-	OmitContainersGlobal    []string                `yaml:"omit_containers,flow"`
-	NFSMountEnabledGlobal   bool                    `yaml:"nfs_mount_enabled"`
-	InstrumentationOptIn    bool                    `yaml:"instrumentation_opt_in"`
-	RouterBindAllInterfaces bool                    `yaml:"router_bind_all_interfaces"`
-	DeveloperMode           bool                    `yaml:"developer_mode,omitempty"`
-	InstrumentationUser     string                  `yaml:"instrumentation_user,omitempty"`
-	LastStartedVersion      string                  `yaml:"last_started_version"`
-	MkcertCARoot            string                  `yaml:"mkcert_caroot"`
-	ProjectList             map[string]*ProjectInfo `yaml:"project_info"`
+	OmitContainersGlobal     []string                `yaml:"omit_containers,flow"`
+	NFSMountEnabledGlobal    bool                    `yaml:"nfs_mount_enabled"`
+	InstrumentationOptIn     bool                    `yaml:"instrumentation_opt_in"`
+	RouterBindAllInterfaces  bool                    `yaml:"router_bind_all_interfaces"`
+	InternetDetectionTimeout int64                   `yaml:"internet_detection_timeout_ms"`
+	DeveloperMode            bool                    `yaml:"developer_mode,omitempty"`
+	InstrumentationUser      string                  `yaml:"instrumentation_user,omitempty"`
+	LastStartedVersion       string                  `yaml:"last_started_version"`
+	MkcertCARoot             string                  `yaml:"mkcert_caroot"`
+	ProjectList              map[string]*ProjectInfo `yaml:"project_info"`
 }
 
 // GetGlobalConfigPath() gets the path to global config file
@@ -88,7 +92,7 @@ func ReadGlobalConfig() error {
 	}
 
 	// ReadConfig config values from file.
-	DdevGlobalConfig = GlobalConfig{}
+	DdevGlobalConfig = GlobalConfig{InternetDetectionTimeout: 750}
 	err = yaml.Unmarshal(source, &DdevGlobalConfig)
 	if err != nil {
 		return err
@@ -133,6 +137,11 @@ func WriteGlobalConfig(config GlobalConfig) error {
 #
 # You can enable nfs mounting for all projects with
 # nfs_mount_enabled: true
+#
+# In unusual cases the default value to wait to detect internet availability is too short.
+# You can adjust this value higher to make it less likely that ddev will declare internet
+# unavailable, but ddev may wait longer on some commands.
+# internet_detection_timeout_ms: 750
 
 # instrumentation_user: <your_username> # can be used to give ddev specific info about who you are
 # developer_mode: true # (defaults to false) is not used widely at this time.
@@ -370,4 +379,47 @@ func fileExists(name string) bool {
 		}
 	}
 	return true
+}
+
+var IsInternetActiveAlreadyChecked = false
+var IsInternetActiveResult = false
+
+// IsInternetActiveNetResolver wraps the standard DNS resolver.
+// In order to override net.DefaultResolver with a stub, we have to define an
+// interface on our own since there is none from the standard library.
+var IsInternetActiveNetResolver interface {
+	LookupHost(ctx context.Context, host string) (addrs []string, err error)
+} = net.DefaultResolver
+
+//IsInternetActive() checks to see if we have a viable
+// internet connection. It just tries a quick DNS query.
+// This requires that the named record be query-able.
+// This check will only be made once per command run.
+func IsInternetActive() bool {
+	// if this was already checked, return the result
+	if IsInternetActiveAlreadyChecked {
+		return IsInternetActiveResult
+	}
+
+	timeout := time.Duration(DdevGlobalConfig.InternetDetectionTimeout) * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	randomURL := nodeps.RandomString(10) + ".ddev.site"
+	addrs, err := IsInternetActiveNetResolver.LookupHost(ctx, randomURL)
+
+	// Internet is active (active == true) if both err and ctx.Err() were nil
+	active := err == nil && ctx.Err() == nil
+	if os.Getenv("DDEV_DEBUG") != "" {
+		output.UserOut.Printf("IsInternetActive DEBUG: err=%v ctx.Err()=%v addrs=%v IsInternetactive==%v, randomURL=%v internet_detection_timeout_ms=%dms\n", err, ctx.Err(), addrs, active, randomURL, DdevGlobalConfig.InternetDetectionTimeout)
+	}
+	if active == false {
+		output.UserOut.Println("Internet connection not detected")
+	}
+
+	// remember the result to not call this twice
+	IsInternetActiveAlreadyChecked = true
+	IsInternetActiveResult = active
+
+	return active
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -108,6 +108,11 @@ func ReadGlobalConfig() error {
 	if DdevGlobalConfig.LastStartedVersion == "" {
 		DdevGlobalConfig.LastStartedVersion = "v0.0"
 	}
+	// If they set the internetdetectiontimeout below default, just reset to default
+	// and ignore the setting.
+	if DdevGlobalConfig.InternetDetectionTimeout < nodeps.InternetDetectionTimeoutDefault {
+		DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
+	}
 
 	err = ValidateGlobalConfig()
 	if err != nil {
@@ -140,7 +145,8 @@ func WriteGlobalConfig(config GlobalConfig) error {
 #
 # In unusual cases the default value to wait to detect internet availability is too short.
 # You can adjust this value higher to make it less likely that ddev will declare internet
-# unavailable, but ddev may wait longer on some commands.
+# unavailable, but ddev may wait longer on some commands. This should not be set below the default 750
+# ddev will ignore low values, as they're not useful
 # internet_detection_timeout_ms: 750
 
 # instrumentation_user: <your_username> # can be used to give ddev specific info about who you are

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,8 +39,11 @@ func TestGetFreePort(t *testing.T) {
 	for ; i < max; i++ {
 		ports = append(ports, strconv.Itoa(i))
 	}
-	err = globalconfig.ReservePorts("TestGetFreePort", ports)
+	err = globalconfig.ReservePorts(t.Name(), ports)
 	assert.NoError(err)
+	t.Cleanup(func() {
+		_ = globalconfig.RemoveProjectInfo(t.Name())
+	})
 
 	for try := 0; try < 5; try++ {
 		port, err := globalconfig.GetFreePort(dockerIP)
@@ -64,18 +68,20 @@ func TestSetProjectAppRoot(t *testing.T) {
 	// Make sure existing project with no approot works
 
 	// Non-existing approot should cause a fail
-	err := globalconfig.SetProjectAppRoot("junk", "/nowhere/junk-approot-1")
+	err := globalconfig.SetProjectAppRoot(t.Name(), "/nowhere/junk-approot-1")
 	assert.Error(err)
+	_ = globalconfig.RemoveProjectInfo(t.Name())
 
 	// Create a project in a valid directory
 	tmpDir := testcommon.CreateTmpDir(t.Name())
-	defer os.RemoveAll(tmpDir)
 	err = globalconfig.SetProjectAppRoot(t.Name(), tmpDir)
 	assert.NoError(err)
-	//nolint: errcheck
-	defer globalconfig.RemoveProjectInfo(t.Name())
 
-	// nolint: errcheck
+	t.Cleanup(func() {
+		_ = globalconfig.RemoveProjectInfo(t.Name())
+		_ = os.RemoveAll(tmpDir)
+	})
+
 	project := globalconfig.GetProject(t.Name())
 	require.NotNil(t, project)
 
@@ -112,13 +118,13 @@ func TestSetProjectAppRoot(t *testing.T) {
 	assert.Equal(tmpDir, project.AppRoot)
 }
 
-type netResolverStub struct {
+type internetActiveNetResolverStub struct {
 	sleepTime time.Duration
 	err       error
 }
 
 // LookupHost is a custom version of net.LookupHost that just wastes some time and then returns
-func (t netResolverStub) LookupHost(ctx context.Context, _ string) ([]string, error) {
+func (t internetActiveNetResolverStub) LookupHost(ctx context.Context, _ string) ([]string, error) {
 	select {
 	case <-time.After(t.sleepTime):
 	case <-ctx.Done():
@@ -127,18 +133,19 @@ func (t netResolverStub) LookupHost(ctx context.Context, _ string) ([]string, er
 	return nil, t.err
 }
 
-// resetVariables resets the global variables IsInternetActive() uses back to their defaults
-func resetVariables() {
+// internetActiveResetVariables resets the global variables IsInternetActive() uses back to their defaults
+func internetActiveResetVariables() {
 	globalconfig.IsInternetActiveNetResolver = net.DefaultResolver
 	globalconfig.IsInternetActiveAlreadyChecked = false
 	globalconfig.IsInternetActiveResult = false
+	globalconfig.DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
 }
 
 // TestIsInternetActiveErrorOccurred tests if IsInternetActive() returns false when LookupHost returns an error
 func TestIsInternetActiveErrorOccurred(t *testing.T) {
-	resetVariables()
+	internetActiveResetVariables()
 
-	globalconfig.IsInternetActiveNetResolver = netResolverStub{
+	globalconfig.IsInternetActiveNetResolver = internetActiveNetResolverStub{
 		sleepTime: 0,
 		err:       errors.New("test error"),
 	}
@@ -148,9 +155,9 @@ func TestIsInternetActiveErrorOccurred(t *testing.T) {
 
 // TestIsInternetActiveTimeout tests if IsInternetActive() returns false when it times out
 func TestIsInternetActiveTimeout(t *testing.T) {
-	resetVariables()
+	internetActiveResetVariables()
 
-	globalconfig.IsInternetActiveNetResolver = netResolverStub{
+	globalconfig.IsInternetActiveNetResolver = internetActiveNetResolverStub{
 		sleepTime: 1000 * time.Millisecond,
 	}
 
@@ -160,7 +167,7 @@ func TestIsInternetActiveTimeout(t *testing.T) {
 // TestIsInternetActiveAlreadyChecked tests if IsInternetActive() returns true when it has already
 // been called and returned true on an earlier execution.
 func TestIsInternetActiveAlreadyChecked(t *testing.T) {
-	resetVariables()
+	internetActiveResetVariables()
 
 	globalconfig.IsInternetActiveAlreadyChecked = true
 	globalconfig.IsInternetActiveResult = true
@@ -171,11 +178,9 @@ func TestIsInternetActiveAlreadyChecked(t *testing.T) {
 // TestIsInternetActive tests if IsInternetActive() returns true, when the LookupHost call goes well
 // and if it properly sets the globals so it won't execute the LookupHost again.
 func TestIsInternetActive(t *testing.T) {
-	resetVariables()
-	err := globalconfig.ReadGlobalConfig()
-	asrt.NoError(t, err)
+	internetActiveResetVariables()
 
-	globalconfig.IsInternetActiveNetResolver = netResolverStub{
+	globalconfig.IsInternetActiveNetResolver = internetActiveNetResolverStub{
 		sleepTime: 0,
 	}
 

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -1,10 +1,7 @@
 package nodeps
 
 import (
-	"context"
-	"github.com/drud/ddev/pkg/output"
 	"math/rand"
-	"net"
 	"os"
 	"time"
 )
@@ -35,48 +32,6 @@ func IsDockerToolbox() bool {
 		return true
 	}
 	return false
-}
-
-var isInternetActiveAlreadyChecked = false
-var isInternetActiveResult = false
-
-// In order to override net.DefaultResolver with a stub, we have to define an
-// interface on our own since there is none from the standard library.
-var isInternetActiveNetResolver interface {
-	LookupHost(ctx context.Context, host string) (addrs []string, err error)
-} = net.DefaultResolver
-
-//IsInternetActive() checks to see if we have a viable
-// internet connection. It just tries a quick DNS query.
-// This requires that the named record be query-able.
-// This check will only be made once per command run.
-func IsInternetActive() bool {
-	// if this was already checked, return the result
-	if isInternetActiveAlreadyChecked {
-		return isInternetActiveResult
-	}
-
-	const timeout = 500 * time.Millisecond
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	randomURL := RandomString(10) + ".ddev.site"
-	addrs, err := isInternetActiveNetResolver.LookupHost(ctx, randomURL)
-
-	// Internet is active (active == true) if both err and ctx.Err() were nil
-	active := err == nil && ctx.Err() == nil
-	if os.Getenv("DDEV_DEBUG") != "" {
-		output.UserOut.Printf("IsInternetActive DEBUG: err=%v ctx.Err()=%v addrs=%v IsInternetactive==%v, randomURL=%v\n", err, ctx.Err(), addrs, active, randomURL)
-	}
-	if active == false {
-		output.UserOut.Println("Internet connection not detected")
-	}
-
-	// remember the result to not call this twice
-	isInternetActiveAlreadyChecked = true
-	isInternetActiveResult = active
-
-	return active
 }
 
 // From https://www.calhoun.io/creating-random-strings-in-go/

--- a/pkg/nodeps/utils_test.go
+++ b/pkg/nodeps/utils_test.go
@@ -1,88 +1,9 @@
 package nodeps
 
 import (
-	"context"
-	"errors"
 	"github.com/stretchr/testify/assert"
-	"net"
 	"testing"
-	"time"
 )
-
-type netResolverStub struct {
-	sleepTime time.Duration
-	err       error
-}
-
-// LookupHost is a custom version of net.LookupHost that just wastes some time and then returns
-func (t netResolverStub) LookupHost(ctx context.Context, _ string) ([]string, error) {
-	select {
-	case <-time.After(t.sleepTime):
-	case <-ctx.Done():
-		return nil, errors.New("context timed out")
-	}
-	return nil, t.err
-}
-
-// resetVariables resets the global variables IsInternetActive() uses back to their defaults
-func resetVariables() {
-	isInternetActiveNetResolver = net.DefaultResolver
-	isInternetActiveAlreadyChecked = false
-	isInternetActiveResult = false
-}
-
-// TestIsInternetActiveErrorOccurred tests if IsInternetActive() returns false when LookupHost returns an error
-func TestIsInternetActiveErrorOccurred(t *testing.T) {
-	resetVariables()
-
-	isInternetActiveNetResolver = netResolverStub{
-		sleepTime: 0,
-		err:       errors.New("test error"),
-	}
-
-	assert.False(t, IsInternetActive())
-}
-
-// TestIsInternetActiveTimeout tests if IsInternetActive() returns false when it times out
-func TestIsInternetActiveTimeout(t *testing.T) {
-	resetVariables()
-
-	isInternetActiveNetResolver = netResolverStub{
-		sleepTime: 1000 * time.Millisecond,
-	}
-
-	assert.False(t, IsInternetActive())
-}
-
-// TestIsInternetActiveAlreadyChecked tests if IsInternetActive() returns true when it has already
-// been called and returned true on an earlier execution.
-func TestIsInternetActiveAlreadyChecked(t *testing.T) {
-	resetVariables()
-
-	isInternetActiveAlreadyChecked = true
-	isInternetActiveResult = true
-
-	assert.True(t, IsInternetActive())
-}
-
-// TestIsInternetActive tests if IsInternetActive() returns true, when the LookupHost call goes well
-// and if it properly sets the globals so it won't execute the LookupHost again.
-func TestIsInternetActive(t *testing.T) {
-	resetVariables()
-
-	isInternetActiveNetResolver = netResolverStub{
-		sleepTime: 0,
-	}
-
-	// should return true
-	assert.True(t, IsInternetActive())
-	// should have set the isInternetActiveAlreadyChecked to true
-	assert.True(t, isInternetActiveAlreadyChecked)
-	// result should still be true
-	assert.True(t, isInternetActiveResult)
-	// and calling it again, should also still be true
-	assert.True(t, IsInternetActive())
-}
 
 // TestRandomString tests if RandomString returns the correct character length
 func TestRandomString(t *testing.T) {

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -149,7 +149,8 @@ const (
 	DdevDefaultMailhogPort      = "8025"
 	DdevDefaultMailhogHTTPSPort = "8026"
 	// DdevDefaultTLD is the top-level-domain used by default, can be overridden
-	DdevDefaultTLD = "ddev.site"
+	DdevDefaultTLD                  = "ddev.site"
+	InternetDetectionTimeoutDefault = 750
 )
 
 // IsValidProvider is a helper function to determine if a provider value is valid, returning


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2302 points out that there are times when ddev's internet check times out faster than people would prefer, resulting in `ddev start` trying to add a hostname to /etc/hosts.

There are also cases where "internet not detected" shows on the screen when it's unnecessary.

## How this PR Solves The Problem:

* Increase the default timeout from 500ms to 750ms
* Make the timeout configurable in ~/.ddev/global_config.yaml by changing `internet_detection_timeout_ms`

## Manual Testing Instructions:

In a VM, slow down internet

Verify that the global config can make it work even with slowed internet.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

