### PR TITLE
Update database_types.md for mysql 5.7

### DIFF
--- a/docs/users/extend/database_types.md
+++ b/docs/users/extend/database_types.md
@@ -1,20 +1,26 @@
 ## Database Server Types
 
-ddev supports most versions of MariaDB and MySQL database servers. You can configure the type that you want using the `.ddev/config.yaml` file, for example:
+DDEV-Local supports most versions of MariaDB and MySQL database servers, but of course the two types are mutually exclusive.
 
-`mariadb_version: 10.4` or `mysql_version: 8.0`
+The default database type is MariaDB, and the default version is currently 10.2, but you can use nearly any MariaDB version (5.5 through 10.5) and nearly any MySQL version (5.5 through 8.0). For example, you can use `ddev config --mariadb-version="" --mysql-version=5.7` to configure for MySQL 5.7.
 
-Note that `mariadb_version` and `mysql_version` are mutually exclusive.
+In the config.yaml, either `mysql_version` or `mariadb_version` should be left blank, for example:
 
-The default version is MariaDB 10.2 and it works for most purposes.
+```yaml
+mysql_version: ""
+mariadb_version: 10.5
+```
 
-If you decide to use MySQL, you can set the version to 5.7 with `mysql_version: 5.7`
+or
 
-You can also use `ddev config --mariadb-version=10.4` or `ddev config --mysql-version=8.0`
+```yaml
+mariadb_version: ""
+mysql_version: 8.0
+```
 
 ### Caveats
 
-* If you change the database type or version, the existing database may not be compatible with your change, so you'll want to use `ddev export-db` to save a dump first.
+* If you change the database type or version in an existing project, the existing database may not be compatible with your change, so you'll want to use `ddev export-db` to save a dump first.
 * When you change database type, it's best to destroy the existing database using `ddev stop --remove-data` before changing, then use `ddev import-db` to import the db you already exported.
 * Despite those warnings, the db container will do its best to upgrade if you're upgrading from compatible versions. For example, a change from MariaDB 10.1 to 10.4 is likely to work and upgrade correctly, but your mileage may vary. If you change from MySQL 8.0 to MariaDB 5.5, all hell will break loose and you'll have to `ddev stop --remove-data --omit-snapshot` to get back where you were.
-* Snapshots are always per-database-type. So if you have snapshots from MariaDB 10.2 and you switch to MariaDB 10.1, don't expect to be able to restore them.
+* Snapshots are always per-database-type. So if you have snapshots from MariaDB 10.2 and you switch to MariaDB 10.5, don't expect to be able to restore the old snapshot.

--- a/docs/users/extend/database_types.md
+++ b/docs/users/extend/database_types.md
@@ -8,6 +8,8 @@ Note that `mariadb_version` and `mysql_version` are mutually exclusive.
 
 The default version is MariaDB 10.2 and it works for most purposes.
 
+If you decide to use MySQL, you can set the version to 5.7 with `mysql_version: 5.7`
+
 You can also use `ddev config --mariadb-version=10.4` or `ddev config --mysql-version=8.0`
 
 ### Caveats


### PR DESCRIPTION
Just a propopal to give DDEV users a clear hint for mysql 5.7 support (which still runs on many  webspace hosting providers, therefore having the same version on DDEV is very helpful). 

Best regards.& thanks for providing DDEV!

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

