### PR TITLE
Bump db version to pinned 8.0.21

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -48,7 +48,7 @@ var WebTag = "20201017_php8.0" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20201017_unpin_mysql_8_0"
+var BaseDBTag = "20201023_mysql_version_bump"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

When I changed the mysql containers to pin mysql 8.0.21, I didn't add new bump in version.go

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

