### PR TITLE
nginx shouldn't have long expires on css/js, fixes #2404

### DIFF
--- a/pkg/ddevapp/webserver_config_packr_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/nginx-site-backdrop.conf
@@ -92,9 +92,16 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
         try_files $uri @rewrite;
         expires max;
+        log_not_found off;
+    }
+
+    # js and css always loaded
+    location ~* \.(js|css)$ {
+        try_files $uri @rewrite;
+        expires -1;
         log_not_found off;
     }
     include /mnt/ddev_config/nginx/*.conf;

--- a/pkg/ddevapp/webserver_config_packr_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/nginx-site-drupal6.conf
@@ -77,9 +77,16 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
         try_files $uri @rewrite;
         expires max;
+        log_not_found off;
+    }
+
+    # js and css always loaded
+    location ~* \.(js|css)$ {
+        try_files $uri @rewrite;
+        expires -1;
         log_not_found off;
     }
 

--- a/pkg/ddevapp/webserver_config_packr_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/nginx-site-drupal7.conf
@@ -70,9 +70,16 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
         try_files $uri @rewrite;
         expires max;
+        log_not_found off;
+    }
+
+    # js and css always loaded
+    location ~* \.(js|css)$ {
+        try_files $uri @rewrite;
+        expires -1;
         log_not_found off;
     }
 

--- a/pkg/ddevapp/webserver_config_packr_assets/nginx-site-drupal8.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/nginx-site-drupal8.conf
@@ -90,9 +90,16 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
         try_files $uri @rewrite;
         expires max;
+        log_not_found off;
+    }
+
+    # js and css always loaded
+    location ~* \.(js|css)$ {
+        try_files $uri @rewrite;
+        expires -1;
         log_not_found off;
     }
 

--- a/pkg/ddevapp/webserver_config_packr_assets/nginx-site-drupal9.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/nginx-site-drupal9.conf
@@ -91,9 +91,16 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
         try_files $uri @rewrite;
         expires max;
+        log_not_found off;
+    }
+
+    # js and css always loaded
+    location ~* \.(js|css)$ {
+        try_files $uri @rewrite;
+        expires -1;
         log_not_found off;
     }
 

--- a/pkg/ddevapp/webserver_config_packr_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/nginx-site-magento2.conf
@@ -105,7 +105,7 @@ server {
             rewrite ^/static/(version[^/]+/)?(.*)$ /static/$2 last;
         }
 
-        location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|json)$ {
+        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2|json)$ {
             add_header Cache-Control "public";
             add_header X-Frame-Options "SAMEORIGIN";
             expires +1y;
@@ -114,6 +114,16 @@ server {
                 rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
             }
         }
+        location ~* \.(js|css)$ {
+            add_header Cache-Control "public";
+            add_header X-Frame-Options "SAMEORIGIN";
+            expires -1;
+
+            if (!-f $request_filename) {
+                rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
+            }
+        }
+
         location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
             add_header Cache-Control "no-store";
             add_header X-Frame-Options "SAMEORIGIN";
@@ -136,12 +146,19 @@ server {
             deny all;
         }
 
-        location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2)$ {
+        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2)$ {
             add_header Cache-Control "public";
             add_header X-Frame-Options "SAMEORIGIN";
             expires +1y;
             try_files $uri $uri/ /get.php$is_args$args;
         }
+        location ~* \.(js|css)$ {
+            add_header Cache-Control "public";
+            add_header X-Frame-Options "SAMEORIGIN";
+            expires -1;
+            try_files $uri $uri/ /get.php$is_args$args;
+        }
+
         location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
             add_header Cache-Control "no-store";
             add_header X-Frame-Options "SAMEORIGIN";

--- a/pkg/ddevapp/webserver_config_packr_assets/nginx-site-wordpress.conf
+++ b/pkg/ddevapp/webserver_config_packr_assets/nginx-site-wordpress.conf
@@ -81,9 +81,14 @@ server {
         fastcgi_param HTTPS $fcgi_https;
     }
 
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+    location ~* \.(png|jpg|jpeg|gif|ico)$ {
         expires max;
         log_not_found off;
     }
+    location ~* \.(js|css)$ {
+        expires -1;
+        log_not_found off;
+    }
+
     include /mnt/ddev_config/nginx/*.conf;
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

Front-end developers really want changes to css and js to come through right away, and ddev is a developers' tool. 

#2404 explains how the Expires setting in nginx makes it so devs can't see their CSS changes.

I ran into this exact problem exploring #2410 , so figure it will probably affect others. 

## How this PR Solves The Problem:

Turn off the expires header for css and js.

## Manual Testing Instructions:

Must test for every changed CMS project type.
* Start the project
* Visit pages
* Use Chrome debugger or whatever to see the expires situation for css

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

