### PR TITLE
Remove php7.2 config override for typo3 and drupal7

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -70,7 +70,7 @@ func init() {
 			settingsCreator: createDrupal6SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal6Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal6App, postImportDBAction: nil, configOverrideAction: drupal6ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal6PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal7: {
-			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: drupal7ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
+			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal8: {
 			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: drupal8ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
@@ -83,7 +83,7 @@ func init() {
 			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: wordpressPostStartAction, importFilesAction: wordpressImportFilesAction,
 		},
 		nodeps.AppTypeTYPO3: {
-			settingsCreator: createTypo3SettingsFile, uploadDir: getTypo3UploadDir, hookDefaultComments: getTypo3Hooks, apptypeSettingsPaths: setTypo3SiteSettingsPaths, appTypeDetect: isTypo3App, postImportDBAction: nil, configOverrideAction: typo3ConfigOverrideAction, postConfigAction: nil, postStartAction: typo3PostStartAction, importFilesAction: typo3ImportFilesAction,
+			settingsCreator: createTypo3SettingsFile, uploadDir: getTypo3UploadDir, hookDefaultComments: getTypo3Hooks, apptypeSettingsPaths: setTypo3SiteSettingsPaths, appTypeDetect: isTypo3App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: typo3PostStartAction, importFilesAction: typo3ImportFilesAction,
 		},
 		nodeps.AppTypeBackdrop: {
 			settingsCreator: createBackdropSettingsFile, uploadDir: getBackdropUploadDir, hookDefaultComments: getBackdropHooks, apptypeSettingsPaths: setBackdropSiteSettingsPaths, appTypeDetect: isBackdropApp, postImportDBAction: backdropPostImportDBAction, configOverrideAction: nil, postConfigAction: nil, postStartAction: backdropPostStartAction, importFilesAction: backdropImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
@@ -96,10 +96,6 @@ func init() {
 		},
 		nodeps.AppTypeLaravel:   {appTypeDetect: isLaravelApp, postStartAction: laravelPostStartAction},
 		nodeps.AppTypeShopware6: {appTypeDetect: isShopware6App, apptypeSettingsPaths: setShopware6SiteSettingsPaths, uploadDir: getShopwareUploadDir, configOverrideAction: shopware6ConfigOverrideAction, postStartAction: shopware6PostStartAction, importFilesAction: shopware6ImportFilesAction},
-
-		//nodeps.AppTypeShopware6: {
-		//	settingsCreator: createShopware6SettingsFile, uploadDir: getMagento2UploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setShopware6SiteSettingsPaths, appTypeDetect: isShopware6App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: Shopware6ImportFilesAction, defaultWorkingDirMap: nil,
-		//},
 	}
 }
 

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -54,11 +54,12 @@ func TestPostConfigAction(t *testing.T) {
 
 	appTypes := map[string]string{
 		nodeps.AppTypeDrupal6:   nodeps.PHP56,
-		nodeps.AppTypeDrupal7:   nodeps.PHP72,
+		nodeps.AppTypeDrupal7:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal8:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal9:   nodeps.PHPDefault,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:  nodeps.PHPDefault,
+		nodeps.AppTypeMagento:   nodeps.PHP56,
 	}
 
 	for appType, expectedPHPVersion := range appTypes {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -211,8 +211,8 @@ func TestConfigCommand(t *testing.T) {
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {nodeps.AppTypeDrupal6, nodeps.PHP56},
-		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHP72},
-		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP73},
+		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHPDefault},
+		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHPDefault},
 	}
 
 	for testName, testValues := range testMatrix {
@@ -295,8 +295,8 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {nodeps.AppTypeDrupal6, nodeps.PHP56},
-		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHP72},
-		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP73},
+		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHPDefault},
+		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHPDefault},
 	}
 
 	for testName := range testMatrix {
@@ -341,8 +341,8 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
 		"drupal6phpversion": {nodeps.AppTypeDrupal6, nodeps.PHP56},
-		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHP72},
-		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHP73},
+		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHPDefault},
+		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHPDefault},
 	}
 
 	for testName, testValues := range testMatrix {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1391,9 +1391,6 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 
 	app.Hooks = map[string][]ddevapp.YAMLTask{"post-snapshot": {{"exec-host": "touch hello-post-snapshot-" + app.Name}}, "pre-snapshot": {{"exec-host": "touch hello-pre-snapshot-" + app.Name}}}
 
-	// Try using php72 to avoid SIGBUS failures after restore.
-	app.PHPVersion = nodeps.PHP72
-
 	// First do regular start, which is good enough to get us to an ImportDB()
 	err = app.Start()
 	require.NoError(t, err)

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -585,13 +585,6 @@ func drupal6ConfigOverrideAction(app *DdevApp) error {
 	return nil
 }
 
-// drupal7ConfigOverrideAction overrides php_version for D7,
-// since it is not yet compatible with php7.3
-func drupal7ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP72
-	return nil
-}
-
 // drupal8ConfigOverrideAction overrides mariadb_version for Druapl 8 for future
 // compatibility with Drupal 9, since it requires at least 10.3.
 func drupal8ConfigOverrideAction(app *DdevApp) error {

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -2,7 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/drud/ddev/pkg/nodeps"
 	"io/ioutil"
 
 	"os"
@@ -162,12 +161,6 @@ func isTypo3App(app *DdevApp) bool {
 		return true
 	}
 	return false
-}
-
-// typo3ConfigOverrideAction sets a safe php_version for TYPO3
-func typo3ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP72
-	return nil
 }
 
 // typo3ImportFilesAction defines the TYPO3 workflow for importing project files.


### PR DESCRIPTION
## The Problem/Issue/Bug:

Both TYPO3 and Drupal7 had configOverrideActions that set the PHP version to 7.2, and neither requires it.

In a recent TYPO3 test (with ddev v1.16.0-rc1), with latest deb.sury.org build PHP 7.2.34-8+0~20201103.52+debian10~1.gbpafa084 failed, even though 7.2.34-4 had worked fine. 

> An exception occurred while executing 'DELETE tags2, cache1 FROM cf_cache_pages_tags AS tags1 JOIN cf_cache_pages_tags AS tags2 ON tags1.identifier = tags2.identifier JOIN cf_cache_pages AS cache1 ON tags1.identifier = cache1.identifier WHERE tags1.tag = 'redirects'': Malformed communication packet

## How this PR Solves The Problem:

* Remove the php7.2 setting for Drupal7 and TYPO3. Both should work fine with the default php7.3. This seems to make more sense than chasing an obscure "malformed communication packet" issue in an obsolete PHP version.


## Manual Testing Instructions:

Automated testing should be fine, but I recreated it manually as well.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

