### PR TITLE
Provide DRUSH_ALLOW_XDEBUG=1 to allow drush launcher xdebug usage

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -124,6 +124,7 @@ services:
 {{ if not .DisableSettingsManagement }}
       - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
 {{ end }}
+      - DRUSH_ALLOW_XDEBUG=1
       - DOCKER_IP={{ .DockerIP }}
       - HOST_DOCKER_INTERNAL_IP={{ .HostDockerInternalIP }}
       # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>


### PR DESCRIPTION
## The Problem/Issue/Bug:

drush-launcher (/usr/local/bin/drush in web container) disables xdebug by default, see https://github.com/drush-ops/drush-launcher#xdebug-compatibility

But people will want it if they're using drush in the container and have `ddev xdebug on`

## How this PR Solves The Problem:

Per https://github.com/drush-ops/drush-launcher#xdebug-compatibility, set `DRUSH_ALLOW_XDEBUG=1` by default

## Manual Testing Instructions:

`ddev start`
`ddev exec 'echo $DRUSH_ALLOW_XDEBUG'`

Value should be 1

