### PR TITLE
Remove .DS_Store files before restoring snapshot, fixes #2765

### DIFF
--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -29,6 +29,8 @@ if [ $# = "2" -a "${1:-}" = "restore_snapshot" ] ; then
   snapshot_dir="/mnt/ddev_config/db_snapshots/${2:-nothingthere}"
   if [ -d "$snapshot_dir" ] ; then
     echo "Restoring from snapshot directory $snapshot_dir"
+    # Ugly macOS .DS_Store in this directory can break the restore
+    find ${snapshot_dir} -name .DS_Store -print0 | xargs rm -f
     sudo rm -rf /var/lib/mysql/*
   else
     echo "$snapshot_dir does not exist, not attempting restore of snapshot"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,13 +40,13 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210215_ds_store" // Note that this can be overridden by make
+var WebTag = "20210210_acquia" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20210214_db_build_refactor"
+var BaseDBTag = "20210215_ds_store"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210210_acquia" // Note that this can be overridden by make
+var WebTag = "20210215_ds_store" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2765 : `ddev snapshot restore` can fail when there is already a .DS_Store file in the snapshot directory and when the snapshot also contains a .DS_Store

## How this PR Solves The Problem:

Remove .DS_Store before restoring

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

