### PR TITLE
Don't use root privileges when writing files #2349

### DIFF
--- a/cmd/ddev/cmd/a.go
+++ b/cmd/ddev/cmd/a.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
-	"os"
 )
 
 // This file is a.go because global config must be loaded before anybody else
@@ -12,12 +10,6 @@ import (
 // uninitialized data
 
 func init() {
-	// Prevent running as root for most cases
-	// We really don't want ~/.ddev to have root ownership, breaks things.
-	if os.Geteuid() == 0 && len(os.Args) > 1 && os.Args[1] != "hostname" {
-		output.UserOut.Fatal("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
-	}
-
 	err := globalconfig.ReadGlobalConfig()
 	if err != nil {
 		util.Failed("unable to read global config: %v", err)

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -231,12 +231,12 @@ func findDirectiveInScript(script string, directive string) string {
 	return ""
 }
 
-// populateExamplesAndCommands grabs packr2 assets
+// populateExamplesCommandsHomeadditions grabs packr2 assets
 // When the items in the assets directory are changed, the packr2 command
 // must be run again in this directory (cmd/ddev/cmd) to update the saved
 // embedded files.
 // "make packr2" can be used to update the packr2 cache.
-func populateExamplesAndCommands() error {
+func populateExamplesCommandsHomeadditions() error {
 	app, err := ddevapp.GetActiveApp("")
 	if err != nil {
 		return nil

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -40,6 +40,22 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 		// again *after* --json flag is parsed.
 		output.LogSetUp()
 
+		// We really don't want ~/.ddev or .ddev/homeadditions or .ddev/.globalcommands to have root ownership, breaks things.
+		if os.Geteuid() == 0 {
+			output.UserOut.Warning("Not populating custom commands or hostadditions because running with root privileges")
+		} else {
+
+			err := populateExamplesCommandsHomeadditions()
+			if err != nil {
+				util.Warning("populateExamplesCommandsHomeadditions() failed: %v", err)
+			}
+
+			err = addCustomCommands(cmd)
+			if err != nil {
+				util.Warning("Adding custom commands failed: %v", err)
+			}
+		}
+
 		// Skip docker validation for any command listed in "ignores"
 		for _, k := range ignores {
 			if strings.Contains(command, k) {
@@ -148,16 +164,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&output.JSONOutput, "json-output", "j", false, "If true, user-oriented output will be in JSON format.")
 
 	output.LogSetUp()
-
-	err := populateExamplesAndCommands()
-	if err != nil {
-		util.Warning("populateExamplesAndCommands() failed: %v", err)
-	}
-
-	err = addCustomCommands(RootCmd)
-	if err != nil {
-		util.Warning("Adding custom commands failed: %v", err)
-	}
 
 }
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -40,22 +40,6 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 		// again *after* --json flag is parsed.
 		output.LogSetUp()
 
-		// We really don't want ~/.ddev or .ddev/homeadditions or .ddev/.globalcommands to have root ownership, breaks things.
-		if os.Geteuid() == 0 {
-			output.UserOut.Warning("Not populating custom commands or hostadditions because running with root privileges")
-		} else {
-
-			err := populateExamplesCommandsHomeadditions()
-			if err != nil {
-				util.Warning("populateExamplesCommandsHomeadditions() failed: %v", err)
-			}
-
-			err = addCustomCommands(cmd)
-			if err != nil {
-				util.Warning("Adding custom commands failed: %v", err)
-			}
-		}
-
 		// Skip docker validation for any command listed in "ignores"
 		for _, k := range ignores {
 			if strings.Contains(command, k) {
@@ -165,6 +149,20 @@ func init() {
 
 	output.LogSetUp()
 
+	// We really don't want ~/.ddev or .ddev/homeadditions or .ddev/.globalcommands to have root ownership, breaks things.
+	if os.Geteuid() == 0 {
+		output.UserOut.Warning("Not populating custom commands or hostadditions because running with root privileges")
+	} else {
+		err := populateExamplesCommandsHomeadditions()
+		if err != nil {
+			util.Warning("populateExamplesAndCommands() failed: %v", err)
+		}
+
+		err = addCustomCommands(RootCmd)
+		if err != nil {
+			util.Warning("Adding custom commands failed: %v", err)
+		}
+	}
 }
 
 func instrumentationNotSetUpWarning() {

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -2,8 +2,16 @@ package main
 
 import (
 	"github.com/drud/ddev/cmd/ddev/cmd"
+	"github.com/drud/ddev/pkg/output"
+	"os"
 )
 
 func main() {
+	// Prevent running as root for most cases
+	// We really don't want ~/.ddev to have root ownership, breaks things.
+	if os.Geteuid() == 0 && len(os.Args) > 1 && os.Args[1] != "hostname" {
+		output.UserOut.Fatal("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
+	}
+
 	cmd.Execute()
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -957,6 +957,13 @@ func (app *DdevApp) CheckExistingAppInApproot() error {
 
 // GenerateWebserverConfig generates the default nginx and apache config files
 func (app *DdevApp) GenerateWebserverConfig() error {
+	// Prevent running as root for most cases
+	// We really don't want ~/.ddev to have root ownership, breaks things.
+	if os.Geteuid() == 0 {
+		output.UserOut.Warning("not generating webserver config files because running with root privileges")
+		return nil
+	}
+
 	var items = map[string]string{
 		"nginx":                         app.GetConfigPath(filepath.Join("nginx_full", "nginx-site.conf")),
 		"apache":                        app.GetConfigPath(filepath.Join("apache", "apache-site.conf")),

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2971,17 +2971,19 @@ func TestHostDBPort(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	commandsDir := filepath.Join(site.Dir, ".ddev", "commands", "host")
-	err := os.MkdirAll(commandsDir, 0755)
-	assert.NoError(err)
-	err = fileutil.CopyFile(filepath.Join(testDir, "testdata", t.Name(), "showport"), filepath.Join(commandsDir, "showport"))
-	require.NoError(t, err)
-
 	app, err := ddevapp.NewApp(site.Dir, false, "")
+	assert.NoError(err)
+
+	showportPath := app.GetConfigPath("commands/host/showport")
+	err = os.MkdirAll(filepath.Dir(showportPath), 0755)
+	assert.NoError(err)
+	err = fileutil.CopyFile(filepath.Join(testDir, "testdata", t.Name(), "showport"), showportPath)
+	assert.NoError(err)
+
 	defer func() {
+		_ = os.RemoveAll(showportPath)
 		_ = app.Stop(true, false)
 	}()
-	require.NoError(t, err)
 
 	// Make sure that everything works with and without
 	// an explicitly specified hostDBPort


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2349 points out that we should never be writing files in the rare case where we're running as root (`ddev hostname` only). 

## How this PR Solves The Problem:

Try to prevent that situation.

## Manual Testing Instructions:

* `sudo rm -rf .ddev/{commands,homeadditions,.global_commands} ~/.ddev/{commands,homeadditions}`
* Try `sudo ddev start` - it should balk
* Try `sudo ddev hostname junker42.ddev.site` - it should add the hostname without creating any files in the above directories
* `find ~/.ddev . -user root` in project directory; nothing should be found.
* Add an `additional_fqdns` entry to config.yaml, it needs to be something that is not already in /etc/hosts
* `ddev start` - You should see the hostname get added
* `find ~/.ddev . -user root` in project directory; nothing should be found.
* Test basic functionality of custom commands and built-in commands. They should work fine.


## Automated Testing Overview:

It's hard to do this because we don't want the root/sudo access running around on the test machines.

## Related Issue Link(s):

#2349

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

