### PR TITLE
Magento2 Quickstart improvements, fixes #2600, fixes #2602

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -258,10 +258,15 @@ Normal details of a composer build for Magento 2 are on [Magento 2 site](https:/
 ```bash
 mkdir ddev-magento2 && cd ddev-magento2
 ddev config --project-type=magento2 --docroot=pub --create-docroot
+```
+
+Copy [docker-compose.elasticsearch.yaml](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml) to local `.ddev` directory.
+
+```bash
 ddev start
 ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition
 ddev ssh
-bin/magento setup:install  --db-host=db --db-name=db --db-user=db --db-password=db  --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com  --admin-user=admin --admin-password=admin123 --language=en_US
+bin/magento setup:install --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
 bin/magento setup:store-config:set --base-url="https://ddev-magento2.ddev.site/"
 bin/magento cache:clean
 bin/magento deploy:mode:set developer

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -266,9 +266,7 @@ Copy [docker-compose.elasticsearch.yaml](https://github.com/drud/ddev-contrib/bl
 ddev start
 ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition
 ddev ssh
-bin/magento setup:install --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
-bin/magento setup:store-config:set --base-url="https://ddev-magento2.ddev.site/"
-bin/magento cache:clean
+bin/magento setup:install --base-url=https://ddev-magento2.ddev.site/ --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
 bin/magento deploy:mode:set developer
 ```
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -253,7 +253,7 @@ Note that OpenMage is a huge codebase and using `nfs_mount_enabled: true` is rec
 
 ### Magento 2 Quickstart
 
-Normal details of a composer build for Magento 2 are on [Magento 2 site](https://devdocs.magento.com/guides/v2.3/install-gde/composer.html) You must have a public and private key to install from Magento's repository; when prompted for "username" and "password" in the composer create it's asking for your public and private keys.
+Normal details of a composer build for Magento 2 are on [Magento 2 site](https://devdocs.magento.com/guides/v2.4/install-gde/composer.html) You must have a public and private key to install from Magento's repository; when prompted for "username" and "password" in the composer create it's asking for your public and private keys.
 
 ```bash
 mkdir ddev-magento2 && cd ddev-magento2
@@ -269,7 +269,7 @@ bin/magento deploy:mode:set developer
 
 Of course, change the admin name and related information is needed. The project name here is derived from the directory name (ddev-magento2 in this example). Your project name (and thus the `setup:store-config:set --base-url`) will almost certainly be different.
 
-You may want to add the [Magento 2 Sample Data](https://devdocs.magento.com/guides/v2.3/install-gde/install/sample-data-after-composer.html).
+You may want to add the [Magento 2 Sample Data](https://devdocs.magento.com/guides/v2.4/install-gde/install/sample-data-after-composer.html).
 
 Note that Magento 2 is a huge codebase and using `nfs_mount_enabled: true` is recommended for performance on macOS and Windows, see [docs](performance/#using-nfs-to-mount-the-project-into-the-container).
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -92,7 +92,7 @@ func init() {
 			settingsCreator: createMagentoSettingsFile, uploadDir: getMagentoUploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagentoSiteSettingsPaths, appTypeDetect: isMagentoApp, postImportDBAction: nil, configOverrideAction: magentoConfigOverrideAction, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction, defaultWorkingDirMap: nil,
 		},
 		nodeps.AppTypeMagento2: {
-			settingsCreator: createMagento2SettingsFile, uploadDir: getMagento2UploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagento2SiteSettingsPaths, appTypeDetect: isMagento2App, postImportDBAction: nil, configOverrideAction: magento2ConfigOverrideAction, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction, defaultWorkingDirMap: nil,
+			settingsCreator: createMagento2SettingsFile, uploadDir: getMagento2UploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagento2SiteSettingsPaths, appTypeDetect: isMagento2App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction, defaultWorkingDirMap: nil,
 		},
 		nodeps.AppTypeLaravel:   {appTypeDetect: isLaravelApp, postStartAction: laravelPostStartAction},
 		nodeps.AppTypeShopware6: {appTypeDetect: isShopware6App, apptypeSettingsPaths: setShopware6SiteSettingsPaths, uploadDir: getShopwareUploadDir, configOverrideAction: shopware6ConfigOverrideAction, postStartAction: shopware6PostStartAction, importFilesAction: shopware6ImportFilesAction},

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -166,13 +166,6 @@ func setMagento2SiteSettingsPaths(app *DdevApp) {
 	app.SiteSettingsPath = filepath.Join(app.AppRoot, "app", "etc", "env.php")
 }
 
-// magento2ConfigOverrideAction overrides php_version for magento2, since it is incompatible
-// with php7.3+
-func magento2ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP72
-	return nil
-}
-
 // magentoConfigOverrideAction overrides php_version for magento2, since it is incompatible
 // with php7.3+
 func magentoConfigOverrideAction(app *DdevApp) error {


### PR DESCRIPTION
## The Problem/Issue/Bug:
- The Magento2 DevDoc links are outdated (version 2.3 instead of 2.4)
- The Magento 2 Quickstart doesn't work with latest Magento 2.4.1 version because of missing elasticsearch.
- Added Magento 2 base-url to the install command instead of running it manually afterwards and having to flush the cache.
- The magento2 project type doesn't work with latest Magento 2.4.1 because it runs with php7.2 which is not supported

## How this PR Solves The Problem:
I added missing elasticsearch from ddev-contrib to the doc
https://github.com/drud/ddev-contrib/tree/master/docker-compose-services/elasticsearch

I removed `magento2ConfigOverrideAction` from the magento2 project type to use standard php7.3 which is minimum requirement for Magento 2.4.1

## Manual Testing Instructions:
Just folow the Magento 2 Quickstart.

## Automated Testing Overview:
It would be awesome to cover all quickstarts with automated tests, but I couldn't find any solution to this in this repo.

## Related Issue Link(s):
#2600 
#2602

## Release/Deployment notes:


