### PR TITLE
Use root user for PHPMyAdmin

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -172,7 +172,7 @@ services:
     hostname: {{ .Name }}-dba
     environment:
       - PMA_USER=root
-      - PMA_USER=root
+      - PMA_PASSWORD=root
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - UPLOAD_LIMIT=1024M
       - TZ={{ .Timezone }}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -171,8 +171,8 @@ services:
       - "80"
     hostname: {{ .Name }}-dba
     environment:
-      - PMA_USER=db
-      - PMA_PASSWORD=db
+      - PMA_USER=root
+      - PMA_USER=root
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - UPLOAD_LIMIT=1024M
       - TZ={{ .Timezone }}


### PR DESCRIPTION
## The Problem/Issue/Bug:

It makes sense for PHPMyAdmin (dba) to use the root user instead of the 'db' user.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

