### PR TITLE
Adds Drush site:install and uli to D8 and D9 quickstart

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -140,7 +140,8 @@ ddev config --project-type=drupal8 --docroot=web --create-docroot
 ddev start
 ddev composer create "drupal/recommended-project:^8"
 ddev composer require drush/drush
-ddev launch
+ddev drush site:install
+ddev drush uli
 ```
 
 #### Drupal 8 Git Clone Example
@@ -167,7 +168,8 @@ ddev config --project-type=drupal9 --docroot=web --create-docroot
 ddev start
 ddev composer create "drupal/recommended-project"
 ddev composer require drush/drush
-ddev launch
+ddev drush site:install
+ddev drush uli
 ```
 
 #### Drupal 9 Git Clone Example

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -140,7 +140,7 @@ ddev config --project-type=drupal8 --docroot=web --create-docroot
 ddev start
 ddev composer create "drupal/recommended-project:^8"
 ddev composer require drush/drush
-ddev drush site:install
+ddev drush site:install -y
 ddev drush uli
 ```
 
@@ -168,7 +168,7 @@ ddev config --project-type=drupal9 --docroot=web --create-docroot
 ddev start
 ddev composer create "drupal/recommended-project"
 ddev composer require drush/drush
-ddev drush site:install
+ddev drush site:install -y
 ddev drush uli
 ```
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -142,6 +142,7 @@ ddev composer create "drupal/recommended-project:^8"
 ddev composer require drush/drush
 ddev drush site:install -y
 ddev drush uli
+ddev launch
 ```
 
 #### Drupal 8 Git Clone Example
@@ -170,6 +171,7 @@ ddev composer create "drupal/recommended-project"
 ddev composer require drush/drush
 ddev drush site:install -y
 ddev drush uli
+ddev drush launch
 ```
 
 #### Drupal 9 Git Clone Example


### PR DESCRIPTION
## The Problem/Issue/Bug:
Adding `drush site:install` and `drush uli` to the the Drupal 8 and [Drupal 9 Quickstart instructions](https://ddev.readthedocs.io/en/stable/users/cli-usage/#drupal-9-quickstart) could help on-ramp new DDEV users faster, see #2769.

## How this PR Solves The Problem:
Adds Drush commands `site:install` and `uli` to D8 and D9 quickstart guide.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

