### PR TITLE
Add docs and longer timeout for restore-snapshot and start, fixes #1477, fixes #2542

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -662,6 +662,8 @@ Restored database snapshot: /Users/rfay/workspace/d8git/.ddev/db_snapshots/d8git
 
 Snapshots are stored in the project's .ddev/db_snapshots directory, and the directory can be renamed as necessary. For example, if you rename the above d8git_20180801132403 directory to "working_before_migration", then you can use `ddev restore-snapshot working_before_migration`.
 
+There are some interesting consequences of restoring huge multi-gigabyte databases. Ddev may show the project as ready and started when in reality tables are still being loaded. You can see this behavior with `ddev logs -s db -f`.
+
 ## Interacting with your project
 
 DDEV provides several commands to facilitate interacting with your project in the development environment. These commands can be run within the working directory of your project while the project is running in ddev.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1569,7 +1569,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	err = os.Unsetenv("DDEV_MARIADB_LOCAL_COMMAND")
 	util.CheckErr(err)
 
-	util.Success("Restored database snapshot: %s", hostSnapshotDir)
+	util.Success("Restored database snapshot %s\n(On huge databases restore may be ongoing, view with 'ddev logs -s db -f')", hostSnapshotDir)
 	err = app.ProcessHooks("post-restore-snapshot")
 	if err != nil {
 		return fmt.Errorf("Failed to process post-restore-snapshot hooks: %v", err)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -57,8 +57,8 @@ services:
     command: "$DDEV_MARIADB_LOCAL_COMMAND"
     healthcheck:
       interval: 1s
-      retries: 30
-      start_period: 20s
+      retries: 120
+      start_period: 120s
       timeout: 120s
 {{end}}
   web:
@@ -446,8 +446,8 @@ services:
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     healthcheck:
       interval: 1s
-      retries: 20
-      start_period: 20s
+      retries: 120
+      start_period: 120s
       timeout: 120s
 
 networks:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -151,8 +151,8 @@ services:
     {{ end }}
     healthcheck:
       interval: 1s
-      retries: 20
-      start_period: 20s
+      retries: 120
+      start_period: 120s
       timeout: 120s
 
 {{ if not .OmitDBA }}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Sometimes restore-snapshot seems to have timed out on large databases
* Currently huge restores show completed restore when it's still ongoing
* Occasional support requests for timeouts on ddev-webserver

## How this PR Solves The Problem:

This is a bit of a niche problem, but add docs and better message showing what's going on.

* Increase timeout numbers for ddev-webserver
* Increase timeout numbers for ddev-router

## Manual Testing Instructions:

- [x] `time ddev start`
- [x] Compare to results from v1.15.3
- [x] `time ddev restore-snapshot snapshotname` and compare to earlier versions.

## Automated Testing Overview:

No changes.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

