### PR TITLE
Pin mysql 8 to 8.0.21

### DIFF
--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -7,7 +7,7 @@ VERSION := $(shell git describe --tags --always --dirty)
 # The format here is majorversion:pinnedimageversion
 # This allows to pin the version (as currently required with 8.0.19
 MARIADB_VERSIONS_amd64=5.5:5.5 10.0:10.0 10.1:10.1 10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5
-MYSQL_VERSIONS_amd64=5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0
+MYSQL_VERSIONS_amd64=5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0.21
 MARIADB_VERSIONS_arm64=10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5
 # MySQL images on Docker Hub currently are amd64 only
 MYSQL_VERSIONS_arm64=


### PR DESCRIPTION
Unfortunately, there's once again an incompatibilty between
xtrabackup (based on 8.0.21) and mysql 8.0.22

Mysql 8.0.22 became available and the builds suddenly started breaking, see https://app.circleci.com/pipelines/github/drud/ddev/2972/workflows/6a6762db-b33f-4cf3-be22-761663c6191a/jobs/28469

I'm guessing the bug is https://jira.percona.com/browse/PXB-2301