### PR TITLE
Use official golang container instead of golang-build-container

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -22,12 +22,15 @@ fi
 # Upgrade various items on various operating systems
 case $os in
 darwin)
-    for item in mkcert golang bats-core ddev; do
+    for item in mkcert mkdocs golang golangci-lint bats-core ddev; do
         brew upgrade $item || brew install $item || true
     done
     ;;
 windows)
-    choco upgrade -y golang mkcert || true
+    choco upgrade -y golang markdownlint-cli mkcert mkdocs || true
+    if ! command -v golangci-lint >/dev/null 2>&1 ; then
+      (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0) || true
+    fi
     if [ "$(bats --version)" != "Bats 1.2.0" ]; then
         cd ~/workspace/bats-core/ && git fetch && git checkout v1.2.0 && ./install.sh /usr/local
     fi

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -25,7 +25,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 brew tap drud/ddev >/dev/null
-for item in osslsigncode golang mkcert ddev makensis bats-core; do
+for item in osslsigncode golang golangci-lint mkcert mkdocs ddev makensis bats-core; do
     brew install $item >/dev/null || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item >/dev/null
 done
 
@@ -52,10 +52,6 @@ ${HOME} ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)
 EOF"
 
 sudo service nfs-kernel-server restart
-
-# gotestsum
-GOTESTSUM_VERSION=0.3.2
-curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTESTSUM_VERSION/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum && sudo chmod +x /usr/local/bin/gotestsum
 
 # Install ghr
 GHR_RELEASE="v0.13.0"

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -35,12 +35,6 @@ mkcert -install
 
 pip3 install -q yq
 
-curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v0.3.2/gotestsum_0.3.2_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
-
-# gotestsum
-GOTESTSUM_VERSION=0.3.2
-curl -fsSL -o /tmp/gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_darwin_amd64.tar.gz && tar -C /usr/local/bin -zxf /tmp/gotestsum.tgz gotestsum
-
 sudo bash -c "cat <<EOF >/etc/exports
 ${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost
 /private/var -alldirs -mapall=$(id -u):$(id -g) localhost

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ DOCKERBUILDCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)              
           	    -e GOPATH="//workdir/$(GOTMP)" \
           	    -e GOCACHE="//workdir/$(GOTMP)/.cache" \
           	    -e GOFLAGS="$(USEMODVENDOR)" \
+          	    -e CGO_ENABLED=0 \
           	    -w //workdir              \
           	    $(BUILD_IMAGE)
 DOCKERTESTCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)                    \

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,6 @@ GOTESTSUM_FORMAT ?= short-verbose
 TESTTMP=/tmp/testresults
 DOWNLOADTMP=$(HOME)/tmp
 
-TESTTOOL ?= $(shell if command -v gotestsum >/dev/null ; then echo "gotestsum --format $(GOTESTSUM_FORMAT) --junitfile '$(TESTTMP)/$(@).xml'  --"; else echo "go test"; fi)
-##### These variables need to be adjusted in most repositories #####
-
 # This repo's root import path (under GOPATH).
 PKG := github.com/drud/ddev
 
@@ -73,7 +70,7 @@ BUILD_OS = $(shell go env GOHOSTOS)
 BUILD_ARCH = $(shell go env GOHOSTARCH)
 VERSION_LDFLAGS=$(foreach v,$(VERSION_VARIABLES),-X '$(PKG)/pkg/version.$(v)=$($(v))')
 LDFLAGS=-extldflags -static $(VERSION_LDFLAGS)
-BUILD_IMAGE ?= drud/golang-build-container:v1.15.2
+BUILD_IMAGE ?= golang:1.15.2
 DOCKERBUILDCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
           	    -v "/$(PWD)://workdir$(DOCKERMOUNTFLAG)"                              \
           	    -e GOPATH="//workdir/$(GOTMP)" \


### PR DESCRIPTION
Use official golang container instead of golang-build-container

This frees us to move forward with building/testing on arm64, see https://github.com/drud/ddev/issues/2543