### PR TITLE
Reset global mkcert var if  has changed, fixes #2373

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -100,7 +100,9 @@ func ReadGlobalConfig() error {
 	if DdevGlobalConfig.ProjectList == nil {
 		DdevGlobalConfig.ProjectList = map[string]*ProjectInfo{}
 	}
-	if DdevGlobalConfig.MkcertCARoot == "" {
+	// Set/read the CAROOT if it's unset or different from $CAROOT (perhaps $CAROOT changed)
+	caRootEnv := os.Getenv("CAROOT")
+	if DdevGlobalConfig.MkcertCARoot == "" || (caRootEnv != "" && caRootEnv != DdevGlobalConfig.MkcertCARoot) {
 		DdevGlobalConfig.MkcertCARoot = readCAROOT()
 	}
 	// This is added just so we can see it in global; not checked.


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2373 points out that `DdevGlobalConfig.MkcertCARoot` never gets updated of $CAROOT changes, which means that especially in WSL2, if any mistake is made in $CAROOT, it never gets corrected.

## How this PR Solves The Problem:

If $CAROOT isn't the same as `DdevGlobalConfig.MkcertCARoot` then re-read the correct value.

## Manual Testing Instructions:

Test in WSL2. 

* Mess up the setx command so that WSLENV contains a semicolon instead of colon.
* You should now have a broken CAROOT on WSL side
* `ddev start` and see that the bad CAROOT gets into ~/.ddev/global_config.yaml
* Now fix CAROOT via a proper setx. 
* `ddev start` and see that it get fixed in global_config.
* Verify that chrome trusts a site.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

