### PR TITLE
Bump image versions to v1.16.2 for release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20201211_php8.0.0" // Note that this can be overridden by make
+var WebTag = "v1.16.2" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
@@ -58,7 +58,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20201127_fix_router_github_actions" // Note that this can be overridden by make
+var RouterTag = "v1.16.2" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

In preparation for release, bumping ddev-router and ddev-webserver versions to v1.16.2

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

