### PR TITLE
Using fully-qualified name `brew install drud/ddev/ddev`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,10 +33,10 @@ Docker and docker-compose are required before anything will work with DDEV. This
 For macOS and Linux users, we recommend installing and upgrading via [Homebrew](https://brew.sh/) (macOS) or [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) (Linux):
 
 ```
-brew tap drud/ddev && brew install ddev
+brew tap drud/ddev/ddev && brew install ddev
 ```
 
-If you would like more frequent "edge" releases then use `brew tap drud/ddev-edge` instead.)
+If you would like more frequent "edge" releases then use `brew tap drud/ddev-edge/ddev` instead.)
 
 As a one-time initialization, run `mkcert -install`. Linux users may have to take additional actions as discussed below in "Linux `mkcert -install` additional instructions".
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,10 +33,10 @@ Docker and docker-compose are required before anything will work with DDEV. This
 For macOS and Linux users, we recommend installing and upgrading via [Homebrew](https://brew.sh/) (macOS) or [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) (Linux):
 
 ```
-brew tap drud/ddev/ddev && brew install ddev
+brew tap drud/ddev && brew install drud/ddev/ddev
 ```
 
-If you would like more frequent "edge" releases then use `brew tap drud/ddev-edge/ddev` instead.)
+If you would like more frequent "edge" releases then use `brew tap drud/ddev-edge` instead.)
 
 As a one-time initialization, run `mkcert -install`. Linux users may have to take additional actions as discussed below in "Linux `mkcert -install` additional instructions".
 


### PR DESCRIPTION
When running the existing command `brew tap drud/ddev && brew install ddev`, I got this error:

```
Error: Formulae found in multiple taps:
       * drud/ddev/ddev
       * drud/ddev-edge/ddev

Please use the fully-qualified name (e.g. drud/ddev/ddev) to refer to the formula.
```

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

