### PR TITLE
Remove drush launcher config from web image [skip ci][ci skip]

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -158,7 +158,6 @@ ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
 ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
 ENV CAROOT /mnt/ddev-global-cache/mkcert
-ENV DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 
 ENV DDEV_LIVE_CONFIG_FILE_PATH /mnt/ddev-global-cache/ddev-live/cli-config.json
 ENV DDEV_LIVE_NO_VERSION_PROMPT true
@@ -279,7 +278,6 @@ ENV PHP_DEFAULT_VERSION="7.4"
 ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
 ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
 ENV CAROOT /mnt/ddev-global-cache/mkcert
-ENV DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV COMPOSER_CACHE_DIR=/mnt/ddev-global-cache/composer
 ENV COMPOSER_PROCESS_TIMEOUT=2000

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -69,7 +69,7 @@ If you need to debug command-line PHP processes, especially code that is outside
 
 * If you have used PhpStorm with xdebug you already have a PhpStorm "server" with the same name as your primary URL (see "Languages and Frameworks" -> "PHP" -> "Servers"). The key job of the "server" is to map filesystem locations on the workstation (your computer) to filesystem locations on the remote server (in this case the ddev-webserver container). Often, PhpStorm has automatically set up a mapping that doesn't include the entire project (so the vendor directory is not mapped, for example). So map the top-level directory of your project to /var/www/html in the container, as in this image:
 ![PhpStorm mapping](images/PHPStormServerMapping.png)
-* When debugging a command-line script inside the container, the environment variable PHP_IDE_CONFIG is automatically set for you, so it will be something like `PHP_IDE_CONFIG=serverName=d8composer.ddev.site`.  If debugging Drupal's drush command, you may find that launching the site-installed drush directly will avoid confusing PhpStorm with the execution of /usr/local/bin/drush (which is the drush launcher). Run it as `ddev exec /var/www/html/vendor/bin/drush` or wherever it was installed. It's often easiest to just `ddev ssh` into the web container and execute command-line scripts directly.
+* When debugging a command-line script inside the container, the environment variable PHP_IDE_CONFIG is automatically set for you, so it will be something like `PHP_IDE_CONFIG=serverName=d8composer.ddev.site`.  
 
 <a name="atom"></a>
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Drush launcher is no longer used, remove references to it. 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

