### PR TITLE
Bump default mariadb version to 10.3, fixes #2232

### DIFF
--- a/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.mariawithemptymysql
+++ b/cmd/ddev/cmd/testdata/TestMariaMysqlConflicts/config.yaml.mariawithemptymysql
@@ -2,4 +2,4 @@ name: mariawithemptymysql
 type: php
 docroot: ""
 mysql_version: ""
-mariadb_version: "10.2"
+mariadb_version: "10.3"

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -73,10 +73,10 @@ func init() {
 			settingsCreator: createDrupal7SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal8: {
-			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: drupal8ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
+			settingsCreator: createDrupal8SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal9: {
-			settingsCreator: createDrupal9SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: drupal9ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
+			settingsCreator: createDrupal9SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 
 		nodeps.AppTypeWordPress: {
@@ -95,7 +95,7 @@ func init() {
 			settingsCreator: createMagento2SettingsFile, uploadDir: getMagento2UploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagento2SiteSettingsPaths, appTypeDetect: isMagento2App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction, defaultWorkingDirMap: nil,
 		},
 		nodeps.AppTypeLaravel:   {appTypeDetect: isLaravelApp, postStartAction: laravelPostStartAction},
-		nodeps.AppTypeShopware6: {appTypeDetect: isShopware6App, apptypeSettingsPaths: setShopware6SiteSettingsPaths, uploadDir: getShopwareUploadDir, configOverrideAction: shopware6ConfigOverrideAction, postStartAction: shopware6PostStartAction, importFilesAction: shopware6ImportFilesAction},
+		nodeps.AppTypeShopware6: {appTypeDetect: isShopware6App, apptypeSettingsPaths: setShopware6SiteSettingsPaths, uploadDir: getShopwareUploadDir, configOverrideAction: nil, postStartAction: shopware6PostStartAction, importFilesAction: shopware6ImportFilesAction},
 	}
 }
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -585,20 +585,6 @@ func drupal6ConfigOverrideAction(app *DdevApp) error {
 	return nil
 }
 
-// drupal8ConfigOverrideAction overrides mariadb_version for Druapl 8 for future
-// compatibility with Drupal 9, since it requires at least 10.3.
-func drupal8ConfigOverrideAction(app *DdevApp) error {
-	app.MariaDBVersion = nodeps.MariaDB103
-	return nil
-}
-
-// drupal9ConfigOverrideAction overrides mariadb_version for D9,
-// since it requires at least 10.3
-func drupal9ConfigOverrideAction(app *DdevApp) error {
-	app.MariaDBVersion = nodeps.MariaDB103
-	return nil
-}
-
 // drupal8PostStartAction handles default post-start actions for D8 apps, like ensuring
 // useful permissions settings on sites/default.
 func drupal8PostStartAction(app *DdevApp) error {

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"os"
 	"path/filepath"
@@ -112,12 +111,5 @@ func shopware6PostStartAction(app *DdevApp) error {
 		util.Warning("the .env file has not yet been created (%s)", envFile)
 	}
 
-	return nil
-}
-
-// shopware6ConfigOverrideAction overrides mariadb_version for shopware6,
-// since it requires at least 10.3
-func shopware6ConfigOverrideAction(app *DdevApp) error {
-	app.MariaDBVersion = nodeps.MariaDB103
 	return nil
 }

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -3,7 +3,7 @@
 package nodeps
 
 // MariaDBDefaultVersion is the default MariaDB version
-const MariaDBDefaultVersion = MariaDB102
+const MariaDBDefaultVersion = MariaDB103
 
 var ValidMariaDBVersions = map[string]bool{
 	MariaDB55:  true,

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -1,7 +1,7 @@
 package nodeps
 
 // MariaDBDefaultVersion is the default MariaDB version
-const MariaDBDefaultVersion = MariaDB102
+const MariaDBDefaultVersion = MariaDB103
 
 var ValidMariaDBVersions = map[string]bool{
 	MariaDB101: true,


### PR DESCRIPTION
## The Problem/Issue/Bug:

MariaDB 10.3 is required by several CMSs now, we're leaving 10.2 behind. #2232 

## How this PR Solves The Problem:

Change the default to 10.3. 10.2 is still fully supported, and any project that has it configured will still use it.

## Manual Testing Instructions:

- [ ] `ddev config` a project from scratch. The .ddev/config.yaml should get mariadb 10.3

