### PR TITLE
Fix config sync directory for Drupal 8 websites that are using a custom sync directory

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -118,14 +118,21 @@ $settings['trusted_host_patterns'] = ['.*'];
 $settings['class_loader_auto_detect'] = FALSE;
 
 // This specifies the default configuration sync directory.
-// $config_directories (pre-Drupal 8.8) and
-// $settings['config_sync_directory'] are supported
-// so it should work on any Drupal 8 or 9 version.
-if (defined('CONFIG_SYNC_DIRECTORY') && empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
-  $config_directories[CONFIG_SYNC_DIRECTORY] = '{{ joinPath $config.SitePath $config.SyncDir }}';
+// If a configuration sync directory wasn't set yet, ddev is going to set a default one.
+// Ddev checks first which setup (Drupal 8 or Drupal 9) is being used.
+
+// Pre-Drupal 8.8 configuration
+if (defined('CONFIG_SYNC_DIRECTORY')) {
+  if (empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
+    // Set the configuration sync directory if it is not set for the project.
+    $config_directories[CONFIG_SYNC_DIRECTORY] = 'sites/default/files/sync';
+  }
 }
+
+// Post-Drupal 8.8 configuration
 elseif (empty($settings['config_sync_directory'])) {
-  $settings['config_sync_directory'] = '{{ joinPath $config.SitePath $config.SyncDir }}';
+  // Set the configuration sync directory if it is not set for the project.
+  $settings['config_sync_directory'] = 'sites/default/files/sync';
 }
 `
 )

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -92,7 +92,7 @@ $port = {{ $config.DatabasePort }};
 if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
   $host = "{{ $config.DockerIP }}";
   $port = {{ $config.DBPublishedPort }};
-} 
+}
 
 $databases['default']['default'] = array(
   'database' => "{{ $config.DatabaseName }}",
@@ -121,18 +121,21 @@ $settings['class_loader_auto_detect'] = FALSE;
 // If a configuration sync directory wasn't set yet, ddev is going to set a default one.
 // Ddev checks first which setup (Drupal 8 or Drupal 9) is being used.
 
-// Pre-Drupal 8.8 configuration
-if (defined('CONFIG_SYNC_DIRECTORY')) {
-  if (empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
-    // Set the configuration sync directory if it is not set for the project.
-    $config_directories[CONFIG_SYNC_DIRECTORY] = 'sites/default/files/sync';
-  }
-}
+// Check if post-Drupal 8.8 configuration already exists.
+if (empty($settings['config_sync_directory'])) {
 
-// Post-Drupal 8.8 configuration
-elseif (empty($settings['config_sync_directory'])) {
-  // Set the configuration sync directory if it is not set for the project.
-  $settings['config_sync_directory'] = 'sites/default/files/sync';
+  // Check for pre-Drupal 8.8 configuration.
+  if (defined('CONFIG_SYNC_DIRECTORY')) {
+    if (empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
+      // Set a default configuration sync directory.
+      $config_directories[CONFIG_SYNC_DIRECTORY] = 'sites/default/files/sync';
+    }
+  }
+  // Post-Drupal 8.8 configuration is needed.
+  else {
+    // Set a default configuration sync directory.
+    $settings['config_sync_directory'] = 'sites/default/files/sync';
+  }
 }
 `
 )
@@ -155,7 +158,7 @@ $port = {{ $config.DatabasePort }};
 if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
   $host = "{{ $config.DockerIP }}";
   $port = {{ $config.DBPublishedPort }};
-} 
+}
 
 $databases['default']['default'] = array(
   'database' => "{{ $config.DatabaseName }}",
@@ -188,7 +191,7 @@ $port = {{ $config.DatabasePort }};
 if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
   $host = "{{ $config.DockerIP }}";
   $port = {{ $config.DBPublishedPort }};
-} 
+}
 
 $db_url = "{{ $config.DatabaseDriver }}://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@$host:$port/{{ $config.DatabaseName }}";
 `

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -136,7 +136,6 @@ if (version_compare(DRUPAL::VERSION, "9.0.0", '>=') &&
   empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = 'sites/default/files/sync';
 }
-}
 `
 )
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -118,24 +118,24 @@ $settings['trusted_host_patterns'] = ['.*'];
 $settings['class_loader_auto_detect'] = FALSE;
 
 // This specifies the default configuration sync directory.
-// If a configuration sync directory wasn't set yet, ddev is going to set a default one.
-// Ddev checks first which setup (Drupal 8 or Drupal 9) is being used.
-
-// Check if post-Drupal 8.8 configuration already exists.
-if (empty($settings['config_sync_directory'])) {
-
-  // Check for pre-Drupal 8.8 configuration.
-  if (defined('CONFIG_SYNC_DIRECTORY')) {
-    if (empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
-      // Set a default configuration sync directory.
-      $config_directories[CONFIG_SYNC_DIRECTORY] = 'sites/default/files/sync';
-    }
-  }
-  // Post-Drupal 8.8 configuration is needed.
-  else {
-    // Set a default configuration sync directory.
-    $settings['config_sync_directory'] = 'sites/default/files/sync';
-  }
+// For D8 before 8.8.0, we set $config_directories[CONFIG_SYNC_DIRECTORY] if not set
+if (version_compare(Drupal::VERSION, "8.8.0", '<') &&
+  empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
+  $config_directories[CONFIG_SYNC_DIRECTORY] = 'sites/default/files/sync';
+}
+// For D8.8/D8.9, set $settings['config_sync_directory'] if neither 
+// $config_directories nor $settings['config_sync_directory is set
+if (version_compare(DRUPAL::VERSION, "8.8.0", '>=') &&
+  version_compare(DRUPAL::VERSION, "9.0.0", '<') &&
+  empty($config_directories[CONFIG_SYNC_DIRECTORY]) &&
+  empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = 'sites/default/files/sync';
+}
+// For Drupal9, it's always $settings['config_sync_directory']
+if (version_compare(DRUPAL::VERSION, "9.0.0", '>=') &&
+  empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = 'sites/default/files/sync';
+}
 }
 `
 )


### PR DESCRIPTION
## The Problem/Issue/Bug:
Drupal 8.9.6 website, that is using a custom deprecated (but still supported) setup for configuration sync directory, gets overridden by ddev default setup.
```
CONFIG_SYNC_DIRECTORY = 'sync'
$config_directories[CONFIG_SYNC_DIRECTORY] = `/var/www/html/config/sync`
```

## How this PR Solves The Problem:
Rearranging the conditions that check if a configuration sync directory already exist.

## Manual Testing Instructions:
I am thinking testing for this, would require 6 scenarios, installing Drupal Umami + Drush 10, and then run `drush cex -y`.

(no custom config directory)
Drupal 8.7 Umami
Drupal 8.8 Umami
Drupal 9.0 Umami

(with custom config directory)
Drupal 8.7 Umami
Drupal 8.8 Umami
Drupal 9.0 Umami

Some of these tests should fail with the conditions set in ddev `master`, but pass with the new set of conditions (in this patch)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

