### PR TITLE
Make PHP_IDE_CONFIG work for both command-line and web debugging

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
@@ -56,3 +56,4 @@ fi
 
 export HISTFILE=/mnt/ddev-global-cache/bashhistory/${HOSTNAME}/bash_history
 
+export PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
@@ -1,2 +1,1 @@
-# add composer bin dir to PATH
 export PATH="$PATH:/var/www/html/vendor/bin"

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/php_ide.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/php_ide.bashrc
@@ -1,3 +1,0 @@
-# add composer bin dir to PATH
-export PATH="$PATH:/var/www/html/vendor/bin"
-PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.15.2" // Note that this can be overridden by make
+var WebTag = "v1.15.3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Unfortunately version v1.15.2 made Xdebug with PHPStorm work fine for people using it for web debugging, but broke it for command-line debugging.  See https://github.com/drud/ddev/pull/2424

This revision works with both command-line and web debugging. 

## How this PR Solves The Problem:

Make sure that PHP_IDE_CONFIG does *not* get loaded by php-fpm (which breaks web debugging) but *does* get loaded by `ddev ssh` (using /etc/bash.bashrc)

## Manual Testing Instructions:

Try debugging with PHPStorm both with a web setup and a command-line setup.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

