### PR TITLE
Stop using the /ping URL in webserver since it is not checked anyway

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/monitoring.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/monitoring.conf
@@ -6,7 +6,7 @@
         return 200;
     }
 
-    location ~ ^/(phpstatus|ping)$ {
+    location ~ ^/phpstatus$ {
         access_log off;
         stub_status     on;
         keepalive_timeout 0;    # Disable HTTP keepalive

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20200818_remove_apache_cgi" // Note that this can be overridden by make
+var WebTag = "20200831_nlisgo_ping" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
Since `/ping` is not checked we should remove it so that the path is available for hosted applications.

## The Problem/Issue/Bug:
I would like to host an application that uses the `/ping` path as part of it's own healthcheck.  In [this PR](https://github.com/drud/ddev/commit/3976b9431b9b87101ba2416268f6f3cbfe317ffd#diff-d8376a050ab0946a67f42cd13bfff9e3) you replace the line:

```
The `location ~ ^/(phpstatus|ping)$ {` block is required for the webserver container healthcheck to work.
```
with
```
The alias `Alias "/phpstatus" "/var/www/phpstatus.php"` is required for the healthcheck script to work.
```

## How this PR Solves The Problem:
This PR removes the `ping` reference in `monitoring.conf` which is redundant and therefore will make it available for hosted applications to use.
