### PR TITLE
Fixed small typo

### DIFF
--- a/docs/users/shell-completion.md
+++ b/docs/users/shell-completion.md
@@ -1,6 +1,6 @@
 ## Shell Completion
 
-Most people like to have shell completion on the command line. In other words, when you're typing a command, you can hit <TAB> and the shell will show you what the options are. For example, if you type `ddev <TAB>`, you'll see all the possible commands. `ddev debug <TAB>` will show you the options for the command. And `ddev list -<TAB>` will show you all the flags available for `ddev list`.
+Most people like to have shell completion on the command line. In other words, when you're typing a command, you can hit `<TAB>` and the shell will show you what the options are. For example, if you type `ddev <TAB>`, you'll see all the possible commands. `ddev debug <TAB>` will show you the options for the command. And `ddev list -<TAB>` will show you all the flags available for `ddev list`.
 
 Shells like bash and zsh need help to do this though, they have to know what the options are. DDEV-Local provides the necessary hint scripts, and if you use homebrew, they get installed automatically. But if you use oh-my-zsh, for example, you may have to manually install the hint script.
 


### PR DESCRIPTION
Added backticks to shell completions docs.

## The Problem/Issue/Bug: 
N/A

## How this PR Solves The Problem:
The word `<TAB>` was missing the backticks and therefore was not displaying on the page. This fixes the issue and not the word is visible.

## Manual Testing Instructions:
N/A

## Automated Testing Overview:
N/A

## Related Issue Link(s):
https://github.com/drud/ddev/blob/master/docs/users/shell-completion.md

## Release/Deployment notes:
No ramifications.

