### PR TITLE
v1.15: Improved/Fixed documentation for Apache config override files

### DIFF
--- a/pkg/ddevapp/webserver_config_packr_assets/README.apache.txt-site-php.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/README.apache.txt-site-php.conf
@@ -10,3 +10,5 @@ as you see fit. Use `ddev start` to restart.
 
 You can also add more configurations, for example with separate configurations
 for each site, as demonstrated by the second_docroot.conf.example, which shows how to have apache serve completely different configurations for a named site that is different from the default.
+
+The files will be copied into /etc/apache2/sites-enabled directory.

--- a/pkg/ddevapp/webserver_config_packr_assets/apache-site-php.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/apache-site-php.conf
@@ -3,7 +3,7 @@
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above
 # and ddev will respect it and won't overwrite the file.
-# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-apache-configuration
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTP:X-Forwarded-Proto} =https

--- a/pkg/ddevapp/webserver_config_packr_assets/apache_second_docroot_example-site-php.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/apache_second_docroot_example-site-php.conf
@@ -3,7 +3,7 @@
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above
 # and ddev will respect it and won't overwrite the file.
-# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-apache-configuration
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTP:X-Forwarded-Proto} =https


### PR DESCRIPTION
## The Problem/Issue/Bug:
The 1.15 Apache config files were linking to Nginx manual section. 

## How this PR Solves The Problem:
Fixed the link. Also added a sentence in README file on where this config files end up to help understanding.