### PR TITLE
Delete any existing ddev projects at buildkite startup

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -38,5 +38,7 @@ esac
 docker rmi -f $(docker images --filter "dangling=true" -q --no-trunc) >/dev/null || true
 docker rmi -f $(docker images | awk '/drud.*-built/ {print $3}' ) >/dev/null || true
 
+ddev delete -Oy --all
+
 # Make sure the global internet detection timeout is not set to 0 (broken)
 perl -pi -e 's/^internet_detection_timeout_ms:.*$/internet_detection_timeout_ms: 750/g' ~/.ddev/global_config.yaml

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -38,7 +38,7 @@ esac
 docker rmi -f $(docker images --filter "dangling=true" -q --no-trunc) >/dev/null || true
 docker rmi -f $(docker images | awk '/drud.*-built/ {print $3}' ) >/dev/null || true
 
-ddev delete -Oy --all
+ddev stop --unlist --all
 
 # Make sure the global internet detection timeout is not set to 0 (broken)
 perl -pi -e 's/^internet_detection_timeout_ms:.*$/internet_detection_timeout_ms: 750/g' ~/.ddev/global_config.yaml


### PR DESCRIPTION
## The Problem/Issue/Bug:

Failed tests have left some random projects still listed on buildkite-agents. Delete them at startup.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

