### PR TITLE
Work around WSL2 docker flaw with incorrect mount ownership - affects ddev-live pull

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -977,7 +977,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-compose-base.yaml", ".ddev-docker-compose-full.yaml", ".global_commands", ".sshimageBuild", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/live", "commands/web/xdebug", "config.*.y*ml", "db_snapshots", "import-db", "import.yaml", "nginx_full/nginx-site.conf", "sequelpro.spf", "**/README.*")
+	err := CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-compose-base.yaml", ".ddev-docker-compose-full.yaml", ".ddevlive-downloads", ".global_commands", ".sshimageBuild", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/live", "commands/web/xdebug", "config.*.y*ml", "db_snapshots", "import-db", "import.yaml", "nginx_full/nginx-site.conf", "sequelpro.spf", "**/README.*")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -38,12 +38,10 @@ func SetInstrumentationBaseTags() {
 		isToolbox := nodeps.IsDockerToolbox()
 
 		nodeps.InstrumentationTags["OS"] = runtime.GOOS
-		if runtime.GOOS == "linux" {
-			wslDistro := os.Getenv("WSL_DISTRO_NAME")
-			if wslDistro != "" {
-				nodeps.InstrumentationTags["isWSL"] = "true"
-				nodeps.InstrumentationTags["wslDistro"] = wslDistro
-			}
+		wslDistro := nodeps.GetWSLDistro()
+		if wslDistro != "" {
+			nodeps.InstrumentationTags["isWSL"] = "true"
+			nodeps.InstrumentationTags["wslDistro"] = wslDistro
 		}
 		nodeps.InstrumentationTags["dockerVersion"] = dockerVersion
 		nodeps.InstrumentationTags["dockerComposeVersion"] = composeVersion

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -3,6 +3,7 @@ package nodeps
 import (
 	"math/rand"
 	"os"
+	"runtime"
 	"time"
 )
 
@@ -47,4 +48,13 @@ func RandomString(length int) string {
 		b[i] = charset[seededRand.Intn(len(charset))]
 	}
 	return string(b)
+}
+
+// GetWSLDistro returns the WSL2 distro name if on Linux
+func GetWSLDistro() string {
+	wslDistro := ""
+	if runtime.GOOS == "linux" {
+		wslDistro = os.Getenv("WSL_DISTRO_NAME")
+	}
+	return wslDistro
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

There's a flaw in docker on WSL2 where running a container right after another one gets the wrong mount permissions.

A sleep seems to fix it. 

This only affects `ddev pull` with ddev-live provider type.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

