### PR TITLE
Fix umask problem with tests on NFS on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,9 @@ jobs:
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     # Run the built-in ddev tests with the executables just built.
     - run:
-        command: make -s test EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+        # CircleCI image ubuntu-1604:202007-01 has umask 002, which results in
+        # default perms 700 for new directories, which doesn't seem to work with NFS
+        command: umask u=rwx,g=rwx,o=rx && make -s test EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: ddev tests
         no_output_timeout: "120m"
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v12
+        - linux-v13
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker, golang
@@ -34,7 +34,7 @@ jobs:
         root: ~/
         paths: ddev
     - save_cache:
-        key: linux-v12
+        key: linux-v13
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -52,7 +52,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v12
+        - linux-v13
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
@@ -66,7 +66,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v12
+        key: linux-v13
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -173,7 +173,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v12
+        - linux-v13
     - attach_workspace:
         at: ~/
     - run:
@@ -188,7 +188,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v12
+        key: linux-v13
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -206,7 +206,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v12
+        - linux-v13
     - attach_workspace:
         at: ~/
     - run:
@@ -219,7 +219,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v12
+        key: linux-v13
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -237,7 +237,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v12
+        - linux-v13
     - attach_workspace:
         at: ~/
     - run:
@@ -253,7 +253,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v12
+        key: linux-v13
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -268,7 +268,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v12
+        - linux-v13
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
@@ -287,7 +287,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v12
+        - linux-v13
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
@@ -305,7 +305,7 @@ jobs:
           done
         name: linux container test
     - save_cache:
-        key: linux-v12
+        key: linux-v13
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -340,7 +340,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v12
+        - linux-v13
     - attach_workspace:
         at: ~/
     - run:
@@ -348,7 +348,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-v12
+        key: linux-v13
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -172,6 +172,8 @@ func CreateTmpDir(prefix string) string {
 	if err != nil {
 		log.Fatalln("Failed to create temp directory, err=", err)
 	}
+	// Make the tmpdir fully writeable/readable, NFS problems
+	_ = os.Chmod(fullPath, 0777)
 	return fullPath
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

TestComposeCmd is failing under NFS on CircleCI, for no reason I understand. It seems to fail only on NFS, and only since we updated to new CircleCI image in https://github.com/drud/ddev/commit/fa8fb704f32fcc24e81f3ebdc650c50a647c1a0d

This appears to be a result of a umask setting (022) in the new image, along with NFS being unwilling to grant access to *some* directories if the perm is 700.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

