### PR TITLE
Large snapshot restore shouldn't return until it's done

### DIFF
--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -57,7 +57,7 @@ if command -v xtrabackup; then BACKUPTOOL="xtrabackup"; fi
 if [ ! -f "/var/lib/mysql/db_mariadb_version.txt" ]; then
     # If snapshot_dir is not set, this is a normal startup, so
     # tell healthcheck to wait by touching /tmp/initializing
-    if [ -z "${snapshot_dir}" ] ; then
+    if [ -z "${snapshot_dir:-}" ] ; then
       touch /tmp/initializing
     fi
     target=${snapshot_dir:-/mysqlbase/}

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -56,13 +56,15 @@ if command -v xtrabackup; then BACKUPTOOL="xtrabackup"; fi
 # If mariadb has not been initialized, copy in the base image from either the default starter image (/mysqlbase)
 # or from a provided $snapshot_dir.
 if [ ! -f "/var/lib/mysql/db_mariadb_version.txt" ]; then
+    touch /tmp/initializing
     target=${snapshot_dir:-/mysqlbase/}
     name=$(basename $target)
     sudo rm -rf /var/lib/mysql/* /var/lib/mysql/.[a-z]* && sudo chmod -R ugo+w /var/lib/mysql
     sudo chmod -R ugo+r $target
     ${BACKUPTOOL} --prepare --skip-innodb-use-native-aio --target-dir "$target" --user=root --password=root --socket=$SOCKET 2>&1 | tee "/var/log/mariabackup_prepare_$name.log"
     ${BACKUPTOOL} --copy-back --skip-innodb-use-native-aio --force-non-empty-directories --target-dir "$target" --user=root --password=root --socket=$SOCKET 2>&1 | tee "/var/log/mariabackup_copy_back_$name.log"
-    echo 'Database initialized from $target'
+    echo "Database initialized from ${target}"
+    rm /tmp/initializing
 fi
 
 database_db_version=$(cat /var/lib/mysql/db_mariadb_version.txt)

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -18,7 +18,6 @@ function serverwait {
             echo "MariaDB initialization startup failed"
             return 2
         fi
-#        echo "MariaDB initialization startup process in progress... Try# $i"
         sleep 1
 	done
 	return 1

--- a/containers/ddev-dbserver/files/healthcheck.sh
+++ b/containers/ddev-dbserver/files/healthcheck.sh
@@ -16,7 +16,7 @@ if [ -f /tmp/healthy ]; then
 fi
 
 
-if ! killall -HUP mariabackup && ! killall -HUP xtrabackup && mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
+if [ ! -f /tmp/initializing ] && mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
     printf "healthy"
     touch /tmp/healthy
     exit 0

--- a/containers/ddev-dbserver/files/healthcheck.sh
+++ b/containers/ddev-dbserver/files/healthcheck.sh
@@ -15,8 +15,13 @@ if [ -f /tmp/healthy ]; then
     sleep ${sleeptime}
 fi
 
+if killall -0 mariabackup || killall -0 xtrabackup ; then
+  printf "restoring snapshot"
+  touch /tmp/healthy
+  exit 0
+fi
 
-if [ ! -f /tmp/initializing ] && mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
+if  mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
     printf "healthy"
     touch /tmp/healthy
     exit 0

--- a/containers/ddev-dbserver/files/healthcheck.sh
+++ b/containers/ddev-dbserver/files/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## mysql health check for docker. original source: https://github.com/docker-library/healthcheck/blob/master/mysql/docker-healthcheck
+## mysql health check for docker
 
 set -eo pipefail
 sleeptime=59

--- a/containers/ddev-dbserver/files/healthcheck.sh
+++ b/containers/ddev-dbserver/files/healthcheck.sh
@@ -15,12 +15,21 @@ if [ -f /tmp/healthy ]; then
     sleep ${sleeptime}
 fi
 
+# If /tmp/initializing, it means we're loading the default starter database
+if [ -f /tmp/initializing ]; then
+  printf "initializing"
+  exit 1
+fi
+
+# If mariabackup or xtrabackup is running (and not initializing)
+# It means snapshot restore is in progress
 if killall -0 mariabackup || killall -0 xtrabackup ; then
   printf "restoring snapshot"
   touch /tmp/healthy
   exit 0
 fi
 
+# If we can now access the server, we're healthy and ready
 if  mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
     printf "healthy"
     touch /tmp/healthy

--- a/containers/ddev-dbserver/files/healthcheck.sh
+++ b/containers/ddev-dbserver/files/healthcheck.sh
@@ -16,7 +16,7 @@ if [ -f /tmp/healthy ]; then
 fi
 
 
-if mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
+if ! killall -HUP mariabackup && ! killall -HUP xtrabackup && mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
     printf "healthy"
     touch /tmp/healthy
     exit 0

--- a/containers/ddev-dbserver/test/basic_database.bats
+++ b/containers/ddev-dbserver/test/basic_database.bats
@@ -19,13 +19,14 @@ function setup {
     fi
     docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
 
-    echo "# Starting image with database image $IMAGE"
+    echo "# Starting container using: docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE"
     docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
     containercheck
 }
 
 function teardown {
-    docker rm -f $CONTAINER_NAME
+    docker stop $CONTAINER_NAME
+    docker rm $CONTAINER_NAME
     docker volume rm $VOLUME || true
 }
 

--- a/containers/get_arch.sh
+++ b/containers/get_arch.sh
@@ -4,6 +4,8 @@ case ${unamearch} in
   ;;
   aarch64) ARCH="arm64";
   ;;
+  arm64) ARCH="arm64";
+  ;;
   *) printf "${RED}Sorry, your machine architecture ${unamearch} is not currently supported.\n${RESET}" && exit 106
   ;;
 esac

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -15,7 +15,7 @@ Each of these commands has full help. For example, `ddev start -h` or `ddev help
 * `ddev heidisql` (Windows/WSL2 only, if installed) gives access to the HeidiSQL database browser GUI.
 * `ddev import-db` and `ddev export-db` let you import or export a sql or compressed sql file.
 * `ddev composer` lets you run composer (inside the container), for example `ddev composer install` will do a full composer install for you without even needing composer on your computer. See [developer tools](developer-tools.md#ddev-and-composer).
-* `ddev snapshot` makes a very fast snapshot of your database that can be easily and quickly restored with `ddev restore-snapshot`.
+* `ddev snapshot` makes a very fast snapshot of your database that can be easily and quickly restored with `ddev snapshot restore`.
 * `ddev share` works with [ngrok](https://ngrok.com/) (and requires ngrok) so you can let someone in the next office or on the other side of the planet see your project and what you're working on. `ddev share -h` gives more info about how to set up ngrok (it's easy).
 * `ddev ssh` opens a bash session in the web container (or other container).
 * `ddev launch` or `ddev launch some/uri` will launch a browser with the current project's URL (or a full URL to `/some/uri`). `ddev launch -p` will launch the phpMyAdmin UI, and `ddev launch -m` will launch the MailHog UI.
@@ -673,10 +673,8 @@ ddev snapshot restore d8git_20180801132403
 Restored database snapshot: /Users/rfay/workspace/d8git/.ddev/db_snapshots/d8git_20180801132403
 ```
 
-Snapshots are stored in the project's .ddev/db_snapshots directory, and the directory can be renamed as necessary. For example, if you rename the above d8git_20180801132403 directory to "working_before_migration", then you can use `ddev snapshot restore working_before_migration`.
+Snapshots are stored in the project's .ddev/db_snapshots directory, and the directory created for a snapshot can be renamed as necessary. For example, if you rename the above d8git_20180801132403 directory to "working_before_migration", then you can use `ddev snapshot restore working_before_migration`.
 To restore the latest snapshot add the `--latest` flag (`ddev snapshot restore --latest`).
-
-To delete a snapshot, delete its folder from the .ddev/db_snapshots directory. Snapshots are not removed from the filesystem by `ddev delete`. It is safe to remove all the snapshots with `rm -r .ddev/db_snapshots` if you no longer need the snapshots.
 
 All snapshots of a project can be removed with `ddev snapshot --cleanup`. A single snapshot can be removed by `ddev snapshot --cleanup --name <snapshot-name>`.
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -46,7 +46,7 @@ var WebTag = "20210207_provider_cleanup" // Note that this can be overridden by 
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "switch-to-github-actions"
+var BaseDBTag = "20210115_huge_db_snapshot_restore"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The db container shows healthy during a snapshot restore, meaning the project can come up and look healthy, but in reality it's still restoring.

## How this PR Solves The Problem:

* Make sure that db container shows unhealthy while restoring.

## TODO

- [x] Remove the verbiage that says the log may still be going. This is both in snapshot restore and also in the docs.
- [x] Tell people they may have to wait. Maybe guess based on size of snapshot?
- [x] Change the timeout/numtries on snapshot restore so it waits a long time
- [x] See if there's any way to give feedback about how long it's going to be.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

