### PR TITLE
Improve fragile test TestComposeWithStreams

### DIFF
--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -239,14 +239,14 @@ func TestComposeWithStreams(t *testing.T) {
 	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stderr, os.Stdout, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
 	assert.Error(err)
 	output = stdout()
-	assert.Equal("ls: cannot access 'xx': No such file or directory\n", output)
+	assert.Contains(output, "ls: cannot access 'xx': No such file or directory")
 
 	// Flip stdout and stderr and create an error and normal stdout. We should see only the success captured in stdout
 	stdout = util.CaptureStdOut()
 	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stdout, os.Stderr, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
 	assert.Error(err)
 	output = stdout()
-	assert.Equal("/var/run/apache2\n", output)
+	assert.Contains(output, "/var/run/apache2", output)
 }
 
 // TestCheckCompose tests detection of docker-compose.


### PR DESCRIPTION
## The Problem/Issue/Bug:

TestComposeWithStreams was fragile expecting exact input, which is broken in upcoming Docker release. 

## How this PR Solves The Problem:

Use assert.Contains() instead of assert.Equal()

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

