### PR TITLE
[docs] Improve wording of "In-container home directory configuration"

### DIFF
--- a/docs/users/extend/in-container-configuration.md
+++ b/docs/users/extend/in-container-configuration.md
@@ -1,10 +1,10 @@
 ## In-Container home directory configuration
 
-Custom shell config (bash or your preferred shell), your usual git configuration, a composer auth.json and more can be achieved within your containers.
+Custom shell config (bash or your preferred shell), your usual git configuration, a composer auth.json and more can be achieved within your containers.  Place all your dotfiles in your `~/.ddev/homeadditions` directory and DDev will use these in all your projects' Docker containers.
 
 On `ddev start`, ddev attempts to create a user inside the web and db containers with the same name and use id as the one you have on the host.
 
-If you have `homeadditions` directory either in `~/.ddev/homeadditions` (the global .ddev directory) or the `.ddev/homeadditions` directory of a particular project, their contents will be copied recursively into the in-container home directory during `ddev start`. (Note that project homeadditions contents override the global homeadditions.)
+DDev looks for `homeadditions` directory either in `~/.ddev/homeadditions` (the global .ddev directory) or the `.ddev/homeadditions` directory of a particular project, and will copy their contents recursively into the in-container home directory during `ddev start`. (Note that project homeadditions contents override the global homeadditions.)
 
 If you want to use a shell other than bash, add it as a package to [customize the Docker image](https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/).
 

--- a/docs/users/extend/in-container-configuration.md
+++ b/docs/users/extend/in-container-configuration.md
@@ -1,16 +1,14 @@
-## In-Container home directory configuration
+## In-Container home directory and shell configuration
 
-Custom shell config (bash or your preferred shell), your usual git configuration, a composer auth.json and more can be achieved within your containers.  Place all your dotfiles in your `~/.ddev/homeadditions` directory and DDev will use these in all your projects' Docker containers.
+Custom shell configuration (bash or your preferred shell), your usual git configuration, a composer auth.json and more can be achieved within your containers.  Place all your dotfiles in your global`~/.ddev/homeadditions` or your project's .ddev/homeadditions directory and DDEV will use these in your project's web containers.
 
 On `ddev start`, ddev attempts to create a user inside the web and db containers with the same name and use id as the one you have on the host.
 
-DDev looks for `homeadditions` directory either in `~/.ddev/homeadditions` (the global .ddev directory) or the `.ddev/homeadditions` directory of a particular project, and will copy their contents recursively into the in-container home directory during `ddev start`. (Note that project homeadditions contents override the global homeadditions.)
-
-If you want to use a shell other than bash, add it as a package to [customize the Docker image](https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/).
+DDEV looks for the `homeadditions` directory either in `~/.ddev/homeadditions` (the global .ddev directory) or the `.ddev/homeadditions` directory of a particular project, and will copy their contents recursively into the in-container home directory during `ddev start`. (Note that project homeadditions contents override the global homeadditions.)
 
 Usage examples:
 
-* If you make git commits inside the container, you may want to copy your ~/.gitconfig into ~/.ddev/homeadditions or the project's .ddev/homeadditions so that use of git inside the container will use your regular username and email, etc.
+* If you use git inside the container, you may want to copy your ~/.gitconfig into ~/.ddev/homeadditions or the project's .ddev/homeadditions so that use of git inside the container will use your regular username and email, etc.
 * If you use private password-protected composer repositories with satis, for example, and use a global auth.json, you might want to `cp ~/.composer/auth.json into .ddev/homeadditions/.composer/auth.json`, but be careful that you exclude it from checking using a .gitignore or equivalent.
 * Some people have specific configuration needs for their .ssh/config. If you provide your own .ssh/config though, please make sure it includes these lines:
 

--- a/docs/users/extend/in-container-configuration.md
+++ b/docs/users/extend/in-container-configuration.md
@@ -1,11 +1,12 @@
 ## In-Container home directory configuration
 
-There are a number of reasons that your web container home directory may need custom configuration. You may want your normal git configuration in there, or a composer auth.json, etc.
+Custom shell config (bash or your preferred shell), your usual git configuration, a composer auth.json and more can be achieved within your containers.
 
 On `ddev start`, ddev attempts to create a user inside the web and db containers with the same name and use id as the one you have on the host.
 
-If you have a ~/.ddev/homeadditions
-If you have a ~/.ddev/homeadditions directory (in the global .ddev directory) or your project has a .ddev/homeadditions directory, their contents will be copied recursively into the in-container home directory during `ddev start`. (Note that project homeadditions contents override the global homeadditions.)
+If you have `homeadditions` directory either in `~/.ddev/homeadditions` (the global .ddev directory) or the `.ddev/homeadditions` directory of a particular project, their contents will be copied recursively into the in-container home directory during `ddev start`. (Note that project homeadditions contents override the global homeadditions.)
+
+If you want to use a shell other than bash, add it as a package to [customize the Docker image](https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/).
 
 Usage examples:
 


### PR DESCRIPTION
In response to https://stackoverflow.com/questions/63084369/in-ddev-how-to-automatically-use-custom-shell-config-inside-docker-container I tried to make the shell configuration more explicit... particularly including the exact words "shell config" and "dotfiles" so the readthedocs search can find them.

In regards to "If you want to use a shell other than bash, add it as a package to [customize the Docker image](https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/).".... I presume that's correct for adding a shell like zsh but I'm not sure..?