### PR TITLE
Don't assume that project list populated, fixes #2537

### DIFF
--- a/cmd/ddev/cmd/delete.go
+++ b/cmd/ddev/cmd/delete.go
@@ -32,7 +32,9 @@ ddev delete --all`,
 		if err != nil {
 			util.Failed("Failed to get project(s): %v", err)
 		}
-		instrumentationApp = projects[0]
+		if len(projects) > 0 {
+			instrumentationApp = projects[0]
+		}
 
 		// Iterate through the list of projects built above, removing each one.
 		for _, project := range projects {

--- a/cmd/ddev/cmd/pause.go
+++ b/cmd/ddev/cmd/pause.go
@@ -21,7 +21,9 @@ in any directory by running 'ddev pause projectname [projectname ...]' or pause 
 		if err != nil {
 			util.Failed("Unable to get project(s): %v", err)
 		}
-		instrumentationApp = projects[0]
+		if len(projects) > 0 {
+			instrumentationApp = projects[0]
+		}
 
 		for _, project := range projects {
 			if err := ddevapp.CheckForMissingProjectFiles(project); err != nil {

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -28,7 +28,9 @@ ddev restart --all`,
 		if err != nil {
 			util.Failed("Failed to get project(s): %v", err)
 		}
-		instrumentationApp = projects[0]
+		if len(projects) > 0 {
+			instrumentationApp = projects[0]
+		}
 
 		for _, app := range projects {
 

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -21,7 +21,9 @@ ddev snapshot --all`,
 		if err != nil {
 			util.Failed("Unable to get project(s) %v: %v", args, err)
 		}
-		instrumentationApp = apps[0]
+		if len(apps) > 0 {
+			instrumentationApp = apps[0]
+		}
 
 		for _, app := range apps {
 			if snapshotNameOutput, err := app.Snapshot(snapshotName); err != nil {

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -24,7 +24,7 @@ ddev ssh -d /var/www/html`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projects, err := getRequestedProjects(args, false)
-		if err != nil {
+		if err != nil || len(projects) == 0 {
 			util.Failed("Failed to ddev ssh: %v", err)
 		}
 		app := projects[0]

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -40,7 +40,9 @@ ddev start --all`,
 		if err != nil {
 			util.Failed("Failed to get project(s): %v", err)
 		}
-		instrumentationApp = projects[0]
+		if len(projects) > 0 {
+			instrumentationApp = projects[0]
+		}
 
 		for _, project := range projects {
 			if err := ddevapp.CheckForMissingProjectFiles(project); err != nil {

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -55,7 +55,9 @@ ddev stop --remove-data`,
 		if err != nil {
 			util.Failed("Failed to get project(s): %v", err)
 		}
-		instrumentationApp = projects[0]
+		if len(projects) > 0 {
+			instrumentationApp = projects[0]
+		}
 
 		// Iterate through the list of projects built above, removing each one.
 		for _, project := range projects {


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2537 describes a bug resulting in a panic when one uses `ddev <command> --all`, but there are no projects.

## How this PR Solves The Problem:

Don't assume there are projects

## Manual Testing Instructions:

`ddev stop --unlist --all`
`ddev stop --all` should not result in a panic

Make sure all affected commands still work fine. start, stop, restart, pause

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

