### PR TITLE
Refactor default custom commands [skip ci][ci skip]

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/commands/db/mysql
+++ b/cmd/ddev/cmd/dotddev_assets/commands/db/mysql
@@ -1,9 +1,43 @@
 #!/bin/bash
 
 ## #ddev-generated
-## Description: run mysql client in db container
+## Description: Run MySql client in db container
 ## Usage: mysql [flags] [args]
-## Example: "ddev mysql" or "ddev mysql -uroot -proot" or "echo 'SHOW TABLES;' | ddev mysql"
+## Flags: [{"Long":"user","Short":"u","Usage":"User for login if not user db."},{"Long":"password","Short":"p","Usage":"Password to use when connecting to server if not db. If password is not given it's asked from the tty."}]
+## Example: ddev mysql\nddev mysql -uroot -proot\necho 'SHOW TABLES;' | ddev mysql
 ## `ddev mysql --database=mysql -uroot -proot` gets you to the 'mysql' database with root privileges
+
+USER="db"
+PASSWORD="db"
+
+while :; do
+    case ${1:-} in
+        -u|--user)
+            if [ "${HTTPS}" = "" ]; then
+                FULLURL="${FULLURL%:[0-9]*}:${DDEV_PHPMYADMIN_PORT}"
+            else
+                FULLURL="${FULLURL%:[0-9]*}:${DDEV_PHPMYADMIN_HTTPS_PORT}"
+            fi
+            ;;
+        -m|--mailhog)
+            if [ "${HTTPS}" = "" ]; then
+                FULLURL="${FULLURL%:[0-9]*}:${DDEV_MAILHOG_PORT}"
+            else
+                FULLURL="${FULLURL%:[0-9]*}:${DDEV_MAILHOG_HTTPS_PORT}"
+            fi
+            ;;
+        --)     # End of all options.
+            shift
+            break
+            ;;
+        -?*)
+            printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+            ;;
+        *)      # Default case: No more options, so break out of the loop.
+            break
+    esac
+
+    shift
+ done
 
 mysql -udb -pdb $@

--- a/cmd/ddev/cmd/dotddev_assets/commands/host/launch
+++ b/cmd/ddev/cmd/dotddev_assets/commands/host/launch
@@ -3,53 +3,49 @@
 ## #ddev-generated: If you want to edit and own this file, remove this line.
 ## Description: Launch a browser with the current site
 ## Usage: launch [path] [-p|--phpmyadmin] [-m|--mailhog]
-## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php", for PHPMyAdmin "ddev launch -p", MailHog "ddev launch -m"
+## Flags: [{"Long":"phpmyadmin","Short":"p","Usage":"Launch phpMyAdmin"},{"Long":"mailhog","Short":"m","Usage":"Launch MailHog"}]
+## Example: ddev launch\nddev launch /admin/reports/status/php\nddev launch phpinfo.php\nddev launch -p\nddev launch
 
 FULLURL=${DDEV_PRIMARY_URL}
 HTTPS=""
 if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then HTTPS=true; fi
 
 while :; do
-     case ${1:-} in
-         -h|-\?|--help)
-             show_help
-             exit
-             ;;
-         -p|--phpmyadmin)
+    case ${1:-} in
+        -p|--phpmyadmin)
             if [ "${HTTPS}" = "" ]; then
                 FULLURL="${FULLURL%:[0-9]*}:${DDEV_PHPMYADMIN_PORT}"
             else
                 FULLURL="${FULLURL%:[0-9]*}:${DDEV_PHPMYADMIN_HTTPS_PORT}"
             fi
-             ;;
-         -m|--mailhog)
+            ;;
+        -m|--mailhog)
             if [ "${HTTPS}" = "" ]; then
                 FULLURL="${FULLURL%:[0-9]*}:${DDEV_MAILHOG_PORT}"
             else
                 FULLURL="${FULLURL%:[0-9]*}:${DDEV_MAILHOG_HTTPS_PORT}"
             fi
-             ;;
+            ;;
+        --)     # End of all options.
+            shift
+            break
+            ;;
+        -?*)
+            printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+            ;;
+        *)      # Default case: No more options, so break out of the loop.
+            break
+    esac
 
-         --)              # End of all options.
-             shift
-             break
-             ;;
-         -?*)
-             printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
-             ;;
-         *)               # Default case: No more options, so break out of the loop.
-             break
-     esac
-
-     shift
+    shift
  done
 
 if [ -n "${1:-}" ] ; then
-  if [[ ${1::1} != "/" ]] ; then
-    FULLURL="${FULLURL}/";
-  fi
+    if [[ ${1::1} != "/" ]] ; then
+        FULLURL="${FULLURL}/";
+    fi
 
-  FULLURL="${FULLURL}${1}";
+    FULLURL="${FULLURL}${1}";
 fi
 
 if [ ! -z ${DDEV_DEBUG:-} ]; then
@@ -57,13 +53,13 @@ if [ ! -z ${DDEV_DEBUG:-} ]; then
 fi
 
 case $OSTYPE in
-  linux-gnu)
-    xdg-open ${FULLURL}
-    ;;
-  "darwin"*)
-    open ${FULLURL}
-    ;;
-  "win*"* | "msys"*)
-    start ${FULLURL}
-    ;;
+    linux-gnu)
+        xdg-open ${FULLURL}
+        ;;
+    "darwin"*)
+        open ${FULLURL}
+        ;;
+    "win*"* | "msys"*)
+        start ${FULLURL}
+        ;;
 esac


### PR DESCRIPTION
## The Problem/Issue/Bug:
The patches #2493, #2495 an #2519 introduced new features for a nicer styling of the help output of custom commands. This patch applies changes to various custom commands to profit from the new styling and make the help better understandable for the users.

## Manual Testing Instructions:
The following commands are touched by this change so run every command with the `-h` flag to verify:

- mysql
- launch

## Automated Testing Overview:
No changes so far.

## Related Issue Link(s):
- #2493
- #2495
- #2519

## Release/Deployment notes:
Nothing special needed.

