### PR TITLE
mariadb_version should not be omitted, fixes #2555

### DIFF
--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -38,7 +38,7 @@ func TestCmdVersion(t *testing.T) {
 	assert.Contains(versionData["msg"], version.WebImg)
 	assert.Contains(versionData["msg"], version.WebTag)
 	assert.Contains(versionData["msg"], version.DBImg)
-	assert.Contains(versionData["msg"], version.GetDBImage(nodeps.MariaDB, version.MariaDBDefaultVersion))
+	assert.Contains(versionData["msg"], version.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion))
 	assert.Contains(versionData["msg"], version.DBAImg)
 	assert.Contains(versionData["msg"], version.DBATag)
 	assert.NotEmpty(version.DockerVersion)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -448,17 +448,19 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		app.HostDBPort = hostDBPortArg
 	}
 
-	// If the mariaDBVersionArg is set, use it
+	// If the mariadb-version changed, use it
 	if cmd.Flag("mariadb-version").Changed {
-		app.MariaDBVersion = mariaDBVersionArg
+		app.MariaDBVersion, err = cmd.Flags().GetString("mariadb-version")
+		if err != nil {
+			util.Failed("Incorrect mariadb-version: %v", err)
+		}
 	}
-	// If the mariaDBVersionArg is set, use it
+	// If the mysql-version was changed is set, use it
 	if cmd.Flag("mysql-version").Changed {
 		app.MySQLVersion, err = cmd.Flags().GetString("mysql-version")
 		if err != nil {
 			util.Failed("Incorrect mysql-version: %v", err)
 		}
-
 	}
 
 	if cmd.Flag("nfs-mount-enabled").Changed {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -450,6 +450,10 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	// If the mariadb-version changed, use it
 	if cmd.Flag("mariadb-version").Changed {
+		if app.MySQLVersion != "" {
+			util.Failed(`mariadb-version cannot be set if mysql-version is already set. mysql-version is set to %s. Use ddev config --mariadb-version=%s --mysql-version=""`, app.MySQLVersion, app.MySQLVersion)
+		}
+
 		app.MariaDBVersion, err = cmd.Flags().GetString("mariadb-version")
 		if err != nil {
 			util.Failed("Incorrect mariadb-version: %v", err)
@@ -457,6 +461,9 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	}
 	// If the mysql-version was changed is set, use it
 	if cmd.Flag("mysql-version").Changed {
+		if app.MariaDBVersion != "" {
+			util.Failed(`mysql-version cannot be set if mariadb-version is already set. mariadb-version is set to %s. Use ddev config --mysql-version=%s --mariadb-version=""`, app.MariaDBVersion, app.MariaDBVersion)
+		}
 		app.MySQLVersion, err = cmd.Flags().GetString("mysql-version")
 		if err != nil {
 			util.Failed("Incorrect mysql-version: %v", err)

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/drud/ddev/pkg/version"
 	"github.com/mitchellh/go-homedir"
 	"os"
 	"strings"
@@ -424,12 +423,6 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	err = app.ConfigFileOverrideAction()
 	if err != nil {
 		util.Failed("failed to run ConfigFileOverrideAction: %v", err)
-	}
-
-	// We don't want to write out dbimage if it's just the one that goes with
-	// the mariadb_version.
-	if app.DBImage == version.GetDBImage(nodeps.MariaDB, "", app.MariaDBVersion) {
-		app.DBImage = ""
 	}
 
 	if phpVersionArg != "" {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -460,7 +460,7 @@ func TestConfigMariaDBVersion(t *testing.T) {
 	assert.NoError(err)
 	_, err = app.ReadConfig(false)
 	assert.NoError(err)
-	assert.Equal("", app.MariaDBVersion)
+	assert.Equal(version.MariaDBDefaultVersion, app.MariaDBVersion)
 	err = app.Start()
 	assert.NoError(err)
 	assert.EqualValues(version.GetDBImage(nodeps.MariaDB, version.MariaDBDefaultVersion), app.DBImage)

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -460,10 +460,10 @@ func TestConfigMariaDBVersion(t *testing.T) {
 	assert.NoError(err)
 	_, err = app.ReadConfig(false)
 	assert.NoError(err)
-	assert.Equal(version.MariaDBDefaultVersion, app.MariaDBVersion)
+	assert.Equal(nodeps.MariaDBDefaultVersion, app.MariaDBVersion)
 	err = app.Start()
 	assert.NoError(err)
-	assert.EqualValues(version.GetDBImage(nodeps.MariaDB, version.MariaDBDefaultVersion), app.DBImage)
+	assert.EqualValues(version.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion), app.DBImage)
 	_ = app.Stop(true, false)
 
 	// Verify behavior with no existing config.yaml. It should

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -644,7 +644,7 @@ func TestConfigMySQLVersion(t *testing.T) {
 	configArgs := append(args, "--project-name=conflicting-db-versions")
 	out, err := exec.RunCommand(DdevBin, configArgs)
 	assert.Error(err)
-	assert.Contains(out, "failed to validate config: both mariadb_version (10.1) and mysql_version (5.6) are set")
+	assert.Contains(out, "mysql-version cannot be set if mariadb-version is already set. mariadb-version is set to 10.1")
 
 	for cmdMySQLVersion := range versionsToTest {
 		for cmdDBImageVersion := range versionsToTest {
@@ -657,6 +657,7 @@ func TestConfigMySQLVersion(t *testing.T) {
 				"--project-name=" + projectName,
 				"--db-image=" + version.GetDBImage(nodeps.MySQL, cmdDBImageVersion),
 				"--mysql-version=" + cmdMySQLVersion,
+				`--mariadb-version=`,
 			}...)
 			ddevCmd := strings.Join(configArgs, " ")
 			out, err = exec.RunCommand(DdevBin, configArgs)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -182,9 +182,6 @@ func (app *DdevApp) WriteConfig() error {
 	if appcopy.ProjectTLD == nodeps.DdevDefaultTLD {
 		appcopy.ProjectTLD = ""
 	}
-	if appcopy.MariaDBVersion == version.GetDBImage(nodeps.MariaDB) {
-		appcopy.MariaDBVersion = ""
-	}
 
 	// We now want to reserve the port we're writing for HostDBPort and HostWebserverPort and so they don't
 	// accidentally get used for other projects.
@@ -443,7 +440,7 @@ func (app *DdevApp) ValidateConfig() error {
 	}
 
 	if app.MariaDBVersion != "" {
-		// Validate mariadb version version
+		// Validate mariadb version
 		if !nodeps.IsValidMariaDBVersion(app.MariaDBVersion) {
 			return fmt.Errorf("invalid mariadb_version: %s, must be one of %s", app.MariaDBVersion, nodeps.GetValidMariaDBVersions()).(invalidMariaDBVersion)
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -80,6 +80,7 @@ func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, e
 	app.ConfigPath = app.GetConfigPath("config.yaml")
 	app.Type = nodeps.AppTypePHP
 	app.PHPVersion = nodeps.PHPDefault
+	app.MariaDBVersion = nodeps.MariaDBDefaultVersion
 	app.WebserverType = nodeps.WebserverDefault
 	app.NFSMountEnabled = nodeps.NFSMountEnabledDefault
 	app.NFSMountEnabledGlobal = globalconfig.DdevGlobalConfig.NFSMountEnabledGlobal
@@ -182,7 +183,8 @@ func (app *DdevApp) WriteConfig() error {
 	if appcopy.ProjectTLD == nodeps.DdevDefaultTLD {
 		appcopy.ProjectTLD = ""
 	}
-	if appcopy.MariaDBVersion == "" {
+	// If mariadb-version is "" and mysql-version is not set, then set mariadb-version to default
+	if appcopy.MariaDBVersion == "" && appcopy.MySQLVersion == "" {
 		appcopy.MariaDBVersion = nodeps.MariaDBDefaultVersion
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -182,6 +182,9 @@ func (app *DdevApp) WriteConfig() error {
 	if appcopy.ProjectTLD == nodeps.DdevDefaultTLD {
 		appcopy.ProjectTLD = ""
 	}
+	if appcopy.MariaDBVersion == "" {
+		appcopy.MariaDBVersion = nodeps.MariaDBDefaultVersion
+	}
 
 	// We now want to reserve the port we're writing for HostDBPort and HostWebserverPort and so they don't
 	// accidentally get used for other projects.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -242,7 +242,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 		appDesc["database_type"] = "mariadb" // default
 		appDesc["mariadb_version"] = app.MariaDBVersion
 		if app.MariaDBVersion == "" {
-			appDesc["mariadb_version"] = version.MariaDBDefaultVersion
+			appDesc["mariadb_version"] = nodeps.MariaDBDefaultVersion
 		}
 	}
 
@@ -267,7 +267,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 				if app.MariaDBVersion != "" {
 					dbinfo["mariadb_version"] = app.MariaDBVersion
 				} else {
-					dbinfo["mariadb_version"] = version.MariaDBDefaultVersion
+					dbinfo["mariadb_version"] = nodeps.MariaDBDefaultVersion
 				}
 			}
 			appDesc["dbinfo"] = dbinfo
@@ -1521,7 +1521,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 		return fmt.Errorf("Failed to process pre-restore-snapshot hooks: %v", err)
 	}
 
-	currentDBVersion := version.MariaDBDefaultVersion
+	currentDBVersion := nodeps.MariaDBDefaultVersion
 	if app.MariaDBVersion != "" {
 		currentDBVersion = app.MariaDBVersion
 	} else if app.MySQLVersion != "" {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -76,7 +76,7 @@ type DdevApp struct {
 	NoProjectMount            bool                   `yaml:"no_project_mount,omitempty"`
 	AdditionalHostnames       []string               `yaml:"additional_hostnames"`
 	AdditionalFQDNs           []string               `yaml:"additional_fqdns"`
-	MariaDBVersion            string                 `yaml:"mariadb_version,omitempty"`
+	MariaDBVersion            string                 `yaml:"mariadb_version"`
 	MySQLVersion              string                 `yaml:"mysql_version,omitempty"`
 	NFSMountEnabled           bool                   `yaml:"nfs_mount_enabled,omitempty"`
 	NFSMountEnabledGlobal     bool                   `yaml:"-"`

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -77,7 +77,7 @@ type DdevApp struct {
 	AdditionalHostnames       []string               `yaml:"additional_hostnames"`
 	AdditionalFQDNs           []string               `yaml:"additional_fqdns"`
 	MariaDBVersion            string                 `yaml:"mariadb_version"`
-	MySQLVersion              string                 `yaml:"mysql_version,omitempty"`
+	MySQLVersion              string                 `yaml:"mysql_version"`
 	NFSMountEnabled           bool                   `yaml:"nfs_mount_enabled,omitempty"`
 	NFSMountEnabledGlobal     bool                   `yaml:"-"`
 	ConfigPath                string                 `yaml:"-"`

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -76,6 +76,9 @@ var ValidPHPVersions = map[string]bool{
 	PHP74: true,
 }
 
+// MariaDBDefaultVersion is the default MariaDB version
+const MariaDBDefaultVersion = MariaDB102
+
 var ValidMariaDBVersions = map[string]bool{
 	MariaDB55:  true,
 	MariaDB100: true,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,9 +9,6 @@ import (
 	"strings"
 )
 
-// MariaDBDefaultVersion is the default version we use in the db container
-const MariaDBDefaultVersion = "10.2"
-
 // VERSION is supplied with the git committish this is built from
 var VERSION = ""
 
@@ -115,7 +112,7 @@ func GetWebImage() string {
 
 // GetDBImage returns the correctly formatted db image:tag reference
 func GetDBImage(dbType string, dbVersion ...string) string {
-	v := MariaDBDefaultVersion
+	v := nodeps.MariaDBDefaultVersion
 	if len(dbVersion) > 0 {
 		v = dbVersion[0]
 	}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"github.com/drud/ddev/pkg/nodeps"
 	"runtime"
 	"testing"
 
@@ -15,7 +16,7 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Contains(v["web"], WebImg)
 	assert.Contains(v["web"], WebTag)
 	assert.Contains(v["db"], DBImg)
-	assert.Contains(v["db"], MariaDBDefaultVersion)
+	assert.Contains(v["db"], nodeps.MariaDBDefaultVersion)
 	assert.Contains(v["dba"], DBAImg)
 	assert.Contains(v["dba"], DBATag)
 	assert.Equal(COMMIT, v["commit"])


### PR DESCRIPTION
## The Problem/Issue/Bug:

In v1.15, mariadb_version started being omitted from the config.yaml if it was the same as default.

Unfortunately, this made it impossible to change the default without surprising people with odd behavior.

## How this PR Solves The Problem:

mariadb_version will now be included in config.yaml on `ddev config`, but it can still be empty and result in default

## Manual Testing Instructions:

- [x]  `ddev config --project-type=php` should result in a config.yaml that has mariadb_version: 10.2
- [x]  Removing that line should not change behavior
- [x] Setting `mariadb_version: "" ` should result in default behavior
- [x] Check all conflicts: Trying to set mysql_version when mariadb_version is set in config.yaml. Editing config.yaml to introduce conflicts. 

## Automated Testing Overview:

TestConfigMariadbVersion and TestConfigMysqlVersion were updated, but should have the same strength.

