### PR TITLE
Update cli-usage.md for bedrock

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -78,6 +78,8 @@ Now, since [Bedrock](https://roots.io/bedrock/) uses a configuration technique w
     DB_PASSWORD=db
     DB_HOST=db
     WP_HOME=https://my-wp-bedrock-site.ddev.site
+    WP_SITEURL=${WP_HOME}/wp
+    WP_ENV=development
 ```
 
 You can then `ddev start` and `ddev launch`.


### PR DESCRIPTION
Minor change in the .env file for wp-bedrock installation

## The Problem/Issue/Bug:

The `.env` file for Bedrock example is not complete. It miss 2 important variables that are important:
* `WP_SITEURL` (because bedrock put the `wp` install behind the `wp` directory!)
* `WP_ENV` (by default it consider the environment as production which is not the case generally when you use this magic tool ddev ! )

## How this PR Solves The Problem:

It fix a reasonable good values for the 2 environment variables

## Manual Testing Instructions:

Install `ddev` on a bedrock-wp site, and check: 
* if WP_SITEURL is missing then you will have broken link in bedrock
* if WP_ENV then bedrock will not show you the plugin to update (as a classic bedrock dev environment is doing)

## Automated Testing Overview:

I don't know how to automate this kind of tests, sorry!

## Related Issue Link(s):

No linked issues.

## Release/Deployment notes:

It's a documentation modification.

*By the way thanks for `ddev` it's really helpful !*
