### PR TITLE
Web image maintenance: Simpler terminus install, xdebug on by default

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -83,7 +83,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     zip
 
 ADD ddev-webserver-base-files /
-RUN phpdismod xdebug
 RUN curl -sSL "https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_amd64" -o /usr/local/bin/mailhog
 
 RUN curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod +x /usr/local/bin/terminus

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -86,7 +86,7 @@ ADD ddev-webserver-base-files /
 RUN phpdismod xdebug
 RUN curl -sSL "https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_amd64" -o /usr/local/bin/mailhog
 
-RUN curl -sSL -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
+RUN curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod +x /usr/local/bin/terminus
 RUN curl -sSL -O $DDEV_LIVE_DOWNLOAD_URL && unzip ddev-live.zip && mv ddev-live /usr/local/bin && chmod +x /usr/local/bin/ddev-live && rm ddev-live.zip
 
 # magerun and magerun2 for magento

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -58,7 +58,9 @@ fi
 
 # Disable xdebug by default. Users can enable with /usr/local/bin/enable_xdebug
 if [ "$DDEV_XDEBUG_ENABLED" = "true" ]; then
-    enable_xdebug
+  enable_xdebug
+else
+  disable_xdebug
 fi
 
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -12,7 +12,7 @@
 }
 
 @test "verify that xdebug is enabled by default" {
-    docker exec $CONTAINER_NAME php --re xdebug | grep "xdebug version"
+    docker exec $CONTAINER_NAME bash -c 'php --version | grep "with Xdebug"'
 }
 
 @test "verify there aren't \"closed keepalive connection\" complaints" {

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -11,12 +11,11 @@
     docker exec $CONTAINER_NAME bash -c 'echo $PATH | grep /var/www/html/vendor/bin'
 }
 
-@test "verify that xdebug is disabled by default ($project_type)" {
-	# xdebug should be disabled by default.
-    docker exec -t $CONTAINER_NAME php --re xdebug | grep "xdebug does not exist"
+@test "verify that xdebug is enabled by default" {
+    docker exec $CONTAINER_NAME php --re xdebug | grep "xdebug version"
 }
 
-@test "verify there aren't \"closed keepalive connection\" complaints ($project_type)" {
+@test "verify there aren't \"closed keepalive connection\" complaints" {
 	(docker logs $CONTAINER_NAME 2>&1 | grep -v "closed keepalive connection")  || (echo "Found unwanted closed keepalive connection messages" && exit 103)
 }
 

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -11,8 +11,8 @@
     docker exec $CONTAINER_NAME bash -c 'echo $PATH | grep /var/www/html/vendor/bin'
 }
 
-@test "verify that xdebug is enabled by default" {
-    docker exec $CONTAINER_NAME bash -c 'php --version | grep "with Xdebug"'
+@test "verify that xdebug is disabled by default when using start.sh to start" {
+    docker exec $CONTAINER_NAME bash -c 'php --version | grep -v "with Xdebug"'
 }
 
 @test "verify there aren't \"closed keepalive connection\" complaints" {

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -22,6 +22,10 @@
     curl -s 127.0.0.1:$HOST_HTTP_PORT/test/xdebug.php | grep "Xdebug is disabled"
 }
 
+@test "verify that xdebug is enabled by default when the image is not run with start.sh php${PHP_VERSION}" {
+  docker run  -e "DDEV_PHP_VERSION=${PHP_VERSION}" --rm $DOCKER_IMAGE bash -c 'php --version | grep "with Xdebug"'
+}
+
 @test "verify mailhog for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
     curl -s 127.0.0.1:$HOST_HTTP_PORT/test/test-email.php | grep "Test email sent"
     curl -s --fail 127.0.0.1:$HOST_HTTP_PORT/test/phptest.php

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -61,7 +61,7 @@ cleanup
 
 for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4; do
     for WEBSERVER_TYPE in nginx-fpm apache-fpm apache-cgi; do
-        export PHP_VERSION WEBSERVER_TYPE
+        export PHP_VERSION WEBSERVER_TYPE DOCKER_IMAGE
         docker run -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=${PHP_VERSION}" -e "DDEV_WEBSERVER_TYPE=${WEBSERVER_TYPE}" -d --name $CONTAINER_NAME -v ddev-global-cache:/mnt/ddev-global-cache -d $DOCKER_IMAGE >/dev/null
         if ! containerwait; then
             echo "=============== Failed containerwait after docker run with  DDEV_WEBSERVER_TYPE=${WEBSERVER_TYPE} DDEV_PHP_VERSION=$PHP_VERSION ==================="

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200818_gilbertsoft_imagemagick" // Note that this can be overridden by make
+var WebTag = "20200818_web_image_maint" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #2245 requests that xdebug be on by default for usage of the image in other contexts (PHPStorm)
* Terminus switch from composer install to download-and-install, much faster.

## How this PR Solves The Problem:

## Manual Testing Instructions:

- [ ] Verify that terminus works in container
- [ ] Verify that xdebug is on by default in the container (`php -i`)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

