### PR TITLE
Activate GitHub Actions

### DIFF
--- a/.github/workflows/activate.yml
+++ b/.github/workflows/activate.yml
@@ -1,0 +1,27 @@
+name: DDEV GH Actions activation
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILDKIT_PROGRESS: plain
+  DOCKER_CLI_EXPERIMENTAL: enabled
+
+jobs:
+
+  container-tests:
+    name: Container tests - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Hello world!
+        run: echo "Hello world!"


### PR DESCRIPTION
Simple PR to activate GitHub Actions on the `master` branch (both for commits to that branch and all PRs that target that branch), so that we can continue working on https://github.com/drud/ddev/pull/2615 more easily