### PR TITLE
Hardened webserver needs to allow /usr/local/bin update, fixes #2725

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -36,8 +36,11 @@ RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2
 
 ADD ddev-webserver-base-files /
 ADD ddev-webserver-base-scripts /
-RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 
+# /usr/local/bin may need to be updated by start.sh, etc
+RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
+
+RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 
 # END ddev-webserver-base
 
@@ -135,7 +138,7 @@ ADD ddev-webserver-base-scripts /
 RUN chmod ugo+x /start.sh /healthcheck.sh
 
 # Composer, etc may need to be updated by composer self-update
-RUN chmod -f ugo+wx /usr/local/bin /usr/local/bin/composer /usr/local/bin/ddev-live
+RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer /usr/local/bin/ddev-live
 
 #TODO: Security implications; must be revisited
 RUN chmod ugo+w /etc/ssl/certs

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210106_nginx_default_server" // Note that this can be overridden by make
+var WebTag = "20210107_hardened_drush" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2725  - hardened webimage needs to allow relinking of drush

## How this PR Solves The Problem:

Open up /usr/local/bin permissions so that non-privileged user can link drush in there on startup if it's needed. 

## Manual Testing Instructions:

- [x] `ddev config global --use-hardened-images && ddev start` in a Drupal 7 and Drupal8 environment


