### PR TITLE
Fix validation error for string flag, fixes #2631

### DIFF
--- a/cmd/ddev/cmd/flags.go
+++ b/cmd/ddev/cmd/flags.go
@@ -223,6 +223,8 @@ func (v *defValueValue) validate(aType typeValue) error {
 		*v = defValueValue(strconv.FormatBool(false))
 	case FtCount, FtDuration, FtFloat32, FtFloat64, FtInt, FtInt8, FtInt16, FtInt32, FtUint, FtUint8, FtUint16, FtUint32:
 		*v = defValueValue(strconv.FormatInt(0, 10))
+	case FtString:
+		*v = ""
 	case ftTest3: // used for testing only
 		*v = ""
 	default:


### PR DESCRIPTION
## The Problem/Issue/Bug:
An empty defValue for string flags leads to panic.

## How this PR Solves The Problem:
This patch implements the missing case for the string type.

## Manual Testing Instructions:
Create a custom command with a string type flag and without providing a DefValue.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#2631
#2493 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

