### PR TITLE
Don't try to assign to nil app.Name in GetProjects(), fixes #2483

### DIFF
--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -351,13 +351,14 @@ func GetProjects(activeOnly bool) ([]*DdevApp, error) {
 
 		app, err := NewApp(info.AppRoot, true, nodeps.ProviderDefault)
 		if err != nil {
-			util.Warning("unable to create project at project root %s: %v", info.AppRoot, err)
-			app.Name = name
+			util.Warning("unable to create project at project root '%s': %v", info.AppRoot, err)
+			continue
 		}
 
 		// If the app we just loaded was already found with a different name, complain
 		if _, ok := apps[app.Name]; ok {
 			util.Warning(`Project '%s' was found in configured directory %s and it is already used by project '%s'. If you have changed the name of the project, please "ddev stop --unlist %s" `, app.Name, app.AppRoot, name, name)
+			continue
 		}
 
 		if !activeOnly || (app.SiteStatus() != SiteStopped && app.SiteStatus() != SiteConfigMissing && app.SiteStatus() != SiteDirMissing) {


### PR DESCRIPTION
## The Problem/Issue/Bug:

In the case of a corrupted ~/.ddev/global_config.yaml, we were failing loading an app, but then trying to use it. #2483 

Thanks so much to @mtelgkamp for the careful reporting on this one!

## How this PR Solves The Problem:

Don't use the failed app load. 

## Manual Testing Instructions:

Run `ddev list` with the corrupted global_config.yaml as in #2483 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

