### PR TITLE
Refactor ddev-dbserver builds

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        containers: [mariadb, mysql, webserver, others]
+        containers: [dbserver, webserver, others]
 
     steps:
       - uses: actions/checkout@v2
@@ -40,16 +40,10 @@ jobs:
           docker version
           set -eu -o pipefail
 
-          if [[ "${{ matrix.containers }}" == "mariadb" ]]; then
+          if [[ "${{ matrix.containers }}" == "dbserver" ]]; then
             pushd containers/ddev-dbserver
-            echo "--- Test container mariadb"
-            time make test_mariadb DOCKER_ARGS="--no-cache"
-            popd
-
-          elif [[ "${{ matrix.containers }}" == "mysql" ]]; then
-            pushd containers/ddev-dbserver
-            echo "--- Test container mysql"
-            time make test_mysql DOCKER_ARGS="--no-cache"
+            echo "--- Test container dbserver"
+            time make test DOCKER_ARGS="--no-cache"
             popd
 
           elif [[ "${{ matrix.containers }}" == "webserver" ]]; then

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -12,6 +12,7 @@ on:
 env:
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
+  NO_LOAD: true
 
 jobs:
 

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -4,7 +4,7 @@ FROM ${DB_TYPE}:${DB_PINNED_VERSION}
 
 # This must be reiterated because everything is emptied on FROM
 ARG DB_TYPE
-ARG DB_PINNED_VERSION
+ARG DB_VERSION
 
 ENV MYSQL_DATABASE db
 ENV MYSQL_USER db
@@ -15,7 +15,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN apt-get -qq update && apt-get -qq install -y tzdata sudo gnupg2 pv less vim wget curl lsb-release >/dev/null
 
-RUN if ( ! command -v xtrabackup && ! command -v mariabackup ); then \
+RUN set -x; if ( ! command -v xtrabackup && ! command -v mariabackup ); then \
     curl -sSL https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb -o percona-release_latest.$(lsb_release -sc)_all.deb; \
     sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb >/dev/null; \
     rm percona-release*.deb ; \

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -1,10 +1,10 @@
-ARG DBTYPE
-ARG PARENTIMAGEVERSION
-FROM ${DBTYPE}:${PARENTIMAGEVERSION}
+ARG DB_TYPE
+ARG DB_PINNED_VERSION
+FROM ${DB_TYPE}:${DB_PINNED_VERSION}
 
 # This must be reiterated because everything is emptied on FROM
-ARG DBVERSION
-ARG DBTYPE
+ARG DB_TYPE
+ARG DB_PINNED_VERSION
 
 ENV MYSQL_DATABASE db
 ENV MYSQL_USER db
@@ -20,7 +20,7 @@ RUN if ( ! command -v xtrabackup && ! command -v mariabackup ); then \
     sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb >/dev/null; \
     rm percona-release*.deb ; \
     xtrabackup_version=percona-xtrabackup-24 ; \
-    if [ "$DBVERSION" = "8.0" ]; then xtrabackup_version=percona-xtrabackup-80; fi ; \
+    if [ "$DB_VERSION" = "8.0" ]; then xtrabackup_version=percona-xtrabackup-80; fi ; \
     apt-get -qq update && apt-get -qq install -y ${xtrabackup_version} >/dev/null ; \
 fi
 RUN apt-get -qq autoclean

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,7 +10,7 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_amd64 mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_amd64 mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64_8.0.22
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
 	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \
@@ -30,20 +30,25 @@ mariadb_10.5: mariadb_10.5_both
 mysql_5.5: mysql_5.5_amd64
 mysql_5.6: mysql_5.6_amd64
 mysql_5.7: mysql_5.7_amd64
-mysql_8.0: mysql_8.0_amd64
+# Mysql 8.0 often must be pinned because xtrabackup is not ready for latest 8.0
+# So check whether xtrabackup is available for latest 8.0 before changing pin
+mysql_8.0: mysql_8.0_amd64_8.0.22
 
 
 # Examples:
+# make <dbtype>_<dbmajor>_[both|amd64]_<pin>  # pin is optional, often needed for mysql 8.0
 # make mariadb_10.3_both VERSION=someversion PUSH=true
-# make mysql_8.0_amd64 VERSION=someversion
+# make mysql_8.0_amd64_8.0.22 VERSION=someversion
 $(BUILD_TARGETS):
 	@echo "building $@";
 	export DB_TYPE=$(word 1, $(subst _, ,$@)) && \
 	export DB_MAJOR_VERSION=$(word 2, $(subst _, ,$@)) && \
 	export ARCH=$(word 3, $(subst _, ,$@)) && \
+	export DB_PINNED_VERSION=$(word 4, $(subst _, ,$@)) && \
 	if [ $${ARCH} = "both" ]; then ARCHS="linux/amd64,linux/arm64"; else ARCHS="linux/amd64"; fi && \
-	cmd="./build_image.sh --db-type=$${DB_TYPE} --db-major-version $${DB_MAJOR_VERSION} --archs=$${ARCHS} --tag=$(VERSION)" && \
+	cmd="./build_image.sh --db-type=$${DB_TYPE} --db-major-version=$${DB_MAJOR_VERSION} --archs=$${ARCHS} --tag=$(VERSION) --docker-args=$(DOCKER_ARGS)" && \
 	if [ ! -z $${PUSH} ]; then cmd="$$cmd --push"; fi && \
+	if [ ! -z $${DB_PINNED_VERSION} ]; then cmd="$$cmd --db-pinned-version=$${DB_PINNED_VERSION}"; fi && \
 	echo $${cmd} && \
 	$${cmd}
 

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -32,6 +32,13 @@ mysql_containers:
 		docker buildx build -o type=docker $(DOCKER_ARGS) --build-arg="DBVERSION=$$baseversion" --build-arg="PARENTIMAGEVERSION=$$fullversion" --build-arg="DBTYPE=mysql" -t "drud/ddev-dbserver-mysql-$${baseversion%%%.*}:$(VERSION)" . ; \
 	done
 
+# Need to be able to
+# * Build each version of mariadb and mysql
+# * Build only if supported on architecture
+# * Build for each architecture (or both)
+# * Test built item
+mariadb_10.2:
+
 # Below has mariadb_containers and mysql_containers as a prerequisite because those build the amd64 images.
 # So, the multi-arch approach here is a bit different from the ones in the other Makefiles.
 multi-arch: mariadb_containers mysql_containers

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -2,19 +2,23 @@ DOCKER_REPO ?= drud/ddev-dbserver
 
 VERSION := $(shell git describe --tags --always --dirty)
 
-.PHONY: build container mariadb_containers mysql_containers multi-arch push test clean
+.PHONY: build clean test
 
-include database-versions
-
-CURRENT_ARCH=$(shell ../get_arch.sh)
+CURRENT_ARCH=$(shell arch)
 
 # This Makefile explicitly does not include containers/containers_shared.mak,
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-container: mariadb_containers mysql_containers
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_amd64 mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64
+TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
+	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
+	else \
+	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test"; \
+  	fi )
 
-mariadb_containers: mariadb_5.5 mariadb_10.0 mariadb_10.1 mariadb_10.2 mariadb_10.3 mariadb_10.4 mariadb_10.5
+build: $(BUILD_TARGETS)
+
 mariadb_5.5: mariadb_5.5_amd64
 mariadb_10.0: mariadb_10.0_amd64
 mariadb_10.1: mariadb_10.1_amd64
@@ -23,34 +27,35 @@ mariadb_10.3: mariadb_10.3_both
 mariadb_10.4: mariadb_10.4_both
 mariadb_10.5: mariadb_10.5_both
 
-mysql_containers: mysql_5.5 mysql_5.6 mysql_5.7 mysql_8.0
 mysql_5.5: mysql_5.5_amd64
 mysql_5.6: mysql_5.6_amd64
 mysql_5.7: mysql_5.7_amd64
 mysql_8.0: mysql_8.0_amd64
 
-TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_amd64 mariadb_10.2_both mariadb_10.3_both .3_amd64 mariadb_10.4_both mariadb_10.5_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64
 
-$(TARGETS):
+# Examples:
+# make mariadb_10.3_both VERSION=someversion PUSH=true
+# make mysql_8.0_amd64 VERSION=someversion
+$(BUILD_TARGETS):
 	@echo "building $@";
-	@export DB_TYPE=$(word 1, $(subst _, ,$@)) && \
+	export DB_TYPE=$(word 1, $(subst _, ,$@)) && \
 	export DB_MAJOR_VERSION=$(word 2, $(subst _, ,$@)) && \
 	export ARCH=$(word 3, $(subst _, ,$@)) && \
-	if [ $${ARCH} = "both" ]; then ARCHS="linux/arm64,linux/amd64"; else ARCHS="linux/amd64"; fi && \
+	if [ $${ARCH} = "both" ]; then ARCHS="linux/amd64,linux/arm64"; else ARCHS="linux/amd64"; fi && \
 	cmd="./build_image.sh --db-major-version $${DB_MAJOR_VERSION} --archs=$${ARCHS} --tag=$(VERSION)" && \
 	if [ ! -z $${PUSH} ]; then cmd="$$cmd --push"; fi && \
 	echo $${cmd} && \
 	$${cmd}
 
+test: build $(TEST_TARGETS)
 
-test_mariadb:
-	bash ./test/test_dbserver.sh $(VERSION) mariadb # bash execution just for windows make, only mariadb tests
-
-test_mysql:
-	bash ./test/test_dbserver.sh $(VERSION) mysql # bash execution just for windows make, only mysql tests
-
-test:
-	bash ./test/test_dbserver.sh $(VERSION) # bash execution just for windows make
+# make mariadb_10.2_test mysql_8.0_test
+# make test # for all
+$(TEST_TARGETS):
+	@export DB_TYPE=$(word 1, $(subst _, ,$@)) && \
+	export DB_MAJOR_VERSION=$(word 2, $(subst _, ,$@)) && \
+	export ARCH=$(CURRENT_ARCH) && \
+	./test/test_dbserver.sh $${DB_TYPE} $${DB_MAJOR_VERSION} $(VERSION)
 
 clean:
 	@rm -rf VERSION.txt

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -14,71 +14,43 @@ SHELL = /bin/bash
 
 container: mariadb_containers mysql_containers
 
-mariadb_containers:
-	set -eu -o pipefail; \
-	for item in $(subst $\",,$(MARIADB_VERSIONS_$(CURRENT_ARCH))); do \
-		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
-		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
-		printf "\n\n========== Building MariaDB $${baseversion} with image $${fullversion} ==========\n"; \
-		docker buildx build -o type=docker $(DOCKER_ARGS) --build-arg="DBVERSION=$${baseversion}" --build-arg="PARENTIMAGEVERSION=$$fullversion" --build-arg="DBTYPE=mariadb" -t "drud/ddev-dbserver-mariadb-$${baseversion}:$(VERSION)" . ; \
-	done
+mariadb_containers: mariadb_5.5 mariadb_10.0 mariadb_10.1 mariadb_10.2 mariadb_10.3 mariadb_10.4 mariadb_10.5
+mariadb_5.5: mariadb_5.5_amd64
+mariadb_10.0: mariadb_10.0_amd64
+mariadb_10.1: mariadb_10.1_amd64
+mariadb_10.2: mariadb_10.2_both
+mariadb_10.3: mariadb_10.3_both
+mariadb_10.4: mariadb_10.4_both
+mariadb_10.5: mariadb_10.5_both
 
-mysql_containers:
-	set -eu -o pipefail ; \
-	for item in $(subst $\",,$(MYSQL_VERSIONS_$(CURRENT_ARCH))); do \
-		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
-		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
-		printf "\n\n========== Building MySQL $${baseversion} with image $${fullversion} ==========\n", ${baseversion}, ${fullversion}; \
-		docker buildx build -o type=docker $(DOCKER_ARGS) --build-arg="DBVERSION=$$baseversion" --build-arg="PARENTIMAGEVERSION=$$fullversion" --build-arg="DBTYPE=mysql" -t "drud/ddev-dbserver-mysql-$${baseversion%%%.*}:$(VERSION)" . ; \
-	done
+mysql_containers: mysql_5.5 mysql_5.6 mysql_5.7 mysql_8.0
+mysql_5.5: mysql_5.5_amd64
+mysql_5.6: mysql_5.6_amd64
+mysql_5.7: mysql_5.7_amd64
+mysql_8.0: mysql_8.0_amd64
 
-# Need to be able to
-# * Build each version of mariadb and mysql
-# * Build only if supported on architecture
-# * Build for each architecture (or both)
-# * Test built item
-mariadb_10.2:
+TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_amd64 mariadb_10.2_both mariadb_10.3_both .3_amd64 mariadb_10.4_both mariadb_10.5_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64
 
-# Below has mariadb_containers and mysql_containers as a prerequisite because those build the amd64 images.
-# So, the multi-arch approach here is a bit different from the ones in the other Makefiles.
-multi-arch: mariadb_containers mysql_containers
-	set -eu -o pipefail ; \
-	for item in $(subst $\",,$(MARIADB_VERSIONS_arm64)); do \
-		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
-		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
-		printf "\n\n========== Building MariaDB $${baseversion} with image $${fullversion} ==========\n"; \
-		docker buildx build --platform=linux/arm64 $(DOCKER_ARGS) --build-arg="DBVERSION=$${baseversion}" --build-arg="PARENTIMAGEVERSION=$$fullversion" --build-arg="DBTYPE=mariadb" -t "drud/ddev-dbserver-mariadb-$${baseversion}:$(VERSION)" . ; \
-	done	
+$(TARGETS):
+	@echo "building $@";
+	@export DB_TYPE=$(word 1, $(subst _, ,$@)) && \
+	export DB_MAJOR_VERSION=$(word 2, $(subst _, ,$@)) && \
+	export ARCH=$(word 3, $(subst _, ,$@)) && \
+	if [ $${ARCH} = "both" ]; then ARCHS="linux/arm64,linux/amd64"; else ARCHS="linux/amd64"; fi && \
+	cmd="./build_image.sh --db-major-version $${DB_MAJOR_VERSION} --archs=$${ARCHS} --tag=$(VERSION)" && \
+	if [ ! -z $${PUSH} ]; then cmd="$$cmd --push"; fi && \
+	echo $${cmd} && \
+	$${cmd}
 
-push:
-	set -euo pipefail ;\
-	for item in $(subst $\",,$(MARIADB_VERSIONS_amd64)); do \
-		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
-		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
-		export archs=$$(if [[ "$(subst $\",,$(MARIADB_VERSIONS_arm64))" == *"$$item"* ]]; then echo "linux/amd64,linux/arm64"; else echo "linux/amd64"; fi); \
-		docker buildx build --push --platform $${archs} $(DOCKER_ARGS)  --build-arg="DBVERSION=$${baseversion}" --build-arg="PARENTIMAGEVERSION=$$fullversion" --build-arg="DBTYPE=mariadb" -t "drud/ddev-dbserver-mariadb-$${baseversion}:$(VERSION)" .; \
-	done
-	set -euo pipefail ;\
-	for item in $(subst $\",,$(MYSQL_VERSIONS_amd64)); do \
-		export baseversion=$$(echo $$item | awk -F ':' '{print $$1}'); \
-		export fullversion=$$(echo $$item | awk -F ':' '{print $$2}'); \
-		docker buildx build --push --platform linux/amd64 $(DOCKER_ARGS) --build-arg="DBVERSION=$$baseversion" --build-arg="PARENTIMAGEVERSION=$$fullversion" --build-arg="DBTYPE=mysql" -t "drud/ddev-dbserver-mysql-$${baseversion%%%.*}:$(VERSION)" .; \
-	done
 
-test_mariadb: mariadb_containers
+test_mariadb:
 	bash ./test/test_dbserver.sh $(VERSION) mariadb # bash execution just for windows make, only mariadb tests
 
-test_mysql: mysql_containers
+test_mysql:
 	bash ./test/test_dbserver.sh $(VERSION) mysql # bash execution just for windows make, only mysql tests
 
-test: container
+test:
 	bash ./test/test_dbserver.sh $(VERSION) # bash execution just for windows make
 
 clean:
-	for item in $(subst $\",,$(MARIADB_VERSIONS_$(CURRENT_ARCH))); do \
-		if docker image inspect $(DOCKER_REPO)-mariadb-${item}:$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO)-mariadb-$${item}:$(VERSION); fi; \
-	done
-	for item in $(subst $\",,$(MYSQL_VERSIONS_$(CURRENT_ARCH))); do \
-		if docker image inspect $(DOCKER_REPO)-mysql-${item}:$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO)-mysql-$${item}:$(VERSION); fi; \
-	done
 	@rm -rf VERSION.txt

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -4,7 +4,7 @@ VERSION := $(shell git describe --tags --always --dirty)
 
 .PHONY: build clean test
 
-CURRENT_ARCH=$(shell arch)
+CURRENT_ARCH=$(shell ../get_arch.sh)
 
 # This Makefile explicitly does not include containers/containers_shared.mak,
 # So has to explicitly declare anything it might need from there (like SHELL)

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -42,7 +42,7 @@ $(BUILD_TARGETS):
 	export DB_MAJOR_VERSION=$(word 2, $(subst _, ,$@)) && \
 	export ARCH=$(word 3, $(subst _, ,$@)) && \
 	if [ $${ARCH} = "both" ]; then ARCHS="linux/amd64,linux/arm64"; else ARCHS="linux/amd64"; fi && \
-	cmd="./build_image.sh --db-major-version $${DB_MAJOR_VERSION} --archs=$${ARCHS} --tag=$(VERSION)" && \
+	cmd="./build_image.sh --db-type=$${DB_TYPE} --db-major-version $${DB_MAJOR_VERSION} --archs=$${ARCHS} --tag=$(VERSION)" && \
 	if [ ! -z $${PUSH} ]; then cmd="$$cmd --push"; fi && \
 	echo $${cmd} && \
 	$${cmd}

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -54,6 +54,9 @@ $(BUILD_TARGETS):
 
 test: build $(TEST_TARGETS)
 
+push:
+	@echo "To push all images, use make PUSH=true VERSION=<tag>, to push a specific image, use something like make mariadb_10.3 PUSH=true VERSION=<tag>" && exit 1
+
 # make mariadb_10.2_test mysql_8.0_test
 # make test # for all
 $(TEST_TARGETS):

--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -38,7 +38,7 @@ fi
 
 eval set -- "$PARSED"
 
-ARCHS=linux/$(arch)
+ARCHS=linux/$(../get_arch.sh)
 MYARCH=${ARCHS}
 PUSH=""
 NO_LOAD=""

--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Build a ddev-dbserver image for variety of mariadb/mysql
+# and per architecture, optionally push
+# By default loads to local docker
+
+set -eu -o pipefail
+
+OS=$(uname -s)
+if [ ${OS} = "Darwin" ]; then
+  if ! command -v brew >/dev/null; then
+    echo "On macOS, homebrew is required to get gnu-getopt" && exit 1
+  fi
+  if ! brew info gnu-getopt >/dev/null; then
+    echo "On macOS, brew install gnu-getopt"
+    exit 1
+  fi
+  PATH="$(brew --prefix gnu-getopt)/bin:$PATH"
+fi
+
+! getopt --test >/dev/null
+if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
+  echo 'getopt --test` failed in this environment.'
+  exit 1
+fi
+
+OPTS=-h,-v:,-d:
+LONGOPTS=db-type:,db-major-version:,db-pinned-version:,archs:,tag:,push,help
+
+! PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@")
+if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+  # e.g. return value is 1
+  #  then getopt has complained about wrong arguments to stdout
+  printf "\n\nFailed parsing options:\n"
+  getopt --longoptions=$LONGOPTS --name "$0" -- "$@"
+  exit 3
+fi
+
+eval set -- "$PARSED"
+
+ARCHS=linux/$(arch)
+MYARCH=${ARCHS}
+PUSH=""
+NO_LOAD=""
+DB_TYPE=mariadb
+DB_MAJOR_VERSION=10.3
+IMAGE_TAG=$(git describe --tags --always --dirty)
+DOCKER_ARGS=""
+
+while true; do
+  case "$1" in
+  --db-type | -d)
+    DB_TYPE=$2
+    shift 2
+    ;;
+  --db-major-version | -v)
+    DB_MAJOR_VERSION=$2
+    shift 2
+    ;;
+  --db-pinned-version)
+    DB_PINNED_VERSION=$2
+    shift 2
+    ;;
+  --archs)
+    ARCHS=$2
+    shift 2
+    ;;
+  --push)
+    PUSH=true
+    shift 1
+    ;;
+  --no-load)
+    NO_LOAD=true
+    shift 1
+    ;;
+  --docker-args)
+    DOCKER_ARGS=$2
+    shift 2
+    ;;
+  --tag)
+    IMAGE_TAG=$2
+    shift 2
+    ;;
+  -h | --help)
+    echo "Usage: $0 --db-type [mariadb|mysql] --db-major-version <major> --tag <image_tag> --archs <comma-delimted_architectures> --push --no-load"
+    printf "Examples: $0 ./build_image.sh --db-type mysql --db-major-version 8.0 --tag junker99 --archs linux/amd64 --push
+  $0 --db-type mariadb --db-major-version 10.3 --tag junker99 --archs linux/amd64,linux/arm64"
+    exit 0
+    ;;
+  --)
+    break
+    ;;
+  esac
+done
+
+set -o nounset
+
+if [ -z ${DB_PINNED_VERSION:-} ]; then
+  DB_PINNED_VERSION=${DB_MAJOR_VERSION}
+fi
+
+printf "\n\n========== Building drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG} with pinned version ${DB_PINNED_VERSION} ==========\n"
+
+if [ ! -z ${PUSH:-} ]; then
+  echo "building/pushing drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
+  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" -t "drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}" .
+fi
+
+# By default, load/import into local docker
+if [ -z ${NO_LOAD:-} ]; then
+  if [[ ${ARCHS} =~ ${MYARCH} ]]; then
+    echo "Loading to local docker drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
+    docker buildx build --load --platform ${MYARCH} ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" -t "drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}" .
+  else
+    echo "This architecture (${MYARCH}) was not built, so not loading"
+    exit
+  fi
+fi

--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -25,7 +25,7 @@ if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
 fi
 
 OPTS=-h,-v:,-d:
-LONGOPTS=db-type:,db-major-version:,db-pinned-version:,archs:,tag:,push,help
+LONGOPTS=archs:,db-type:,db-major-version:,db-pinned-version:,docker-args:,tag:,push,help
 
 ! PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@")
 if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
@@ -103,14 +103,18 @@ printf "\n\n========== Building drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION
 
 if [ ! -z ${PUSH:-} ]; then
   echo "building/pushing drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
-  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" -t "drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}" .
+  set -x
+  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_VERSION=${DB_MAJOR_VERSION}" -t "drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}" .
+  set +x
 fi
 
 # By default, load/import into local docker
 if [ -z ${NO_LOAD:-} ]; then
   if [[ ${ARCHS} =~ ${MYARCH} ]]; then
     echo "Loading to local docker drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
-    docker buildx build --load --platform ${MYARCH} ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" -t "drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}" .
+    set -x
+    docker buildx build --load --platform ${MYARCH} ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_VERSION=${DB_MAJOR_VERSION}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" -t "drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}" .
+    set +x
   else
     echo "This architecture (${MYARCH}) was not built, so not loading"
     exit

--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -99,7 +99,7 @@ if [ -z ${DB_PINNED_VERSION:-} ]; then
   DB_PINNED_VERSION=${DB_MAJOR_VERSION}
 fi
 
-printf "\n\n========== Building drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG} with pinned version ${DB_PINNED_VERSION} ==========\n"
+printf "\n\n========== Building drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG} for ${ARCHS} with pinned version ${DB_PINNED_VERSION} ==========\n"
 
 if [ ! -z ${PUSH:-} ]; then
   echo "building/pushing drud/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"

--- a/containers/ddev-dbserver/database-versions
+++ b/containers/ddev-dbserver/database-versions
@@ -1,7 +1,0 @@
-# The format here is majorversion:pinnedimageversion
-# This allows to pin the version (as currently required with 8.0.21)
-MARIADB_VERSIONS_amd64="5.5:5.5 10.0:10.0 10.1:10.1.47 10.2:10.2.34 10.3:10.3.25 10.4:10.4.15 10.5:10.5.6"
-MYSQL_VERSIONS_amd64="5.5:5.5 5.6:5.6 5.7:5.7 8.0:8.0.21"
-MARIADB_VERSIONS_arm64="10.2:10.2.34 10.3:10.3.25 10.4:10.4.15 10.5:10.5.6"
-# MySQL images on Docker Hub currently are amd64 only
-MYSQL_VERSIONS_arm64=

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -1,59 +1,24 @@
 #!/bin/bash
 
 # Find the directory of this script
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 set -o errexit
 set -o pipefail
 set -o nounset
 
-if [ -z "$1" ]; then echo "Argument 'version' is required"; exit 1; fi
-VERSION=$1
-
-if [[ -n "${2-}" ]]; then
-    ONLY_TESTS_FOR=$2
-else
-    ONLY_TESTS_FOR=
+if [ $# != 3 ]; then
+  echo "Usage: $0 <db_type> <db_version> <tag>, for example $0 mariadb 10.3 v1.17.0"
+  exit 1
 fi
+export DB_TYPE=$1
+export DB_VERSION=$2
+export TAG=$3
+export IMAGE=drud/ddev-dbserver-${DB_TYPE}-${DB_VERSION}:${TAG}
 
-function cleanup {
-    true
-}
-trap cleanup EXIT
+export CURRENT_ARCH=$(arch)
 
-export tag=${VERSION}
-export CURRENT_ARCH=$($DIR/../../get_arch.sh)
-
-# Get database versions per database type
-source $DIR/../database-versions
-
-export MARIADB_VERSIONS="MARIADB_VERSIONS_$CURRENT_ARCH"
-export MYSQL_VERSIONS="MYSQL_VERSIONS_$CURRENT_ARCH"
-
-export DB_TYPE=mariadb
-for v in ${!MARIADB_VERSIONS}; do
-    if [[ "$ONLY_TESTS_FOR" == "mysql" ]]; then continue; fi;
-    export baseversion=$(echo $v | awk -F ':' '{print $1}')
-    export fullversion=$(echo $v | awk -F ':' '{print $2}')
-    export IMAGE="drud/ddev-dbserver-$DB_TYPE-$baseversion:$tag"
-    export DB_VERSION=$baseversion
-    # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
-    export PATH="/usr/local/bin:$PATH"
-    bats test || ( echo "bats tests failed for $DB_TYPE $baseversion" && exit 5 )
-    printf "Test successful for $DB_TYPE $baseversion\n\n"
-done
-
-export DB_TYPE=mysql
-for v in ${!MYSQL_VERSIONS}; do
-    if [[ "$ONLY_TESTS_FOR" == "mariadb" ]]; then continue; fi;
-    export baseversion=$(echo $v | awk -F ':' '{print $1}')
-	export fullversion=$(echo $v | awk -F ':' '{print $2}')
-    export IMAGE="drud/ddev-dbserver-$DB_TYPE-$baseversion:$tag"
-    export DB_VERSION=$baseversion
-    # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
-    export PATH="/usr/local/bin:$PATH"
-    bats test || ( echo "bats tests failed for $DB_TYPE $baseversion" && exit 5 )
-    printf "Test successful for $DB_TYPE $baseversion\n\n"
-done
-
-echo "Test successful"
+# /usr/local/bin is added for git-bash, where it may not be in the $PATH.
+export PATH="/usr/local/bin:$PATH"
+bats test || (echo "bats tests failed for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}" && exit 2)
+echo "Test successful for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}"

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -16,7 +16,7 @@ export DB_VERSION=$2
 export TAG=$3
 export IMAGE=drud/ddev-dbserver-${DB_TYPE}-${DB_VERSION}:${TAG}
 
-export CURRENT_ARCH=$(arch)
+export CURRENT_ARCH=$(../get_arch.sh)
 
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -21,4 +21,4 @@ export CURRENT_ARCH=$(arch)
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"
 bats test || (echo "bats tests failed for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}" && exit 2)
-echo "Test successful for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}"
+printf "Test successful for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}\n\n"

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -7,8 +7,6 @@ VERSION := $(shell git describe --tags --always --dirty)
 
 DOCKER_BUILDKIT=1
 
-# Tests always run against amd64 (build host). Once tests have passed, a multi-arch build
-# will be generated and pushed (the amd64 build will be cached automatically to prevent it from building twice).
 BUILD_ARCHS=linux/amd64,linux/arm64
 
 include ../containers_shared.mak

--- a/containers/get_arch.sh
+++ b/containers/get_arch.sh
@@ -1,10 +1,8 @@
 unamearch=$(uname -m)
 case ${unamearch} in
-  x86_64) ARCH="amd64";
+  x86_64 | amd64) ARCH="amd64";
   ;;
-  aarch64) ARCH="arm64";
-  ;;
-  arm64) ARCH="arm64";
+  aarch64 | arm64) ARCH="arm64";
   ;;
   *) printf "${RED}Sorry, your machine architecture ${unamearch} is not currently supported.\n${RESET}" && exit 106
   ;;

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -46,7 +46,7 @@ var WebTag = "20210210_acquia" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20210115_huge_db_snapshot_restore"
+var BaseDBTag = "20210214_db_build_refactor"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

ddev-dbserver builds have been awkward to test; there weren't targets for each version, so you had to wait forever, etc.

## How this PR Solves The Problem:

* Provide a separate target for each build. For example `make mariadb_10.3_both`
* Provide a target to build all, `make build` or just `make`
* Provide a target to test each one, like `make mariadb_10.3_test`
* Provide `make test` for the do-all build and test

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

