### PR TITLE
Discourage users more strongly from modifying DDEV's settings.ddev.php

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -385,7 +385,7 @@ And you can now visit your working project by URL or just give the command `ddev
 
 ### Configuration files
 
-_**Note:** If you're providing the settings.php or wp-config.php and DDEV is creating the settings.ddev.php (or wp-config-local.php, AdditionalConfig.php, or similar), the main settings file must explicitly include the appropriate DDEV-generated settings file._
+_**Note:** If you're providing the settings.php or wp-config.php and DDEV is creating the settings.ddev.php (or wp-config-local.php, AdditionalConfig.php, or similar), the main settings file must explicitly include the appropriate DDEV-generated settings file.  Any changes you need should be in a configuration file that loads after DDEV's settings file (see "Adding Configuration" below)._
 
 _**Note:** If you do *not* want DDEV-Local to create or manage settings files, set `disable_settings_management: true` in your .ddev/config.yaml or `ddev config --disable-settings-management` and you will be the only one that edits or updates settings files._
 
@@ -420,6 +420,12 @@ How do you know if DDEV manages a settings file? You will see the following comm
  */
 
 ```
+
+#### Adding configuration
+
+__Drupal and Backdrop__:  Load a settings.local.php file after settings.ddev.php (create one if it doesn't already exist), and make changes there (wrapping with `if (getenv('IS_DDEV_PROJECT') == 'true')` as needed).
+
+__WordPress__:  Load a wp-config-local.php after wp-config-ddev.php, and make changes there (wrapping with `if (getenv('IS_DDEV_PROJECT') == 'true')` as needed).
 
 ## Listing project information
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -385,7 +385,7 @@ And you can now visit your working project by URL or just give the command `ddev
 
 ### Configuration files
 
-_**Note:** If you're providing the settings.php or wp-config.php and DDEV is creating the settings.ddev.php (or wp-config-local.php, AdditionalConfig.php, or similar), the main settings file must explicitly include the appropriate DDEV-generated settings file.  Any changes you need should be in a configuration file that loads after DDEV's settings file (see "Adding Configuration" below)._
+_**Note:** If you're providing the settings.php or wp-config.php and DDEV is creating the settings.ddev.php (or wp-config-local.php, AdditionalConfig.php, or similar), the main settings file must explicitly include the appropriate DDEV-generated settings file.  Any changes you need should be included somewhere that loads after DDEV's settings file, for example in Drupal's settings.php *after* settings.ddev.php is included. (see "Adding Configuration" below)._
 
 _**Note:** If you do *not* want DDEV-Local to create or manage settings files, set `disable_settings_management: true` in your .ddev/config.yaml or `ddev config --disable-settings-management` and you will be the only one that edits or updates settings files._
 
@@ -423,7 +423,7 @@ How do you know if DDEV manages a settings file? You will see the following comm
 
 #### Adding configuration
 
-__Drupal and Backdrop__:  Load a settings.local.php file after settings.ddev.php (create one if it doesn't already exist), and make changes there (wrapping with `if (getenv('IS_DDEV_PROJECT') == 'true')` as needed).
+__Drupal and Backdrop__:  In settings.php, enable loading settings.local.php after settings.ddev.php is included (create a new one if it doesn't already exist), and make changes there (wrapping with `if (getenv('IS_DDEV_PROJECT') == 'true')` as needed).
 
 __WordPress__:  Load a wp-config-local.php after wp-config-ddev.php, and make changes there (wrapping with `if (getenv('IS_DDEV_PROJECT') == 'true')` as needed).
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -410,7 +410,7 @@ For **Wordpress**, DDEV settings are written to a DDEV-managed file, wp-config-d
 * If a DDEV-managed wp-config.php exists, create one that includes wp-config.php
 * If a user-managed wp-config.php exists, instruct the user on how to modify it to include DDEV settings
 
-How do you know if DDEV manages a settings file? You will see the following comment. Remove the comment and DDEV will not attempt to overwrite it!
+How do you know if DDEV manages a settings file? You will see the following comment. Remove the comment and DDEV will not attempt to overwrite it!  If you are letting DDEV create its settings file, it is recommended that you leave this comment so DDEV can continue to manage it, and make any needed changes in another settings file.
 
 ```
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -81,7 +81,7 @@ const (
  * @file
  * {{ $config.Signature }}: Automatically generated Drupal settings file.
  * ddev manages this file and may delete or overwrite the file unless this
- * comment is removed.
+ * comment is removed.  It is recommended that you leave this file alone.
  */
 
 $host = "{{ $config.DatabaseHost }}";

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -19,6 +19,7 @@ const typo3AdditionalConfigTemplate = `<?php
 /**
  * ` + DdevFileSignature + `: Automatically generated TYPO3 AdditionalConfiguration.php file.
  * ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ * It is recommended that you leave this file alone.
  */
 
 if (getenv('IS_DDEV_PROJECT') == 'true') {

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -89,6 +89,7 @@ const wordpressSettingsTemplate = `<?php
 /**
  {{ $config.Signature }}: Automatically generated WordPress settings file.
  ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ It is recommended that you leave this file alone.
  */
 
 /** Authentication Unique Keys and Salts. */


### PR DESCRIPTION
## The Problem/Issue/Bug:

Maybe this was just me, but I thought it was fine to modify the settings.ddev.php file in a Drupal project after the initial config.  I know it does technically work, but I've found out it's not recommended.  I think the comment template, and docs, should be updated to make this a smidge clearer.

## How this PR Solves The Problem:

Added a line to the docs, and modified the comment templates for Drupal, Typo3, and WordPress settings files (the only ones I saw that seemed applicable).

## Automated Testing Overview:

Only comments changed, so as long as the build succeeds, all should be well.

