### PR TITLE
Make install_ddev.sh work with v1.16.0-rc1 and hopefully future versions

### DIFF
--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -56,8 +56,7 @@ semver_compare() {
     number_b=$(echo ${pr_b//[!0-9]/})
     [ -z "${number_a}" ] && number_a=0
     [ -z "${number_b}" ] && number_b=0
-
-    [ "$pr_a" \> "$pr_b" ] && [ -n "$pr_b" ] && [ "$number_a" -gt "$number_b" ] && echo 1 && return 0
+    [ "$pr_a" \> "$pr_b" ] && [ -n "$pr_b" ] && echo 1 && return 0
 
     ####
     # Retrun -1 when A is lower than B
@@ -129,9 +128,9 @@ fi
 TARBALL="$FILEBASE.$VERSION.tar.gz"
 SHAFILE="$TARBALL.sha256.txt"
 
-curl -fsSL "$RELEASE_BASE_URL/$TARBALL" -o "${TMPDIR}/${TARBALL}"
-curl -fsSL "$RELEASE_BASE_URL/$SHAFILE" -o "${TMPDIR}/${SHAFILE}"
-curl -fsSL "https://raw.githubusercontent.com/${GITHUB_USERNAME}/ddev/master/scripts/macos_ddev_nfs_setup.sh" -o "${TMPDIR}/macos_ddev_nfs_setup.sh"
+curl -fsSL "$RELEASE_BASE_URL/$TARBALL" -o "${TMPDIR}/${TARBALL}" || (printf "${RED}Failed downloading $RELEASE_BASE_URL/$TARBALL${RESET}\n" && exit 108)
+curl -fsSL "$RELEASE_BASE_URL/$SHAFILE" -o "${TMPDIR}/${SHAFILE}" || (printf "${RED}Failed downloading $RELEASE_BASE_URL/$SHAFILE${RESET}\n" && exit 109)
+curl -fsSL "https://raw.githubusercontent.com/${GITHUB_USERNAME}/ddev/master/scripts/macos_ddev_nfs_setup.sh" -o "${TMPDIR}/macos_ddev_nfs_setup.sh" || (printf "${RED}Failed downloading "https://raw.githubusercontent.com/${GITHUB_USERNAME}/ddev/master/scripts/macos_ddev_nfs_setup.sh"${RESET}\n" && exit 110)
 
 cd $TMPDIR
 $SHACMD -c "$SHAFILE"


### PR DESCRIPTION
## The Problem/Issue/Bug:

install_ddev.sh is broken when trying to download ddev v1.16.0-rc1.

## How this PR Solves The Problem:

Improve the version_compare (see [gist](https://gist.github.com/Ariel-Rodriguez/9e3c2163f4644d7a389759b224bfe7f3#gistcomment-35184970) so it does the right thing.

Output useful information when a curl fails

## Manual Testing Instructions:

- [x] Download normally, just install_ddev.sh
- [x] `./install_ddev.sh v1.16.0-rc1`
- [x] `./install_ddev.sh v1.15.3`
- [x] `./install_ddev.sh v1.16.0-rc2` and view error message

## Automated Testing Overview:

It would be great to figure out a good way to test this script. 

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

