### PR TITLE
Fix missing global prefix of command suffix

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -135,7 +135,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 				}
 
 				descSuffix := " (shell " + service + " container command)"
-				if serviceDirOnHost[0:1] == "." {
+				if commandSet == targetGlobalCommandPath {
 					descSuffix = " (global shell " + service + " container command)"
 				}
 				commandToAdd := &cobra.Command{

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -95,8 +95,10 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err)
 	assert.Contains(out, "testhostcmd project (shell host container command)")
 	assert.Contains(out, "testwebcmd project (shell web container command)")
+	assert.Contains(out, "testhostglobal global (global shell host container command)")
+	assert.Contains(out, "testwebglobal global (global shell web container command)")
+	assert.NotContains(out, "testhostcmd global") //the global testhostcmd should have been overridden by the projct one
 	assert.NotContains(out, "testwebcmd global") //the global testwebcmd should have been overridden by the projct one
-	assert.Contains(out, "testhostglobal")
 
 	for _, c := range []string{"testhostcmd", "testhostglobal", "testwebcmd", "testwebglobal"} {
 		args := []string{c, "hostarg1", "hostarg2", "--hostflag1"}

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -98,7 +98,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.Contains(out, "testhostglobal global (global shell host container command)")
 	assert.Contains(out, "testwebglobal global (global shell web container command)")
 	assert.NotContains(out, "testhostcmd global") //the global testhostcmd should have been overridden by the projct one
-	assert.NotContains(out, "testwebcmd global") //the global testwebcmd should have been overridden by the projct one
+	assert.NotContains(out, "testwebcmd global")  //the global testwebcmd should have been overridden by the projct one
 
 	for _, c := range []string{"testhostcmd", "testhostglobal", "testwebcmd", "testwebglobal"} {
 		args := []string{c, "hostarg1", "hostarg2", "--hostflag1"}


### PR DESCRIPTION
## The Problem/Issue/Bug:
The global prefix in the command suffix of global commands is missing.

## How this PR Solves The Problem:
This patch fixes the condition and adds tests to avoid regressions in this place.

## Manual Testing Instructions:
run `ddev` and check if the global prefix is added to global commands suffixes e.g.

`Run TYPO3 CLI (typo3) command inside the web container (global shell web container command)`

## Automated Testing Overview:
The new tests are checking the correct behavior of global host and web commands. Also a new test is provided to ensure global host commands gets properly overwritten by the project ones.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

