### PR TITLE
Use only go 1.16 now that it's released

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ BUILD_OS = $(shell go env GOHOSTOS)
 BUILD_ARCH = $(shell go env GOHOSTARCH)
 VERSION_LDFLAGS=$(foreach v,$(VERSION_VARIABLES),-X '$(PKG)/pkg/version.$(v)=$($(v))')
 LDFLAGS=-extldflags -static $(VERSION_LDFLAGS)
-BUILD_IMAGE ?= drud/golang-build-container:v1.16-rc1
+BUILD_IMAGE ?= drud/golang-build-container:v1.16.0
 DOCKERBUILDCMD=docker run -t --rm                     \
           	    -v "/$(PWD)://workdir$(DOCKERMOUNTFLAG)"                              \
           	    -e GOPATH="//workdir/$(GOTMP)" \
@@ -116,7 +116,6 @@ $(TARGETS): pullbuildimage $(GOFILES)
 	export GOOS="$${TARGET%_*}" && \
 	export GOARCH="$${TARGET#*_}" && \
 	export GOBUILDER=go && \
-	if [ $$TARGET = "darwin_arm64" ]; then GOBUILDER=go1.16; fi && \
 	mkdir -p $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	chmod 777 $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	$(DOCKERBUILDCMD) \


### PR DESCRIPTION
## The Problem/Issue/Bug:

Before go 1.16 was released we used a hodgepodge of go1.15 for non-M1 and go1.16-beta for M1 builds. 

Now consolidated since go 1.16 is out.

