### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: drud


### PR DESCRIPTION
Adding sponsorship button to DDEV-Local repo on GitHub

## The Problem/Issue/Bug:
It is now possible to sponsor DDEV as an organization on GitHub. However the "sponsor" button is only available on the parent organization page.

## How this PR Solves The Problem:
This PR creates a FUNDING.yml file to display a GitHub sponsorship button on the DDEV-Local repository.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
https://github.com/drud/ddev/issues/2478

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

