### PR TITLE
Fix release scripts for new naming of tarballs

### DIFF
--- a/.circleci/bump_aur.sh
+++ b/.circleci/bump_aur.sh
@@ -22,8 +22,8 @@ AUR_REPO=$1
 VERSION_NUMBER=$2
 ARTIFACTS_DIR=$3
 NO_V_VERSION=$(echo ${VERSION_NUMBER} | awk  -F"-" '{ OFS="-"; sub(/^./, "", $1); printf $0; }')
-LINUX_HASH=$(cat $ARTIFACTS_DIR/ddev_linux.${VERSION_NUMBER}.tar.gz.sha256.txt | awk '{print $1;}' )
-LINUX_TARBALL_URL=https://github.com/${GITHUB_USERNAME}/ddev/releases/download/${VERSION_NUMBER}/ddev_linux.${VERSION_NUMBER}.tar.gz
+LINUX_HASH=$(cat $ARTIFACTS_DIR/ddev_linux-amd64.${VERSION_NUMBER}.tar.gz.sha256.txt | awk '{print $1;}' )
+LINUX_TARBALL_URL=https://github.com/${GITHUB_USERNAME}/ddev/releases/download/${VERSION_NUMBER}/ddev_linux-amd64.${VERSION_NUMBER}.tar.gz
 if [ ! -z "${LINUX_TARBALL_OVERRIDE:-}" ]; then
     LINUX_TARBALL_URL=${LINUX_TARBALL_OVERRIDE}
     LINUX_HASH=$(curl -sSL "${LINUX_TARBALL_URL}.sha256.txt" | awk '{print $1}')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,8 +349,7 @@ jobs:
         name: RELEASE BUILD (macOS) Circle VM setup
     - run: echo "version=$(make version)  CIRCLE_TAG=${CIRCLE_TAG}"
     - run:
-        command: make -s clean linux windows_install chocolatey
-
+        command: make -s linux_amd64 linux_arm64 darwin_amd64 windows_amd64 windows_install chocolatey
     - run:
         command: make -s darwin_notarized
         no_output_timeout: 30m


### PR DESCRIPTION
## The Problem/Issue/Bug:

Because we now have both amd64 and arm64 tarballs for download, the naming has changed.

The homebrew and AUR scripts need to point to the right (amd64) ones.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

