### PR TITLE
PHP_IDE_CONFIG must not be set for php-fpm

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -86,8 +86,8 @@ ADD ddev-webserver-base-files /
 RUN phpdismod xdebug
 RUN curl -sSL "https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_amd64" -o /usr/local/bin/mailhog
 
-RUN curl -ssL -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
-RUN curl -ssL -O $DDEV_LIVE_DOWNLOAD_URL && unzip ddev-live.zip && mv ddev-live /usr/local/bin && chmod +x /usr/local/bin/ddev-live && rm ddev-live.zip
+RUN curl -sSL -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
+RUN curl -sSL -O $DDEV_LIVE_DOWNLOAD_URL && unzip ddev-live.zip && mv ddev-live /usr/local/bin && chmod +x /usr/local/bin/ddev-live && rm ddev-live.zip
 
 # magerun and magerun2 for magento
 RUN curl -sSL https://files.magerun.net/n98-magerun-latest.phar -o /usr/local/bin/magerun

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
@@ -1,2 +1,4 @@
 # This file is loaded in non-interactive bash shells through $BASH_ENV
-source /etc/bashrc/*.bashrc
+for f in /etc/bashrc/*.bashrc; do
+  source $f;
+done

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/php_ide.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/php_ide.bashrc
@@ -1,0 +1,3 @@
+# add composer bin dir to PATH
+export PATH="$PATH:/var/www/html/vendor/bin"
+PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/skel/.bashrc
@@ -112,4 +112,6 @@ if ! shopt -oq posix; then
   fi
 fi
 
-source /etc/bashrc/*.bashrc
+for f in /etc/bashrc/*.bashrc; do
+  source $f;
+done

--- a/docs/users/extend/custom-commands.md
+++ b/docs/users/extend/custom-commands.md
@@ -74,10 +74,12 @@ A number of environment variables are provided to the script. Useful variables f
 * DDEV_HOST_HTTPS_PORT: Localhost port for https on webserver
 * DDEV_HOST_WEBSERVER_PORT: Localhost port of the webserver
 * DDEV_PHP_VERSION
+* DDEV_PRIMARY_URL: Primary URL for the project
 * DDEV_PROJECT_TYPE: drupal8, typo3, backdrop, wordpress, etc.
 * DDEV_ROUTER_HTTP_PORT: Router port for http
 * DDEV_ROUTER_HTTPS_PORT: Router port for https
-* DDEV_SITENAME: Project name, like "d8composer". Same as $DDEV_PROJECT inside container
+* DDEV_SITENAME: Project name, like "d8composer".
+* DDEV_TLD: Top-level domain of project, like "ddev.site"
 * DDEV_WEBSERVER_TYPE: nginx-fpm, apache-fpm
 
 Useful variables for container scripts are:
@@ -85,10 +87,13 @@ Useful variables for container scripts are:
 * DDEV_DOCROOT: Relative path from approot to docroot
 * DDEV_HOSTNAME: Comma-separated list of FQDN hostnames
 * DDEV_PHP_VERSION
+* DDEV_PRIMARY_URL: Primary URL for the project
 * DDEV_PROJECT: Project name, like "d8composer"
 * DDEV_PROJECT_TYPE: drupal8, typo3, backdrop, wordpress, etc.
 * DDEV_ROUTER_HTTP_PORT: Router port for http
 * DDEV_ROUTER_HTTPS_PORT: Router port for https
+* DDEV_SITENAME: Project name, like "d8composer".
+* DDEV_TLD: Top-level domain of project, like "ddev.site"
 * DDEV_WEBSERVER_TYPE: nginx-fpm, apache-fpm
 
 ### Known Windows OS issues

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -26,7 +26,6 @@ version: '3.6'
 services:
   web:
     environment:
-      - PHP_IDE_CONFIG=serverName=mysite.ddev.site
       - TYPO3_CONTEXT=Development
 ```
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -111,7 +111,6 @@ services:
       - COLUMNS=$COLUMNS
       - LINES=$LINES
       - TZ={{ .Timezone }}
-      - PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
       - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:{{ .MailhogPort }}
@@ -120,6 +119,9 @@ services:
       - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:{{ .MailhogPort }}
       - SSH_AUTH_SOCK=/home/.ssh-agent/socket
       - DDEV_PROJECT={{ .Name }}
+      - DDEV_SITENAME
+      - DDEV_TLD
+      - DDEV_PRIMARY_URL
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .Plugin }}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.15.1" // Note that this can be overridden by make
+var WebTag = "20200727_xdebug_server" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

This fixes a regression in v1.15.0 - 

DDEV-Local v1.15 adds automatic settings of PHP_IDE_CONFIG to help people who are doing command-line debugging and want to use xdebug. Otherwise they'd have to set it themselves. 

However, setting this throughout the web container (in php-fpm's context) results in PHPStorm not popping up the normal server/mapping creation dialog box. It's possible to work around it, but we've always been proud of how ddev makes PHPStorm so easy... and suddenly it's not.

## How this PR Solves The Problem:

Only set PHP_IDE_CONFIG in the `ddev ssh` or `ddev exec` context

## Manual Testing Instructions:

Set up PHPStorm
Remove all servers
`ddev xdebug on`
Set a breakpoint in index.php
Visit the site

It should pop up a mapping dialog.


