### PR TITLE
Fix typo in custom-commands documentation

### DIFF
--- a/docs/users/extend/custom-commands.md
+++ b/docs/users/extend/custom-commands.md
@@ -39,7 +39,7 @@ To provide a command which will execute in a container, add a bash script to `.d
 drush $@
 ```
 
-In addition to commands that run in the standard ddev containers like "web" and "db", you can run commands in custom containers, just using the service name, like `.ddev/commands/solr/<command>`. Not, however, that your service must mount /mnt/ddev_config as the web and db containers do, so the `volumes` section of docker-compose.<servicename>.yaml needs:
+In addition to commands that run in the standard ddev containers like "web" and "db", you can run commands in custom containers, just using the service name, like `.ddev/commands/solr/<command>`. Note, however, that your service must mount /mnt/ddev_config as the web and db containers do, so the `volumes` section of docker-compose.<servicename>.yaml needs:
 
 ```
     volumes:


### PR DESCRIPTION
## The Problem/Issue/Bug:
Typo in documentation

## How this PR Solves The Problem:
Fixed typo
