### PR TITLE
Bump images to v1.16.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,13 +43,13 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20201111_ssl_protocols" // Note that this can be overridden by make
+var WebTag = "v1.16.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20201109_pin_mariadb"
+var BaseDBTag = "v1.16.0"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"
@@ -61,11 +61,11 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20201111_ssl_protocols" // Note that this can be overridden by make
+var RouterTag = "v1.16.0" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "v1.16.0-rc1"
+var SSHAuthTag = "v1.16.0"
 
 // COMMIT is the actual committish, supplied by make
 var COMMIT = "COMMIT should be overridden"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Tagging built images for v1.16.0

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

