### PR TITLE
MariaDB default didn't get changed to 10.3 for M1 [skip ci][ci skip]

### DIFF
--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -1,7 +1,7 @@
 package nodeps
 
 // MariaDBDefaultVersion is the default MariaDB version
-const MariaDBDefaultVersion = MariaDB102
+const MariaDBDefaultVersion = MariaDB103
 
 var ValidMariaDBVersions = map[string]bool{
 	MariaDB101: true,


### PR DESCRIPTION
## The Problem/Issue/Bug:

I discovered working on an M1 machine that although the mariadb default was changed to 10.3 on amd64 and linux_arm64, it got lost on darwin_arm64.

## How this PR Solves The Problem:

Bump it.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

