### PR TITLE
Add Travis config for arm64 tests, fixes #2543

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,9 @@ jobs:
      virt: lxd
      group: edge
 
+before_install:
+  # Install mkcert
+  - curl -sSL https://github.com/drud/mkcert/releases/download/v1.4.6/mkcert-v1.4.6-linux-arm64 -o /usr/local/bin/mkcert && chmod +x /usr/local/bin/mkcert
+  - mkcert -install
+
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,4 @@ jobs:
           popd
         done
         popd
+        set +eu

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   global:
     - BUILDKIT_PROGRESS=plain
     - GOTEST_SHORT=true
+    - DOCKER_CLI_EXPERIMENTAL=enabled
 
 before_install:
   - ./.travis/linux_travis_arm64_setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ language: go
 go:
 - 1.x
 
-jobs:
-  include:
-   - os: linux
-     arch: arm64-graviton2
-     virt: lxd
-     group: edge
+arch: arm64-graviton2
+virt: lxd
+os: linux
+dist: focal
+group: edge
 
 before_install:
   # Install mkcert

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,6 @@ env:
 
 before_install:
   - ./.travis/linux_travis_arm64_setup.sh
-  # Configure environment so changes are picked up when the Docker daemon is restarted after upgrading
-  - echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
-  - export DOCKER_CLI_EXPERIMENTAL=enabled
-  # Upgrade to Docker CE 19.03 for BuildKit support
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  # Show info to simplify debugging and create a builder
-  - docker info
-  - docker buildx create --name ddev-builder-multi --use  
 
 # Group tests to break up travis-CI build so it doesn't hit time limit.
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ jobs:
     - name: container tests
       script: |
         set -eu -o pipefail
-        pushd containers
         for dir in containers/*/
           do pushd $dir
           echo "--- Build container $dir"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ os: linux
 dist: focal
 group: edge
 
+env:
+  global:
+    - BUILDKIT_PROGRESS=plain
+
 before_install:
   - ./.travis/linux_travis_arm64_setup.sh
   # Configure environment so changes are picked up when the Docker daemon is restarted after upgrading

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,4 @@ jobs:
           time make test
           popd
         done
-        popd
         set +eu

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       script: make test
     - name: Linux container tests
       script: |
+        set -eu -o pipefail 
         for dir in containers/*/
           do pushd $dir
           echo "--- Build container $dir"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
 
 before_install:
   # Install mkcert
-  - curl -sSL https://github.com/drud/mkcert/releases/download/v1.4.6/mkcert-v1.4.6-linux-arm64 -o /usr/local/bin/mkcert && chmod +x /usr/local/bin/mkcert
+  - sudo curl -sSL https://github.com/drud/mkcert/releases/download/v1.4.6/mkcert-v1.4.6-linux-arm64 -o /usr/local/bin/mkcert && sudo chmod +x /usr/local/bin/mkcert
   - mkcert -install
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,9 @@ jobs:
       script: make testcmd
     - name: Linux container tests
       script: |
-        set -eu -o pipefail 
-        for dir in containers/*/
+        set -eu -o pipefail
+        pushd containers
+        for dir in ddev-dbserver ddev-router ddev-ssh-agent ddev-webserver
           do pushd $dir
           echo "--- Build container $dir"
           time make container DOCKER_ARGS=--no-cache
@@ -69,5 +70,6 @@ jobs:
           time make test
           popd
         done
+        popd
 
 script: make testpkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,13 @@ before_install:
 #
 jobs:
   include:
-    - stage: test
-      name: test
-    - name: make testcmd
+    - name: testcmd tests
       script: make testcmd
-    - name: make testnotddevapp
+    - name: testpkg tests except ddevapp
       script: make testnotddevapp
-    - name: make testddevapp
+    - name: ddevapp tests
       script: make testddevapp
-    - name: Container tests
+    - name: container tests
       script: |
         set -eu -o pipefail
         pushd containers

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ before_install:
   - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
   - mkdir -p $HOME/.docker
   - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
-  - sudo service docker start
+  - export DOCKER_CLI_EXPERIMENTAL=enabled
+  - sudo service docker restart
 
 install:
+  - docker info
   - docker buildx create --name ddev-builder-multi --use
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ dist: focal
 group: edge
 
 before_install:
-  # Install mkcert
-  - sudo curl -sSL https://github.com/drud/mkcert/releases/download/v1.4.6/mkcert-v1.4.6-linux-arm64 -o /usr/local/bin/mkcert && sudo chmod +x /usr/local/bin/mkcert
-  - mkcert -install
+  - ./.travis/linux_travis_arm64_setup.sh
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+- 1.x
+
+arch:
+- arm64-graviton2
+
+script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,4 @@ jobs:
           popd
         done
 
-script: make test
+script: make testpkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ group: edge
 env:
   global:
     - BUILDKIT_PROGRESS=plain
+    - GOTEST_SHORT=true
 
 before_install:
   - ./.travis/linux_travis_arm64_setup.sh
@@ -27,11 +28,36 @@ before_install:
   - docker info
   - docker buildx create --name ddev-builder-multi --use  
 
+# Group tests by directory to logically break up travis-CI build.
+#
+# Here's the bash if you need to update this. Be sure to maintain the 
+# lines that are currently commented out (these cannot run in Travis)
+#   cd pkg
+#   find . -maxdepth 1 -type d | sed 's|./|    - env: TESTDIR=|' | sed 's/$//g'
+#
 jobs:
   include:
     - stage: test
-      name: Run make test
-      script: make test
+      name: testpkg
+      env: TESTDIR=nodeps
+    - env: TESTDIR=appports
+    - env: TESTDIR=fileutil
+    - env: TESTDIR=version
+    - env: TESTDIR=ddevhosts
+    - env: TESTDIR=exec
+    - env: TESTDIR=output
+    - env: TESTDIR=globalconfig
+    - env: TESTDIR=util
+    - env: TESTDIR=testcommon
+    - env: TESTDIR=appimport
+    - env: TESTDIR=ddevapp
+    - env: TESTDIR=netutil
+    - env: TESTDIR=servicetest
+    - env: TESTDIR=updatecheck
+    - env: TESTDIR=archive
+    - env: TESTDIR=dockerutil
+    - name: make testcmd
+      script: make testcmd
     - name: Linux container tests
       script: |
         set -eu -o pipefail 
@@ -43,3 +69,5 @@ jobs:
           time make test
           popd
         done
+
+script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       script: |
         set -eu -o pipefail
         pushd containers
-        for dir in ddev-dbserver ddev-router ddev-ssh-agent ddev-webserver
+        for dir in containers/*/
           do pushd $dir
           echo "--- Build container $dir"
           time make container DOCKER_ARGS=--no-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 - 1.x
 
 arch: arm64-graviton2
-virt: lxd
+virt: vm
 os: linux
 dist: focal
 group: edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: go
 go:
 - 1.x
 
-services:
-  - docker
-
 arch: arm64-graviton2
 virt: vm
 os: linux
@@ -14,6 +11,13 @@ group: edge
 
 before_install:
   - ./.travis/linux_travis_arm64_setup.sh
+  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - mkdir -p $HOME/.docker
+  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+  - sudo service docker start
+
+install:
+  - docker buildx create --name ddev-builder-multi --use
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,18 @@ group: edge
 before_install:
   - ./.travis/linux_travis_arm64_setup.sh
 
-script: make test
+jobs:
+  include:
+    - stage: test
+      name: Run make test
+      script: make test
+    - name: Linux container tests
+      script: |
+        for dir in containers/*/
+          do pushd $dir
+          echo "--- Build container $dir"
+          time make container DOCKER_ARGS=--no-cache
+          echo "--- Test container $dir"
+          time make test
+          popd
+        done

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
 - 1.x
 
+services:
+  - docker
+
 arch: arm64-graviton2
 virt: vm
 os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,8 @@ before_install:
   - mkdir -p $HOME/.docker
   - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
   - export DOCKER_CLI_EXPERIMENTAL=enabled
-  - sudo service docker restart
-
-install:
   - docker info
-  - docker buildx create --name ddev-builder-multi --use
+  - docker buildx create --name ddev-builder-multi --use  
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ go:
 arch:
 - arm64-graviton2
 
+virt: lxd
+
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ language: go
 go:
 - 1.x
 
-arch:
-- arm64-graviton2
-
-virt: lxd
+jobs:
+  include:
+   - os: linux
+     arch: arm64-graviton2
+     virt: lxd
+     group: edge
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,27 +38,14 @@ before_install:
 jobs:
   include:
     - stage: test
-      name: testpkg
-      env: TESTDIR=nodeps
-    - env: TESTDIR=appports
-    - env: TESTDIR=fileutil
-    - env: TESTDIR=version
-    - env: TESTDIR=ddevhosts
-    - env: TESTDIR=exec
-    - env: TESTDIR=output
-    - env: TESTDIR=globalconfig
-    - env: TESTDIR=util
-    - env: TESTDIR=testcommon
-    - env: TESTDIR=appimport
-    - env: TESTDIR=ddevapp
-    - env: TESTDIR=netutil
-    - env: TESTDIR=servicetest
-    - env: TESTDIR=updatecheck
-    - env: TESTDIR=archive
-    - env: TESTDIR=dockerutil
+      name: test
     - name: make testcmd
       script: make testcmd
-    - name: Linux container tests
+    - name: make testnotddevapp
+      script: make testnotddevapp
+    - name: make testddevapp
+      script: make testddevapp
+    - name: Container tests
       script: |
         set -eu -o pipefail
         pushd containers
@@ -71,5 +58,3 @@ jobs:
           popd
         done
         popd
-
-script: make testpkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,15 @@ group: edge
 
 before_install:
   - ./.travis/linux_travis_arm64_setup.sh
-  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
-  - mkdir -p $HOME/.docker
-  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+  # Configure environment so changes are picked up when the Docker daemon is restarted after upgrading
+  - echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
   - export DOCKER_CLI_EXPERIMENTAL=enabled
+  # Upgrade to Docker CE 19.03 for BuildKit support
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  # Show info to simplify debugging and create a builder
   - docker info
   - docker buildx create --name ddev-builder-multi --use  
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,7 @@ before_install:
   - docker info
   - docker buildx create --name ddev-builder-multi --use  
 
-# Group tests by directory to logically break up travis-CI build.
-#
-# Here's the bash if you need to update this. Be sure to maintain the 
-# lines that are currently commented out (these cannot run in Travis)
-#   cd pkg
-#   find . -maxdepth 1 -type d | sed 's|./|    - env: TESTDIR=|' | sed 's/$//g'
-#
+# Group tests to break up travis-CI build so it doesn't hit time limit.
 jobs:
   include:
     - name: testcmd tests

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -15,6 +15,9 @@ fi
 sudo apt-get update -qq
 sudo apt-get install -qq mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev docker-compose
 
+# Copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
+sudo cp /usr/bin/docker-compose /usr/local/bin/docker-compose
+
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 
 # Without this .curlrc CircleCI linux image doesn't respect mkcert certs

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -15,7 +15,7 @@ fi
 sudo apt-get update -qq
 sudo apt-get install -qq mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
 
-curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.tgz && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
+curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 
 # Without this .curlrc CircleCI linux image doesn't respect mkcert certs
 echo "capath=/etc/ssl/certs/" >>~/.curlrc

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -13,7 +13,7 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
 fi
 
 sudo apt-get update -qq
-sudo apt-get install -qq mysql-client realpath zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
+sudo apt-get install -qq mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
 
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.tgz && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+# Basic tools
+
+set -x
+
+if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
+  set +x
+  echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
+  set -x
+fi
+
+sudo apt-get update -qq
+sudo apt-get install -qq mysql-client realpath zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
+
+curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.tgz && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
+
+# Without this .curlrc CircleCI linux image doesn't respect mkcert certs
+echo "capath=/etc/ssl/certs/" >>~/.curlrc
+
+. ~/.bashrc
+
+npm install -g bats
+
+# Install mkcert
+sudo curl -sSL https://github.com/drud/mkcert/releases/download/v1.4.6/mkcert-v1.4.6-linux-arm64 -o /usr/local/bin/mkcert && sudo chmod +x /usr/local/bin/mkcert
+mkcert -install
+
+primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
+
+sudo bash -c "cat <<EOF >/etc/exports
+${HOME} ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)
+/tmp ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)
+EOF"
+
+sudo service nfs-kernel-server restart

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -13,7 +13,7 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
 fi
 
 sudo apt-get update -qq
-sudo apt-get install -qq mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
+sudo apt-get install -qq mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev docker-compose
 
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -39,3 +39,15 @@ ${HOME} ${primary_ip}/255.255.255.255(rw,sync,no_subtree_check)
 EOF"
 
 sudo service nfs-kernel-server restart
+
+# Configure environment so changes are picked up when the Docker daemon is restarted after upgrading
+echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+export DOCKER_CLI_EXPERIMENTAL=enabled
+# Upgrade to Docker CE 19.03 for BuildKit support
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+# Show info to simplify debugging and create a builder
+docker info
+docker buildx create --name ddev-builder-multi --use  

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ packr2:
 # Required static analysis targets used in circleci - these cause fail if they don't work
 staticrequired: setup golangci-lint markdownlint mkdocs
 
+# Best to install markdownlint-cli locally with "npm install -g markdownlint-cli"
 markdownlint:
 	@echo "markdownlint: "
 	@CMD="markdownlint *.md docs 2>&1"; \
@@ -183,6 +184,7 @@ markdownlint:
 		bash -c "$$CMD"; \
 	fi
 
+# Best to install mkdocs locally with "sudo pip3 install mkdocs"
 mkdocs:
 	@echo "mkdocs: "
 	@CMD="mkdocs -q build -d /tmp/mkdocsbuild"; \
@@ -242,6 +244,7 @@ $(GOTMP)/bin/windows_amd64/nssm.exe $(GOTMP)/bin/windows_amd64/winnfsd_license.t
 	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/nssm.exe https://github.com/drud/nssm/releases/download/$(NSSM_VERSION)/nssm.exe
 	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/winnfsd_license.txt https://www.gnu.org/licenses/gpl.txt
 
+# Best to install golangci-lint locally with "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.31.0"
 golangci-lint:
 	@echo "golangci-lint: "
 	@CMD="golangci-lint run $(GOLANGCI_LINT_ARGS) $(SRC_AND_UNDER)"; \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ export PATH := $(EXTRA_PATH):$(PATH)
 DOCKERMOUNTFLAG := :cached
 
 BUILD_BASE_DIR ?= $(PWD)
+TESTDIR ?= ...
 
 GOTMP=.gotmp
 SHELL = /bin/bash
@@ -138,7 +139,7 @@ testcmd: $(DEFAULT_BUILD) setup
 
 testpkg: $(DEFAULT_BUILD) setup
 	@echo LDFLAGS=$(LDFLAGS)
-	DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " ./pkg/... $(TESTARGS)
+	DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=0 DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH) go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " ./pkg/$(TESTDIR) $(TESTARGS)
 
 setup:
 	@mkdir -p $(GOTMP)/{src,pkg/mod/cache,.cache}

--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -22,7 +22,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	if !util.IsCommandAvailable("expect") {
 		t.Skip("Skipping TestCmdAuthSSH because expect scripting tool is not available")
 	}
-	if runtime.GOOS == "arm64" {
+	if runtime.GOARCH == "arm64" {
 		t.Skip("Skipping TestCmdAuthSSH on arm64 because necessary test-ssh-server image not available")
 	}
 

--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -21,9 +20,6 @@ func TestCmdAuthSSH(t *testing.T) {
 	assert := asrt.New(t)
 	if !util.IsCommandAvailable("expect") {
 		t.Skip("Skipping TestCmdAuthSSH because expect scripting tool is not available")
-	}
-	if runtime.GOARCH == "arm64" {
-		t.Skip("Skipping TestCmdAuthSSH on arm64 because necessary test-ssh-server image not available")
 	}
 
 	testDir, _ := os.Getwd()

--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -20,6 +21,9 @@ func TestCmdAuthSSH(t *testing.T) {
 	assert := asrt.New(t)
 	if !util.IsCommandAvailable("expect") {
 		t.Skip("Skipping TestCmdAuthSSH because expect scripting tool is not available")
+	}
+	if runtime.GOOS == "arm64" {
+		t.Skip("Skipping TestCmdAuthSSH on arm64 because necessary test-ssh-server image not available")
 	}
 
 	testDir, _ := os.Getwd()

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -456,9 +456,6 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		if err != nil {
 			util.Failed("Incorrect mariadb-version %s: '%v'", wantVer, err)
 		}
-		if wantVer != "" && !nodeps.IsValidMariaDBVersion(wantVer) {
-			util.Failed("Invalid mariadb-version %s", wantVer)
-		}
 
 		if app.MySQLVersion != "" && wantVer != "" {
 			util.Failed(`mariadb-version cannot be set if mysql-version is already set. mysql-version is set to %s. Use ddev config --mysql-version="" and then ddev config --mariadb-version=%s`, app.MySQLVersion, wantVer)
@@ -471,9 +468,6 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		wantVer, err := cmd.Flags().GetString("mysql-version")
 		if err != nil {
 			util.Failed("Incorrect mysql-version %s: '%v'", wantVer, err)
-		}
-		if wantVer != "" && !nodeps.IsValidMySQLVersion(wantVer) {
-			util.Failed("Invalid mysql-version %s", wantVer)
 		}
 		if app.MariaDBVersion != "" && wantVer != "" {
 			util.Failed(`mysql-version cannot be set if mariadb-version is already set. mariadb-version is set to %s. Use ddev config --mariadb-version="" --mysql-version=%s`, app.MariaDBVersion, wantVer)

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -110,7 +110,7 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	assert.NoError(err)
 
 	// Create a config
-	args := []string{"config", "--project-name=config-with-sitename"}
+	args := []string{"config", "--project-name=config-with-sitename", "--php-version=7.2"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 	defer func() {

--- a/containers/containers_shared.mak
+++ b/containers/containers_shared.mak
@@ -6,7 +6,7 @@ SANITIZED_DOCKER_REPO = $(subst /,_,$(DOCKER_REPO))
 DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
 
 container: container-name
-	docker buildx build --platform linux/amd64 -o type=docker -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) --label "build-info=$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)" .
+	docker buildx build -o type=docker -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) --label "build-info=$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)" .
 
 container-name:
 	@echo "container: $(DOCKER_REPO):$(VERSION)"

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -11,6 +11,7 @@ MYSQL_VERSIONS_amd64=5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0.21
 MARIADB_VERSIONS_arm64=10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5
 # MySQL images on Docker Hub currently are amd64 only
 MYSQL_VERSIONS_arm64=
+CURRENT_ARCH= $(shell ../get_arch.sh)
 
 # This Makefile explicitly does not include containers/containers_shared.mak,
 # So has to explicitly declare anything it might need from there (like SHELL)
@@ -20,7 +21,7 @@ container: mariadb_containers mysql_containers
 
 mariadb_containers:
 	set -eu -o pipefail; \
-	for item in $(MARIADB_VERSIONS_amd64); do \
+	for item in $(MARIADB_VERSIONS_$(CURRENT_ARCH)); do \
 		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
 		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
 		printf "\n\n========== Building MariaDB $${baseversion} with image $${fullversion} ==========\n"; \
@@ -29,7 +30,7 @@ mariadb_containers:
 
 mysql_containers:
 	set -eu -o pipefail ; \
-	for item in $(MYSQL_VERSIONS_amd64) ; do \
+	for item in $(MYSQL_VERSIONS_$(CURRENT_ARCH)) ; do \
 		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
 		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
 		printf "\n\n========== Building MySQL $${baseversion} with image $${fullversion} ==========\n", ${baseversion}, ${fullversion}; \

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -6,7 +6,7 @@ VERSION := $(shell git describe --tags --always --dirty)
 
 include database-versions
 
-CURRENT_ARCH= $(shell ../get_arch.sh)
+CURRENT_ARCH=$(shell ../get_arch.sh)
 
 # This Makefile explicitly does not include containers/containers_shared.mak,
 # So has to explicitly declare anything it might need from there (like SHELL)

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -4,13 +4,8 @@ VERSION := $(shell git describe --tags --always --dirty)
 
 .PHONY: build container mariadb_containers mysql_containers multi-arch push test clean
 
-# The format here is majorversion:pinnedimageversion
-# This allows to pin the version (as currently required with 8.0.19
-MARIADB_VERSIONS_amd64=5.5:5.5 10.0:10.0 10.1:10.1 10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5
-MYSQL_VERSIONS_amd64=5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0.21
-MARIADB_VERSIONS_arm64=10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5
-# MySQL images on Docker Hub currently are amd64 only
-MYSQL_VERSIONS_arm64=
+include database-versions
+
 CURRENT_ARCH= $(shell ../get_arch.sh)
 
 # This Makefile explicitly does not include containers/containers_shared.mak,
@@ -21,7 +16,7 @@ container: mariadb_containers mysql_containers
 
 mariadb_containers:
 	set -eu -o pipefail; \
-	for item in $(MARIADB_VERSIONS_$(CURRENT_ARCH)); do \
+	for item in $(subst $\",,$(MARIADB_VERSIONS_$(CURRENT_ARCH))); do \
 		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
 		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
 		printf "\n\n========== Building MariaDB $${baseversion} with image $${fullversion} ==========\n"; \
@@ -30,7 +25,7 @@ mariadb_containers:
 
 mysql_containers:
 	set -eu -o pipefail ; \
-	for item in $(MYSQL_VERSIONS_$(CURRENT_ARCH)) ; do \
+	for item in $(subst $\",,$(MYSQL_VERSIONS_$(CURRENT_ARCH))); do \
 		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
 		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
 		printf "\n\n========== Building MySQL $${baseversion} with image $${fullversion} ==========\n", ${baseversion}, ${fullversion}; \
@@ -41,7 +36,7 @@ mysql_containers:
 # So, the multi-arch approach here is a bit different from the ones in the other Makefiles.
 multi-arch: mariadb_containers mysql_containers
 	set -eu -o pipefail ; \
-	for item in $(MARIADB_VERSIONS_arm64); do \
+	for item in $(subst $\",,$(MARIADB_VERSIONS_arm64)); do \
 		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
 		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
 		printf "\n\n========== Building MariaDB $${baseversion} with image $${fullversion} ==========\n"; \
@@ -50,14 +45,14 @@ multi-arch: mariadb_containers mysql_containers
 
 push:
 	set -euo pipefail ;\
-	for item in $(MARIADB_VERSIONS_amd64); do \
+	for item in $(subst $\",,$(MARIADB_VERSIONS_amd64)); do \
 		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
 		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
-		export archs=$$(if [[ "$(MARIADB_VERSIONS_arm64)" == *"$$item"* ]]; then echo "linux/amd64,linux/arm64"; else echo "linux/amd64"; fi); \
+		export archs=$$(if [[ "$(subst $\",,$(MARIADB_VERSIONS_arm64))" == *"$$item"* ]]; then echo "linux/amd64,linux/arm64"; else echo "linux/amd64"; fi); \
 		docker buildx build --push --platform $${archs} $(DOCKER_ARGS)  --build-arg="DBVERSION=$${baseversion}" --build-arg="PARENTIMAGEVERSION=$$fullversion" --build-arg="DBTYPE=mariadb" -t "drud/ddev-dbserver-mariadb-$${baseversion}:$(VERSION)" .; \
 	done
 	set -euo pipefail ;\
-	for item in $(MYSQL_VERSIONS_amd64) ; do \
+	for item in $(subst $\",,$(MYSQL_VERSIONS_amd64)); do \
 		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
 		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
 		docker buildx build --push --platform linux/amd64 $(DOCKER_ARGS) --build-arg="DBVERSION=$$baseversion" --build-arg="PARENTIMAGEVERSION=$$fullversion" --build-arg="DBTYPE=mysql" -t "drud/ddev-dbserver-mysql-$${baseversion%%%.*}:$(VERSION)" .; \
@@ -67,10 +62,10 @@ test: container
 	bash ./test/test_dbserver.sh $(VERSION) # bash execution just for windows make
 
 clean:
-	for item in $(MARIADB_VERSIONS); do \
+	for item in $(subst $\",,$(MARIADB_VERSIONS_$(CURRENT_ARCH))); do \
 		if docker image inspect $(DOCKER_REPO)-mariadb-${item}:$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO)-mariadb-$${item}:$(VERSION); fi; \
 	done
-	for item in $(MYSQL_VERSIONS); do \
+	for item in $(subst $\",,$(MYSQL_VERSIONS_$(CURRENT_ARCH))); do \
 		if docker image inspect $(DOCKER_REPO)-mysql-${item}:$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO)-mysql-$${item}:$(VERSION); fi; \
 	done
 	@rm -rf VERSION.txt

--- a/containers/ddev-dbserver/database-versions
+++ b/containers/ddev-dbserver/database-versions
@@ -1,0 +1,7 @@
+# The format here is majorversion:pinnedimageversion
+# This allows to pin the version (as currently required with 8.0.21)
+MARIADB_VERSIONS_amd64="5.5:5.5 10.0:10.0 10.1:10.1 10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5"
+MYSQL_VERSIONS_amd64="5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0.21"
+MARIADB_VERSIONS_arm64="10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5"
+# MySQL images on Docker Hub currently are amd64 only
+MYSQL_VERSIONS_arm64=

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -13,24 +13,36 @@ function cleanup {
 trap cleanup EXIT
 
 export tag=${VERSION}
+export CURRENT_ARCH=$(../../get_arch.sh)
+
+# Get database versions per database type
+source ../database-versions
+
+export MARIADB_VERSIONS="MARIADB_VERSIONS_$CURRENT_ARCH"
+export MYSQL_VERSIONS="MYSQL_VERSIONS_$CURRENT_ARCH"
+
 export DB_TYPE=mariadb
-for v in 5.5 10.0 10.1 10.2 10.3 10.4 10.5; do
-    export IMAGE="drud/ddev-dbserver-$DB_TYPE-$v:$tag"
-    export DB_VERSION=$v
+for v in ${!MARIADB_VERSIONS}; do
+    export baseversion=$(echo $v | awk -F ':' '{print $1}')
+	export fullversion=$(echo $v | awk -F ':' '{print $2}')
+    export IMAGE="drud/ddev-dbserver-$DB_TYPE-$baseversion:$tag"
+    export DB_VERSION=$baseversion
     # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
     export PATH="/usr/local/bin:$PATH"
-    bats test || ( echo "bats tests failed for $DB_TYPE $v" && exit 5 )
-    printf "Test successful for $DB_TYPE $v\n\n"
+    bats test || ( echo "bats tests failed for $DB_TYPE $baseversion" && exit 5 )
+    printf "Test successful for $DB_TYPE $baseversion\n\n"
 done
 
 export DB_TYPE=mysql
-for v in 5.5 5.6 5.7 8.0; do
-    export IMAGE="drud/ddev-dbserver-$DB_TYPE-$v:$tag"
-    export DB_VERSION=$v
+for v in ${!MYSQL_VERSIONS}; do
+    export baseversion=$(echo $v | awk -F ':' '{print $1}')
+	export fullversion=$(echo $v | awk -F ':' '{print $2}')
+    export IMAGE="drud/ddev-dbserver-$DB_TYPE-$baseversion:$tag"
+    export DB_VERSION=$baseversion
     # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
     export PATH="/usr/local/bin:$PATH"
-    bats test || ( echo "bats tests failed for $DB_TYPE $v" && exit 5 )
-    printf "Test successful for $DB_TYPE $v\n\n"
+    bats test || ( echo "bats tests failed for $DB_TYPE $baseversion" && exit 5 )
+    printf "Test successful for $DB_TYPE $baseversion\n\n"
 done
 
 echo "Test successful"

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Find the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
 set -o errexit
 set -o pipefail
 set -o nounset
@@ -13,10 +16,10 @@ function cleanup {
 trap cleanup EXIT
 
 export tag=${VERSION}
-export CURRENT_ARCH=$(../../get_arch.sh)
+export CURRENT_ARCH=$($DIR/../../get_arch.sh)
 
 # Get database versions per database type
-source ../database-versions
+source $DIR/../database-versions
 
 export MARIADB_VERSIONS="MARIADB_VERSIONS_$CURRENT_ARCH"
 export MYSQL_VERSIONS="MYSQL_VERSIONS_$CURRENT_ARCH"

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -27,7 +27,7 @@ export MYSQL_VERSIONS="MYSQL_VERSIONS_$CURRENT_ARCH"
 export DB_TYPE=mariadb
 for v in ${!MARIADB_VERSIONS}; do
     export baseversion=$(echo $v | awk -F ':' '{print $1}')
-	export fullversion=$(echo $v | awk -F ':' '{print $2}')
+    export fullversion=$(echo $v | awk -F ':' '{print $2}')
     export IMAGE="drud/ddev-dbserver-$DB_TYPE-$baseversion:$tag"
     export DB_VERSION=$baseversion
     # /usr/local/bin is added for git-bash, where it may not be in the $PATH.

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -32,7 +32,7 @@ multi-arch:
 	done
 
 ddev-webserver:
-	docker buildx build --platform linux/amd64 -o type=docker --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	docker buildx build -o type=docker --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 test: images
 	set -eu -o pipefail; \

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -14,6 +14,12 @@
 }
 
 @test "enable and disable xdebug for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
+    CURRENT_ARCH=$(../get_arch.sh)
+
+    if [ ${PHP_VERSION} == "5.6" ] && [ ${CURRENT_ARCH} == 'arm64' ]; then
+      skip "XDebug isn't available on arm64 PHP 5.6"
+    fi
+
     docker exec -t $CONTAINER_NAME enable_xdebug
     if [ ]${PHP_VERSION} != "8.0" ] ; then
       docker exec -t $CONTAINER_NAME php --re xdebug | grep "xdebug.remote_enable"
@@ -27,6 +33,12 @@
 }
 
 @test "verify that xdebug is enabled by default when the image is not run with start.sh php${PHP_VERSION}" {
+  CURRENT_ARCH=$(../get_arch.sh)
+
+  if [ ${PHP_VERSION} == "5.6" ] && [ ${CURRENT_ARCH} == 'arm64' ]; then
+    skip "XDebug isn't available on arm64 PHP 5.6"
+  fi
+
   docker run  -e "DDEV_PHP_VERSION=${PHP_VERSION}" --rm $DOCKER_IMAGE bash -c 'php --version | grep "with Xdebug"'
 }
 

--- a/containers/get_arch.sh
+++ b/containers/get_arch.sh
@@ -1,0 +1,11 @@
+unamearch=$(uname -m)
+case ${unamearch} in
+  x86_64) ARCH="amd64";
+  ;;
+  aarch64) ARCH="arm64";
+  ;;
+  *) printf "${RED}Sorry, your machine architecture ${unamearch} is not currently supported.\n${RESET}" && exit 106
+  ;;
+esac
+
+echo ${ARCH}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -669,6 +669,12 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	phpVersions := nodeps.ValidPHPVersions
+
+	// arm64 builds from deb.sury.org do not have xdebug in php5.6
+	if runtime.GOARCH == "arm64" {
+		t.Log("Skipping php5.6 test on arm64 because deb.sury.org packages do not include it currently")
+		delete(phpVersions, "5.6")
+	}
 	phpKeys := make([]string, 0, len(phpVersions))
 	for k := range phpVersions {
 		phpKeys = append(phpKeys, k)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1067,10 +1067,17 @@ func TestDdevAllDatabases(t *testing.T) {
 	}
 	//Use a smaller list if GOTEST_SHORT
 	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Log("Using limited set of database servers because GOTEST_SHORT is set")
 		dbVersions = map[string]map[string]bool{
-			"mariadb": {"10.2": true, "10.1": true},
-			"mysql":   {"8.0": true, "5.5": true},
+			"mariadb": {nodeps.MariaDB102: true, nodeps.MariaDB103: true},
+			"mysql":   {nodeps.MySQL80: true, nodeps.MySQL56: true},
 		}
+	}
+	if runtime.GOARCH == "arm64" {
+		t.Log("Skipping mariadb < 10.1 and mysql servers because not supported on arm64")
+		delete(dbVersions, "mysql")
+		delete(dbVersions["mariadb"], nodeps.MariaDB55)
+		delete(dbVersions["mariadb"], nodeps.MariaDB100)
 	}
 
 	app := &ddevapp.DdevApp{}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1064,7 +1064,10 @@ func TestDdevAllDatabases(t *testing.T) {
 		t.Log("Using limited set of database servers because GOTEST_SHORT is set")
 		dbVersions = map[string]map[string]bool{
 			"mariadb": {nodeps.MariaDB102: true, nodeps.MariaDB103: true},
-			"mysql":   {nodeps.MySQL80: true, nodeps.MySQL56: true},
+		}
+		// If we have any mysql, limit what we test (but there may not be any)
+		if len(dbVersions["mysql"]) != 0 {
+			dbVersions["mysql"] = map[string]bool{nodeps.MySQL80: true, nodeps.MySQL56: true}
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -669,12 +669,6 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	phpVersions := nodeps.ValidPHPVersions
-
-	// arm64 builds from deb.sury.org do not have xdebug in php5.6
-	if runtime.GOARCH == "arm64" {
-		t.Log("Skipping php5.6 test on arm64 because deb.sury.org packages do not include it currently")
-		delete(phpVersions, "5.6")
-	}
 	phpKeys := make([]string, 0, len(phpVersions))
 	for k := range phpVersions {
 		phpKeys = append(phpKeys, k)
@@ -1072,12 +1066,6 @@ func TestDdevAllDatabases(t *testing.T) {
 			"mariadb": {nodeps.MariaDB102: true, nodeps.MariaDB103: true},
 			"mysql":   {nodeps.MySQL80: true, nodeps.MySQL56: true},
 		}
-	}
-	if runtime.GOARCH == "arm64" {
-		t.Log("Skipping mariadb < 10.1 and mysql servers because not supported on arm64")
-		delete(dbVersions, "mysql")
-		delete(dbVersions["mariadb"], nodeps.MariaDB55)
-		delete(dbVersions["mariadb"], nodeps.MariaDB100)
 	}
 
 	app := &ddevapp.DdevApp{}

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -23,9 +22,6 @@ import (
 
 // TestSSHAuth tests basic ssh authentication
 func TestSSHAuth(t *testing.T) {
-	if runtime.GOARCH == "arm64" {
-		t.Skip(("Skipping TestSSHAuth on arm64 because the test-ssh-server is not available for arm64"))
-	}
 	assert := asrt.New(t)
 	testDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,9 @@ import (
 
 // TestSSHAuth tests basic ssh authentication
 func TestSSHAuth(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip(("Skipping TestSSHAuth on arm64 because the test-ssh-server is not available for arm64"))
+	}
 	assert := asrt.New(t)
 	testDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
@@ -48,7 +52,7 @@ func TestSSHAuth(t *testing.T) {
 		}
 	}
 	destDdev := filepath.Join(app.AppRoot, ".ddev")
-	srcDdev := filepath.Join(testDir, "testdata", "TestSSHAuth", ".ddev")
+	srcDdev := filepath.Join(testDir, "testdata", t.Name(), ".ddev")
 	err = fileutil.CopyDir(filepath.Join(srcDdev, ".ssh"), filepath.Join(destDdev, ".ssh"))
 	require.NoError(t, err)
 	err = os.Chmod(filepath.Join(destDdev, ".ssh"), 0700)

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -1,0 +1,25 @@
+package nodeps
+
+// MariaDBDefaultVersion is the default MariaDB version
+const MariaDBDefaultVersion = MariaDB102
+
+var ValidMariaDBVersions = map[string]bool{
+	MariaDB55:  true,
+	MariaDB100: true,
+	MariaDB101: true,
+	MariaDB102: true,
+	MariaDB103: true,
+	MariaDB104: true,
+	MariaDB105: true,
+}
+
+// MariaDB Versions
+const (
+	MariaDB55  = "5.5"
+	MariaDB100 = "10.0"
+	MariaDB101 = "10.1"
+	MariaDB102 = "10.2"
+	MariaDB103 = "10.3"
+	MariaDB104 = "10.4"
+	MariaDB105 = "10.5"
+)

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -1,3 +1,5 @@
+// +build !arm64
+
 package nodeps
 
 // MariaDBDefaultVersion is the default MariaDB version

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -1,0 +1,23 @@
+package nodeps
+
+// MariaDBDefaultVersion is the default MariaDB version
+const MariaDBDefaultVersion = MariaDB102
+
+var ValidMariaDBVersions = map[string]bool{
+	MariaDB101: true,
+	MariaDB102: true,
+	MariaDB103: true,
+	MariaDB104: true,
+	MariaDB105: true,
+}
+
+// MariaDB Versions
+const (
+	MariaDB55  = "5.5"
+	MariaDB100 = "10.0"
+	MariaDB101 = "10.1"
+	MariaDB102 = "10.2"
+	MariaDB103 = "10.3"
+	MariaDB104 = "10.4"
+	MariaDB105 = "10.5"
+)

--- a/pkg/nodeps/mysql_values.go
+++ b/pkg/nodeps/mysql_values.go
@@ -1,3 +1,5 @@
+// +build !arm64
+
 package nodeps
 
 var ValidMySQLVersions = map[string]bool{

--- a/pkg/nodeps/mysql_values.go
+++ b/pkg/nodeps/mysql_values.go
@@ -1,0 +1,16 @@
+package nodeps
+
+var ValidMySQLVersions = map[string]bool{
+	MySQL55: true,
+	MySQL56: true,
+	MySQL57: true,
+	MySQL80: true,
+}
+
+// Oracle MySQL versions
+const (
+	MySQL55 = "5.5"
+	MySQL56 = "5.6"
+	MySQL57 = "5.7"
+	MySQL80 = "8.0"
+)

--- a/pkg/nodeps/mysql_values_linux_arm64.go
+++ b/pkg/nodeps/mysql_values_linux_arm64.go
@@ -1,0 +1,11 @@
+package nodeps
+
+var ValidMySQLVersions = map[string]bool{}
+
+// Oracle MySQL versions
+const (
+	MySQL55 = "5.5"
+	MySQL56 = "5.6"
+	MySQL57 = "5.7"
+	MySQL80 = "8.0"
+)

--- a/pkg/nodeps/php_values.go
+++ b/pkg/nodeps/php_values.go
@@ -1,0 +1,27 @@
+package nodeps
+
+// PHP Versions
+const (
+	PHP56 = "5.6"
+	PHP70 = "7.0"
+	PHP71 = "7.1"
+	PHP72 = "7.2"
+	PHP73 = "7.3"
+	PHP74 = "7.4"
+	PHP80 = "8.0"
+)
+
+// PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
+const PHPDefault = PHP73
+
+// ValidPHPVersions should be updated whenever PHP versions are added or removed, and should
+// be used to ensure user-supplied values are valid.
+var ValidPHPVersions = map[string]bool{
+	PHP56: true,
+	PHP70: true,
+	PHP71: true,
+	PHP72: true,
+	PHP73: true,
+	PHP74: true,
+	PHP80: true,
+}

--- a/pkg/nodeps/php_values.go
+++ b/pkg/nodeps/php_values.go
@@ -1,3 +1,5 @@
+// +build !arm64
+
 package nodeps
 
 // PHP Versions

--- a/pkg/nodeps/php_values_linux_arm64.go
+++ b/pkg/nodeps/php_values_linux_arm64.go
@@ -1,0 +1,26 @@
+package nodeps
+
+// PHP Versions
+const (
+	PHP56 = "5.6"
+	PHP70 = "7.0"
+	PHP71 = "7.1"
+	PHP72 = "7.2"
+	PHP73 = "7.3"
+	PHP74 = "7.4"
+	PHP80 = "8.0"
+)
+
+// PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
+const PHPDefault = PHP73
+
+// ValidPHPVersions should be updated whenever PHP versions are added or removed, and should
+// be used to ensure user-supplied values are valid.
+var ValidPHPVersions = map[string]bool{
+	PHP70: true,
+	PHP71: true,
+	PHP72: true,
+	PHP73: true,
+	PHP74: true,
+	PHP80: true,
+}

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -161,7 +161,7 @@ func GetValidMariaDBVersions() []string {
 	for p := range ValidMariaDBVersions {
 		s = append(s, p)
 	}
-
+	sort.Strings(s)
 	return s
 }
 
@@ -172,7 +172,7 @@ func GetValidMySQLVersions() []string {
 	for p := range ValidMySQLVersions {
 		s = append(s, p)
 	}
-
+	sort.Strings(s)
 	return s
 }
 

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -18,36 +18,6 @@ var ValidProviders = map[string]bool{
 	ProviderDdevLive: true,
 }
 
-// PHP Versions
-const (
-	PHP56 = "5.6"
-	PHP70 = "7.0"
-	PHP71 = "7.1"
-	PHP72 = "7.2"
-	PHP73 = "7.3"
-	PHP74 = "7.4"
-	PHP80 = "8.0"
-)
-
-// MariaDB Versions
-const (
-	MariaDB55  = "5.5"
-	MariaDB100 = "10.0"
-	MariaDB101 = "10.1"
-	MariaDB102 = "10.2"
-	MariaDB103 = "10.3"
-	MariaDB104 = "10.4"
-	MariaDB105 = "10.5"
-)
-
-// Oracle MySQL versions
-const (
-	MySQL55 = "5.5"
-	MySQL56 = "5.6"
-	MySQL57 = "5.7"
-	MySQL80 = "8.0"
-)
-
 // Database Types
 const (
 	MariaDB = "mariadb"
@@ -62,41 +32,6 @@ const (
 	WebContainer          = "web"
 	RouterContainer       = "ddev-router"
 )
-
-// PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
-const PHPDefault = PHP73
-
-// ValidPHPVersions should be updated whenever PHP versions are added or removed, and should
-// be used to ensure user-supplied values are valid.
-var ValidPHPVersions = map[string]bool{
-	PHP56: true,
-	PHP70: true,
-	PHP71: true,
-	PHP72: true,
-	PHP73: true,
-	PHP74: true,
-	PHP80: true,
-}
-
-// MariaDBDefaultVersion is the default MariaDB version
-const MariaDBDefaultVersion = MariaDB102
-
-var ValidMariaDBVersions = map[string]bool{
-	MariaDB55:  true,
-	MariaDB100: true,
-	MariaDB101: true,
-	MariaDB102: true,
-	MariaDB103: true,
-	MariaDB104: true,
-	MariaDB105: true,
-}
-
-var ValidMySQLVersions = map[string]bool{
-	MySQL55: true,
-	MySQL56: true,
-	MySQL57: true,
-	MySQL80: true,
-}
 
 // Webserver types
 const (


### PR DESCRIPTION
As discussed in https://github.com/drud/ddev/issues/2543#issuecomment-706209596, this PR tries to add a TravisCI config for running tests on arm64 Linux. It's using the brand-new [arm64-graviton2 processor](https://docs.travis-ci.com/user/multi-cpu-architectures/#multi-cpu-availaibility) which should result in good performance 🚀 

First test run: https://travis-ci.com/github/dennisameling/ddev/builds/191266714

Small note: Linuxbrew is not supported on arm64 ([no binary packages](https://docs.brew.sh/Homebrew-on-Linux#arm)), and mkcert is not available for arm64 as well. I therefore used our custom mkcert version: https://github.com/drud/mkcert/releases/download/v1.4.6/mkcert-v1.4.6-linux-arm64. 

The config likely needs some tweaks so that it will support more tests. I'll try to take inspiration from https://github.com/drud/ddev/blob/master/.circleci/linux_circle_vm_setup.sh where applicable.

- [x] Please add Travis to the `drud/ddev` repo so that it can run here as well 😊 