### PR TITLE
Improve DDEV configuration validation errors (php_version, mysql_version, etc.)

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -439,28 +439,31 @@ func (app *DdevApp) ValidateConfig() error {
 
 	// validate PHP version
 	if !nodeps.IsValidPHPVersion(app.PHPVersion) {
-		return fmt.Errorf("unsupported PHP version: %s, ddev (%s) only supports the following versions %v", app.PHPVersion, runtime.GOARCH, nodeps.GetValidPHPVersions()).(invalidPHPVersion)
+		return fmt.Errorf("unsupported PHP version: %s, ddev (%s) only supports the following versions: %v", app.PHPVersion, runtime.GOARCH, nodeps.GetValidPHPVersions()).(invalidPHPVersion)
 	}
 
 	// validate webserver type
 	if !nodeps.IsValidWebserverType(app.WebserverType) {
-		return fmt.Errorf("unsupported webserver type: %s, ddev (%s) only supports the following versions %s", app.WebserverType, runtime.GOARCH, nodeps.GetValidWebserverTypes()).(invalidWebserverType)
+		return fmt.Errorf("unsupported webserver type: %s, ddev (%s) only supports the following webserver types: %s", app.WebserverType, runtime.GOARCH, nodeps.GetValidWebserverTypes()).(invalidWebserverType)
 	}
 
 	if !nodeps.IsValidOmitContainers(app.OmitContainers) {
-		return fmt.Errorf("unsupported omit_containers: %s, ddev (%s) only supports the following versions %s", app.OmitContainers, runtime.GOARCH, nodeps.GetValidOmitContainers()).(InvalidOmitContainers)
+		return fmt.Errorf("unsupported omit_containers: %s, ddev (%s) only supports the following for omit_containers: %s", app.OmitContainers, runtime.GOARCH, nodeps.GetValidOmitContainers()).(InvalidOmitContainers)
 	}
 
 	if app.MariaDBVersion != "" {
 		// Validate mariadb version
 		if !nodeps.IsValidMariaDBVersion(app.MariaDBVersion) {
-			return fmt.Errorf("unsupported mariadb_version: %s, ddev (%s) only supports the following versions %s", app.MariaDBVersion, runtime.GOARCH, nodeps.GetValidMariaDBVersions()).(invalidMariaDBVersion)
+			return fmt.Errorf("unsupported mariadb_version: %s, ddev (%s) only supports the following versions: %s", app.MariaDBVersion, runtime.GOARCH, nodeps.GetValidMariaDBVersions()).(invalidMariaDBVersion)
 		}
 	}
 	if app.MySQLVersion != "" {
 		// Validate /mysql version
 		if !nodeps.IsValidMySQLVersion(app.MySQLVersion) {
-			return fmt.Errorf("unsupported mysql_version: %s, ddev (%s) only supports the following versions %s", app.MySQLVersion, runtime.GOARCH, nodeps.GetValidMySQLVersions()).(invalidMySQLVersion)
+			if len(nodeps.GetValidMySQLVersions()) == 0 {
+				return fmt.Errorf("MySQL is not yet supported on your architecture (%s) because mysql does not provide packages (or docker images)", runtime.GOARCH)
+			}
+			return fmt.Errorf("unsupported mysql_version: %s; ddev (%s) only supports the following versions %s", app.MySQLVersion, runtime.GOARCH, nodeps.GetValidMySQLVersions()).(invalidMySQLVersion)
 		}
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -439,28 +439,28 @@ func (app *DdevApp) ValidateConfig() error {
 
 	// validate PHP version
 	if !nodeps.IsValidPHPVersion(app.PHPVersion) {
-		return fmt.Errorf("invalid PHP version: %s, must be one of %v", app.PHPVersion, nodeps.GetValidPHPVersions()).(invalidPHPVersion)
+		return fmt.Errorf("unsupported PHP version: %s, ddev (%s) only supports the following versions %v", app.PHPVersion, runtime.GOARCH, nodeps.GetValidPHPVersions()).(invalidPHPVersion)
 	}
 
 	// validate webserver type
 	if !nodeps.IsValidWebserverType(app.WebserverType) {
-		return fmt.Errorf("invalid webserver type: %s, must be one of %s", app.WebserverType, nodeps.GetValidWebserverTypes()).(invalidWebserverType)
+		return fmt.Errorf("unsupported webserver type: %s, ddev (%s) only supports the following versions %s", app.WebserverType, runtime.GOARCH, nodeps.GetValidWebserverTypes()).(invalidWebserverType)
 	}
 
 	if !nodeps.IsValidOmitContainers(app.OmitContainers) {
-		return fmt.Errorf("invalid omit_containers: %s, must be one of %s", app.OmitContainers, nodeps.GetValidOmitContainers()).(InvalidOmitContainers)
+		return fmt.Errorf("unsupported omit_containers: %s, ddev (%s) only supports the following versions %s", app.OmitContainers, runtime.GOARCH, nodeps.GetValidOmitContainers()).(InvalidOmitContainers)
 	}
 
 	if app.MariaDBVersion != "" {
 		// Validate mariadb version
 		if !nodeps.IsValidMariaDBVersion(app.MariaDBVersion) {
-			return fmt.Errorf("invalid mariadb_version: %s, must be one of %s", app.MariaDBVersion, nodeps.GetValidMariaDBVersions()).(invalidMariaDBVersion)
+			return fmt.Errorf("unsupported mariadb_version: %s, ddev (%s) only supports the following versions %s", app.MariaDBVersion, runtime.GOARCH, nodeps.GetValidMariaDBVersions()).(invalidMariaDBVersion)
 		}
 	}
 	if app.MySQLVersion != "" {
 		// Validate /mysql version
 		if !nodeps.IsValidMySQLVersion(app.MySQLVersion) {
-			return fmt.Errorf("invalid mysql_version: %s, must be one of %s", app.MySQLVersion, nodeps.GetValidMySQLVersions()).(invalidMySQLVersion)
+			return fmt.Errorf("unsupported mysql_version: %s, ddev (%s) only supports the following versions %s", app.MySQLVersion, runtime.GOARCH, nodeps.GetValidMySQLVersions()).(invalidMySQLVersion)
 		}
 	}
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -582,13 +582,13 @@ func TestConfigValidate(t *testing.T) {
 	app.PHPVersion = "1.1"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "invalid PHP")
+	assert.Contains(err.Error(), "unsupported PHP")
 
 	app.PHPVersion = nodeps.PHPDefault
 	app.WebserverType = "server"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "invalid webserver type")
+	assert.Contains(err.Error(), "unsupported webserver type")
 
 	app.WebserverType = nodeps.WebserverDefault
 	app.AdditionalHostnames = []string{"good", "b@d"}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Container config validation errors can be a little confusing as, while a previous version may have (at one point) been "valid", the current version of ddev may no longer actually support it. Note: this came up when a project which worked on previous Macs (using MariaDB 10.0) would show this error because of the new Apple Silicon arm64 architecture; of which MariaDB does not include packages for this version.

## How this PR Solves The Problem:

Changes the verbiage of "invalid" to "unsupported" and as specifies that it is ddev (and current architecture) that does not support the requested version.

## Manual Testing Instructions:
Specify a version that isn't supported and check that the message matches the PR.

## Automated Testing Overview:
Not sure if this is tested anywhere?

## Related Issue Link(s):

## Release/Deployment notes:
Doesn't affect anything, just a better error message.
