### PR TITLE
Bump minimum macOS requirement to High Sierra because Docker Desktop already has

### DIFF
--- a/.circleci/bump_homebrew.sh
+++ b/.circleci/bump_homebrew.sh
@@ -22,7 +22,7 @@ SOURCE_URL="https://github.com/drud/ddev/archive/${VERSION_NUMBER}.tar.gz"
 SOURCE_SHA=$(curl -sSL ${SOURCE_URL} | shasum -a 256 | awk '{print $1}')
 
 LINUX_BOTTLE_SHA=$(awk '{print $1}' <"${ARTIFACTS_DIR}/${PROJECT_NAME}-${NO_V_VERSION}.x86_64_linux.bottle.tar.gz.sha256.txt")
-MACOS_BOTTLE_SHA=$(awk '{print $1}' <${ARTIFACTS_DIR}/${PROJECT_NAME}-${NO_V_VERSION}.sierra.bottle.tar.gz.sha256.txt)
+MACOS_BOTTLE_SHA=$(awk '{print $1}' <${ARTIFACTS_DIR}/${PROJECT_NAME}-${NO_V_VERSION}.high_sierra.bottle.tar.gz.sha256.txt)
 
 
 TMPDIR=$(mktemp -d)
@@ -46,7 +46,7 @@ class Ddev < Formula
     root_url "https://github.com/drud/ddev/releases/download/${VERSION_NUMBER}/"
     cellar :any_skip_relocation
     sha256 "${LINUX_BOTTLE_SHA}" => :x86_64_linux
-    sha256 "${MACOS_BOTTLE_SHA}" => :sierra
+    sha256 "${MACOS_BOTTLE_SHA}" => :high_sierra
   end
   def install
     system "make", "VERSION=v#{version}", "COMMIT=v#{version}"

--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -81,7 +81,7 @@ cp ddev_windows_installer*.exe $ARTIFACTS
 tar -czf $ARTIFACTS/ddev_shell_completion_scripts.$VERSION.tar.gz *completion*.sh
 
 # Create macOS and Linux homebrew bottles
-for os in sierra x86_64_linux ; do
+for os in high_sierra x86_64_linux ; do
     NO_V_VERSION=${VERSION#v}
     rm -rf /tmp/bottle
     BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
@@ -90,7 +90,7 @@ for os in sierra x86_64_linux ; do
     cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh/site-functions/_ddev
     cp $BASE_DIR/.gotmp/bin/ddev_fish_completion.sh $BOTTLE_BASE/share/fish/vendor_completions.d/ddev.fish
 
-    if [ "${os}" = "sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin ; fi
+    if [ "${os}" = "high_sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin ; fi
     if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/ddev $BOTTLE_BASE/bin ; fi
     cp $BASE_DIR/{README.md,LICENSE} $BOTTLE_BASE
     tar -czf $ARTIFACTS/ddev-$NO_V_VERSION.$os.bottle.tar.gz -C /tmp/bottle .

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,11 +25,12 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Version and configuration information (please complete the following information):**
- - Host computer OS and Version: [e.g. Windows 10, macOS High Sierra]
- - Docker version information (use `docker version`) and insert it here.
- - ddev version information (use `ddev version`)
- - config.yaml contents for the misbehaving project
- - Do you have any custom configuration (nginx, php, mysql) in the .ddev folder? If so, have you tried without them?
+
+- Host computer OS and Version: [e.g. Windows 10, macOS Catalina]
+- Docker Desktop version if on macOS or Windows (from "About Docker Desktop")
+- ddev version information (use `ddev version`)
+- config.yaml contents for the misbehaving project
+- Do you have any custom configuration (nginx, php, mysql) in the .ddev folder? If so, have you tried without them?
 
 **Additional context**
 Add any other context about the problem here. Thanks!

--- a/docs/developers/buildkite-testmachine-setup.md
+++ b/docs/developers/buildkite-testmachine-setup.md
@@ -32,7 +32,7 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 9. Add the path `/private/var` or on Catalina `/System/Volumes/Data/private/var` to `/etc/exports` and `sudo nfsd restart`.
 10. Edit the buildkite-agent.cfg in /usr/local/etc/buildkite-agent.cfg to add
     * the agent token
-    * Tags, like `"os=macos,osvariant=highsierra,dockertype=dockerformac"`
+    * Tags, like `"os=macos,osvariant=catalina,dockertype=dockerformac"`
     * `build-path="~/tmp/buildkite-agent/builds"`
 11. `brew services start buildkite-agent`
 12. Enable nosleep using its shortcut in the Mac status bar.

--- a/docs/developers/release-checklist.md
+++ b/docs/developers/release-checklist.md
@@ -33,7 +33,7 @@ The following environment variables must be added to the **org context** named [
 
 ## Manually updating homebrew formulas
 
-* Update the `ddev` homebrew formulas (ddev-edge and ddev) as necessary, <https://github.com/drud/homebrew-ddev> and <https://github.com/drud/homebrew-ddev-edge,> with the source .tar.gz and SHA checksum of the tarball and the bottle builds and tarballs. The bottles and checksums for macOS (sierra) and x86_64_linux are built and pushed to the release page automatically by the CircleCI release build process. Test `brew upgrade ddev` both on macOS and Linux and make sure ddev is the right version and behaves well.
+* Update the `ddev` homebrew formulas (ddev-edge and ddev) as necessary, <https://github.com/drud/homebrew-ddev> and <https://github.com/drud/homebrew-ddev-edge,> with the source .tar.gz and SHA checksum of the tarball and the bottle builds and tarballs. The bottles and checksums for macOS (high sierra) and x86_64_linux are built and pushed to the release page automatically by the CircleCI release build process. Test `brew upgrade ddev` both on macOS and Linux and make sure ddev is the right version and behaves well.
 
 ## Manually updating Chocolatey
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 * docker-compose 1.21.0 and higher (bundled with Docker in Docker Desktop for Mac and Docker Desktop for Windows)
 * OS Support
-    * macOS Sierra and higher (macOS 10.12 and higher; it should run anywhere Docker Desktop for Mac runs.
+    * macOS High Sierra and higher (macOS 10.13 and higher; it should run anywhere Docker Desktop for Mac runs.
     * Linux: Most Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 16.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
     * Windows 10 (all editions) with WSL2 (version 2004 or later)
     * (Non-WSL2) Windows 10 Home, Pro, or Enterprise with [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/install/)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Docker Desktop for Mac minimum requirement has changed to High Sierra. 

## How this PR Solves The Problem:

Switch to High Sierra

## Manual Testing Instructions:

- [ ] Do a private release on a private edge repo (rfay/ddev-edge) and make sure that the homebrew result is usable.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

