### PR TITLE
[Docs] Add PHP 8.0 to the supported php versions

### DIFF
--- a/docs/users/extend/config_yaml.md
+++ b/docs/users/extend/config_yaml.md
@@ -12,7 +12,7 @@ the .ddev/config.yaml is the primary configuration for the project.
 | name  | Project name   | Must be unique on the host (no two projects can have the same name). It's best if this is the same as the directory name.   |
 | type | Project type | php/drupal6/drupal7/drupal8/backdrop/typo3wordpress. Project type "php" does not try to do any CMS configuration or settings file management, and can work with any project|
 | docroot | Relative path of the docroot (where index.php or index.html is) from the project root| |
-| php_version | 5.6/7.0/7.1/7.2/7.3/7.4 | It is only possible to provide the major version (like "7.3"), not a minor version like "7.3.2", and it is only possible to use the provided php versions. |
+| php_version | 5.6/7.0/7.1/7.2/7.3/7.4/8.0 | It is only possible to provide the major version (like "7.3"), not a minor version like "7.3.2", and it is only possible to use the provided php versions. |
 | webimage | docker image to use for webserver | It is unusual to change the default and is not recommended, but the webimage can be overridden with a correctly crafted image, probably derived from drud/ddev-webserver |
 | dbimage | docker image to use for db server | It is unusual to change the default and is not recommended, but the dbimage can be overridden with a correctly crafted image, probably derived from drud/ddev-dbserver |
 | dbaimage | docker image to use for dba server (phpMyAdmin server) | It is unusual to change the default and is not recommended, but the dbimage can be overridden with a correctly crafted image, probably derived from drud/phpmyadmin |


### PR DESCRIPTION


## The Problem/Issue/Bug:

PHP 8.0 is missing in the supported versions in the config section

## How this PR Solves The Problem:

/

## Manual Testing Instructions:

no testing needed
## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
no testing needed
## Related Issue Link(s):
#2553
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

