### PR TITLE
Add support for persistent data on old Solr.

### DIFF
--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -51,10 +51,12 @@ services:
       # to the host port 8984 vid ddev-router reverse proxy.
       - HTTPS_EXPOSE=8984:8983
     volumes:
-      # solr core *data* is stored on the 'solr' docker volume
+      # solr core *data* is stored on the 'solr_var' or `solr_opt` docker
+      # volumes depending on the version of solr.
       # This mount is optional; without it your search index disappears
       # each time the ddev project is stopped and started.
-      - solr:/var/solr
+      - solr_var:/var/solr
+      - solr_opt:/opt/solr
 
       # This mounts the conf in .ddev/solr into the container where
       # the solr-precreate command in the entrypoint uses it as a one-time
@@ -83,7 +85,6 @@ services:
     links:
       - solr:solr
 volumes:
-  # solr is a persistent Docker volume for solr data
-  # The persistent volume should have the same name as the service so it can be deleted
-  # when the project is deleted.
-  solr:
+  # solr_var and solr_opt are persistent Docker volumes for solr data
+  solr_var:
+  solr_opt:


### PR DESCRIPTION
This provides support for persistent data on older versions of Solr. Tested with 5.

It seems like 5 stores data in `/opt/solr/server/solr/mycores/dev/data` while 8 stores data in `/var/solr/data/dev/data`.

![Solr_Admin_and_Solr_Admin](https://user-images.githubusercontent.com/397902/107084321-83f02c80-67bc-11eb-8948-7a66d7c5aa2b.jpg)

This breaks the `The persistent volume should have the same name as the service so it can be deleted when the project is deleted.` part.

I'm not sure if `5` uses `/var/solr` at all, although there was stuff in it. Maybe an alternative is to add a comment to pick the relevant directory based on versions?

## The Problem/Issue/Bug:

Solr 5 does not persist data.

## How this PR Solves The Problem:

Add an additional volume that is used by Solr 5 and maybe other older versions.

## Manual Testing Instructions:

Follow the standard Solr setup direction, but set `image: solr:5`.

Without this code:
- Spin up the server
- View the core at `:8983/solr/#/dev`
- Add a document from the UI `:8983/solr/#/dev/documents`
- View the core and see the document count
- Restart DDEV `ddev restart`
- View the core, it will be `0` again

## Automated Testing Overview:
No tests were added. For automated tests, we'd have to include Solr 5 configuration files in addition to 8.

## Related Issue Link(s):

## Release/Deployment notes:
