### PR TITLE
Add note about composer global issues

### DIFF
--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -38,7 +38,7 @@ To execute a fully-featured `composer create-project` command, you can execute t
 
 `ddev exec composer create-project ...`
 
-Note: if you use `composer global` command, the packages will be installed in the user's home directory and will disappear on the next container restart, requiring rerun of the command. You may need an additional step of synchronizing created composer configuration and installed packages with the DDev's [homeadditions folder](extend/in-container-configuration.md) on the host.
+Note: if you run `ddev composer global`, the global packages will be installed in the in-container user's home directory ( ~/.composer) and will disappear on the next container restart, requiring rerun of the command. You may need an additional step of synchronizing created composer configuration and installed packages with the DDev's [homeadditions folder](extend/in-container-configuration.md) on the host.
 
 <a name="windows-os-and-ddev-composer"></a>
 

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -38,6 +38,8 @@ To execute a fully-featured `composer create-project` command, you can execute t
 
 `ddev exec composer create-project ...`
 
+Note: if you use `composer global` command, the packages will be installed in the user's home directory and will disappear on the next container restart, requiring rerun of the command. You may need an additional step of synchronizing created composer configuration and installed packages with the DDev's [homeadditions folder](extend/in-container-configuration.md) on the host.
+
 <a name="windows-os-and-ddev-composer"></a>
 
 #### Windows OS and `ddev composer`

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -38,7 +38,7 @@ To execute a fully-featured `composer create-project` command, you can execute t
 
 `ddev exec composer create-project ...`
 
-Note: if you run `ddev composer global`, the global packages will be installed in the in-container user's home directory ( ~/.composer) and will disappear on the next container restart, requiring rerun of the command. You may need an additional step of synchronizing created composer configuration and installed packages with the DDev's [homeadditions folder](extend/in-container-configuration.md) on the host.
+Note: if you run `ddev composer global require`, (or run `composer global require` inside the web container) the global packages will be installed in the in-container user's home directory ( ~/.composer) and will disappear on the next container restart, requiring rerun of the command. You may need an additional step of synchronizing created composer configuration and installed packages with the DDev's [homeadditions folder](extend/in-container-configuration.md) on the host.
 
 <a name="windows-os-and-ddev-composer"></a>
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
Running `composer global require x/y` in web container creates a bunch of files in in-container user's home directory. That directory seems to get wipeout on container restart. This leads to really obscure errors and possibly non-reproducible state (if module resolution changed since last install).

## How this PR Solves The Problem:
There is no easy solution, but at least a note to point out this side-effect would be useful. I added cross-link to homeaddition , but I don't think there is an easy way to sync, it has to be done manually.
