### PR TITLE
Use docker login with team member user, fixes #2544

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -30,6 +30,12 @@ if ! docker ps >/dev/null 2>&1 ; then
   exit 1
 fi
 
+if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
+  set +x
+  echo "${DOCKERHUB_PULL_PASSWORD:-}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
+  set -x
+fi
+
 rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml ~/.ddev/homeadditions ~/.ddev/commands
 
 # There are discrepancies in golang hash checking in 1.11+, so kill off modcache to solve.

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
 set -o errexit
-set -x
 
 # Basic tools
+
+set -x
+
+if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
+  set +x
+  echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
+  set -x
+fi
 
 sudo apt-get update -qq
 sudo apt-get install -qq mysql-client realpath zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -56,3 +56,9 @@ timeout -v 10m bash -c 'while ! docker ps 2>/dev/null ; do
   sleep 5
   echo "Waiting for docker to come up: $(date)"
 done'
+
+if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
+  set +x
+  echo "${DOCKERHUB_PULL_PASSWORD:-}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
+  set -x
+fi


### PR DESCRIPTION
## The Problem/Issue/Bug:

See #2544: docker login with a team-member user is required, especially on CircleCI.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

