### PR TITLE
Solve problem with unreachable sites due to ddev-router config fail, fixes #2648

### DIFF
--- a/containers/ddev-dbserver/README.md
+++ b/containers/ddev-dbserver/README.md
@@ -8,4 +8,3 @@ make push
 make push VERSION=someversion
 make clean
 ```
-

--- a/containers/ddev-router/etc/nginx/conf.d/default.conf
+++ b/containers/ddev-router/etc/nginx/conf.d/default.conf
@@ -1,0 +1,86 @@
+# DEFAULT default.conf SOMETHING IS WRONG
+# This is the "default"" default.conf and if you see this it means
+# that a proper default.conf has not been generated and something
+# is wrong
+
+# If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+# scheme used to connect to this server
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+# If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
+# server port the client connected to
+map $http_x_forwarded_port $proxy_x_forwarded_port {
+  default $http_x_forwarded_port;
+  ''      $server_port;
+}
+# If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+# Connection header that may have been passed to this server
+map $http_upgrade $proxy_connection {
+  default upgrade;
+  '' close;
+}
+# Default dhparam
+# ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
+# Set appropriate X-Forwarded-Ssl header
+map $scheme $proxy_x_forwarded_ssl {
+  default off;
+  https on;
+}
+gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+log_format vhost '$host $remote_addr - $remote_user [$time_local] '
+                 '"$request" $status $body_bytes_sent '
+                 '"$http_referer" "$http_user_agent"';
+access_log off;
+client_max_body_size 0;
+resolver 127.0.0.11;
+# HTTP 1.1 support
+proxy_http_version 1.1;
+proxy_buffering off;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $proxy_connection;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
+proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+# Mitigate httpoxy attack (see README for details)
+proxy_set_header Proxy "";
+server {
+	server_name _; # Catch-all for any server_name that is not matched in the config
+	listen 80;
+	access_log /var/log/nginx/access.log vhost;
+    error_page 503 @noupstream;
+    location @noupstream {
+        rewrite ^(.*)$ /503.html break;
+        root /app;
+    }
+    location / {
+        return 503;
+    }
+    ## provide a health check endpoint
+    location = /healthcheck {
+        access_log off;
+        return 200;
+    }
+}
+server {
+ 	server_name _; # Catch-all for any server_name that is not matched in the config
+	listen 443;
+ 	access_log /var/log/nginx/access.log vhost;
+     error_page 503 @noupstream;
+     location @noupstream {
+         rewrite ^(.*)$ /503.html break;
+         root /app;
+     }
+     location / {
+         return 503;
+     }
+     ## provide a health check endpoint
+     location = /healthcheck {
+         access_log off;
+         return 200;
+     }
+}

--- a/containers/ddev-router/gen-cert-and-nginx-config.sh.tmpl
+++ b/containers/ddev-router/gen-cert-and-nginx-config.sh.tmpl
@@ -10,7 +10,7 @@ set -eu -o pipefail
 {{/* unique so that docker-gen won't fail to update it if any of these details change */}}
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 {{ range $container := $containers }}
-# {{ $container.Name }} HTTP_EXPOSE={{ $container.Env.HTTP_EXPOSE }} HTTPS_EXPOSE={{ $container.Env.HTTPS_EXPOSE }}
+# {{ $container.Name }} VIRTUAL_HOST={{ $container.Env.VIRTUAL_HOST }} HTTP_EXPOSE={{ $container.Env.HTTP_EXPOSE }} HTTPS_EXPOSE={{ $container.Env.HTTPS_EXPOSE }}
 {{ end }}
 {{ end }}
 
@@ -44,4 +44,4 @@ mkcert -cert-file /etc/nginx/certs/master.crt -key-file /etc/nginx/certs/master.
 # This is not recursive, as it executes completely different instructions.
 # It's important for the nginx config creation and the nginx reload to take place after all cert
 # activities are completed.
-docker-gen -only-exposed -notify-output -notify "sleep 1 && nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+docker-gen -only-exposed -notify-output -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf

--- a/containers/ddev-router/gen-cert-and-nginx-config.sh.tmpl
+++ b/containers/ddev-router/gen-cert-and-nginx-config.sh.tmpl
@@ -5,6 +5,15 @@
 
 set -eu -o pipefail
 
+{{/* Output details about each container into the output script file */}}
+{{/* Not only is this good for debugging, but it makes the output file */}}
+{{/* unique so that docker-gen won't fail to update it if any of these details change */}}
+{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+{{ range $container := $containers }}
+# {{ $container.Name }} HTTP_EXPOSE={{ $container.Env.HTTP_EXPOSE }} HTTPS_EXPOSE={{ $container.Env.HTTPS_EXPOSE }}
+{{ end }}
+{{ end }}
+
 hostnames='{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}{{ trim $host }} {{ end }}'
 echo "Processing certs and nginx for hostnames: $hostnames"
 

--- a/containers/ddev-router/healthcheck.sh
+++ b/containers/ddev-router/healthcheck.sh
@@ -10,33 +10,45 @@ sleeptime=59
 # sleep at startup. This requires the timeout to be set
 # higher than the sleeptime used here.
 if [ -f /tmp/healthy ]; then
-    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
-    sleep ${sleeptime}
+  printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
+  sleep ${sleeptime}
 fi
 
 config=false
 connect=false
+configgenerated=false
 
-if nginx -t ; then
-    config=true
-    printf "nginx config: OK  "
+if nginx -t 2>/dev/null; then
+  config=true
+  printf "nginx config valid:OK  "
 else
-  printf "nginx configuration invalid: $(nginx -t)"
+  printf "nginx configuration invalid: $(nginx -t 2>&1)"
   exit 2
 fi
 
-# Check our healthcheck endpoint
-if curl --fail --connect-timeout 2 --retry 2 http://127.0.0.1/healthcheck; then
-    connect=true
-    echo "nginx healthcheck endpoint: OK "
+# If SOMETHING IS WRONG is in default.conf, then the config
+# has not been generated yet, or a failure happened generating
+if grep -v "SOMETHING IS WRONG" /etc/nginx/conf.d/default.conf >/dev/null; then
+  configgenerated=true
+  printf "nginx default config:OK "
 else
-    echo "ddev-router healthcheck endpoint not responding "
+  printf "nginx default.conf not yet generated "
+  exit 3
+fi
+
+# Check our healthcheck endpoint
+if curl -s --fail --connect-timeout 2 --retry 2 http://127.0.0.1/healthcheck; then
+  connect=true
+  printf "nginx healthcheck endpoint:OK "
+else
+  printf "healthcheck endpoint not responding "
+  exit 4
 fi
 
 if [ ${config} = true -a ${connect} = true ]; then
-    printf "healthy"
-    touch /tmp/healthy
-    exit 0
+  printf "ddev-router is healthy "
+  touch /tmp/healthy
+  exit 0
 fi
 
 rm -f /tmp/healthy

--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -8,11 +8,11 @@
 			server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
 		{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
 		{{ else if .Network }}
-			# {{ .Container.Name }}
+			# Container={{ .Container.Name }} {{ .Network.IP }}:{{ .Address.Port }}
 			server {{ .Network.IP }}:{{ .Address.Port }};
 		{{ end }}
 	{{ else if .Network }}
-		# {{ .Container.Name }}
+			# Container={{ .Container.Name }} {{ .Network.IP }}:{{ .Address.Port }} (down)
 		server {{ .Network.IP }} down;
 	{{ end }}
 {{ end }}
@@ -152,7 +152,7 @@ server {
 {{ $is_regexp := hasPrefix "~" $host }}
 {{ $upstream_name := when $is_regexp (sha1 $host) $host }}
 
-{{/* # {{ $host }} */}}
+# host={{ $host }} }}
 {{/* upstream {{ $upstream_name }} { */}}
 
 {{ range $container := $containers }}
@@ -285,7 +285,7 @@ server {
 {{/* HTTPS_EXPOSE works similar to HTTP_EXPOSE, only no upstreams are created for HTTPS_EXPOSE ports. */}}
 {{/* Instead, an existing upstream for HTTP should be defined along with the port to listen for. e.g. 443:80 would listen on 443 and use an existing port 80 upstream */}}
 {{ range $container := whereExist $containers "Env.HTTPS_EXPOSE" }}
-    {{/* Get the HTTP_EXPOSE defined by containers w/ the same vhost, falling back to port 443:80 */}}
+    {{/* Get the HTTPS_EXPOSE defined by containers w/ the same vhost, falling back to port 443:80 */}}
     {{ $ports := coalesce $container.Env.HTTPS_EXPOSE "443:80" }}
     {{ $ports := split $ports "," }}
     {{ range $port := $ports }}

--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -12,7 +12,7 @@
 			server {{ .Network.IP }}:{{ .Address.Port }};
 		{{ end }}
 	{{ else if .Network }}
-			# Container={{ .Container.Name }} {{ .Network.IP }}:{{ .Address.Port }} (down)
+			# Container={{ .Container.Name }} (down)
 		server {{ .Network.IP }} down;
 	{{ end }}
 {{ end }}
@@ -111,8 +111,8 @@ server {
     }
 }
 
- {{ if exists (printf "/etc/nginx/certs/%s.crt" $default_cert) }}
- server {
+{{ if exists (printf "/etc/nginx/certs/%s.crt" $default_cert) }}
+server {
  	server_name _; # Catch-all for any server_name that is not matched in the config
 
  	# Listen on all configured https ports + 443 (HTTPS_EXPOSE)
@@ -152,9 +152,7 @@ server {
 {{ $is_regexp := hasPrefix "~" $host }}
 {{ $upstream_name := when $is_regexp (sha1 $host) $host }}
 
-# host={{ $host }} }}
 {{/* upstream {{ $upstream_name }} { */}}
-
 {{ range $container := $containers }}
     {{/* HTTP_EXPOSE replaces the VIRTUAL_PORT var originally provided by jwilder/nginx-proxy. */}}
     {{/* HTTP_EXPOSE provides comma-separated ports to serve for container. Ports can be defined as hostPort:containerPort */}}

--- a/containers/ddev-router/testtools/testgen.sh
+++ b/containers/ddev-router/testtools/testgen.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Test default.conf generation for https://github.com/drud/ddev/issues/2648
+
+cpfiles="nginx.tmpl gen-cert-and-nginx-config.sh.tmpl"
+
+for item in $cpfiles; do
+  docker cp $item ddev-router:/app
+done
+
+docker exec ddev-router docker-gen -only-exposed /app/nginx.tmpl /tmp/default.conf
+
+docker exec ddev-router grep "upstream.*-" /tmp/default.conf

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -61,7 +61,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.16.0" // Note that this can be overridden by make
+var RouterTag = "20201124_router_fails_to_expose" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2648 : In ddev v1.16.0 and v1.16.1, a `ddev start` might result in a site that was unreachable; the newly started site would get "503: No ddev back-end site available."

<img width="589" alt="503__No_ddev_back-end_site_available" src="https://user-images.githubusercontent.com/112444/100257195-e4343980-2f02-11eb-833a-6fb7a952ab30.png">


## How this PR Solves The Problem:

It turns out that this was timing related, but more importantly, 

* the listener (`-watch`) docker-gen process creates a script which is then run to create the nginx configuration
* However, the script is not recreated if docker-gen does not see that it changed
* However, the generated script had hostnames in it (container names) but it did *not* include the ports from HTTP_EXPOSE or HTTPS_EXPOSE. So if those came through in separate events, docker-gen would read the later events but decide that because the generated script did not change, it did not need to be recreated (and the script didn't get run... so the nginx configuration was not updated)

This also
* Improves the healthcheck to detect whether the /etc/nginx/conf.d/default.conf has been properly generated
* Cleans up the healthcheck in general
* Provides a default.conf that is more appropriate than the one put there by the nginx package (and includes healthcheck)


## Manual Testing Instructions:

- [x] If you do *not* have the ddev binary build with this PR, then add this file as ~/.ddev/router-compose.nginx.yaml (router-compose.nginx.yaml in your global .ddev directory, the one in your home directory), then `ddev poweroff` and do the normal testing that was earlier able to create the problem: 

```yaml
version: '3.6'
services:
  ddev-router:
    image: drud/ddev-router:20201124_router_fails_to_expose
```
- [x] Otherwise, test with the ddev binary from this PR
- [x] Make sure to test with the varnish recipe from ddev-contrib and other 3rd party services. 
- [x] The script linked in #2648 may induce the failure described there, so try it.

## Automated Testing Overview:

This seems to be timing related and dependent on docker's state somehow and difficult to test.

## Related Issue Link(s):

#2648

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

