### PR TITLE
Stop testing for apache-cgi and docker toolbox for #2286, for #2284, for #2288

### DIFF
--- a/.buildkite/windows10dockertoolbox.yml
+++ b/.buildkite/windows10dockertoolbox.yml
@@ -1,7 +1,0 @@
-  - command: ".buildkite/test.cmd"
-    agents:
-      - "os=windows"
-      - "dockertype=toolbox"
-    env:
-      BUILDKITE_CLEAN_CHECKOUT: true
-    parallelism: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,9 +463,9 @@ workflows:
     - lx_apache_fpm_test:
         requires:
         - build
-    - lx_apache_cgi_test:
-        requires:
-        - build
+#    - lx_apache_cgi_test:
+#        requires:
+#        - build
     - lx_nfsmount_test:
         requires:
         - build


### PR DESCRIPTION
## The Problem/Issue/Bug:

In v1.16 we'll no longer be supporting apache-cgi or docker-toolbox. So we should stop wasting testing time on those.

## How this PR Solves The Problem:

Stop the explicit tests for those.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

#2286: Deprecating apache-cgi
#2284: Deprecating docker-toolbox
#2288: Reallocate windows test-runners.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

