### PR TITLE
Bump webtag for latest ddev-live

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -248,7 +248,7 @@ func TestMain(m *testing.M) {
 	if token != "" {
 		// ddev auth ddev-live can create a .ddev folder, which we don't need right now,
 		// so drop it in /tmp
-		out, err := exec.RunCommand("bash", []string{"-c", "cd /tmp && ddev auth ddev-live " + token})
+		out, err := exec.RunCommand("bash", []string{"-c", fmt.Sprintf("cd /tmp && %s auth ddev-live %s", DdevBin, token)})
 		if err != nil {
 			log.Fatalf("Unable to ddev auth ddev-live: %v (%v)", err, out)
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,7 +43,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20201107_writeable_composer" // Note that this can be overridden by make
+var WebTag = "20201109_ddev_live_update" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

A new version of ddev-live client is out, and it could break ddev-live tests. See what happens. 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

