### PR TITLE
Add example custom command for Sequel Ace or Sequel Pro (macOS)

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/commands/host/mysqlworkbench.example
+++ b/cmd/ddev/cmd/dotddev_assets/commands/host/mysqlworkbench.example
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 ## #ddev-generated
-## Description: Run MySQLWorkbench against current db
+## Description: Run MySQL Workbench against current db
 ## Usage: mysqlworkbench
 ## Example: "ddev mysqlworkbench"
 
-# Note that this examle uses $DDEV_HOST_DB_PORT to get the port for the connection
-# Mysql Workbench can be obtained from https://dev.mysql.com/downloads/workbench/
+# Note that this example uses $DDEV_HOST_DB_PORT to get the port for the connection
+# MySQL Workbench can be obtained from https://dev.mysql.com/downloads/workbench/
 
 query="root:root@127.0.0.1:${DDEV_HOST_DB_PORT}"
 

--- a/cmd/ddev/cmd/dotddev_assets/commands/host/sequel.example
+++ b/cmd/ddev/cmd/dotddev_assets/commands/host/sequel.example
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Run Sequel Ace or SequelPro against current db
+## Usage: sequel
+## Example: "ddev sequel"
+
+# This command uses $DDEV_HOST_DB_PORT to get the port for the connection
+#
+# Both apps are free, but available only for macOS-only 
+# Find Sequel Ace in the Mac App Store or at https://sequel-ace.com/
+# Find Sequel Pro at https://www.sequelpro.com/
+
+query="mysql://root:root@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
+
+app=""
+if [ -f "/Applications/Sequel Ace.app/Contents/MacOS/Sequel Ace" ]; then
+    app="Sequel Ace"
+elif [ -f "/Applications/Sequel Pro.app/Contents/MacOS/Sequel Pro" ]; then
+    app="Sequel Pro"
+fi
+
+if [ ! -z "$app" ]; then
+    echo "Opening $app..."
+    open "$query" -a "$app"
+else
+    echo "ERROR - Neither Sequel Ace nor Pro seems to be installed."
+fi


### PR DESCRIPTION
## The Problem/Issue/Bug:

We'd like to support either Sequel Ace or Sequel Pro for Mac users to connect directly to the db container visually.  This example custom command does that, assuming the apps are installed in the default location (`/Applications/`)

This might be a better solution than #2370.

## How this PR Solves The Problem:

Adds a custom command example file `sequel.example` to `.ddev/commands/host`

## Manual Testing Instructions:

- Rename `sequel.example` to `sequel` and run `ddev sequel`.

If Sequel Ace is installed, it is preferred.  If neither is installed, the command should just print an error message.

## Automated Testing Overview:

n/a

## Related Issue Link(s):

#2369 

## Release/Deployment notes:

Might possibly want to update the docs to note this.