### PR TITLE
Remove duplicate menu entry for shell autocompletion in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ extra_javascript:
   - assets/fix-search.js
 markdown_extensions:
   - markdown.extensions.toc
-nav:
+pages:
   - 'Home': 'index.md'
   - 'ddev Basics':
     - 'Using the CLI': 'users/cli-usage.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ extra_javascript:
   - assets/fix-search.js
 markdown_extensions:
   - markdown.extensions.toc
-pages:
+nav:
   - 'Home': 'index.md'
   - 'ddev Basics':
     - 'Using the CLI': 'users/cli-usage.md'
@@ -22,7 +22,6 @@ pages:
     - 'Frequently-Asked Questions (FAQ)': 'users/faq.md'
     - '.ddev/config.yaml Options': 'users/extend/config_yaml.md'
     - 'Database Server Types': 'users/extend/database_types.md'
-    - 'Bash and Zsh Completion': 'users/shell-completion.md'
     - 'Additional Project Hostnames': 'users/extend/additional-hostnames.md'
     - 'Shell Completion (bash, zsh, etc.)': 'users/shell-completion.md'
     - 'Alternate Uses of DDEV-Local': 'users/alternate-uses.md'


### PR DESCRIPTION
The menu entries "Shell completion" and "Bach and Zsh Completion" did the same thing. Removed the latter.

WARNING:
My local copy behaves differently than the live page: it shows only the first h3 submenu level instead of all h2 and h3. Not sure why...