### PR TITLE
Improve 3rd-party Apache SOLR setup in additional-services.md

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -10,11 +10,11 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
 
 #### Installation
 
-* Copy [docker-compose.solr.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml) to the .ddev folder for your project.
-* The recommended Solr version is: `image: solr:8`, from [hub.docker.com](https://hub.docker.com/_/solr/).
-* Create the folder path .ddev/solr/conf.
-* Copy/extract the Solr configuration files for your project into `.ddev/solr/conf`.
-* Ensure that the configuration files are present before running `ddev start`.
+1. Copy [docker-compose.solr.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml) to the .ddev folder for your project.
+    * The recommended Solr version is: `image: solr:8`, from [hub.docker.com](https://hub.docker.com/_/solr/).
+2. Create the folder path .ddev/solr/conf.
+    * If needed, you may copy/extract the Solr configuration files for your project into `.ddev/solr/conf`. Ensure that the configuration files are present before running `ddev start`.
+3. Run `ddev start` or `ddev restart` if your project is already running.
 
 ##### Drupal8-specific extra steps
 

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -11,7 +11,8 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
 #### Installation
 
 1. Copy [docker-compose.solr.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml) to the .ddev folder for your project.
-    * The recommended Solr version is: `image: solr:8`, from [hub.docker.com](https://hub.docker.com/_/solr/).
+    * Solr version can be changed by updating this line `image: solr:8` in `docker-compose.solr.yaml` file.
+    * [List of all Solr versions supported](https://hub.docker.com/_/solr/).
 2. Create the folder path .ddev/solr/conf.
     * If needed, you may copy/extract the Solr configuration files for your project into `.ddev/solr/conf`. Ensure that the configuration files are present before running `ddev start`.
 3. Run `ddev start` or `ddev restart` if your project is already running.


### PR DESCRIPTION
Updating the SOLR "Installation" steps to be a 3 step process with clearly marked steps. The previous list implied there were more than 3 steps, and was confusing as to which was required, and which was optional. Numbering the steps clears the ambiguity and implies simplicity.
