### PR TITLE
Don't set DRUSH_OPTIONS_URI if disable_settings_management, fixes #2443

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -643,36 +643,37 @@ func (app *DdevApp) CheckDeprecations() {
 }
 
 type composeYAMLVars struct {
-	Name                  string
-	Plugin                string
-	AppType               string
-	MailhogPort           string
-	DBAPort               string
-	DBPort                string
-	DdevGenerated         string
-	HostDockerInternalIP  string
-	ComposeVersion        string
-	MountType             string
-	WebMount              string
-	WebBuildContext       string
-	DBBuildContext        string
-	WebBuildDockerfile    string
-	DBBuildDockerfile     string
-	SSHAgentBuildContext  string
-	OmitDB                bool
-	OmitDBA               bool
-	OmitSSHAgent          bool
-	NFSMountEnabled       bool
-	NFSSource             string
-	DockerIP              string
-	IsWindowsFS           bool
-	NoProjectMount        bool
-	Hostnames             []string
-	Timezone              string
-	Username              string
-	UID                   string
-	GID                   string
-	AutoRestartContainers bool
+	Name                      string
+	Plugin                    string
+	AppType                   string
+	MailhogPort               string
+	DBAPort                   string
+	DBPort                    string
+	DdevGenerated             string
+	HostDockerInternalIP      string
+	ComposeVersion            string
+	DisableSettingsManagement bool
+	MountType                 string
+	WebMount                  string
+	WebBuildContext           string
+	DBBuildContext            string
+	WebBuildDockerfile        string
+	DBBuildDockerfile         string
+	SSHAgentBuildContext      string
+	OmitDB                    bool
+	OmitDBA                   bool
+	OmitSSHAgent              bool
+	NFSMountEnabled           bool
+	NFSSource                 string
+	DockerIP                  string
+	IsWindowsFS               bool
+	NoProjectMount            bool
+	Hostnames                 []string
+	Timezone                  string
+	Username                  string
+	UID                       string
+	GID                       string
+	AutoRestartContainers     bool
 }
 
 // RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.
@@ -699,34 +700,35 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	uid, gid, username := util.GetContainerUIDGid()
 
 	templateVars := composeYAMLVars{
-		Name:                  app.Name,
-		Plugin:                "ddev",
-		AppType:               app.Type,
-		MailhogPort:           GetPort("mailhog"),
-		DBAPort:               GetPort("dba"),
-		DBPort:                GetPort("db"),
-		DdevGenerated:         DdevFileSignature,
-		HostDockerInternalIP:  hostDockerInternalIP,
-		ComposeVersion:        version.DockerComposeFileFormatVersion,
-		OmitDB:                nodeps.ArrayContainsString(app.GetOmittedContainers(), "db"),
-		OmitDBA:               nodeps.ArrayContainsString(app.GetOmittedContainers(), "dba") || nodeps.ArrayContainsString(app.OmitContainers, "db"),
-		OmitSSHAgent:          nodeps.ArrayContainsString(app.GetOmittedContainers(), "ddev-ssh-agent"),
-		NFSMountEnabled:       app.NFSMountEnabled || app.NFSMountEnabledGlobal,
-		NFSSource:             "",
-		IsWindowsFS:           runtime.GOOS == "windows",
-		NoProjectMount:        app.NoProjectMount,
-		MountType:             "bind",
-		WebMount:              "../",
-		Hostnames:             app.GetHostnames(),
-		Timezone:              app.Timezone,
-		Username:              username,
-		UID:                   uid,
-		GID:                   gid,
-		WebBuildContext:       app.GetConfigPath("web-build"),
-		DBBuildContext:        app.GetConfigPath("db-build"),
-		WebBuildDockerfile:    app.GetConfigPath(".webimageBuild/Dockerfile"),
-		DBBuildDockerfile:     app.GetConfigPath(".dbimageBuild/Dockerfile"),
-		AutoRestartContainers: globalconfig.DdevGlobalConfig.AutoRestartContainers,
+		Name:                      app.Name,
+		Plugin:                    "ddev",
+		AppType:                   app.Type,
+		MailhogPort:               GetPort("mailhog"),
+		DBAPort:                   GetPort("dba"),
+		DBPort:                    GetPort("db"),
+		DdevGenerated:             DdevFileSignature,
+		HostDockerInternalIP:      hostDockerInternalIP,
+		ComposeVersion:            version.DockerComposeFileFormatVersion,
+		DisableSettingsManagement: app.DisableSettingsManagement,
+		OmitDB:                    nodeps.ArrayContainsString(app.GetOmittedContainers(), "db"),
+		OmitDBA:                   nodeps.ArrayContainsString(app.GetOmittedContainers(), "dba") || nodeps.ArrayContainsString(app.OmitContainers, "db"),
+		OmitSSHAgent:              nodeps.ArrayContainsString(app.GetOmittedContainers(), "ddev-ssh-agent"),
+		NFSMountEnabled:           app.NFSMountEnabled || app.NFSMountEnabledGlobal,
+		NFSSource:                 "",
+		IsWindowsFS:               runtime.GOOS == "windows",
+		NoProjectMount:            app.NoProjectMount,
+		MountType:                 "bind",
+		WebMount:                  "../",
+		Hostnames:                 app.GetHostnames(),
+		Timezone:                  app.Timezone,
+		Username:                  username,
+		UID:                       uid,
+		GID:                       gid,
+		WebBuildContext:           app.GetConfigPath("web-build"),
+		DBBuildContext:            app.GetConfigPath("db-build"),
+		WebBuildDockerfile:        app.GetConfigPath(".webimageBuild/Dockerfile"),
+		DBBuildDockerfile:         app.GetConfigPath(".dbimageBuild/Dockerfile"),
+		AutoRestartContainers:     globalconfig.DdevGlobalConfig.AutoRestartContainers,
 	}
 	if app.NFSMountEnabled || app.NFSMountEnabledGlobal {
 		templateVars.MountType = "volume"

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -121,7 +121,9 @@ services:
       - DDEV_WEBSERVER_TYPE
       - DDEV_XDEBUG_ENABLED
       - DEPLOY_NAME=local
+{{ if not .DisableSettingsManagement }}
       - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
+{{ end }}
       - DOCKER_IP={{ .DockerIP }}
       - HOST_DOCKER_INTERNAL_IP={{ .HostDockerInternalIP }}
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2443 points out that people who are doing Drupal multisite don't want DRUSH_OPTIONS_URI set, because it confuses everything. And since that recipe usually has `disable_settings_management: true` it's pretty reasonable to not include $DRUSH_OPTIONS_URI in the web container when set.

## How this PR Solves The Problem:

Don't set DRUSH_OPTIONS_URI if `disable_settings_management: true`


## Manual Testing Instructions:

On a D8+ site, 

- [x] `ddev start` with `disable_settings_management: false`. `ddev exec "set | grep DRUSH"` should show DRUSH_OPTIONS_URI
- [ [ Now set `disable_settings_management: true` and `ddev start`. `ddev exec "set | grep DRUSH"` should NOT show DRUSH_OPTIONS_URI.
- [x] Don't forget to go back and remove the `disable_settings_management` line.


## Automated Testing Overview:

None added. Seems to obscure to bother.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

