### PR TITLE
Remove drupal console from ddev-webserver, fixes #2388

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -95,8 +95,6 @@ RUN curl -sSL https://raw.githubusercontent.com/netz98/n98-magerun/${MAGERUN_VER
 RUN curl -sSL https://files.magerun.net/n98-magerun2-latest.phar -o /usr/local/bin/magerun2
 RUN curl -sSL https://raw.githubusercontent.com/netz98/n98-magerun2/${MAGERUN2_VERSION}/res/autocompletion/bash/n98-magerun2.phar.bash -o /etc/bash_completion.d/magerun2
 
-RUN curl -sSL "https://drupalconsole.com/installer" -L -o /usr/local/bin/drupal && chmod +x /usr/local/bin/drupal
-
 RUN curl -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands
 
 RUN mkdir -p /etc/nginx/sites-enabled /var/log/apache2 /var/run/apache2 /var/lib/apache2/module/enabled_by_admin /var/lib/apache2/module/disabled_by_admin && \

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "Verify required binaries are installed in container" {
-    COMMANDS="composer ddev-live drupal drush git magerun magerun2 mkcert terminus wp"
+    COMMANDS="composer ddev-live drush git magerun magerun2 mkcert terminus wp"
     for item in $COMMANDS; do
        docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"
     done

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.15.3" // Note that this can be overridden by make
+var WebTag = "20200727_abhi_remove_console" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:
Remove drupal console from ddev-webserver #2388 

## How this PR Solves The Problem:
By removing the curl command which installs the drupal console into the ddev-webserver.

## Manual Testing Instructions:
1. Edited `containers/ddev-webserver/Makefile` with my docker hub info.
2. Followed the instruction from the file [README.md](https://github.com/drud/ddev/blob/master/containers/ddev-webserver/README.md)
3. Docker hub repo link: [abhisekmazumdar/ddev-webserver](https://hub.docker.com/r/abhisekmazumdar/ddev-webserver)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

