### PR TITLE
Big Sur: Change tmpdir to ~/tmp/ddevtest for tests: NFS problems (tests only)

### DIFF
--- a/docs/developers/buildkite-testmachine-setup.md
+++ b/docs/developers/buildkite-testmachine-setup.md
@@ -29,17 +29,15 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 6. Run Docker manually and go through its configuration routine.
 7. Run iTerm. On Mojave and higher it may prompt for requiring full disk access permissions, follow through with that.
 8. Set up nfsd by running `macos_ddev_nfs_setup.sh`
-9. Add the path `/private/var` or on Catalina `/System/Volumes/Data/private/var` to `/etc/exports` and `sudo nfsd restart`.
-10. Edit the buildkite-agent.cfg in /usr/local/etc/buildkite-agent.cfg to add
+9. Edit the buildkite-agent.cfg in /usr/local/etc/buildkite-agent.cfg to add
     * the agent token
     * Tags, like `"os=macos,osvariant=catalina,dockertype=dockerformac"`
     * `build-path="~/tmp/buildkite-agent/builds"`
-11. `brew services start buildkite-agent`
-12. Enable nosleep using its shortcut in the Mac status bar.
-13. In nosleep Preferences, enable "Never sleep on AC Adapter", "Never sleep on Battery", and "Start nosleep utility on system startup".
-14. Set up Mac to [automatically log in on boot](https://support.apple.com/en-us/HT201476).
-15. Try checking out ddev and running .buildkite/sanetestbot.sh to check your work.
-16. Log into Chrome with the user testbot@drud.com and enable Chrome Remote Desktop.
-17. Set the timezone properly (US MT)
-18. Start the agent with `brew services start buildkite-agent`
-19. Reboot the machine and do a test run.
+10. `brew services start buildkite-agent`
+11. Enable nosleep using its shortcut in the Mac status bar.
+12. In nosleep Preferences, enable "Never sleep on AC Adapter", "Never sleep on Battery", and "Start nosleep utility on system startup".
+13. Set up Mac to [automatically log in on boot](https://support.apple.com/en-us/HT201476).
+14. Try checking out ddev and running .buildkite/sanetestbot.sh to check your work.
+15. Log into Chrome with the user testbot@drud.com and enable Chrome Remote Desktop.
+16. Set the timezone properly (US MT)
+17. Start the agent with `brew services start buildkite-agent`

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -2,6 +2,7 @@ package testcommon
 
 import (
 	"crypto/tls"
+	"github.com/docker/docker/pkg/homedir"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/output"
@@ -164,13 +165,11 @@ func OsTempDir() (string, error) {
 
 // CreateTmpDir creates a temporary directory and returns its path as a string.
 func CreateTmpDir(prefix string) string {
-	systemTempDir, err := OsTempDir()
+	baseTmpDir := filepath.Join(homedir.Get(), "tmp", "ddevtest")
+	_ = os.MkdirAll(baseTmpDir, 0755)
+	fullPath, err := ioutil.TempDir(baseTmpDir, prefix)
 	if err != nil {
-		log.Fatalln("Failed getting system temp dir", err)
-	}
-	fullPath, err := ioutil.TempDir(systemTempDir, prefix)
-	if err != nil {
-		log.Fatalln("Failed to create temp directory, err=", err)
+		log.Fatalf("Failed to create temp directory %s, err=%v", fullPath, err)
 	}
 	// Make the tmpdir fully writeable/readable, NFS problems
 	_ = os.Chmod(fullPath, 0777)

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -29,12 +29,12 @@ var TestSites = []TestSite{
 	},
 }
 
-// TestTmpDir tests the ability to create a temporary directory.
-func TestTmpDir(t *testing.T) {
+// TestCreateTmpDir tests the ability to create a temporary directory.
+func TestCreateTmpDir(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Create a temporary directory and ensure it exists.
-	testDir := CreateTmpDir("TestTmpDir")
+	testDir := CreateTmpDir("TestCreateTmpDir")
 	dirStat, err := os.Stat(testDir)
 	assert.NoError(err, "There is no error when getting directory details")
 	assert.True(dirStat.IsDir(), "Temp Directory created and exists")


### PR DESCRIPTION
## The Problem/Issue/Bug:

macOS Big Sur, preview 7, doesn't seem to share subdirectories of something exported in /private/var/folders, so a single line static export doesn't work

## How this PR Solves The Problem:

Move the tmpdir created for tests into ~/tmp/ddevtest instead. That way we don't ever have to have that extra share in the /etc/exports anyway.

## Related Issue Link(s):

#2501: Prep Big Sur

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

