### PR TITLE
[wip] Manage WSL2 hosts on Windows side using ddev.exe, fixes #2533

### DIFF
--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 
@@ -25,8 +26,18 @@ var HostNameCmd = &cobra.Command{
 	Short:   "Manage your hostfile entries.",
 	Long: `Manage your hostfile entries. Managing host names has security and usability
 implications and requires elevated privileges. You may be asked for a password
-to allow ddev to modify your hosts file. If you are connected to the internet and using the domain ddev.site this is generally not necessary, becauses the hosts file never gets manipulated.`,
+to allow ddev to modify your hosts file. If you are connected to the internet and using the domain ddev.site this is generally not necessary, becauses the hosts file never gets manipulated. Note that if running on WSL2 and using a browser on Windows, you need to have the Windows ddev.exe installed.'`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if nodeps.GetWSLDistro() != "" {
+			sudoArgs := append([]string{"hostname"}, args...)
+			out, err := exec.RunCommand("sudo.exe", sudoArgs)
+			if err != nil {
+				util.Success("Executed 'sudo.exe %v on Windows", sudoArgs)
+				return
+			} else {
+				util.Warning("Unable to run sudo.exe %v on Windows, your hosts file may not work for you, only available on WSL2: %s", sudoArgs, out)
+			}
+		}
 		hosts, err := goodhosts.NewHosts()
 		if err != nil {
 			rawResult := make(map[string]interface{})

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -29,13 +29,13 @@ implications and requires elevated privileges. You may be asked for a password
 to allow ddev to modify your hosts file. If you are connected to the internet and using the domain ddev.site this is generally not necessary, becauses the hosts file never gets manipulated. Note that if running on WSL2 and using a browser on Windows, you need to have the Windows ddev.exe installed.'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if nodeps.GetWSLDistro() != "" {
-			sudoArgs := append([]string{"hostname"}, args...)
+			sudoArgs := append([]string{"ddev.exe", "hostname"}, args...)
 			out, err := exec.RunCommand("sudo.exe", sudoArgs)
-			if err != nil {
-				util.Success("Executed 'sudo.exe %v on Windows", sudoArgs)
+			if err == nil {
+				util.Success("Executed 'sudo.exe %v on Windows", strings.Join(sudoArgs, " "))
 				return
 			} else {
-				util.Warning("Unable to run sudo.exe %v on Windows, your hosts file may not work for you, only available on WSL2: %s", sudoArgs, out)
+				util.Warning("Unable to run sudo.exe %v on Windows, your hosts file may not work for you, only available on WSL2: %v (%s)", strings.Join(sudoArgs, " "), err, out)
 			}
 		}
 		hosts, err := goodhosts.NewHosts()


### PR DESCRIPTION
## The Problem/Issue/Bug:

On Windows WSL2, /etc/hosts manipulation needs to be done on the Windows WSL2 side, or the browser won't know about it. 

## How this PR Solves The Problem:

Run `ddev.exe hostname` (if it exists) to update the *Windows*-side hosts file.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

