### PR TITLE
[tests only] git install bats-core since it doesn't seem to be working from package

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -22,18 +22,12 @@ fi
 # Upgrade various items on various operating systems
 case $os in
 darwin)
-    for item in mkcert mkdocs golang golangci-lint bats-core ddev; do
+    for item in mkcert mkdocs golang golangci-lint ddev; do
         brew upgrade $item || brew install $item || true
     done
     ;;
 windows)
     choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs || true
-    if ! command -v golangci-lint >/dev/null 2>&1 ; then
-      (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0) || true
-    fi
-    if [ "$(bats --version)" != "Bats 1.2.0" ]; then
-        cd ~/workspace/bats-core/ && git fetch && git checkout v1.2.0 && ./install.sh /usr/local
-    fi
     ;;
 esac
 

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -32,10 +32,13 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 brew tap drud/ddev >/dev/null
-for item in osslsigncode golang mingw-w64 mkcert mkdocs ddev bats-core; do
+brew unlink bats-core || true
+for item in osslsigncode golang mingw-w64 mkcert mkdocs ddev; do
     brew install $item >/dev/null || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item >/dev/null
 done
 brew install --build-from-source makensis
+
+git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local
 
 npm install --global markdownlint-cli
 markdownlint --version

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -19,7 +19,7 @@ brew cask install ngrok >/dev/null
 brew tap drud/ddev >/dev/null
 brew unlink python@2 >/dev/null || true
 
-brew install mysql-client zip makensis jq expect coreutils golang ddev mkcert osslsigncode ghr gnu-getopt libgsf glib pcre bats-core >/dev/null || true
+brew install mysql-client zip makensis jq expect coreutils golang ddev mkcert osslsigncode ghr gnu-getopt libgsf glib pcre >/dev/null || true
 brew link mysql-client zip makensis jq expect coreutils golang ddev mkcert osslsigncode ghr gnu-getopt libgsf glib pcre >/dev/null
 
 brew link --force mysql-client >/dev/null

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -32,11 +32,13 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 brew tap drud/ddev >/dev/null
-for item in golang golangci-lint mkcert bats-core; do
+for item in golang golangci-lint mkcert; do
     brew install $item >/dev/null || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item >/dev/null
 done
 
 mkcert -install
+
+git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local
 
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
 

--- a/.github/workflows/selfhosted-upgrades.sh
+++ b/.github/workflows/selfhosted-upgrades.sh
@@ -22,7 +22,7 @@ fi
 # Upgrade various items on various operating systems
 case $os in
 darwin)
-    for item in mkcert mkdocs golang golangci-lint bats-core ddev; do
+    for item in mkcert mkdocs golang golangci-lint ddev; do
         brew upgrade $item || brew install $item || true
     done
     ;;
@@ -30,9 +30,6 @@ windows)
     choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs || true
     if ! command -v golangci-lint >/dev/null 2>&1 ; then
       (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0) || true
-    fi
-    if [ "$(bats --version)" != "Bats 1.2.0" ]; then
-        cd ~/workspace/bats-core/ && git fetch && git checkout v1.2.0 && ./install.sh /usr/local
     fi
     ;;
 esac

--- a/docs/developers/scripts/windows_buildkite_setup.sh
+++ b/docs/developers/scripts/windows_buildkite_setup.sh
@@ -24,9 +24,6 @@ perl -pi -e 's/autocrlf = true/autocrlf = false\n\teol = lf/' "/c/Program Files/
 # Install Ubuntu from Microsoft store
 # Then wsl --set-default Ubuntu
 
-# install bats
-cd /tmp && curl -L -O https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz && tar -zxf v1.2.0.tar.gz && cd bats-core-1.2.0 && ./install.sh /usr/local
-
 # Install buildkite-agent
 LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/buildkite/agent/releases/latest)
 LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')

--- a/docs/developers/scripts/windows_github_agent_setup.sh
+++ b/docs/developers/scripts/windows_github_agent_setup.sh
@@ -19,9 +19,6 @@ perl -pi -e 's/autocrlf = true/autocrlf = false\n\teol = lf/' "/c/Program Files/
 # Install Ubuntu from Microsoft store
 # Then wsl --set-default Ubuntu
 
-# install bats
-cd /tmp && curl -L -O https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz && tar -zxf v1.2.0.tar.gz && cd bats-core-1.2.0 && ./install.sh /usr/local
-
 # Get firewall set up with a single run
 winpty docker run -it --rm -p 80 busybox ls
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've seen the error from bats a couple of times recently and already fixed it in the travis build. 
```
/home/circleci/ddev/containers/ddev-dbserver/test/functions.sh.bash does not exist
/usr/local/libexec/bats-exec-suite: line 20: let: count+=: syntax error: operand expected (error token is "+=")
bats tests failed for DB_TYPE mariadb DB_VERSION=5.5 TAG=v1.17.0-alpha6
```
This fixed with this approach in the travis build. But there it was npm-installed and a new version. Here it's homebrew and apparently not new. 

Anyway, here's hoping. This only affects the nightly build, because that's the only place we're doing container build (which uses bats) on circleci.

This also removes bats-core from lots of places since we only use it on Linux these days.
