### PR TITLE
Fix percona installation by installing curl

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -12,7 +12,7 @@ ENV MYSQL_PASSWORD db
 ENV MYSQL_ROOT_PASSWORD root
 
 # Install extra packages
-RUN apt-get update && apt-get install -y tzdata sudo gnupg2 pv less vim wget
+RUN apt-get update && apt-get install -y tzdata sudo gnupg2 pv less vim wget curl
 
 RUN if ( ! command -v xtrabackup && ! command -v mariabackup ); then \
     apt-get install -y lsb-release; \


### PR DESCRIPTION
Currently, [CircleCI fails](https://app.circleci.com/pipelines/github/drud/ddev/2673/workflows/6c5de43d-da23-49fc-9d60-a035179b3b1e/jobs/27226) because of these errors:

```
--2020-08-29 03:09:07--  https://repo.percona.com/apt/percona-release_latest.stretch_all.deb
Resolving repo.percona.com (repo.percona.com)... 167.71.118.3, 157.245.119.64, 167.99.233.229
Connecting to repo.percona.com (repo.percona.com)|167.71.118.3|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 11150 (11K) [application/octet-stream]
Saving to: 'percona-release_latest.stretch_all.deb'

     0K ..........                                            100%  113M=0s

2020-08-29 03:09:08 (113 MB/s) - 'percona-release_latest.stretch_all.deb' saved [11150/11150]

Selecting previously unselected package percona-release.
(Reading database ... 11894 files and directories currently installed.)
Preparing to unpack percona-release_latest.stretch_all.deb ...
Unpacking percona-release (1.0-24.generic) ...
Setting up percona-release (1.0-24.generic) ...
/usr/bin/percona-release: line 177: curl: command not found
Specified repository does not exist: http://repo.percona.com/percona/
dpkg: error processing package percona-release (--install):
 subprocess installed post-installation script returned error exit status 2
Errors were encountered while processing:
 percona-release
Hit:1 http://security.debian.org/debian-security stretch/updates InRelease
Ign:2 http://deb.debian.org/debian stretch InRelease
Hit:3 http://deb.debian.org/debian stretch-updates InRelease
Hit:4 http://deb.debian.org/debian stretch Release
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package percona-xtrabackup-24
```

This PR should get things up and running again 🚀 