### PR TITLE
Use XDEBUG_MODE to disable xdebug in Dockerfile, not disable_xdebug

### DIFF
--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -20,13 +20,17 @@ func TestCmdXdebug(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		_, err = exec.RunCommand(DdevBin, []string{"config", "--php-version", nodeps.PHPDefault})
+		_, err = exec.RunCommand(DdevBin, []string{"config", "--php-version", nodeps.PHPDefault, "--composer-version=\"\""})
 		assert.NoError(err)
-		_, err = exec.RunCommand(DdevBin, []string{"debug", "off"})
+		_, err = exec.RunCommand(DdevBin, []string{"xdebug", "off"})
 		assert.NoError(err)
 		err := os.Chdir(pwd)
 		assert.NoError(err)
 	})
+
+	// An odd bug in v1.16.2 popped up only when composer version was set, might as well set it here
+	_, err = exec.RunCommand(DdevBin, []string{"config", "--composer-version=2"})
+	assert.NoError(err)
 
 	for phpVersion := range nodeps.ValidPHPVersions {
 		t.Logf("Testing xdebug command in php%s", phpVersion)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -847,7 +847,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg:
 	// breaking testing.
 	if composerVersion != "" {
 		contents = contents + fmt.Sprintf(`
-RUN if command -v composer >/dev/null 2>&1 ; then ( disable_xdebug >/dev/null && composer self-update %s || composer self-update %s ) && chmod 777 /usr/local/bin/composer;  fi
+RUN if command -v composer >/dev/null 2>&1 ; then export XDEBUG_MODE=off && (composer self-update %s || composer self-update %s ) && chmod 777 /usr/local/bin/composer;  fi
 `, composerSelfUpdateArg, composerSelfUpdateArg)
 	}
 	return WriteImageDockerfile(fullpath, []byte(contents))


### PR DESCRIPTION
## The Problem/Issue/Bug:

In ddev v1.16.3, a bug was discovered where `ddev xdebug on` failed if `composer_version` was set to 1 or 2 in the project .ddev/config.yaml.

## How this PR Solves The Problem:

Previously, xdebug was disabled in the Dockerfile build by `disable_xdebug`; unfortunately, running that as root (as is done in the build). This left key files owned by root, so they couldn't be manipulated by enable_xdebug and disable_xdebug.

Now, it just uses XDEBUG_MODE=off to accomplish the same thing.

This is effective only for PHP7.2+, but that should cover all the bases we need to cover. 

## Manual Testing Instructions:

```
ddev config --composer-version=2 --php-version=7.4
ddev start
ddev xdebug on
ddev exec php --version
```
Should show xdebug

Then test to see that xdebug actually works.

## Automated Testing Overview:

In TestCmdXdebug I changed to set `composer_version: 2` before starting

## Related Issue Link(s):

## Release/Deployment notes:

In the future at some point when xdebug 3.0 is ubiquitous, we could use XDEBUG_MODE=off instead of the technique we're currently using.
