### PR TITLE
Make composer updateable/writeable by user in ddev-webserver, fixes #2614

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod (for DDEV-Live)
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v0.6.0 as ddev-webserver-base
+FROM drud/ddev-php-base:v0.6.1 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6
@@ -93,7 +93,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
 ADD ddev-webserver-dev-base-files /
 RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_${MAILHOG_ARCH} -o /usr/local/bin/mailhog; 
 
-RUN curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod +x /usr/local/bin/terminus
+RUN curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus
 RUN curl -sSL -O $DDEV_LIVE_DOWNLOAD_URL && unzip ddev-live.zip && mv ddev-live /usr/local/bin && chmod +x /usr/local/bin/ddev-live && rm ddev-live.zip
 
 # magerun and magerun2 for magento
@@ -133,6 +133,9 @@ RUN a2enmod ssl headers expires
 # scripts added last because they're most likely place to make changes, speeds up build
 ADD ddev-webserver-base-scripts /
 RUN chmod ugo+x /start.sh /healthcheck.sh
+
+# Composer may need to be updated by composer self-update
+RUN chmod -f ugo+wx /usr/local/bin/composer /usr/local/bin/ddev-live
 
 #TODO: Security implications; must be revisited
 RUN chmod ugo+w /etc/ssl/certs

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -134,8 +134,8 @@ RUN a2enmod ssl headers expires
 ADD ddev-webserver-base-scripts /
 RUN chmod ugo+x /start.sh /healthcheck.sh
 
-# Composer may need to be updated by composer self-update
-RUN chmod -f ugo+wx /usr/local/bin/composer /usr/local/bin/ddev-live
+# Composer, etc may need to be updated by composer self-update
+RUN chmod -f ugo+wx /usr/local/bin /usr/local/bin/composer /usr/local/bin/ddev-live
 
 #TODO: Security implications; must be revisited
 RUN chmod ugo+w /etc/ssl/certs

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -847,7 +847,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg:
 	// breaking testing.
 	if composerVersion != "" {
 		contents = contents + fmt.Sprintf(`
-RUN if command -v composer >/dev/null 2>&1 ; then ( composer self-update %s || composer self-update %s );  fi
+RUN if command -v composer >/dev/null 2>&1 ; then ( composer self-update %s || composer self-update %s ) && chmod 777 /usr/local/bin/composer;  fi
 `, composerSelfUpdateArg, composerSelfUpdateArg)
 	}
 	return WriteImageDockerfile(fullpath, []byte(contents))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,7 +43,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.16.0-rc1" // Note that this can be overridden by make
+var WebTag = "20201107_writeable_composer" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION

## The Problem/Issue/Bug:

`composer self-update` couldn't work because the /usr/local/bin/composer was root-owned

## How this PR Solves The Problem:

Make it writable by all users. 

* Make composer, ddev-live, and terminus all world-writeable


## Manual Testing Instructions:

`ddev exec composer self-update`

