### PR TITLE
Update yarn install to fix replaced yarnpkg key, fixes #2772

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker, golang
 
-    - run:
-        command: source ~/.bashrc && nvm use 10 && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
-        name: staticrequired
+#    - run:
+#        command: source ~/.bashrc && nvm use 10 && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+#        name: staticrequired
     - run:
         command: |
           make linux_amd64 linux_arm64 darwin_amd64 windows_amd64 windows_install EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker, golang
 
+# Temporarily remove this for v1.16 branch of backports
 #    - run:
 #        command: source ~/.bashrc && nvm use 10 && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
 #        name: staticrequired

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -32,9 +32,11 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 brew tap drud/ddev >/dev/null
-for item in osslsigncode golang golangci-lint mkcert mkdocs ddev makensis bats-core; do
+for item in osslsigncode golang mingw-w64 mkcert mkdocs ddev bats-core; do
     brew install $item >/dev/null || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item >/dev/null
 done
+brew install --build-from-source makensis
+
 
 # nvm on CircleCI has a few things. 10 is compatible with markdownlint-cli
 nvm use 10

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -19,6 +19,9 @@ ENV CAROOT /mnt/ddev-global-cache/mkcert
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
+RUN rm -f /etc/apt/sources.list.d/yarn.list && ( apt-get -qq remove yarn || true ) # Temporary change to switch to npm install
+RUN npm config set unsafe-perm true && npm install --global yarn
+
 RUN wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
     apt-key add /tmp/nginx_signing.key && \
     echo "deb http://nginx.org/packages/debian/ $(lsb_release -sc) nginx" > /etc/apt/sources.list.d/nginx.list

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -2,7 +2,7 @@
 
 @test "Verify required binaries are installed in normal image" {
     if [ "${IS_HARDENED}" == "true" ]; then skip "Skipping because IS_HARDENED==true"; fi
-    COMMANDS="composer ddev-live drush git magerun magerun2 mkcert sudo terminus wp"
+    COMMANDS="composer ddev-live drush git magerun magerun2 mkcert sudo terminus wp yarn"
     for item in $COMMANDS; do
        docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"
     done

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -239,14 +239,14 @@ func TestComposeWithStreams(t *testing.T) {
 	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stderr, os.Stdout, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
 	assert.Error(err)
 	output = stdout()
-	assert.Equal("ls: cannot access 'xx': No such file or directory\n", output)
+	assert.Contains(output, "ls: cannot access 'xx': No such file or directory")
 
 	// Flip stdout and stderr and create an error and normal stdout. We should see only the success captured in stdout
 	stdout = util.CaptureStdOut()
 	err = ComposeWithStreams(composeFiles, os.Stdin, os.Stdout, os.Stderr, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
 	assert.Error(err)
 	output = stdout()
-	assert.Equal("/var/run/apache2\n", output)
+	assert.Contains(output, "/var/run/apache2", output)
 }
 
 // TestCheckCompose tests detection of docker-compose.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.16.3" // Note that this can be overridden by make
+var WebTag = "v1.16.6" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2772: The yarn key expired again this year as it seems to on Feb 1 every year. 

But there's a new installation technique, so this uses the new technique. It gets a new minor version of yarn, but otherwise no change. 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

