### PR TITLE
Fix wrong dir creation of sync dir, fixes #2389

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -726,7 +726,7 @@ func createDrupal8SyncDir(app *DdevApp) error {
 	// we may want to do some kind of customization in the future.
 	drupalConfig := NewDrupalSettings(app)
 
-	syncDirPath := path.Join(app.GetAppRoot(), app.GetDocroot(), drupalConfig.SyncDir)
+	syncDirPath := path.Join(app.GetAppRoot(), app.GetDocroot(), "sites/default", drupalConfig.SyncDir)
 	if fileutil.FileExists(syncDirPath) {
 		return nil
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2389 points out that "files/sync" is being created in "web/files/sync" instead of in "web/sites/default/files/sync"

## How this PR Solves The Problem:

Create the right path. 

## Manual Testing Instructions:

in docroot:
rm -rf sites/default/files/sync files/sync
`ddev start`
Check the status page to make sure it doesn't have a complaint about the sync dir.

