### PR TITLE
Gitignore the .homeadditions completely, fixes #2374

### DIFF
--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -689,6 +689,8 @@ func TestConfigGitignore(t *testing.T) {
 	defer func() {
 		_, err = exec.RunCommand(DdevBin, []string{"delete", "-Oy"})
 		assert.NoError(err)
+		_, err = exec.RunCommand("bash", []string{"-c", fmt.Sprintf("rm -f ~/.ddev/commands/web/%s ~/.ddev/homeadditions/%s", t.Name(), t.Name())})
+		assert.NoError(err)
 	}()
 
 	_, err = exec.RunCommand("git", []string{"init"})
@@ -703,6 +705,10 @@ func TestConfigGitignore(t *testing.T) {
 	// .ddev/config.yaml should be the only new file, remove it and check
 	out = strings.ReplaceAll(out, "new file:   .ddev/config.yaml", "")
 	assert.NotContains(out, "new file:")
+
+	_, err = exec.RunCommand("bash", []string{"-c", fmt.Sprintf("touch ~/.ddev/commands/web/%s ~/.ddev/homeadditions/%s", t.Name(), t.Name())})
+	assert.NoError(err)
+
 	_, err = exec.RunCommand(DdevBin, []string{"start"})
 	assert.NoError(err)
 	statusOut, err := exec.RunCommand("bash", []string{"-c", "git status"})

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -977,7 +977,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-compose-base.yaml", ".ddev-docker-compose-full.yaml", ".ddevlive-downloads", ".global_commands", ".sshimageBuild", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/live", "commands/web/xdebug", "config.*.y*ml", "db_snapshots", "import-db", "import.yaml", "nginx_full/nginx-site.conf", "sequelpro.spf", "**/README.*")
+	err := CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-compose-base.yaml", ".ddev-docker-compose-full.yaml", ".ddevlive-downloads", ".global_commands", ".homeadditions", ".sshimageBuild", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/live", "commands/web/xdebug", "config.*.y*ml", "db_snapshots", "import-db", "import.yaml", "nginx_full/nginx-site.conf", "sequelpro.spf", "**/README.*")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2374 describes the issue when something is added to ~/.ddev/homeadditions and then you do a `ddev start`. 

The resulting homeadditions item gets copied into the project at .ddev/.homeadditions and then it is not properly gitignored. 

## How this PR Solves The Problem:

Add .homeadditions to the gitignore.

## Manual Testing Instructions:

* Start with a project that is clean in git. (`git status` is clean)
* Add something to ~/.ddev/homeadditions.
* `ddev start` 
* `git status` should still be clean.


## Automated Testing Overview:

Added this scenario to TestConfigGitIgnore() and also added global commands the same way.

## Related Issue Link(s):

#2374 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

