### PR TITLE
Add 'webroot' and 'html' to the places we look for default docroot

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -849,13 +849,15 @@ func (app *DdevApp) promptForName() error {
 // AvailableDocrootLocations returns an of default docroot locations to look for.
 func AvailableDocrootLocations() []string {
 	return []string{
-		"web/public",
-		"web",
+		"_www",
 		"docroot",
 		"htdocs",
-		"_www",
-		"public",
+		"html",
 		"pub",
+		"public",
+		"web",
+		"web/public",
+		"webroot",
 	}
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Developers sometimes use "webroot" or "html" for the docroot in their projects. Auto-recognize those.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

