### PR TITLE
Bump image tags to v1.15.1

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod (for DDEV-Live)
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v0.3.7 as ddev-webserver-base
+FROM drud/ddev-php-base:v0.3.8 as ddev-webserver-base
 
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4"
 ENV BACKDROP_DRUSH_VERSION=1.4.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,13 +45,13 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200710_dont_use_localhost" // Note that this can be overridden by make
+var WebTag = "v1.15.1" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.15.0"
+var BaseDBTag = "v1.15.1"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin/phpmyadmin"
@@ -63,11 +63,11 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.15.0" // Note that this can be overridden by make
+var RouterTag = "v1.15.1" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.15.0"
+var SSHAuthTag = "v1.15.1"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Rebuilding docker images for v1.15.1

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

