### PR TITLE
Add default usage of custom commands again, fixes #2633

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -106,6 +106,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 					description = val
 				}
 
+				usage = commandName + " [flags] [args]"
 				if val, ok := directives["Usage"]; ok {
 					usage = val
 				}


### PR DESCRIPTION
## The Problem/Issue/Bug:
In case of missing usage annotation no command name is shown anymore. This was accidentally removed with https://github.com/drud/ddev/commit/c34907d7d6cd836e0571ad0b0effcaa1d48a7b83.

## How this PR Solves The Problem:
This patch reintroduces the default value again.

## Manual Testing Instructions:
Create a custom command without the `usage` annotation and check the command name is shown properly on the help screen.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#2633
#2452

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

