### PR TITLE
Added commands for Sequel Ace, the successor to Sequel Pro, fixes #2369

### DIFF
--- a/cmd/ddev/cmd/sequelace.go
+++ b/cmd/ddev/cmd/sequelace.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/drud/ddev/pkg/nodeps"
+
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"runtime"
+
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/output"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// SequelAceLoc is where we expect to find the Sequel Ace.app
+// It's global so it can be mocked in testing.
+var SequelAceLoc = "/Applications/Sequel Ace.app"
+
+// DdevSequelAceCmd represents the sequelpro command
+var DdevSequelAceCmd = &cobra.Command{
+	Use:     "sequelace",
+	Short:   "Connect sequelace to a project database",
+	Long:    `A helper command for using sequelace (macOS database browser) with a running DDEV-Local project's database'.`,
+	Example: `ddev sequelace`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 0 {
+			output.UserOut.Fatalf("invalid arguments to sequelace command: %v", args)
+		}
+
+		out, err := handleSequelAceCommand(SequelAceLoc)
+		if err != nil {
+			output.UserOut.Fatalf("Could not run sequelace command: %s", err)
+		}
+		util.Success(out)
+	},
+}
+
+// handleSequelAceCommand() is the "real" handler for the real command
+func handleSequelAceCommand(appLocation string) (string, error) {
+	app, err := ddevapp.GetActiveApp("")
+	if err != nil {
+		return "", err
+	}
+
+	if app.SiteStatus() != ddevapp.SiteRunning {
+		return "", errors.New("project is not running. The project must be running to create a Sequel Ace connection")
+	}
+
+	db, err := app.FindContainerByType("db")
+	if err != nil {
+		return "", err
+	}
+
+	dbPrivatePort, err := strconv.ParseInt(ddevapp.GetPort("db"), 10, 64)
+	if err != nil {
+		return "", err
+	}
+	dbPublishPort := fmt.Sprint(dockerutil.GetPublishedPort(dbPrivatePort, *db))
+
+	tmpFilePath := filepath.Join(app.GetAppRoot(), ".ddev/sequelace.spf")
+	tmpFile, err := os.Create(tmpFilePath)
+	if err != nil {
+		output.UserOut.Fatalln(err)
+	}
+	defer util.CheckClose(tmpFile)
+
+	dockerIP, err := dockerutil.GetDockerIP()
+	if err != nil {
+		return "", err
+	}
+	_, err = tmpFile.WriteString(fmt.Sprintf(
+		ddevapp.SequelproTemplate,
+		"db",           //dbname
+		dockerIP,       //host
+		app.HostName(), //connection name
+		"db",           // dbpass
+		dbPublishPort,  // port
+		"db",           //dbuser
+	))
+	util.CheckErr(err)
+
+	err = exec.Command("open", tmpFilePath).Run()
+	if err != nil {
+		return "", err
+	}
+	return "sequelace command finished successfully!", nil
+}
+
+// dummyDevSequelAceCmd represents the "not available" sequelace command
+var dummyDevSequelAceCmd = &cobra.Command{
+	Use:   "sequelace",
+	Short: "This command is not available since sequel ace.app is not installed",
+	Long:  `Where installed, "ddev sequelace" launches the sequel ace database browser`,
+	Run: func(cmd *cobra.Command, args []string) {
+		util.Failed("The sequelace command is not available because sequel ace.app is not detected on your workstation")
+
+	},
+}
+
+// init installs the real command if it's available, otherwise dummy command (if on OSX), otherwise no command
+func init() {
+	switch {
+	case detectSequelAce():
+		app, err := ddevapp.GetActiveApp("")
+		if err == nil && app != nil && !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+			RootCmd.AddCommand(DdevSequelAceCmd)
+		}
+	case runtime.GOOS == "darwin":
+		RootCmd.AddCommand(dummyDevSequelAceCmd)
+	}
+}
+
+// detectSequelAce looks for the sequel ace app in /Applications; returns true if found
+func detectSequelAce() bool {
+	if _, err := os.Stat(SequelAceLoc); err == nil {
+		return true
+	}
+	return false
+}

--- a/cmd/ddev/cmd/sequelace_test.go
+++ b/cmd/ddev/cmd/sequelace_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+
+	"path/filepath"
+
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+)
+
+// TestSequelAceOperation tests basic operation.
+func TestSequelAceOperation(t *testing.T) {
+	if !detectSequelAce() {
+		t.SkipNow()
+	}
+	assert := asrt.New(t)
+	v := TestSites[0]
+	cleanup := v.Chdir()
+
+	_, err := ddevapp.GetActiveApp("")
+	assert.NoError(err)
+
+	out, err := handleSequelAceCommand(SequelAceLoc)
+	assert.NoError(err)
+	assert.Contains(string(out), "sequelace command finished successfully")
+
+	dir, err := ddevapp.GetActiveAppRoot("")
+	assert.NoError(err)
+	assert.Equal(true, fileutil.FileExists(filepath.Join(dir, ".ddev/sequelace.spf")))
+
+	cleanup()
+}
+
+// TestSequelAceBadApp tests non-site operation and bad args
+func TestSequelAceBadApp(t *testing.T) {
+	if !detectSequelAce() {
+		t.SkipNow()
+	}
+
+	assert := asrt.New(t)
+
+	// Create a temporary directory and switch to it for the duration of this test.
+	tmpdir := testcommon.CreateTmpDir("sequelace_badargs")
+	defer testcommon.Chdir(tmpdir)()
+	defer testcommon.CleanupDir(tmpdir)
+
+	// Ensure it fails if we run outside of an application root.
+	_, err := handleSequelAceCommand(SequelAceLoc)
+	assert.Error(err)
+	assert.Contains(err.Error(), "Could not find a project in")
+}


### PR DESCRIPTION
(Dippy Dog returns with a PR on the correct repo. 🤦‍♂️)

## The Problem/Issue/Bug:

Sequel Pro still works, but it's crashy and hasn't been updated in a very long time.  There's a successor to the app called Sequel Ace that's based on the same code, and can connect using the same plist spec.

https://github.com/Sequel-Ace/Sequel-Ace
https://sequel-ace.com/

## How this PR Solves The Problem:

This adds a `sequelace` command, with an accompanying sequelace_test.

## Manual Testing Instructions:

I basically copy/pasted the existing commands and modified things where appropriate, so I can't say exactly how this would work, except that after the next compilation of the codebase, you'll hopefully have `sequelace` available.

## Automated Testing Overview:

sequelace_test.go is available, and hopefully does what it should.

## Related Issue Link(s):

## Release/Deployment notes:

If this is approved, I'll make sure to update any other docs and files that reference the generated .spf file.
