### PR TITLE
Add --yes -y flags to composer create and delete images, fixes #2387

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -27,7 +27,7 @@ darwin)
     done
     ;;
 windows)
-    choco upgrade -y golang markdownlint-cli mkcert mkdocs || true
+    choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs || true
     if ! command -v golangci-lint >/dev/null 2>&1 ; then
       (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0) || true
     fi
@@ -36,6 +36,8 @@ windows)
     fi
     ;;
 esac
+
+ddev delete images --yes
 
 # Remove any -built images, as we want to make sure tests do the building.
 docker rmi -f $(docker images --filter "dangling=true" -q --no-trunc) >/dev/null || true

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -37,7 +37,7 @@ windows)
     ;;
 esac
 
-ddev delete images --yes
+yes | ddev delete images
 
 # Remove any -built images, as we want to make sure tests do the building.
 docker rmi -f $(docker images --filter "dangling=true" -q --no-trunc) >/dev/null || true

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -12,16 +12,20 @@ import (
 	"strings"
 )
 
+// noConfirm: If true, --yes, we won't stop and prompt before each deletion
+var deleteImagesNocConfirm bool
+
 // DeleteImagesCmd implements the ddev delete images command
 var DeleteImagesCmd = &cobra.Command{
 	Use:     "images",
 	Short:   "Delete docker images not currently in use",
-	Example: `ddev delete images`,
+	Example: `ddev delete images\nddev delete images -y`,
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		// This is were stuff goes
-		if !util.Confirm("Deleting unused ddev images. \nThis is a non-destructive operation, \nbut it may require that the images be downloaded again when you need them. \nOK to continue?") {
-			os.Exit(1)
+		if !deleteImagesNocConfirm {
+			if !util.Confirm("Deleting unused ddev images. \nThis is a non-destructive operation, \nbut it may require that the images be downloaded again when you need them. \nOK to continue?") {
+				os.Exit(1)
+			}
 		}
 		util.Success("Powering off ddev to avoid conflicts")
 		powerOff()
@@ -94,5 +98,6 @@ var DeleteImagesCmd = &cobra.Command{
 }
 
 func init() {
+	DeleteImagesCmd.Flags().BoolVarP(&deleteImagesNocConfirm, "yes", "y", false, "Yes - skip confirmation prompt")
 	DeleteCmd.AddCommand(DeleteImagesCmd)
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2828,7 +2828,8 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 		for _, item := range URLList {
 			// Make sure internal (web container) access is successful
 			parts, err := url.Parse(item)
-			assert.NoError(err)
+			require.NoError(t, err, "url.Parse of item=%v failed", item)
+			require.NotNil(t, parts, "url.Parse of item=%v failed", item)
 			// Only try it if not an IP address URL; those won't be right
 			hostParts := strings.Split(parts.Host, ".")
 

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -139,6 +139,7 @@ func TestLetsEncrypt(t *testing.T) {
 
 	container, err := dockerutil.FindContainerByName("ddev-router")
 	require.NoError(t, err)
+	require.NotNil(t, container)
 
 	stdout, _, err := dockerutil.Exec(container.ID, "df -T /etc/letsencrypt  | awk 'NR==2 {print $7;}'")
 	assert.NoError(err)

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -9,18 +9,33 @@ import (
 
 // ArrayContainsString returns true if slice contains element
 func ArrayContainsString(slice []string, element string) bool {
-	return !(posString(slice, element) == -1)
+	return !(PosString(slice, element) == -1)
 }
 
-// posString returns the first index of element in slice.
+// PosString returns the first index of element in slice.
 // If slice does not contain element, returns -1.
-func posString(slice []string, element string) int {
+func PosString(slice []string, element string) int {
 	for index, elem := range slice {
 		if elem == element {
 			return index
 		}
 	}
 	return -1
+}
+
+// RemoveItemFromSlice returns a slice with item removed
+// If the item does not exist, the slice is unchanged
+// This is quite slow in the scheme of things, so shouldn't
+// be used without examination
+func RemoveItemFromSlice(slice []string, item string) []string {
+	pos := PosString(slice, item)
+	if pos != -1 {
+		// Remove the element at index i from a.
+		copy(slice[pos:], slice[pos+1:]) // Shift slice[pos+1:] left one index.
+		slice[len(slice)-1] = ""         // Erase last element (write zero value).
+		slice = slice[:len(slice)-1]     // Truncate slice.
+	}
+	return slice
 }
 
 // From https://www.calhoun.io/creating-random-strings-in-go/


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #2387 requests a --yes/-h flag for `ddev composer create`
* buildkite testbot maintenance wants a --yes flag for `ddev delete images`
* buildkite testbot maintenance needs nodejs to install markdownlint-cli

## How this PR Solves The Problem:

Add flags. Update buildkite config.


## Manual Testing Instructions:

- [x] `ddev composer create --prefer-dist --no-interaction --no-dev psr/log --yes`
- [x] `ddev delete images -y`

