### PR TITLE
Don't use pipefail with non-bash exec/custom commands, fixes drud/ddev-contrib#80

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1066,9 +1066,6 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		shell = "sh"
 	}
 	errcheck := "set -eu"
-	if shell == "bash" {
-		errcheck = errcheck + " -o pipefail "
-	}
 	exec = append(exec, shell, "-c", errcheck+` && ( `+opts.Cmd+`)`)
 
 	files, err := app.ComposeFiles()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1065,7 +1065,11 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if !nodeps.ArrayContainsString([]string{"web", "db", "dba"}, opts.Service) {
 		shell = "sh"
 	}
-	exec = append(exec, shell, "-c", "set -eu -o pipefail && ( "+opts.Cmd+")")
+	errcheck := "set -eu"
+	if shell == "bash" {
+		errcheck = errcheck + " -o pipefail "
+	}
+	exec = append(exec, shell, "-c", errcheck+` && ( `+opts.Cmd+`)`)
 
 	files, err := app.ComposeFiles()
 	if err != nil {

--- a/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
@@ -4,3 +4,6 @@ services:
     image: busybox
     command: tail -f /dev/null
     container_name: ddev-${DDEV_SITENAME}-busybox
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT

--- a/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
@@ -1,0 +1,6 @@
+version: '3.6'
+services:
+  busybox:
+    image: busybox
+    command: tail -f /dev/null
+    container_name: ddev-${DDEV_SITENAME}-busybox


### PR DESCRIPTION
##  The Problem/Issue/Bug:

drud/ddev-contrib#80 points out that custom commands (and all execs) on non-ddev-provided containers will fail because the "sh" shell is used by default, and it doesn't provide the "pipefail" error check.

## How this PR Solves The Problem:

Only use -o pipefail if bash is the shell.

* Consider dropping pipefail out completely to simplify the code.

## Manual Testing Instructions:

* Test drud/ddev-contrib#80
* Test other ordinary `ddev exec` with ddev and non-ddev containers.

## Automated Testing Overview:

- [ ] Needs a test with 3rd party service to make sure this is maintained. 

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

