### PR TITLE
Fix Docker Desktop 2.4.0.0 Windows Hyper-V "WARNING: UNPROTECTED PRIVATE KEY FILE"

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -27,7 +27,7 @@ var AuthSSHCommand = &cobra.Command{
 			util.Failed("This command takes no arguments.")
 		}
 
-		uidStr, _, username := util.GetContainerUIDGid()
+		uidStr, _, _ := util.GetContainerUIDGid()
 
 		if sshKeyPath == "" {
 			homeDir, err := homedir.Dir()
@@ -61,7 +61,7 @@ var AuthSSHCommand = &cobra.Command{
 		}
 		sshKeyPath = dockerutil.MassageWindowsHostMountpoint(sshKeyPath)
 
-		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--mount=type=bind,src=" + sshKeyPath + ",dst=/home/" + username + "/.ssh", version.SSHAuthImage + ":" + version.SSHAuthTag + "-built", "ssh-add"}
+		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint=", "--mount=type=bind,src=" + sshKeyPath + ",dst=/tmp/sshtmp", version.SSHAuthImage + ":" + version.SSHAuthTag + "-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && ssh-add`}
 
 		err = exec.RunInteractiveCommand("docker", dockerCmd)
 


### PR DESCRIPTION
##  The Problem/Issue/Bug:

Docker Desktop 2.4.0.0 for Windows (in Hyper-V mode only) changed the ownership of mounted files from root to the actual user, but still does not provide any way to change permissions.

As a result, `ssh-add` fails in the process of `ddev auth ssh` because the (windows) permissions are too loose for ssh purposes.

```
$ ddev auth ssh
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0755 for '/home/anja.leichsenring/.ssh/id_ecdsa' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
Docker command 'docker [run -it --rm --volumes-from=ddev-ssh-agent --user=1000 --mount=type=bind,src=/c/Users/anja.leichsenring/.ssh,dst=/home/anja.leichsenring/.ssh drud/ddev-ssh-agent:v1.15.1-built ssh-a
dd]' failed: exit status 1
```

## How this PR Solves The Problem:

* Mount the .ssh directory to a temporary directory
* Copy the files in it from the temp directory to ~/.ssh
* chmod 400 those files
* THEN ssh-add

## Manual Testing Instructions:

On WIndows, Docker 2.4.0.0, Hyper-V mode, use `ddev auth ssh` and verify that it works.

## Automated Testing Overview:

Since this is actually to support a no-path-forward version of Docker Desktop for Windows, no tests added. I hope people will start using the WSL2 backend.


