### PR TITLE
db container start script needs different test to copy prepped db

### DIFF
--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -53,9 +53,9 @@ fi
 export BACKUPTOOL=mariabackup
 if command -v xtrabackup; then BACKUPTOOL="xtrabackup"; fi
 
-# If mariadb has not been initialized, copy in the base image from either the default starter image (/var/tmp/mysqlbase)
+# If mariadb has not been initialized, copy in the base image from either the default starter image (/mysqlbase)
 # or from a provided $snapshot_dir.
-if [ ! -d "/var/lib/mysql/mysql" ]; then
+if [ ! -f "/var/lib/mysql/db_mariadb_version.txt" ]; then
     target=${snapshot_dir:-/mysqlbase/}
     name=$(basename $target)
     sudo rm -rf /var/lib/mysql/* /var/lib/mysql/.[a-z]* && sudo chmod -R ugo+w /var/lib/mysql
@@ -65,15 +65,11 @@ if [ ! -d "/var/lib/mysql/mysql" ]; then
     echo 'Database initialized from $target'
 fi
 
-if [ -f /var/lib/mysql/db_mariadb_version.txt ]; then
-   database_db_version=$(cat /var/lib/mysql/db_mariadb_version.txt)
-else
-    database_db_version="unknown"
- fi
+database_db_version=$(cat /var/lib/mysql/db_mariadb_version.txt)
 
 if [ "${server_db_version}" != "${database_db_version}" ]; then
    echo "Starting with db server version=${server_db_version} but database was created with '${database_db_version}'."
-   echo "Attempting upgrade, but it may not work, you may need to export your database, 'ddev stop -RO', start, and reimport".
+   echo "Attempting upgrade, but it may not work, you may need to export your database, 'ddev delete --omit-snapshot', start, and reimport".
 
     PATH=$PATH:/usr/sbin:/usr/local/bin:/usr/local/mysql/bin mysqld --skip-networking --skip-grant-tables --socket=$SOCKET >/tmp/mysqld_temp_startup.log 2>&1 &
     pid=$!

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ var WebTag = "20200831_nlisgo_ping" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20200821_remove_docker_toolbox"
+var BaseDBTag = "20200923_improve_mysql_docker_entrypoint"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin/phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

In #2454 @dennisameling encountered a difficult issue where the mysql 5.6 (ONLY) somehow created /var/lib/mysql/mysql (the database folder for the main db) when it never has before. But the start script used the existence of that directory to signal that the database was already set up, so skipped setting it up.

## How this PR Solves The Problem:

Switch to using the /var/lib/mysql/db_mariadb_version.txt file as a signal that the database has been set up, as that gets created whenever the database has actually been copied/initialized the first time.

## Manual Testing Instructions:

I think this should be fine with automated tests... but just using `ddev config --mariadb-version="" --mysql-version=5.6 && ddev start` will fail if `docker buildx build` was used to build the 5.6 image. 

This only shows up in `docker buildx build`, so although it should pass here, it will be most important in #2454

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

