### PR TITLE
mysql_version should override mariadb_version if it is set, fixes #2571

### DIFF
--- a/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.mariawithemptymysql
+++ b/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.mariawithemptymysql
@@ -1,0 +1,5 @@
+name: mariawithemptymysql
+type: php
+docroot: ""
+mysql_version: ""
+mariadb_version: "10.2"

--- a/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.mysql8only
+++ b/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.mysql8only
@@ -1,0 +1,4 @@
+name: mysql8only
+type: php
+docroot: ""
+mysql_version: "8.0"

--- a/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.mysqlwithemptymaria
+++ b/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.mysqlwithemptymaria
@@ -1,0 +1,5 @@
+name: mysqlwithemptymaria
+type: php
+docroot: ""
+mysql_version: "8.0"
+mariadb_version: ""

--- a/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.nodbspecified
+++ b/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.nodbspecified
@@ -1,0 +1,3 @@
+name: nodbspecified
+type: php
+docroot: ""

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -109,6 +109,11 @@ func NewApp(appRoot string, includeOverrides bool, provider string) (*DdevApp, e
 			return app, fmt.Errorf("%v exists but cannot be read. It may be invalid due to a syntax error.: %v", app.ConfigPath, err)
 		}
 	}
+	// If MySQLVersion is now non-default/non-empty, then empty
+	// MariaDBVersion in its favor.
+	if app.MySQLVersion != "" {
+		app.MariaDBVersion = ""
+	}
 	app.SetApptypeSettingsPaths()
 
 	// Rendered yaml is not there until after ddev config or ddev start


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2571 reports a problem with projects that have mysql_version set but where mariadb_version is not yet in the config.yaml (it should be empty in there)

## How this PR Solves The Problem:

If mysql_version is already set, set mariadb_version to ""

## Manual Testing Instructions:

In a working project, set `mysql_version: 8.0` but don't set mariadb_version (it shouldn't be in the config at all)
`ddev start` should work without errors.

## Automated Testing Overview:

Adds TestMariaMysqlConflicts and improves TestConfigMysqlVersion.

## Related Issue Link(s):
 
OP #2571

## Release/Deployment notes:

Release notes should explain how mariadb_version and mysql_version interact, and why, (because we want to change mariadb_version default in the future)
