### PR TITLE
Update Atom XDebug Instructions

### DIFF
--- a/docs/users/snippets/atom_config_cson_snippet.txt
+++ b/docs/users/snippets/atom_config_cson_snippet.txt
@@ -1,3 +1,7 @@
+  "atom-ide-ui":
+    "atom-ide-debugger": {}
+    use:
+      "atom-ide-debugger": "never"
   "php-debug":
     PathMaps: [
       "remotepath;localpath"

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -73,16 +73,21 @@ If you need to debug command-line PHP processes, especially code that is outside
 
 1. Under Preferences->+Install install the php-debug add-on:
 ![php-debug installation](images/atom_php_debug_install.png)
-2. Add configuration to the Atom config.cson by choosing "Config..." under the "Atom" menu. A "php-debug" stanza must be added, with file mappings that relate to your project. (Example [config.cson snippet](snippets/atom_config_cson_snippet.txt)
+2. Add configuration to the Atom config.cson by choosing "Config..." under the "Atom" menu. A "php-debug" stanza must be added, with file mappings that relate to your project. Additionally, you will need to disable the debugger that comes with the `atom-ide-ui` package. (Example [config.cson snippet](snippets/atom_config_cson_snippet.txt)
 ![Atom cson config](images/atom_cson_config.png)
-3. Open a project/folder and open a PHP file you'd like to debug.
-4. Set a breakpoint. (Right-click->PHP Debug->Toggle breakpoint)
-5. Open the debug view and enable debugging by choosing Packages->PHP-Debug->Toggle Debugging. You should see "Listening on address:port 127.0.0.1:9000".
-6. Visit a page that should trigger your breakpoint.
+3. Restart Atom to ensure new settings are loaded.
+4. Open a project/folder and open a PHP file you'd like to debug.
+5. Set a breakpoint. (Right-click->PHP Debug->Toggle breakpoint)
+6. Open the debug view and enable debugging by choosing Packages->PHP-Debug->Toggle Debugging. You should see "Listening on address:port 127.0.0.1:9000".
+7. Visit a page that should trigger your breakpoint.
 
 An example configuration:
 
 ```
+  "atom-ide-ui":
+    "atom-ide-debugger": {}
+    use:
+      "atom-ide-debugger": "never"
   "php-debug":
     PathMaps: [
       "remotepath;localpath"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The `php-debug` package requires `atom-ide-ui`, but `atom-ide-ui` has it’s own debugger system which isn’t compatible with `php-debug`. So you essentially have to disable the debugger that comes with `atom-ide-ui` to use the `php-debug` debugger. After doing that everything works.

## How this PR Solves The Problem:

It updates the XDebug + Atom documentation to provide instructions on doing this

## Manual Testing Instructions:

Step through setup instructions on Atom and ensure Xdebug works

## Automated Testing Overview:
Documentation change only, so no tests.

## Related Issue Link(s):
https://github.com/gwomacks/php-debug/issues/310#issuecomment-419751273

## Release/Deployment notes:
The `atom-ide-ui` dependency adds a few features to Atom, so it might slightly change the user experience, but overall it should be pretty seamless. 

