### PR TITLE
[tests only] Less github actions test on nginx.tmpl

### DIFF
--- a/.github/workflows/multiplesites.sh
+++ b/.github/workflows/multiplesites.sh
@@ -42,7 +42,7 @@ docker --version
 docker-compose --version
 
 #ddev poweroff
-for i in {1..10}; do
+for i in {1..5}; do
   site=testsite-${i}
   sites="$sites $site"
   printf "\n\nStarting ${site}...\n"

--- a/.github/workflows/nginx-tmpl.yml
+++ b/.github/workflows/nginx-tmpl.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest ]
+        os: [ ubuntu-20.04 ]
     steps:
     - uses: actions/checkout@v1
     - name: Set environment variables


### PR DESCRIPTION
## The Problem/Issue/Bug:

The github actions added recently to test nginx.tmpl are a bit onerous and run too many permutations. Slim it down. 

These will be removed completely in #2615
