### PR TITLE
Pin mariadb versions to previous release because of regression that affects php7.2

### DIFF
--- a/containers/ddev-dbserver/database-versions
+++ b/containers/ddev-dbserver/database-versions
@@ -1,7 +1,7 @@
 # The format here is majorversion:pinnedimageversion
 # This allows to pin the version (as currently required with 8.0.21)
-MARIADB_VERSIONS_amd64="5.5:5.5 10.0:10.0 10.1:10.1 10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5"
+MARIADB_VERSIONS_amd64="5.5:5.5 10.0:10.0 10.1:10.1.47 10.2:10.2.34 10.3:10.3.25 10.4:10.4.15 10.5:10.5.6"
 MYSQL_VERSIONS_amd64="5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0.21"
-MARIADB_VERSIONS_arm64="10.2:10.2 10.3:10.3 10.4:10.4 10.5:10.5"
+MARIADB_VERSIONS_arm64="10.2:10.2.34 10.3:10.3.25 10.4:10.4.15 10.5:10.5.6"
 # MySQL images on Docker Hub currently are amd64 only
 MYSQL_VERSIONS_arm64=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,7 +49,7 @@ var WebTag = "20201107_writeable_composer" // Note that this can be overridden b
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.16.0-rc1"
+var BaseDBTag = "20201109_pin_mariadb"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The recently released versions of MariaDB have a regression that affects all PHP versions < 7.3. https://jira.mariadb.org/browse/MDEV-24121

## How this PR Solves The Problem:

Pin MariaDB versions to the previous minor release. 

## Manual Testing Instructions:

Try installing TYPO3 v10 using php7.2. I think it will succeed, whereas it would have failed with php7.2 and ddev v1.16.0-rc2

Some kind of manual test that's more authoritative would be better

## Automated Testing Overview:

I'd love to have a test that clearly demonstrates this, so we could know when to unpin these releases.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

