### PR TITLE
Strip _ce from docker version if added by some linux distros, fixes #2815

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -388,6 +388,8 @@ func CheckDockerVersion(versionConstraint string) error {
 	if err != nil {
 		return fmt.Errorf("no docker")
 	}
+	// If docker version has "_ce", remove it. This happens on OpenSUSE Tumbleweed at least
+	currentVersion = strings.TrimSuffix(currentVersion, "_ce")
 	dockerVersion, err := semver.NewVersion(currentVersion)
 	if err != nil {
 		return err


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2815 reports that OpenSUSE Tumbleweed is building docker with the version "20.10.3_ce", and so we don't consider it valid when checking docker version.

## How this PR Solves The Problem:

Strip the suffix "_ce" from docker version before processing. This is a bit fragile, but it fixes the issue with opensuse. 

## Manual Testing Instructions:

Tested with `ddev start` on OpenSUSE.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

