### PR TITLE
Unpin mysql 8.0, fixes #2546

### DIFF
--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -7,7 +7,7 @@ VERSION := $(shell git describe --tags --always --dirty)
 # The format here is majorversion:pinnedimageversion
 # This allows to pin the version (as currently required with 8.0.19
 MARIADB_VERSIONS_amd64=5.5:5.5 10.0:10.0 10.1:10.1 10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5
-MYSQL_VERSIONS_amd64=5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0.19
+MYSQL_VERSIONS_amd64=5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0
 MARIADB_VERSIONS_arm64=10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5
 # MySQL images on Docker Hub currently are amd64 only
 MYSQL_VERSIONS_arm64=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -48,7 +48,7 @@ var WebTag = "v1.16.0-alpha5" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.16.0-alpha5"
+var BaseDBTag = "20201017_unpin_mysql_8_0"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Mysql 8.0 has been pinned at 8.0.19 for some time due to an incompatibility with xtrabackup. Hopefully that's fixed now and we can move on to standard. 


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

