### PR TITLE
Remove special host.docker.internal handling for mac M1

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -127,7 +127,6 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 	output.UserOut.Printf("auto-restart-containers=%v", globalconfig.DdevGlobalConfig.AutoRestartContainers)
 	output.UserOut.Printf("use-hardened-images=%v", globalconfig.DdevGlobalConfig.UseHardenedImages)
 	output.UserOut.Printf("fail-on-hook-fail=%v", globalconfig.DdevGlobalConfig.FailOnHookFailGlobal)
-	output.UserOut.Printf("host-docker-internal=%v", globalconfig.DdevGlobalConfig.HostDockerInternal)
 }
 
 func init() {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/archive"
 	exec2 "github.com/drud/ddev/pkg/exec"
-	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"io"
@@ -733,8 +732,6 @@ func GetHostDockerInternalIP() (string, error) {
 				return "", fmt.Errorf("docker0 interface IP address cannot be determined. You may need to 'ip link set docker0 up' or restart docker or reboot to get xdebug or nfsmount_enabled to work")
 			}
 		}
-	} else if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		hostDockerInternal = globalconfig.DdevGlobalConfig.HostDockerInternal
 	}
 	return hostDockerInternal, nil
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -53,7 +52,6 @@ type GlobalConfig struct {
 	AutoRestartContainers    bool     `yaml:"auto_restart_containers"`
 	FailOnHookFailGlobal     bool     `yaml:"fail_on_hook_fail"`
 	WebEnvironment           []string `yaml:"web_environment"`
-	HostDockerInternal       string   `yaml:"host_docker_internal"`
 
 	ProjectList map[string]*ProjectInfo `yaml:"project_info"`
 }
@@ -122,10 +120,6 @@ func ReadGlobalConfig() error {
 	// and ignore the setting.
 	if DdevGlobalConfig.InternetDetectionTimeout < nodeps.InternetDetectionTimeoutDefault {
 		DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
-	}
-	// Temporary workaround until Docker on m1 mac has host.docker.internal
-	if DdevGlobalConfig.HostDockerInternal == "" && runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		DdevGlobalConfig.HostDockerInternal = "192.168.64.1"
 	}
 
 	err = ValidateGlobalConfig()


### PR DESCRIPTION
## The Problem/Issue/Bug:

The latest upcoming version of the Mac M1 preview for docker won't require special handling for host.docker.internal.

## How this PR Solves The Problem:

Remove the special handling.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

