### PR TITLE
Don't try to start export-db or docker-compose output will end up in output

### DIFF
--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -34,9 +34,7 @@ ddev export-db someproject > ~/tmp/someproject.sql`,
 		app := projects[0]
 
 		if app.SiteStatus() != ddevapp.SiteRunning {
-			if err = app.Start(); err != nil {
-				util.Failed("Failed to start %s: %v", app.Name, err)
-			}
+			util.Failed("ddev can't export-db until the project is started, please use ddev start.")
 		}
 
 		err = app.ExportDB(outFileName, gzipOption, exportTargetDB)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Testing of v1.15-rc2 showed that `ddev export-db >file.sql.gz` would not work correctly if the project was stopped at the time, because all the output from docker-compose made it into the file.

It will be nice to get that docker-compose output going to stderr maybe, but not right before a release.

Instead, this just does what the original #2281 asked for, which was not having this exact situation fail. So now `ddev export-db` does not auto-start a stopped project.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

