### PR TITLE
Update auth ssh doc to correct --ssh-key-path switch name

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -21,7 +21,7 @@ var sshKeyPath string
 var AuthSSHCommand = &cobra.Command{
 	Use:     "ssh",
 	Short:   "Add ssh key authentication to the ddev-ssh-auth container",
-	Long:    `Use this command to provide the password to your ssh key to the ddev-ssh-agent container, where it can be used by other containers. Normal usage is just "ddev auth ssh", or if your key is not in ~/.ssh, ddev auth ssh --keydir=/some/path/.ssh"`,
+	Long:    `Use this command to provide the password to your ssh key to the ddev-ssh-agent container, where it can be used by other containers. Normal usage is just "ddev auth ssh", or if your key is not in ~/.ssh, ddev auth ssh --ssh-key-path=/some/path/.ssh"`,
 	Example: `ddev auth ssh`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error


### PR DESCRIPTION
## The Problem/Issue/Bug:

The docs for `ddev auth ssh` were still referencing `--keydir` as the long name of the `-d` switch.

## How this PR Solves The Problem:

Corrected the long description to display `--ssh-key-path` instead.

## Manual Testing Instructions:

`ddev auth ssh --help` and see the glory of the correct switch. 😄 
