### PR TITLE
Don't try to load config.yaml if it doesn't exist

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -111,7 +111,7 @@ func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	app.SetApptypeSettingsPaths()
 
 	// Rendered yaml is not there until after ddev config or ddev start
-	if fileutil.FileExists(app.DockerComposeFullRenderedYAMLPath()) {
+	if fileutil.FileExists(app.ConfigPath) && fileutil.FileExists(app.DockerComposeFullRenderedYAMLPath()) {
 		content, err := fileutil.ReadFileIntoString(app.DockerComposeFullRenderedYAMLPath())
 		if err != nil {
 			return app, err
@@ -123,7 +123,7 @@ func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, e
 
 		_, err = app.ReadConfig(includeOverrides)
 		if err != nil {
-			return app, fmt.Errorf("%v exists but cannot be read. It may be invalid due to a syntax error.: %v", app.ConfigPath, err)
+			return app, fmt.Errorf("%v exists but cannot be read. It may be invalid due to a syntax error: %v", app.ConfigPath, err)
 		}
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

1. Start a project
2. `rm .ddev/config.yaml`
3. `ddev config`

You get error:
`could not create new config: /Users/rfay/workspace/d9/.ddev/config.yaml exists but cannot be read. It may be invalid due to a syntax error.: unable to load config file /Users/rfay/workspace/d9/.ddev/config.yaml: could not find an active ddev configuration at /Users/rfay/workspace/d9/.ddev/config.yaml have you run 'ddev config'? open /Users/rfay/workspace/d9/.ddev/config.yaml: no such file or directory`

The error is incorrect (the config.yaml does not exist)

The config.yaml should not have been loaded if it didn't exist in the first place.

## How this PR Solves The Problem:

Only load config.yaml if it exists

## Manual Testing Instructions:

Follow the recreation instructions above. 


