### PR TITLE
Give an error on duplicate snapshot anme, fixes #2515

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1493,6 +1493,15 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 		t := time.Now()
 		snapshotName = app.Name + "_" + t.Format("20060102150405")
 	}
+
+	existingSnapshots, err := app.ListSnapshots()
+	if err != nil {
+		return "", err
+	}
+	if nodeps.ArrayContainsString(existingSnapshots, snapshotName) {
+		return "", fmt.Errorf("snapshot %s already exists, please use another snapshot name or clean up snapshots with `ddev snapshot --cleanup`", snapshotName)
+	}
+
 	// Container side has to use path.Join instead of filepath.Join because they are
 	// targeted at the linux filesystem, so won't work with filepath on Windows
 	snapshotDir := path.Join("db_snapshots", snapshotName)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1464,7 +1464,7 @@ func TestGetLatestSnapshot(t *testing.T) {
 	runTime()
 }
 
-// TestDdevRestoreSnapshot tests creating a snapshot and reverting to it. This runs with Mariadb 10.2
+// TestDdevRestoreSnapshot tests creating a snapshot and reverting to it.
 func TestDdevRestoreSnapshot(t *testing.T) {
 	assert := asrt.New(t)
 	testDir, _ := os.Getwd()
@@ -1535,6 +1535,10 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	assert.NoError(err)
 	err = os.Remove("hello-post-snapshot-" + app.Name)
 	assert.NoError(err)
+
+	// Make sure duplicate snapshot name gives an error
+	_, err = app.Snapshot(snapshotName)
+	assert.Error(err)
 
 	err = app.ImportDB(d7testerTest2Dump, "", false, false, "db")
 	assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", d7testerTest2Dump, err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2515 points out that if you reuse an existing snapshot name it makes a mess

## How this PR Solves The Problem:

Check first

## Manual Testing Instructions:

`ddev snapshot --name=something && ddev snapshot --name=something` should give an intelligible error

## Automated Testing Overview:

Added this situation to the main test

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

