### PR TITLE
Remove several circleci jobs as github actions is doing them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ workflows:
   version: 2
   normal_build_and_test:
     jobs:
-#    - build
+    - build
 #    - mac_container_test
 #    - lx_container_test
 #    - staticrequired

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
       DRUD_NONINTERACTIVE: "true"
     steps:
+    - checkout
     - attach_workspace:
         at: ~/
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
@@ -428,13 +429,13 @@ workflows:
   version: 2
   normal_build_and_test:
     jobs:
-    - build
+#    - build
 #    - mac_container_test
-    - lx_container_test
+#    - lx_container_test
 #    - staticrequired
-    - lx_nginx_fpm_test:
-        requires:
-        - build
+    - lx_nginx_fpm_test
+#        requires:
+#        - build
 #    - mac_nginx_fpm_test:
 #        requires:
 #        - build
@@ -444,15 +445,15 @@ workflows:
 #    - mac_nfsmount_test:
 #        requires:
 #        - build
-    - lx_apache_fpm_test:
-        requires:
-        - build
+#    - lx_apache_fpm_test:
+#        requires:
+#        - build
 #    - lx_apache_cgi_test:
 #        requires:
 #        - build
-    - lx_nfsmount_test:
-        requires:
-        - build
+#    - lx_nfsmount_test:
+#        requires:
+#        - build
 #    - artifacts:
 #        requires:
 #        - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ jobs:
         name: NORMAL Circle VM setup - tools, docker, golang
         no_output_timeout: "40m"
     - run:
-        command: source ~/.bashrc && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
-        name: staticrequired
-    - run:
         command: |
           make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 windows_amd64 windows_install EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: Build the ddev executables

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - run:
-        command: make -s test EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+        command: make -s testpkg TESTARGS='-run "(TestDdevLive.*|TestPantheon.*|TestDdevFullSite.*)"' EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: ddev tests
         no_output_timeout: "40m"
     - store_test_results:

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/stretchr/testify/require"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +25,9 @@ import (
 // runs each service's check function to ensure it's accessible from
 // the web container.
 func TestServices(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping because unreliable on Windows")
+	}
 	assert := asrt.New(t)
 	os.Setenv("DRUD_NONINTERACTIVE", "true")
 	err := globalconfig.ReadGlobalConfig()


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've moved a lot of tests to GitHub actions, so we can build less stuff in CircleCI. 

## How this PR Solves The Problem:

Stop some CircleCI tests

Thanks to @dennisameling !

The next step, could be taken in this PR, is to test only the things that require secrets in CircleCI (pantheon, ddev-live, etc.). 