### PR TITLE
[tests only, circleci] Use Ubuntu 20.04 for builds, bump cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v14
+        - linux-v15
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker, golang
@@ -34,7 +34,7 @@ jobs:
         root: ~/
         paths: ddev
     - save_cache:
-        key: linux-v14
+        key: linux-v15
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -52,7 +52,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v14
+        - linux-v15
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
@@ -66,7 +66,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v14
+        key: linux-v15
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -173,7 +173,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v14
+        - linux-v15
     - attach_workspace:
         at: ~/
     - run:
@@ -188,7 +188,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v14
+        key: linux-v15
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -206,7 +206,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v14
+        - linux-v15
     - attach_workspace:
         at: ~/
     - run:
@@ -224,7 +224,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v14
+        key: linux-v15
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -239,7 +239,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v14
+        - linux-v15
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
@@ -259,7 +259,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v14
+        - linux-v15
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
@@ -283,7 +283,7 @@ jobs:
         name: linux container test
 
     - save_cache:
-        key: linux-v14
+        key: linux-v15
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -318,7 +318,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v14
+        - linux-v15
     - attach_workspace:
         at: ~/
     - run:
@@ -326,7 +326,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-v14
+        key: linux-v15
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         name: NORMAL Circle VM setup - tools, docker, golang
 
     - run:
-        command: source ~/.bashrc && nvm use 10 && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+        command: source ~/.bashrc && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: staticrequired
     - run:
         command: |
@@ -244,7 +244,7 @@ jobs:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
     - run:
-        command: source ~/.bashrc && nvm use 10 && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+        command: source ~/.bashrc && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: staticrequired
 
   lx_container_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     working_directory: ~/ddev
     environment:
       DRUD_NONINTERACTIVE: "true"
@@ -11,7 +11,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v13
+        - linux-v14
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker, golang
@@ -34,14 +34,14 @@ jobs:
         root: ~/
         paths: ddev
     - save_cache:
-        key: linux-v13
+        key: linux-v14
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
 
   lx_nginx_fpm_test:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
@@ -52,7 +52,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v13
+        - linux-v14
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
@@ -66,7 +66,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v13
+        key: linux-v14
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -162,7 +162,7 @@ jobs:
 
   lx_apache_fpm_test:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
@@ -173,7 +173,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v13
+        - linux-v14
     - attach_workspace:
         at: ~/
     - run:
@@ -188,14 +188,14 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v13
+        key: linux-v14
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
 
   lx_nfsmount_test:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_USE_NFSMOUNT: true
@@ -206,7 +206,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v13
+        - linux-v14
     - attach_workspace:
         at: ~/
     - run:
@@ -216,7 +216,7 @@ jobs:
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     # Run the built-in ddev tests with the executables just built.
     - run:
-        # CircleCI image ubuntu-1604:202007-01 has umask 002, which results in
+        # CircleCI image ubuntu-2004:202010-01 has umask 002, which results in
         # default perms 700 for new directories, which doesn't seem to work with NFS
         command: umask u=rwx,g=rwx,o=rx && make -s test EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: ddev tests
@@ -224,14 +224,14 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v13
+        key: linux-v14
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
 
   staticrequired:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     working_directory: ~/ddev
     environment:
     steps:
@@ -239,7 +239,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v13
+        - linux-v14
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
@@ -249,7 +249,7 @@ jobs:
 
   lx_container_test:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     working_directory: ~/ddev
     environment:
       GOTEST_SHORT: true
@@ -259,7 +259,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v13
+        - linux-v14
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup - tools, docker, golang
@@ -283,7 +283,7 @@ jobs:
         name: linux container test
 
     - save_cache:
-        key: linux-v13
+        key: linux-v14
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache
@@ -312,13 +312,13 @@ jobs:
 
   artifacts:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     working_directory: ~/ddev
     steps:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v13
+        - linux-v14
     - attach_workspace:
         at: ~/
     - run:
@@ -326,7 +326,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-v13
+        key: linux-v14
         paths:
         - /home/linuxbrew
         - ~/.ddev/testcache

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -37,8 +37,6 @@ for item in osslsigncode golang golangci-lint mkcert mkdocs ddev bats-core; do
 done
 brew install --build-from-source makensis
 
-# nvm on CircleCI has a few things. 10 is compatible with markdownlint-cli
-nvm use 10
 npm install --global markdownlint-cli
 markdownlint --version
 # readthedocs has ancient version of mkdocs in it.

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -32,7 +32,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 brew tap drud/ddev >/dev/null
-for item in osslsigncode golang golangci-lint mkcert mkdocs ddev bats-core; do
+for item in osslsigncode golang mkcert mkdocs ddev bats-core; do
     brew install $item >/dev/null || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item >/dev/null
 done
 brew install --build-from-source makensis

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -40,7 +40,7 @@ brew install --build-from-source makensis
 npm install --global markdownlint-cli
 markdownlint --version
 # readthedocs has ancient version of mkdocs in it.
-pyenv global 3.8.3 # added to make CircleCi give us pip3
+pyenv global 3.8.5 # added to make CircleCi give us pip3
 pip3 install -q yq mkdocs==0.17.5
 
 # Get the Stubs and Plugins for makensis; the linux makensis build doesn't do this.

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -13,7 +13,7 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
 fi
 
 sudo apt-get update -qq
-sudo apt-get install -qq mysql-client realpath zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
+sudo apt-get install -qq mysql-client coreutils zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
 
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -32,9 +32,10 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 brew tap drud/ddev >/dev/null
-for item in osslsigncode golang golangci-lint mkcert mkdocs ddev makensis bats-core; do
+for item in osslsigncode golang golangci-lint mkcert mkdocs ddev bats-core; do
     brew install $item >/dev/null || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item >/dev/null
 done
+brew install --build-from-source makensis
 
 # nvm on CircleCI has a few things. 10 is compatible with markdownlint-cli
 nvm use 10

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ BUILD_OS = $(shell go env GOHOSTOS)
 BUILD_ARCH = $(shell go env GOHOSTARCH)
 VERSION_LDFLAGS=$(foreach v,$(VERSION_VARIABLES),-X '$(PKG)/pkg/version.$(v)=$($(v))')
 LDFLAGS=-extldflags -static $(VERSION_LDFLAGS)
-BUILD_IMAGE ?= golang:1.15.3
+BUILD_IMAGE ?= drud/golang-build-container:v1.15.6
 DOCKERBUILDCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
           	    -v "/$(PWD)://workdir$(DOCKERMOUNTFLAG)"                              \
           	    -e GOPATH="//workdir/$(GOTMP)" \

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ golangci-lint:
 		$$CMD; \
 	else \
 		$(DOCKERTESTCMD) \
-		time bash -c "$$CMD"; \
+		bash -c "$$CMD"; \
 	fi
 
 version:


### PR DESCRIPTION
## The Problem/Issue/Bug:

Previously, CircleCI only supported Ubuntu 16.04 as builder, nothing newer. But suddenly they have 20.04

* Use the Ubuntu 20.04 builder
* Bump the CircleCI build cache to v15 to refresh it
* Homebrew seems not to have a bottle for makensis for Linux any more, see https://github.com/Homebrew/homebrew-core/issues/67825 - Instead use --build-from-source to see if it can work
