### PR TITLE
Prevent segment from writing to console (especially for pi-hole), fixes #1968, fixes #1767, fixes #1967

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -191,7 +191,9 @@ func checkDdevVersionAndOptInInstrumentation() error {
 		allowStats := util.Confirm("It looks like you have a new ddev release.\nMay we send anonymous ddev usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/stable/users/cli-usage/#opt-in-usage-information\nPermission to beam up?")
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true
-			client := analytics.New(version.SegmentKey)
+			client, _ := analytics.NewWithConfig(version.SegmentKey, analytics.Config{
+				Logger: &ddevapp.SegmentNoopLogger{},
+			})
 			defer func() {
 				_ = client.Close()
 			}()

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -49,6 +49,7 @@ func SetInstrumentationBaseTags() {
 		lang := os.Getenv("LANG")
 
 		nodeps.InstrumentationTags["OS"] = runtime.GOOS
+		nodeps.InstrumentationTags["architecture"] = runtime.GOARCH
 		wslDistro := nodeps.GetWSLDistro()
 		if wslDistro != "" {
 			nodeps.InstrumentationTags["isWSL"] = "true"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#1968: Ad-blockers like pi-hole seem to often define api.segment.io as unwanted, which is fine, but they just resolve its DNS as 127.0.0.1, which doesn't have anything listening and doesn't have a valid cert. So users get ugly error messages.

## How this PR Solves The Problem:

Add a no-op logger for the segment operations.

This also adds the architecture (like 'amd64' or 'arm64' to Segment logging.


## Manual Testing Instructions:

- [x] Verify that segment logging still works normally (use app.segment.io to watch messages go by, and use `ddev config` for example)
- [x] Now add `127.0.0.1 api.segment.io` to /etc/hosts and repeat the operation. Nothing should be shown on the console, and also nothing should be reported on segment.io
- [x] Now go fix your /etc/hosts


## Automated Testing Overview:

Nothing added

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

