### PR TITLE
Export documented environment variables into web container, fixes #2486

### DIFF
--- a/docs/users/extend/custom-commands.md
+++ b/docs/users/extend/custom-commands.md
@@ -79,6 +79,7 @@ A number of environment variables are provided to the script. These are generall
 * DDEV_HOST_WEBSERVER_PORT: Localhost port of the webserver
 * DDEV_PHP_VERSION
 * DDEV_PRIMARY_URL: Primary URL for the project
+* DDEV_PROJECT: Project name, like "d8composer"
 * DDEV_PROJECT_TYPE: drupal8, typo3, backdrop, wordpress, etc.
 * DDEV_ROUTER_HTTP_PORT: Router port for http
 * DDEV_ROUTER_HTTPS_PORT: Router port for https

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1313,6 +1313,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_TLD":                      app.ProjectTLD,
 		"DDEV_DBIMAGE":                  app.GetDBImage(),
 		"DDEV_DBAIMAGE":                 app.DBAImage,
+		"DDEV_PROJECT":                  app.Name,
 		"DDEV_WEBIMAGE":                 app.WebImage,
 		"DDEV_APPROOT":                  app.AppRoot,
 		"DDEV_HOST_DB_PORT":             dbPortStr,

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -39,10 +39,21 @@ services:
       com.ddev.app-type: {{ .AppType }}
       com.ddev.approot: $DDEV_APPROOT
     environment:
-      - COLUMNS=$COLUMNS
-      - LINES=$LINES
-      - TZ={{ .Timezone }}
+      - COLUMNS
+      - DDEV_HOSTNAME
+      - DDEV_PHP_VERSION
+      - DDEV_PRIMARY_URL
       - DDEV_PROJECT={{ .Name }}
+      - DDEV_PROJECT_TYPE
+      - DDEV_ROUTER_HTTP_PORT
+      - DDEV_ROUTER_HTTPS_PORT
+      - DDEV_SITENAME
+      - DDEV_TLD
+      - DOCKER_IP={{ .DockerIP }}
+      - HOST_DOCKER_INTERNAL_IP={{ .HostDockerInternalIP }}
+      - IS_DDEV_PROJECT=true
+      - LINES
+      - TZ={{ .Timezone }}
     command: "$DDEV_MARIADB_LOCAL_COMMAND"
     healthcheck:
       interval: 1s
@@ -95,33 +106,35 @@ services:
       - "{{ .DockerIP }}:$DDEV_HOST_WEBSERVER_PORT:80"
       - "{{ .DockerIP }}:$DDEV_HOST_HTTPS_PORT:443"
     environment:
-      - DOCROOT=$DDEV_DOCROOT
-      - DDEV_PHP_VERSION=$DDEV_PHP_VERSION
-      - DDEV_WEBSERVER_TYPE=$DDEV_WEBSERVER_TYPE
-      - DDEV_PROJECT_TYPE=$DDEV_PROJECT_TYPE
-      - DDEV_ROUTER_HTTP_PORT=$DDEV_ROUTER_HTTP_PORT
-      - DDEV_ROUTER_HTTPS_PORT=$DDEV_ROUTER_HTTPS_PORT
-      - DDEV_XDEBUG_ENABLED=$DDEV_XDEBUG_ENABLED
-      - IS_DDEV_PROJECT=true
+      - COLUMNS
+      - DOCROOT=${DDEV_DOCROOT}
+      - DDEV_DOCROOT
+      - DDEV_HOSTNAME
+      - DDEV_PHP_VERSION
+      - DDEV_PRIMARY_URL
+      - DDEV_PROJECT={{ .Name }}
+      - DDEV_PROJECT_TYPE
+      - DDEV_ROUTER_HTTP_PORT
+      - DDEV_ROUTER_HTTPS_PORT
+      - DDEV_SITENAME
+      - DDEV_TLD
+      - DDEV_WEBSERVER_TYPE
+      - DDEV_XDEBUG_ENABLED
+      - DEPLOY_NAME=local
       - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
       - DOCKER_IP={{ .DockerIP }}
       - HOST_DOCKER_INTERNAL_IP={{ .HostDockerInternalIP }}
-      - DEPLOY_NAME=local
-      - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - COLUMNS=$COLUMNS
-      - LINES=$LINES
-      - TZ={{ .Timezone }}
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
       # To expose a container port to a different host port, define the port as hostPort:containerPort
       - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:{{ .MailhogPort }}
       # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
       # To expose an HTTPS port, define the port as securePort:containerPort.
       - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:{{ .MailhogPort }}
+      - IS_DDEV_PROJECT=true
+      - LINES
       - SSH_AUTH_SOCK=/home/.ssh-agent/socket
-      - DDEV_PROJECT={{ .Name }}
-      - DDEV_SITENAME
-      - DDEV_TLD
-      - DDEV_PRIMARY_URL
+      - TZ={{ .Timezone }}
+      - VIRTUAL_HOST=${DDEV_HOSTNAME}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: {{ .Plugin }}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -43,7 +43,7 @@ services:
       - DDEV_HOSTNAME
       - DDEV_PHP_VERSION
       - DDEV_PRIMARY_URL
-      - DDEV_PROJECT={{ .Name }}
+      - DDEV_PROJECT
       - DDEV_PROJECT_TYPE
       - DDEV_ROUTER_HTTP_PORT
       - DDEV_ROUTER_HTTPS_PORT
@@ -112,7 +112,7 @@ services:
       - DDEV_HOSTNAME
       - DDEV_PHP_VERSION
       - DDEV_PRIMARY_URL
-      - DDEV_PROJECT={{ .Name }}
+      - DDEV_PROJECT
       - DDEV_PROJECT_TYPE
       - DDEV_ROUTER_HTTP_PORT
       - DDEV_ROUTER_HTTPS_PORT

--- a/pkg/ddevapp/testdata/TestEnvironmentVariables/showhostenvvar
+++ b/pkg/ddevapp/testdata/TestEnvironmentVariables/showhostenvvar
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: showhostenvvar envname
+## Usage: showhostenvvar [name]
+## Example: "ddev showhostenvvar DDEV_PROJECT"
+
+ENVNAME=$1
+echo ${!ENVNAME}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2486: Although a number of environment variables were created and were intended to be added into the web container, some of them were not exported via the .ddev-docker-compose*.yaml, so did not end up inside the container.

## How this PR Solves The Problem:

Make sure they get exported. 

## Manual Testing Instructions:

Verify that $DDEV_DOCROOT and all other named environment variables in the container section of https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/#environment-variables-provided are properly set inside the container.

## Automated Testing Overview:

Added TestEnvironmentVariables to verify values in container and on host

## Related Issue Link(s):

## Release/Deployment notes:

I used these custom commands (global) for testing: https://gist.github.com/rfay/8773faca379cc22c9c4b5cc61e75f6e6
