### PR TITLE
Turn off buildkit build in ddev start

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1347,6 +1347,9 @@ func (app *DdevApp) DockerEnv() {
 	}
 
 	envVars := map[string]string{
+		// Without COMPOSE_DOCKER_CLI_BUILD=0, docker-cmpose makes all kinds of mess
+		// of output. BUILDKIT_PROGRESS doesn't help either.
+		"COMPOSE_DOCKER_CLI_BUILD":      "0",
 		"COMPOSE_PROJECT_NAME":          "ddev-" + app.Name,
 		"COMPOSE_CONVERT_WINDOWS_PATHS": "true",
 		"DDEV_SITENAME":                 app.Name,


### PR DESCRIPTION
## The Problem/Issue/Bug:

In upcoming docker-compose in Docker Desktop, they have
buldkit builds turned on, using native docker build. It makes
a big mess visually and isn't very useful for our small web/db build.

## How this PR Solves The Problem:

COMPOSE_DOCKER_CLI_BUILD="0"


## Manual Testing Instructions:

`ddev start` on Windows with new Docker. It should look like it has in the past. See https://github.com/docker/for-win/issues/10008#issuecomment-766654081

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

