### PR TITLE
Use MariaDB 10.3 with Drupal 8, fixes #2369

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -73,7 +73,7 @@ func init() {
 			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: drupal7ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal8: {
-			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
+			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: drupal8ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal9: {
 			settingsCreator: createDrupal9SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: drupal9ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -326,9 +326,6 @@ func TestDdevStart(t *testing.T) {
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 
-	// Before start, since we haven't changed MariaDBVersion, it should be ""
-	assert.EqualValues("", app.MariaDBVersion)
-
 	err = app.Start()
 	assert.NoError(err)
 
@@ -338,10 +335,6 @@ func TestDdevStart(t *testing.T) {
 	exists, err := dockerutil.ImageExistsLocally(webBuilt)
 	assert.NoError(err)
 	assert.True(exists)
-
-	// After start, we haven't changed default version, the dbimage
-	// should now be set and should be the default
-	assert.EqualValues(app.DBImage, version.GetDBImage(nodeps.MariaDB))
 
 	//nolint: errcheck
 	defer app.Stop(true, false)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -878,6 +878,12 @@ func TestDdevImportDB(t *testing.T) {
 		_ = app.Stop(true, false)
 	}()
 
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "db",
+		Cmd:     "mysql -N -e 'DROP DATABASE IF EXISTS test;'",
+	})
+	assert.NoError(err)
+
 	app.Hooks = map[string][]ddevapp.YAMLTask{"post-import-db": {{"exec-host": "touch hello-post-import-db-" + app.Name}}, "pre-import-db": {{"exec-host": "touch hello-pre-import-db-" + app.Name}}}
 
 	// Test simple db loads.

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -583,6 +583,13 @@ func drupal7ConfigOverrideAction(app *DdevApp) error {
 	return nil
 }
 
+// drupal8ConfigOverrideAction overrides mariadb_version for Druapl 8 for future
+// compatibility with Drupal 9, since it requires at least 10.3.
+func drupal8ConfigOverrideAction(app *DdevApp) error {
+	app.MariaDBVersion = nodeps.MariaDB103
+	return nil
+}
+
 // drupal9ConfigOverrideAction overrides mariadb_version for D9,
 // since it requires at least 10.3
 func drupal9ConfigOverrideAction(app *DdevApp) error {


### PR DESCRIPTION
This is to aid with future compatibility for Drupal 9.

## The Problem/Issue/Bug:

Drupal 8 sites that upgrade to Drupal 9 will be stuck with databases that won't work anymore, because ddev uses mariadb 10.2 by default whereas D9 requires 10.3.

## How this PR Solves The Problem:

This changes the configuration to use mariadb 10.3 when building an instance for Drupal 8.

## Manual Testing Instructions:

Build an instance for D8.

## Automated Testing Overview:

TBD.

## Related Issue Link(s):

#2232

## Release/Deployment notes:

TBD.