### PR TITLE
Bring in php8 extensions from upstream

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod (for DDEV-Live)
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v0.7.7 as ddev-webserver-base
+FROM drud/ddev-php-base:v0.7.8 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210111_lolautruche_blackfire" // Note that this can be overridden by make
+var WebTag = "20210126_php8_extensions" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* PHP8.0 did not previously have redis and memcached extensions, but they're now available upstream.
* Drush launcher is completely removed (upstream)


