### PR TITLE
Change xdebug description in config.yaml to new custom command

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -227,7 +227,7 @@ const ConfigInstructions = `
 
 # xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
 # Note that for most people the commands
-# "ddev exec enable_xdebug" and "ddev exec disable_xdebug" work better,
+# "ddev xdebug" to enable xdebug and "ddev xdebug off" to disable it work better,
 # as leaving xdebug enabled all the time is a big performance hit.
 
 # webserver_type: nginx-fpm  # Can be set to apache-fpm or apache-cgi as well


### PR DESCRIPTION
## The Problem/Issue/Bug:
During the addition of the new xdebug custom command the docs were changed but the description in the config.yaml still talks about the old commands.

## How this PR Solves The Problem:
This patch changes the description in the related template.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

