### PR TITLE
Minor test improvment, contains instead of equal

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -73,7 +73,7 @@ func TestCustomCommands(t *testing.T) {
 	command.Stdin = f
 	byteOut, err := command.CombinedOutput()
 	require.NoError(t, err, "Failed ddev mysql; output=%v", string(byteOut))
-	assert.Equal("99\n99\n", string(byteOut))
+	assert.Contains(string(byteOut), "99\n99\n")
 
 	_ = os.RemoveAll(projectCommandsDir)
 	_ = os.RemoveAll(globalCommandsDir)


### PR DESCRIPTION
## The Problem/Issue/Bug:

TestCustomCommands has a fragile test that can be simpler with Contains instead of Equals.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

