### PR TITLE
Add --list and --cleanup options to snapshot command, for #1163

### DIFF
--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -68,7 +68,19 @@ func createAppSnapshot(app *ddevapp.DdevApp) {
 
 func deleteAppSnapshot(app *ddevapp.DdevApp) {
 	var snapshotsToDelete []string
+	var prompt string
 	var err error
+
+	if !snapshotCleanupNoConfirm {
+		if snapshotName == "" {
+			prompt = fmt.Sprintf("OK to delete all snapshots of %s\n.", app.GetName())
+		} else {
+			prompt = fmt.Sprintf("OK to delete the snapshot %s of %s\n.", snapshotName, app.GetName())
+		}
+		if !util.Confirm(prompt) {
+			return
+		}
+	}
 
 	if snapshotName == "" {
 		snapshotsToDelete, err = app.ListSnapshots()
@@ -80,14 +92,6 @@ func deleteAppSnapshot(app *ddevapp.DdevApp) {
 	}
 
 	for _, snapshotToDelete := range snapshotsToDelete {
-
-		if !snapshotCleanupNoConfirm {
-			prompt := "OK to delete the snapshot %s of %s\n."
-			if !util.Confirm(fmt.Sprintf(prompt, snapshotToDelete, app.GetName())) {
-				continue
-			}
-		}
-
 		if err := app.DeleteSnapshot(snapshotToDelete); err != nil {
 			util.Failed("Failed to delete snapshot %s: %v", app.GetName(), err)
 		}

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -73,9 +73,9 @@ func deleteAppSnapshot(app *ddevapp.DdevApp) {
 
 	if !snapshotCleanupNoConfirm {
 		if snapshotName == "" {
-			prompt = fmt.Sprintf("OK to delete all snapshots of %s\n.", app.GetName())
+			prompt = fmt.Sprintf("OK to delete all snapshots of %s.", app.GetName())
 		} else {
-			prompt = fmt.Sprintf("OK to delete the snapshot %s of %s\n.", snapshotName, app.GetName())
+			prompt = fmt.Sprintf("OK to delete the snapshot %s of %s.", snapshotName, app.GetName())
 		}
 		if !util.Confirm(prompt) {
 			return

--- a/cmd/ddev/cmd/snapshot_test.go
+++ b/cmd/ddev/cmd/snapshot_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/exec"
+	asrt "github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+// TestCmdSnapshot runs `ddev snapshot` on the test apps
+func TestCmdSnapshot(t *testing.T) {
+	assert := asrt.New(t)
+
+	testDir, _ := os.Getwd()
+	fmt.Println(testDir)
+	site := TestSites[0]
+	cleanup := site.Chdir()
+	app, err := ddevapp.NewApp(site.Dir, false, "")
+	assert.NoError(err)
+	defer func() {
+		// Make sure all databases are back to default empty
+		_ = app.Stop(true, false)
+		_ = app.Start()
+		cleanup()
+	}()
+
+	// Ensure that a snapshot can be created
+	args := []string{"snapshot", "--name", "test-snapshot"}
+	out, err := exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(string(out), "Created snapshot test-snapshot")
+
+	// Try to delete a not existing snapshot
+	args = []string{"snapshot", "--name", "not-existing-snapshot", "--cleanup"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.Error(err)
+	assert.Contains(string(out), "Failed to delete snapshot")
+
+	// Ensure that an existing snapshot can be deleted
+	args = []string{"snapshot", "--name", "test-snapshot", "--cleanup"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(string(out), "Deleted database snapshot test-snapshot")
+}

--- a/cmd/ddev/cmd/snapshot_test.go
+++ b/cmd/ddev/cmd/snapshot_test.go
@@ -33,7 +33,7 @@ func TestCmdSnapshot(t *testing.T) {
 	assert.Contains(string(out), "Created snapshot test-snapshot")
 
 	// Try to delete a not existing snapshot
-	args = []string{"snapshot", "--name", "not-existing-snapshot", "--cleanup"}
+	args = []string{"snapshot", "--name", "not-existing-snapshot", "--cleanup", "--yes"}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.Error(err)
 	assert.Contains(string(out), "Failed to delete snapshot")

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -670,7 +670,12 @@ Restored database snapshot: /Users/rfay/workspace/d8git/.ddev/db_snapshots/d8git
 
 Snapshots are stored in the project's .ddev/db_snapshots directory, and the directory can be renamed as necessary. For example, if you rename the above d8git_20180801132403 directory to "working_before_migration", then you can use `ddev restore-snapshot working_before_migration`.
 
-To delete a snapshot, delete its folder from the .ddev/db_snapshots directory.  Snapshots are not removed from the filesystem by `ddev delete`. It is safe to remove all the snapshots with `rm -r .ddev/db_snapshots` if you no longer need the snapshots.
+To delete a snapshot, delete its folder from the .ddev/db_snapshots directory. Snapshots are not removed from the filesystem by `ddev delete`. It is safe to remove all the snapshots with `rm -r .ddev/db_snapshots` if you no longer need the snapshots.
+
+All snapshots of a project can be removed with `ddev snapshot --cleanup`. A single snapshot can be removed by `ddev snapshot --cleanup --name <snapshot-name>`.
+
+To see all existing snapshots of a project use `ddev snapshot --list`.
+All existing snapshots of your system can be listed by adding the `--all` option to the command (`ddev snapshot --list --all`).
 
 There are some interesting consequences of restoring huge multi-gigabyte databases. Ddev may show the project as ready and started when in reality tables are still being loaded. You can see this behavior with `ddev logs -s db -f`.
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1550,7 +1550,7 @@ func (app *DdevApp) DeleteSnapshot(snapshotName string) (error) {
 	util.Success("Deleted database snapshot %s in %s", snapshotName, hostSnapshotDir)
 	err = app.ProcessHooks("post-delete-snapshot")
 	if err != nil {
-		return fmt.Errorf("Failed to process pre-stop hooks: %v", err)
+		return fmt.Errorf("Failed to process post-delete-snapshot hooks: %v", err)
 	}
 
 	return nil

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1528,6 +1528,31 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 	return snapshotName, nil
 }
 
+// ListSnapshots returns a list of the names of all project snapshots
+func (app *DdevApp) ListSnapshots() ([]string, error) {
+	var err error
+	var snapshots []string
+
+	snapshotDir := filepath.Join(filepath.Dir(app.ConfigPath), "db_snapshots")
+
+	if !fileutil.FileExists(snapshotDir) {
+		return snapshots, nil
+	}
+
+	files, err := ioutil.ReadDir(snapshotDir)
+	if err != nil {
+		return snapshots, err
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			snapshots = append(snapshots, f.Name())
+		}
+	}
+
+	return snapshots, nil
+}
+
 // RestoreSnapshot restores a mariadb snapshot of the db to be loaded
 // The project must be stopped and docker volume removed and recreated for this to work.
 func (app *DdevApp) RestoreSnapshot(snapshotName string) error {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1529,7 +1529,7 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 }
 
 // DeleteSnapshot removes the snapshot directory inside a project
-func (app *DdevApp) DeleteSnapshot(snapshotName string) (error) {
+func (app *DdevApp) DeleteSnapshot(snapshotName string) error {
 	var err error
 	err = app.ProcessHooks("pre-delete-snapshot")
 	if err != nil {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1367,7 +1367,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 	fmt.Print()
 }
 
-// TestDdevSnapshotDelete tests creating a snapshot and delete it. This runs with Mariadb 10.2
+// TestDdevSnapshotCleanup tests creating a snapshot and deleting it.
 func TestDdevSnapshotCleanup(t *testing.T) {
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1367,6 +1367,47 @@ func TestDdevFullSiteSetup(t *testing.T) {
 	fmt.Print()
 }
 
+// TestDdevSnapshotDelete tests creating a snapshot and delete it. This runs with Mariadb 10.2
+func TestDdevSnapshotCleanup(t *testing.T) {
+	assert := asrt.New(t)
+	app := &ddevapp.DdevApp{}
+	site := TestSites[0]
+	switchDir := site.Chdir()
+	defer switchDir()
+
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("TestDdevSnapshotCleanup"))
+
+	testcommon.ClearDockerEnv()
+	err := app.Init(site.Dir)
+	assert.NoError(err)
+
+	err = app.StartAndWait(0)
+	assert.NoError(err)
+
+	// Make a snapshot of d7 tester test 1
+	backupsDir := filepath.Join(app.GetConfigPath(""), "db_snapshots")
+	snapshotName, err := app.Snapshot("d7testerTest1")
+	assert.NoError(err)
+
+	assert.True(fileutil.FileExists(filepath.Join(backupsDir, snapshotName, "xtrabackup_info")), "Expected that file xtrabackup_info in snapshot exists")
+
+	err = app.Init(site.Dir)
+	require.NoError(t, err)
+
+	err = app.Start()
+	require.NoError(t, err)
+	//nolint: errcheck
+	defer app.Stop(true, false)
+
+	err = app.DeleteSnapshot("d7testerTest1")
+	assert.NoError(err)
+
+	// Snapshot data should be deleted
+	assert.False(fileutil.FileExists(filepath.Join(backupsDir, snapshotName, "xtrabackup_info")), "Expected that file of snapshot is deleted during cleanup")
+
+	runTime()
+}
+
 // TestDdevRestoreSnapshot tests creating a snapshot and reverting to it. This runs with Mariadb 10.2
 func TestDdevRestoreSnapshot(t *testing.T) {
 	assert := asrt.New(t)


### PR DESCRIPTION
## The Problem/Issue/Bug:
I want be able to list and delete existing db-snapshots. A command or option is missing.

## How this PR Solves The Problem:
Add a `--list` option to snapshot command.
Add a `--cleanup` option to snapshot command.

## Release/Deployment notes:
Code should not affect any existing project.

Related snapshot and restore-snapshot issues are at https://github.com/drud/ddev/issues?q=is%3Aissue+is%3Aopen+snapshot