### PR TITLE
removing extra spaces in template.go that end up in .ddev/config.yaml

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -320,9 +320,9 @@ const ConfigInstructions = `
 # In this case the user must provide all such settings.
 
 # no_project_mount: false
-# (Experimental) If true, ddev will not mount the project into the web container; 
+# (Experimental) If true, ddev will not mount the project into the web container;
 # the user is responsible for mounting it manually or via a script.
-# This is to enable experimentation with alternate file mounting strategies. 
+# This is to enable experimentation with alternate file mounting strategies.
 # For advanced users only!
 
 # provider: default # Currently either "default" or "pantheon"
@@ -418,12 +418,12 @@ services:
       timeout: 120s
 
 networks:
-   default:
-     external:
-       name: ddev_default
+  default:
+    external:
+      name: ddev_default
 volumes:
-   ddev-global-cache:
-     name: ddev-global-cache
+  ddev-global-cache:
+    name: ddev-global-cache
 `
 
 const DdevSSHAuthTemplate = `version: '{{ .compose_version }}'


### PR DESCRIPTION
## The Problem/Issue/Bug:
Extra spaces in `templates.go`

## How this PR Solves The Problem:
Removing extra spaces :)

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

