### PR TITLE
Update index.md - link to brew.sh was not correct

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ We'll walk through these in more detail. You may prefer other techniques of inst
 14. Check that docker is working inside Ubuntu (or your distro): `docker ps`
 15. Optional: If you prefer to use the *Windows* ddev instead of working inside WSL2, install it with `choco install -y ddev`. The Windows ddev works fine with the WSL2-based Docker engine.
 16. Open the WSL2 terminal, for example `Ubuntu` from the Windows start menu.
-17. Install Homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"` (See [brew.sh](brew.sh).)
+17. Install Homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"` (See [https://brew.sh/](brew.sh).)
 18. Add brew to your path as prompted, for example, `echo 'eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)' >> ~/.profile && source ~/.profile`
 19. `brew install gcc && brew tap drud/ddev && brew install ddev`
 20. `sudo apt-get update && sudo apt-get install -y xdg-utils` to install the xdg-utils package that allows `ddev launch` to work.

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ We'll walk through these in more detail. You may prefer other techniques of inst
 14. Check that docker is working inside Ubuntu (or your distro): `docker ps`
 15. Optional: If you prefer to use the *Windows* ddev instead of working inside WSL2, install it with `choco install -y ddev`. The Windows ddev works fine with the WSL2-based Docker engine.
 16. Open the WSL2 terminal, for example `Ubuntu` from the Windows start menu.
-17. Install Homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"` (See [https://brew.sh/](brew.sh).)
+17. Install Homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` (See [https://brew.sh/](brew.sh).)
 18. Add brew to your path as prompted, for example, `echo 'eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)' >> ~/.profile && source ~/.profile`
 19. `brew install gcc && brew tap drud/ddev && brew install ddev`
 20. `sudo apt-get update && sudo apt-get install -y xdg-utils` to install the xdg-utils package that allows `ddev launch` to work.


### PR DESCRIPTION
One link to brew.sh was linked relatively to the docs of ddev itself which caused to create a https://ddev.readthedocs.io/en/stable/brew.sh instead of https://brew.sh.

## The Problem/Issue/Bug:
Wrong link as stated above.

## How this PR Solves The Problem:
Updated it properly with a HTTPS scheme protocol.

## Manual Testing Instructions:
Click on the brew.sh link. :)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
It's a simple link anyone can test by clicking on it. Guess it's self-explaining enough.

## Related Issue Link(s):
https://ddev.readthedocs.io/en/stable/

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
Nothing
