### PR TITLE
Add linux types for buildkite-agent

### DIFF
--- a/.buildkite/linux-amd64.yml
+++ b/.buildkite/linux-amd64.yml
@@ -1,6 +1,7 @@
   - command: ".buildkite/test.sh"
     agents:
-      - "os=linux,arch=amd64"
+      - "os=linux"
+      - "architecture=amd64"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/linux-amd64.yml
+++ b/.buildkite/linux-amd64.yml
@@ -1,0 +1,8 @@
+  - command: ".buildkite/test.sh"
+    agents:
+      - "os=linux,arch=amd64"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: true
+      BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
+      BUILDKIT_PROGRESS: plain
+    parallelism: 1

--- a/.buildkite/linux-arm64.yml
+++ b/.buildkite/linux-arm64.yml
@@ -1,6 +1,7 @@
   - command: ".buildkite/test.sh"
     agents:
-      - "os=linux,arch=arm64"
+      - "os=linux"
+      - "architecture=arm64"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/linux-arm64.yml
+++ b/.buildkite/linux-arm64.yml
@@ -1,0 +1,8 @@
+  - command: ".buildkite/test.sh"
+    agents:
+      - "os=linux,arch=arm64"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: true
+      BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
+      BUILDKIT_PROGRESS: plain
+    parallelism: 1

--- a/.buildkite/macos_container.yml
+++ b/.buildkite/macos_container.yml
@@ -2,6 +2,7 @@
     agents:
       - "os=macos"
       - "dockertype=dockerformac"
+      - "architecture=amd64"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -69,7 +69,9 @@ echo "--- running sanetestbot.sh"
 ( docker images | awk '/drud/ {print $1":"$2 }' | xargs -L1 docker pull ) || true
 
 # homebrew sometimes removes /usr/local/etc/my.cnf.d
-mkdir -p "$(brew --prefix)/etc/my.cnf.d"
+if command -v brew >/dev/null; then
+  mkdir -p "$(brew --prefix)/etc/my.cnf.d"
+fi
 
 echo "--- Running tests..."
 make test

--- a/.buildkite/windows10_container.yml
+++ b/.buildkite/windows10_container.yml
@@ -2,6 +2,7 @@
     agents:
       - "os=windows"
       - "dockertype=dockerforwindows"
+      - "architecture=amd64"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
     parallelism: 1

--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -2,6 +2,7 @@
     agents:
       - "os=windows"
       - "dockertype=dockerforwindows"
+      - "architecture=amd64"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       DDEV_TEST_USE_NFSMOUNT: true

--- a/.buildkite/wsl2.yml
+++ b/.buildkite/wsl2.yml
@@ -1,6 +1,7 @@
   - command: ".buildkite/test.sh"
     agents:
       - "os=wsl2"
+      - "architecture=amd64"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds


### PR DESCRIPTION
## The Problem/Issue/Bug:

Experimenting with linux-arm64 and linux-amd64 on buildkite. It might save us some money on travis-ci.

