### PR TITLE
Use 127.0.0.1 in healthcheck instead of localhost - avoid docker corp proxy

### DIFF
--- a/containers/ddev-router/test/containertest.sh
+++ b/containers/ddev-router/test/containertest.sh
@@ -61,4 +61,4 @@ if [ "${OS:-$(uname)}" != "Windows_NT" ]; then
     (curl -s -I https://127.0.0.1:8443 | grep 503) || (echo "Failed to get 503 from nginx-router via https by default" && exit 103)
 fi
 # Make sure internal access to https is working
-docker exec -t $CONTAINER_NAME curl --fail https://localhost/healthcheck || (echo "Failed to run https healthcheck inside container" && exit 104)
+docker exec -t $CONTAINER_NAME curl --fail https://127.0.0.1/healthcheck || (echo "Failed to run https healthcheck inside container" && exit 104)

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
@@ -21,7 +21,7 @@ fi
 phpstatus=false
 htmlaccess=false
 mailhog=false
-if curl --fail -s localhost/phpstatus >/dev/null ; then
+if curl --fail -s 127.0.0.1/phpstatus >/dev/null ; then
     phpstatus=true
     printf "phpstatus: OK "
 else
@@ -35,7 +35,7 @@ else
     printf "/var/www/html access FAILED"
 fi
 
-if curl --fail -s localhost:8025 >/dev/null; then
+if curl --fail -s 127.0.0.1:8025 >/dev/null; then
     mailhog=true
     printf "mailhog: OK " ;
 else

--- a/containers/ddev-webserver/tests/ddev-webserver/custom_config.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/custom_config.bats
@@ -12,9 +12,9 @@
     docker exec -t $CONTAINER_NAME php -i | grep "assert.active.*=> 0 => 0" >/dev/null
 
     # Make sure that our nginx override providing /junker99 works correctly
-    curl -s http://localhost:$HOST_HTTP_PORT/junker99 | grep 'junker99!'
+    curl -s http://127.0.0.1:$HOST_HTTP_PORT/junker99 | grep 'junker99!'
     #TODO: Why wouldn't this work on Windows?
     if [ "${OS:-$(uname)}" != "Windows_NT" ]; then
-        curl -s https://localhost:$HOST_HTTPS_PORT/junker99 | grep 'junker99!'
+        curl -s https://127.0.0.1:$HOST_HTTPS_PORT/junker99 | grep 'junker99!'
     fi
 }

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -21,7 +21,7 @@
 }
 
 @test "verify access to upstream error messages ($project_type)" {
-	ERRMSG="$(curl localhost:$HOST_HTTP_PORT/test/upstream-error.php)"
+	ERRMSG="$(curl 127.0.0.1:$HOST_HTTP_PORT/test/upstream-error.php)"
 	if [ "$ERRMSG" != "Upstream error message" ] ; then
 	  exit 108
 	fi

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -4,27 +4,27 @@
 # bats tests/ddev-websever-dev/php_webserver.bats
 
 @test "http and https phpstatus access work inside and outside container for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
-    curl -sSL --fail http://localhost:$HOST_HTTP_PORT/test/phptest.php
+    curl -sSL --fail http://127.0.0.1:$HOST_HTTP_PORT/test/phptest.php
     if [ "${OS:-$(uname)}" != "Windows_NT" ] ; then
         # TODO: Why doesn't this work on Windows?
-        curl -sSL --fail https://localhost:$HOST_HTTPS_PORT/test/phptest.php
+        curl -sSL --fail https://127.0.0.1:$HOST_HTTPS_PORT/test/phptest.php
     fi
-    docker exec -t $CONTAINER_NAME curl --fail http://localhost/test/phptest.php
-    docker exec -t $CONTAINER_NAME curl --fail https://localhost/test/phptest.php
+    docker exec -t $CONTAINER_NAME curl --fail http://127.0.0.1/test/phptest.php
+    docker exec -t $CONTAINER_NAME curl --fail https://127.0.0.1/test/phptest.php
 }
 
 @test "enable and disable xdebug for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
     docker exec -t $CONTAINER_NAME enable_xdebug
     docker exec -t $CONTAINER_NAME php --re xdebug | grep "xdebug.remote_enable"
-    curl -s localhost:$HOST_HTTP_PORT/test/xdebug.php | grep "Xdebug is enabled"
+    curl -s 127.0.0.1:$HOST_HTTP_PORT/test/xdebug.php | grep "Xdebug is enabled"
     docker exec -t $CONTAINER_NAME disable_xdebug
     docker exec -t $CONTAINER_NAME php --re xdebug | grep "xdebug does not exist"
-    curl -s localhost:$HOST_HTTP_PORT/test/xdebug.php | grep "Xdebug is disabled"
+    curl -s 127.0.0.1:$HOST_HTTP_PORT/test/xdebug.php | grep "Xdebug is disabled"
 }
 
 @test "verify mailhog for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
-    curl -s localhost:$HOST_HTTP_PORT/test/test-email.php | grep "Test email sent"
-    curl -s --fail localhost:$HOST_HTTP_PORT/test/phptest.php
+    curl -s 127.0.0.1:$HOST_HTTP_PORT/test/test-email.php | grep "Test email sent"
+    curl -s --fail 127.0.0.1:$HOST_HTTP_PORT/test/phptest.php
 }
 
 @test "verify PHP ini settings for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
@@ -33,19 +33,19 @@
 }
 
 @test "verify phpstatus endpoint for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
-    curl -s localhost:$HOST_HTTP_PORT/phpstatus | egrep "idle processes|php is working"
+    curl -s 127.0.0.1:$HOST_HTTP_PORT/phpstatus | egrep "idle processes|php is working"
 }
 
 @test "verify error conditions for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
     # These are just the standard nginx 403 and 404 pages
-    curl localhost:$HOST_HTTP_PORT/asdf | grep "404 Not Found"
+    curl 127.0.0.1:$HOST_HTTP_PORT/asdf | grep "404 Not Found"
     # We're just checking the error code here - there's not much more we can do in
     # this case because the container is *NOT* intercepting 50x errors.
     for item in 400 401 500; do
-        curl -w "%{http_code}" localhost:$HOST_HTTP_PORT/test/${item}.php | grep $item
+        curl -w "%{http_code}" 127.0.0.1:$HOST_HTTP_PORT/test/${item}.php | grep $item
     done
 }
 
 @test "verify that test/phptest.php is interpreted ($project_type)" {
-	curl --fail localhost:$HOST_HTTP_PORT/test/phptest.php
+	curl --fail 127.0.0.1:$HOST_HTTP_PORT/test/phptest.php
 }

--- a/containers/ddev-webserver/tests/ddev-webserver/project_type.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/project_type.bats
@@ -13,7 +13,7 @@
 }
 
 @test "verify that both nginx logs and fpm logs are being tailed ($project_type)" {
-    curl --fail localhost:$HOST_HTTP_PORT/test/fatal.php
+    curl --fail 127.0.0.1:$HOST_HTTP_PORT/test/fatal.php
 	docker logs $CONTAINER_NAME 2>&1 | grep "WARNING:.* said into stderr:.*fatal.php on line " >/dev/null
 	docker logs $CONTAINER_NAME 2>&1 | grep "FastCGI sent in stderr: .PHP message: PHP Fatal error:" >/dev/null
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.15.0" // Note that this can be overridden by make
+var WebTag = "20200710_dont_use_localhost" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

It turns out if people have a proxy set up in docker
and they haven't excluded "localhost", then the
healthcheck script will fail accessing http://localhost

There was a change in the web image healthcheck script in v1.15.0 to use "localhost" instead of "127.0.0.1" and this broke somebody with a proxy and 127.0.0.1 (only) excluded from the proxy.


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

