### PR TITLE
Skip TestGetLocalHTTPResponse on Windows

### DIFF
--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -135,6 +136,9 @@ func TestValidTestSite(t *testing.T) {
 
 // TestGetLocalHTTPResponse() brings up a project and hits a URL to get the response
 func TestGetLocalHTTPResponse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows as we always seem to have port conflicts")
+	}
 	// We have to get globalconfig read so CA is known and installed.
 	err := globalconfig.ReadGlobalConfig()
 	require.NoError(t, err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

On Windows, TestGetLocalHTTPResponse gets an enormous number of failures due to a WIndows docker bug, https://github.com/docker/for-win/issues/10008

As a result, skip this one on Windows. The Docker failure happens elsewhere also, but this one pops up again and again. 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

