### PR TITLE
Don't always require port 80 in determineRouterPorts(), fixes #2512

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1639,9 +1639,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		return fmt.Errorf("Failed to process post-stop hooks: %v", err)
 	}
 
-	err = StopRouterIfNoContainers()
-
-	return err
+	return nil
 }
 
 // RemoveGlobalProjectInfo() deletes the project from ProjectList

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -39,18 +39,18 @@ func FullRenderedRouterComposeYAMLPath() string {
 
 // StopRouterIfNoContainers stops the router if there are no ddev containers running.
 func StopRouterIfNoContainers() error {
-	dest, err := generateRouterCompose()
-	if err != nil {
-		return err
-	}
 	containersRunning, err := ddevContainersRunning()
 	if err != nil {
 		return err
 	}
 
 	if !containersRunning {
-		_, _, err = dockerutil.ComposeCmd([]string{dest}, "-p", RouterProjectName, "down")
-		return err
+		err = dockerutil.RemoveContainer(nodeps.RouterContainer, 0)
+		if err != nil {
+			if _, ok := err.(*docker.NoSuchContainer); !ok {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -201,7 +201,7 @@ func GetRouterStatus() (string, string) {
 // determineRouterPorts returns a list of port mappings retrieved from running site
 // containers defining VIRTUAL_PORT env var
 func determineRouterPorts() []string {
-	routerPorts := []string{"80"}
+	var routerPorts []string
 	labels := map[string]string{
 		"com.ddev.platform": "ddev",
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

@chellman points out in #2512 that if port 80 is occupied, ddev refuses to start, even if the project is configured to not use port 80.

## How this PR Solves The Problem:

There was code in determineRouterPorts() that always added port 80 to the ports list. I am not sure if this was debugging code or if I'm about to find out what it was there for. 

## Manual Testing Instructions:

`brew install nmap` and then run it with `ncat -l -k -p 80`
Set project to start with router_http_port: 8080
`ddev start`
It should work


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

