### PR TITLE
Make sure env vars are added to ssh-agent start and all keys are loaded, fixes #2597, fixes #2608

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -71,7 +71,7 @@ var AuthSSHCommand = &cobra.Command{
 		}
 		sshKeyPath = dockerutil.MassageWindowsHostMountpoint(sshKeyPath)
 
-		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint=", "--mount=type=bind,src=" + sshKeyPath + ",dst=/tmp/sshtmp", version.SSHAuthImage + ":" + version.SSHAuthTag + "-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && ssh-add`}
+		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint=", "--mount=type=bind,src=" + sshKeyPath + ",dst=/tmp/sshtmp", version.SSHAuthImage + ":" + version.SSHAuthTag + "-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && ssh-add $(file * | awk -F: "/private key/ { print \$1 }")`}
 
 		err = exec.RunInteractiveCommand("docker", dockerCmd)
 

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -46,7 +46,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 
 	dockerutil.EnsureDdevNetwork()
 
-	path, err := CreateSSHAuthComposeFile()
+	path, err := app.CreateSSHAuthComposeFile()
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func RemoveSSHAgentContainer() error {
 }
 
 // CreateSSHAuthComposeFile creates the docker-compose file for the ddev-ssh-agent
-func CreateSSHAuthComposeFile() (string, error) {
+func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 
 	var doc bytes.Buffer
 	f, ferr := os.Create(SSHAuthComposeYAMLPath())
@@ -107,6 +107,8 @@ func CreateSSHAuthComposeFile() (string, error) {
 	}
 
 	uid, gid, username := util.GetContainerUIDGid()
+
+	app.DockerEnv()
 
 	templateVars := map[string]interface{}{
 		"ssh_auth_image":        version.SSHAuthImage,

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -65,15 +65,16 @@ func TestSSHAuth(t *testing.T) {
 	//nolint: errcheck
 	defer os.Remove(filepath.Join(destDdev, "docker-compose.sshserver.yaml"))
 
+	// Start with the testsite stopped (and everything stopped)
+	err = app.Stop(true, false)
+	assert.NoError(err)
+
 	// Make absolutely sure the ssh-agent is created from scratch.
 	err = ddevapp.RemoveSSHAgentContainer()
 	require.NoError(t, err)
 
-	startErr := app.StartAndWait(0)
-	if startErr != nil {
-		logs, _ := ddevapp.GetErrLogsFromApp(app, startErr)
-		t.Fatalf("app.StartAndWait failed, err=%v, logs=\n========\n%s\n===========\n", startErr, logs)
-	}
+	err = app.Start()
+	require.NoError(t, err)
 
 	err = app.EnsureSSHAgentContainer()
 	require.NoError(t, err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2597 reported that `ddev poweroff && ddev auth ssh` failed. This was a regression from v1.15
#2608 reports that only default keys are added by `ddev auth ssh` in recent alphas, although this seems to be the expected behavior, see https://www.ssh.com/ssh/add. It certainly isn't what we have had before. 

## How this PR Solves The Problem:

Make sure that the ddev-ssh-agent is started with appropriate environment variables.


## Manual Testing Instructions:

- [x] `ddev poweroff && ddev auth ssh` should work ok
- [x]  `ddev auth ssh` should load all keys in ~/.ssh
- [x] `ddev auth ssh -d /some/dir` should load all the keys in that dir.
- [x] `ddev auth ssh` on Windows with docker set to Hyper-V

## Automated Testing Overview:

* Added turning off the testsite to TestSSHAuth

