### PR TITLE
Images of omitted containers should not be pulled, fixes #2262

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/packr/v2"
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"net"
@@ -881,26 +882,12 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
-	// Pull the main images with full output, since docker-compose up won't
-	// show enough output.
-	for _, imageName := range []string{app.WebImage, app.DBImage, version.GetRouterImage()} {
-		err = dockerutil.Pull(imageName)
-		if err != nil {
-			return err
-		}
-	}
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "dba") {
-		err = dockerutil.Pull(app.DBAImage)
-		if err != nil {
-			return err
-		}
+	err = app.PullContainerImages()
+	if err != nil {
+		return err
 	}
 
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "ddev-ssh-agent") {
-		err = dockerutil.Pull(version.GetSSHAuthImage())
-		if err != nil {
-			return err
-		}
 		err = app.EnsureSSHAgentContainer()
 		if err != nil {
 			return err
@@ -1003,6 +990,30 @@ func (app *DdevApp) Start() error {
 	err = app.ProcessHooks("post-start")
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// PullContainerImages pulls the main images with full output, since docker-compose up won't show enough output
+func (app *DdevApp) PullContainerImages() error {
+	containerImages := map[string]string {
+		"db": app.DBImage,
+		"dba": app.DBAImage,
+		"ddev-ssh-agent": version.GetSSHAuthImage(),
+		"web": app.WebImage,
+		"router": version.GetRouterImage(),
+	}
+
+	for containerName, imageName := range containerImages {
+		if !nodeps.ArrayContainsString(app.GetOmittedContainers(), containerName) {
+			err := dockerutil.Pull(imageName)
+			if err != nil {
+				return err
+			}
+		} else if globalconfig.DdevVerbose {
+			logrus.Printf("Not pulling omitted image for %s", containerName)
+		}
 	}
 
 	return nil

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -883,14 +883,24 @@ func (app *DdevApp) Start() error {
 
 	// Pull the main images with full output, since docker-compose up won't
 	// show enough output.
-	for _, imageName := range []string{app.WebImage, app.DBImage, app.DBAImage, version.GetSSHAuthImage(), version.GetRouterImage()} {
+	for _, imageName := range []string{app.WebImage, app.DBImage, version.GetRouterImage()} {
 		err = dockerutil.Pull(imageName)
+		if err != nil {
+			return err
+		}
+	}
+	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "dba") {
+		err = dockerutil.Pull(app.DBAImage)
 		if err != nil {
 			return err
 		}
 	}
 
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "ddev-ssh-agent") {
+		err = dockerutil.Pull(version.GetSSHAuthImage())
+		if err != nil {
+			return err
+		}
 		err = app.EnsureSSHAgentContainer()
 		if err != nil {
 			return err


### PR DESCRIPTION
## The Problem/Issue/Bug:
Images for omitted containers are pulled from registry

## How this PR Solves The Problem:
Prevents pulling of images for omitted containers

## Related Issue Link(s):
#2262