### PR TITLE
Improve install_ddev.sh to take a version and handle architectures, fixes #1587, fixes #2416

### DIFF
--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -17,7 +17,12 @@ FILEBASE=""
 LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/drud/ddev/releases/latest)
 # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
 LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-URL="https://github.com/drud/ddev/releases/download/$LATEST_VERSION"
+
+VERSION=$LATEST_VERSION
+if [ $# -ge 1 ]; then
+  VERSION=$1
+fi
+URL="https://github.com/drud/ddev/releases/download/$VERSION"
 
 if [[ "$OS" == "Darwin" ]]; then
     SHACMD="shasum -a 256"
@@ -38,7 +43,7 @@ if ! docker-compose --version >/dev/null 2>&1; then
     printf "${YELLOW}Docker Compose is required for ddev. Download and install docker-compose at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
 fi
 
-TARBALL="$FILEBASE.$LATEST_VERSION.tar.gz"
+TARBALL="$FILEBASE.$VERSION.tar.gz"
 SHAFILE="$TARBALL.sha256.txt"
 NFS_INSTALLER=macos_ddev_nfs_setup.sh
 

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -55,7 +55,7 @@ cd /tmp; $SHACMD -c "$SHAFILE"
 tar -xzf $TARBALL -C /tmp
 chmod ugo+x /tmp/ddev /tmp/macos_ddev_nfs_setup.sh
 
-printf "Download verified. Ready to place ddev in your /usr/local/bin.\n"
+printf "Download verified. Ready to place ddev and mkcert in your /usr/local/bin.\n"
 
 if [ -L /usr/local/bin/ddev ] ; then
     printf "${RED}ddev already exists as a link in /usr/local/bin. Was it installed with homebrew?${RESET}\n"
@@ -64,10 +64,10 @@ if [ -L /usr/local/bin/ddev ] ; then
     exit 101
 fi
 if [[ "$BINOWNER" == "$USER" ]]; then
-    mv /tmp/ddev /tmp/macos_ddev_nfs_setup.sh /usr/local/bin/
+    mv /tmp/ddev /tmp/mkcert /tmp/macos_ddev_nfs_setup.sh /usr/local/bin/
 else
-    printf "${YELLOW}Running \"sudo mv /tmp/ddev /tmp/macos_ddev_nfs_setup.sh /usr/local/bin/\" Please enter your password if prompted.${RESET}\n"
-    sudo mv /tmp/ddev /tmp/macos_ddev_nfs_setup.sh /usr/local/bin/
+    printf "${YELLOW}Running \"sudo mv /tmp/ddev /tmp/mkcert /tmp/macos_ddev_nfs_setup.sh /usr/local/bin/\" Please enter your password if prompted.${RESET}\n"
+    sudo mv /tmp/ddev /tmp/mkcert /tmp/macos_ddev_nfs_setup.sh /usr/local/bin/
 fi
 
 if command -v brew >/dev/null ; then
@@ -93,6 +93,7 @@ fi
 rm /tmp/$TARBALL /tmp/$SHAFILE
 
 printf "${GREEN}ddev is now installed. Run \"ddev\" to verify your installation and see usage.${RESET}\n"
-if ! command -v mkcert >/dev/null ; then
-    printf "${YELLOW}Please install mkcert from https://github.com/FiloSottile/mkcert/releases and then run 'mkcert -install'.${RESET}\n"
-fi
+
+printf "${YELLOW}Running mkcert -install, which may request your sudo password.'.${RESET}\n"
+mkcert -install
+

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -84,7 +84,7 @@ case ${unamearch} in
   ;;
 esac
 
-LATEST_RELEASE=$(curl -f -L -s -H 'Accept: application/json' https://github.com/${GITHUB_USERNAME}/ddev/releases/latest)
+LATEST_RELEASE=$(curl -fsSL -H 'Accept: application/json' https://github.com/${GITHUB_USERNAME}/ddev/releases/latest || (printf "${RED}Failed to get find latest release${RESET}\n" >/dev/stderr && exit 107))
 # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
 LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -78,7 +78,7 @@ case ${unamearch} in
   ;;
 esac
 
-LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/drud/ddev/releases/latest)
+LATEST_RELEASE=$(curl -f -L -s -H 'Accept: application/json' https://github.com/drud/ddev/releases/latest)
 # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
 LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 
@@ -108,25 +108,27 @@ fi
 USE_ARCH=$(semver_compare "${VERSION}" "v1.16.0-alpha4")
 # Versions after v1.16.0-alpha4 need the architecture in the filename
 if [ "${USE_ARCH}" == 1 ]; then
-  FILEBASE="${FILEBASE}.${ARCH}"
+  FILEBASE="${FILEBASE}-${ARCH}"
 fi
 
 
 if ! docker --version >/dev/null 2>&1; then
-    printf "${YELLOW}Docker is required for ddev. Download and install docker at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
+    printf "${YELLOW}Docker is required for ddev. Please see https://ddev.readthedocs.io/en/stable/#docker-installation.${RESET}\n"
 fi
 
 if ! docker-compose --version >/dev/null 2>&1; then
-    printf "${YELLOW}Docker Compose is required for ddev. Download and install docker-compose at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
+    printf "${YELLOW}docker-compose is required for ddev. Please see https://ddev.readthedocs.io/en/stable/#docker-installation.${RESET}\n"
 fi
 
+set -x
 TARBALL="$FILEBASE.$VERSION.tar.gz"
 SHAFILE="$TARBALL.sha256.txt"
 NFS_INSTALLER=macos_ddev_nfs_setup.sh
 
-curl -sSL "$RELEASE_BASE_URL/$TARBALL" -o "/tmp/$TARBALL"
-curl -sSL "$RELEASE_BASE_URL/$SHAFILE" -o "/tmp/$SHAFILE"
-curl -sSL "$RELEASE_BASE_URL/macos_ddev_nfs_setup.sh" -o /tmp/macos_ddev_nfs_setup.sh
+curl -fsSL "$RELEASE_BASE_URL/$TARBALL" -o "/tmp/$TARBALL"
+curl -fsSL "$RELEASE_BASE_URL/$SHAFILE" -o "/tmp/$SHAFILE"
+curl -fsSL "$RELEASE_BASE_URL/macos_ddev_nfs_setup.sh" -o /tmp/macos_ddev_nfs_setup.sh
+set +x
 
 cd /tmp; $SHACMD -c "$SHAFILE"
 tar -xzf $TARBALL -C /tmp


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #1587 script needs to be able to install a named version
* #2416: run mkcert if possible
* Handle post v1.16.0-alpha4 architecture in the download filename

## Manual Testing Instructions:

* Use the script to install latest stable version (no args)
* Use the script to install a named version post v1.16.0-alpha4
* Use the script to install a named version pre-v1.16.0-alpha4

## Automated Testing Overview:

* We haven't ever tested this script... it's possible we should.

