### PR TITLE
Experiment with removing chown from ddev-ssh-agent startup script

### DIFF
--- a/containers/ddev-ssh-agent/files/entry.sh
+++ b/containers/ddev-ssh-agent/files/entry.sh
@@ -32,7 +32,7 @@ debug_msg ()
   fi
 }
 
-mkdir -p $SSH_KEY_DIR && chown $UID $SSH_KEY_DIR && chmod 700 $SSH_KEY_DIR
+mkdir -p $SSH_KEY_DIR && ( chmod 700 $SSH_KEY_DIR || true )
 mkdir -p $SOCKET_DIR
 
 case "$1" in

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -62,7 +62,7 @@ var RouterTag = "20210106_nginx_default_server" // Note that this can be overrid
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
-var SSHAuthTag = "20210213_db_image_no_sudo"
+var SSHAuthTag = "20210217_ddev_ssh_agent_chown"
 
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The removal of sudo from ddev-ssh-agent missed one thing - a chown that can't work or is unnecessary.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

