### PR TITLE
Don't let app.Exec() run against non-running container, fixes #1858

### DIFF
--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -46,11 +46,14 @@ ddev ssh -d /var/www/html`,
 		if !nodeps.ArrayContainsString([]string{"web", "db", "dba", "solr"}, serviceType) {
 			shell = "sh"
 		}
-		_ = app.ExecWithTty(&ddevapp.ExecOpts{
+		err = app.ExecWithTty(&ddevapp.ExecOpts{
 			Service: serviceType,
 			Cmd:     shell + " -l",
 			Dir:     sshDirArg,
 		})
+		if err != nil {
+			util.Failed("Failed to ddev ssh %s: %v", serviceType, err)
+		}
 	},
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1064,7 +1064,16 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if opts.Service == "" {
 		opts.Service = "web"
 	}
-	err := app.ProcessHooks("pre-exec")
+
+	container, err := dockerutil.FindContainerByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
+	if err != nil || container == nil {
+		return "", "", fmt.Errorf("service %s does not exist in project %s", opts.Service, app.Name)
+	}
+	if container.State != "running" {
+		return "", "", fmt.Errorf("service %s is not current running in project %s", opts.Service, app.Name)
+	}
+
+	err = app.ProcessHooks("pre-exec")
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to process pre-exec hooks: %v", err)
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1068,7 +1068,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	state, err := dockerutil.GetContainerStateByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
 	if state != "running" {
 		if state == "doesnotexist" {
-			return "", "", fmt.Errorf("service %s does not currently exixst in project %s (state=%s)", opts.Service, app.Name, state)
+			return "", "", fmt.Errorf("service %s does not exist in project %s (state=%s)", opts.Service, app.Name, state)
 		}
 		return "", "", fmt.Errorf("service %s is not currently running in project %s (state=%s). Try `ddev logs -s %s` to see what happened to it.", opts.Service, app.Name, state, opts.Service)
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1067,7 +1067,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 
 	container, err := dockerutil.FindContainerByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
 	if err != nil || container == nil {
-		return "", "", fmt.Errorf("service %s does not exist in project %s", opts.Service, app.Name)
+		return "", "", fmt.Errorf("service %s is not running in project %s", opts.Service, app.Name)
 	}
 	if container.State != "running" {
 		return "", "", fmt.Errorf("service %s is not current running in project %s", opts.Service, app.Name)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1067,7 +1067,10 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 
 	state, err := dockerutil.GetContainerStateByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
 	if state != "running" {
-		return "", "", fmt.Errorf("service %s is not currently running in project %s (state=%s)", opts.Service, app.Name, state)
+		if state == "doesnotexist" {
+			return "", "", fmt.Errorf("service %s does not currently exixst in project %s (state=%s)", opts.Service, app.Name, state)
+		}
+		return "", "", fmt.Errorf("service %s is not currently running in project %s (state=%s). Try `ddev logs -s %s` to see what happened to it.", opts.Service, app.Name, state, opts.Service)
 	}
 
 	err = app.ProcessHooks("pre-exec")

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1066,11 +1066,11 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	}
 
 	state, err := dockerutil.GetContainerStateByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
-	if state != "running" {
+	if err != nil || state != "running" {
 		if state == "doesnotexist" {
 			return "", "", fmt.Errorf("service %s does not exist in project %s (state=%s)", opts.Service, app.Name, state)
 		}
-		return "", "", fmt.Errorf("service %s is not currently running in project %s (state=%s). Try `ddev logs -s %s` to see what happened to it.", opts.Service, app.Name, state, opts.Service)
+		return "", "", fmt.Errorf("service %s is not currently running in project %s (state=%s), use `ddev logs -s %s` to see what happened to it", opts.Service, app.Name, state, opts.Service)
 	}
 
 	err = app.ProcessHooks("pre-exec")
@@ -1146,7 +1146,7 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 	}
 
 	state, err := dockerutil.GetContainerStateByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
-	if state != "running" {
+	if err != nil || state != "running" {
 		return fmt.Errorf("service %s is not current running in project %s (state=%s)", opts.Service, app.Name, state)
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1067,7 +1067,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 
 	state, err := dockerutil.GetContainerStateByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
 	if state != "running" {
-		return "", "", fmt.Errorf("service %s is not current running in project %s (state=%s)", opts.Service, app.Name, state)
+		return "", "", fmt.Errorf("service %s is not currently running in project %s (state=%s)", opts.Service, app.Name, state)
 	}
 
 	err = app.ProcessHooks("pre-exec")

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1065,12 +1065,9 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		opts.Service = "web"
 	}
 
-	container, err := dockerutil.FindContainerByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
-	if err != nil || container == nil {
-		return "", "", fmt.Errorf("service %s is not running in project %s", opts.Service, app.Name)
-	}
-	if container.State != "running" {
-		return "", "", fmt.Errorf("service %s is not current running in project %s", opts.Service, app.Name)
+	state, err := dockerutil.GetContainerStateByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
+	if state != "running" {
+		return "", "", fmt.Errorf("service %s is not current running in project %s (state=%s)", opts.Service, app.Name, state)
 	}
 
 	err = app.ProcessHooks("pre-exec")
@@ -1143,6 +1140,11 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 
 	if opts.Service == "" {
 		opts.Service = "web"
+	}
+
+	state, err := dockerutil.GetContainerStateByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
+	if state != "running" {
+		return fmt.Errorf("service %s is not current running in project %s (state=%s)", opts.Service, app.Name, state)
 	}
 
 	exec := []string{"exec"}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1969,10 +1969,11 @@ func TestDdevExec(t *testing.T) {
 	assert.NoError(err)
 
 	// Make sure that exec works on non-ddev container like busybox as well
-	_, _, err = app.Exec(&ddevapp.ExecOpts{
+	grepOpts := &ddevapp.ExecOpts{
 		Service: "busybox",
 		Cmd:     "ls | grep bin",
-	})
+	}
+	_, _, err = app.Exec(grepOpts)
 	assert.NoError(err)
 
 	_, stderr, err := app.Exec(&ddevapp.ExecOpts{
@@ -1982,10 +1983,14 @@ func TestDdevExec(t *testing.T) {
 	assert.Error(err)
 	assert.Contains(stderr, "parameter not set")
 
-	_, stderr, err = app.Exec(&ddevapp.ExecOpts{
+	errorOpts := &ddevapp.ExecOpts{
 		Service: "busybox",
 		Cmd:     "this is an error;",
-	})
+	}
+	_, stderr, err = app.Exec(errorOpts)
+	assert.Error(err)
+	assert.Contains(stderr, "this: not found")
+	err = app.ExecWithTty(errorOpts)
 	assert.Error(err)
 	assert.Contains(stderr, "this: not found")
 
@@ -2009,7 +2014,7 @@ func TestDdevExec(t *testing.T) {
 	assert.NoError(err)
 	_, _, err = app.Exec(&simpleOpts)
 	assert.Error(err)
-	assert.Contains(err.Error(), "not currently running")
+	assert.Contains(err.Error(), "does not exist")
 	assert.Contains(err.Error(), "state=doesnotexist")
 
 	runTime()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1905,126 +1905,115 @@ func TestDdevExec(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 	testDir, _ := os.Getwd()
 
-	for index, site := range TestSites {
-		switchDir := site.Chdir()
-		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevExec", site.Name))
+	site := TestSites[0]
+	switchDir := site.Chdir()
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevExec", site.Name))
 
-		if index == 0 {
+	// Make a dummy service out of busybox
+	err := fileutil.CopyFile(filepath.Join(testDir, "testdata", t.Name(), "docker-compose.busybox.yaml"), filepath.Join(site.Dir, ".ddev", "docker-compose.busybox.yaml"))
+	assert.NoError(err)
 
-			err := fileutil.CopyFile(filepath.Join(testDir, "testdata", t.Name(), "docker-compose.busybox.yaml"), filepath.Join(site.Dir, ".ddev", "docker-compose.busybox.yaml"))
-			defer func() {
-				err = os.RemoveAll(filepath.Join(site.Dir, ".ddev", "docker-compose.busybox.yaml"))
-				assert.NoError(err)
-			}()
-			assert.NoError(err)
-		}
-		err := app.Init(site.Dir)
-		assert.NoError(err)
+	err = app.Init(site.Dir)
+	assert.NoError(err)
 
-		app.Hooks = map[string][]ddevapp.YAMLTask{"post-exec": {{"exec-host": "touch hello-post-exec-" + app.Name}}, "pre-exec": {{"exec-host": "touch hello-pre-exec-" + app.Name}}}
-		defer func() {
-			app.Hooks = nil
-			_ = app.Stop(true, false)
-			_ = app.WriteConfig()
-		}()
-
-		startErr := app.Start()
-		if startErr != nil {
-			logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
-			assert.NoError(err)
-			t.Fatalf("app.Start() failed err=%v, logs from broken container:\n=======\n%s\n========\n", startErr, logs)
-		}
-
-		out, _, err := app.Exec(&ddevapp.ExecOpts{
-			Service: "web",
-			Cmd:     "pwd",
-		})
-		assert.NoError(err)
-		assert.Contains(out, "/var/www/html")
-
-		assert.FileExists("hello-pre-exec-" + app.Name)
-		assert.FileExists("hello-post-exec-" + app.Name)
-		err = os.Remove("hello-pre-exec-" + app.Name)
-		assert.NoError(err)
-		err = os.Remove("hello-post-exec-" + app.Name)
-		assert.NoError(err)
-
-		out, _, err = app.Exec(&ddevapp.ExecOpts{
-			Service: "web",
-			Dir:     "/usr/local",
-			Cmd:     "pwd",
-		})
-		assert.NoError(err)
-		assert.Contains(out, "/usr/local")
-
-		_, _, err = app.Exec(&ddevapp.ExecOpts{
-			Service: "db",
-			Cmd:     "mysql -e 'DROP DATABASE db;'",
-		})
-		assert.NoError(err)
-		_, _, err = app.Exec(&ddevapp.ExecOpts{
-			Service: "db",
-			Cmd:     "mysql information_schema -e 'CREATE DATABASE db;'",
-		})
-		assert.NoError(err)
-
-		switch app.GetType() {
-		case nodeps.AppTypeDrupal6:
-			fallthrough
-		case nodeps.AppTypeDrupal7:
-			out, _, err = app.Exec(&ddevapp.ExecOpts{
-				Service: "web",
-				Cmd:     "drush status",
-			})
-			assert.NoError(err)
-			assert.Regexp("PHP configuration[ :]*/etc/php/[0-9].[0-9]/cli/php.ini", out)
-		case nodeps.AppTypeWordPress:
-			out, _, err = app.Exec(&ddevapp.ExecOpts{
-				Service: "web",
-				Cmd:     "wp --info",
-			})
-			assert.NoError(err)
-			assert.Regexp("/etc/php.*/php.ini", out)
-
-			// Make sure error works for unset env vars, etc.
-			_, stderr, err := app.Exec(&ddevapp.ExecOpts{
-				Service: "web",
-				Cmd:     "echo $ENVDOESNOTEXIST",
-			})
-			assert.Error(err)
-			assert.Contains(stderr, "ENVDOESNOTEXIST: unbound variable")
-
-		}
-
-		// Make sure that exec works on non-ddev container like busybox as well
-		if index == 0 {
-			_, _, err = app.Exec(&ddevapp.ExecOpts{
-				Service: "busybox",
-				Cmd:     "ls | grep bin",
-			})
-			assert.NoError(err)
-
-			_, stderr, err := app.Exec(&ddevapp.ExecOpts{
-				Service: "busybox",
-				Cmd:     "echo $ENVDOESNOTEXIST",
-			})
-			assert.Error(err)
-			assert.Contains(stderr, "parameter not set")
-
-			_, stderr, err = app.Exec(&ddevapp.ExecOpts{
-				Service: "busybox",
-				Cmd:     "this is an error;",
-			})
-			assert.Error(err)
-			assert.Contains(stderr, "this: not found")
-		}
-
+	t.Cleanup(func() {
+		app.Hooks = nil
 		err = app.Stop(true, false)
 		assert.NoError(err)
+		err = app.WriteConfig()
+		assert.NoError(err)
+		err = os.RemoveAll(filepath.Join(site.Dir, ".ddev", "docker-compose.busybox.yaml"))
+		assert.NoError(err)
+	})
 
-		runTime()
-		switchDir()
+	app.Hooks = map[string][]ddevapp.YAMLTask{"post-exec": {{"exec-host": "touch hello-post-exec-" + app.Name}}, "pre-exec": {{"exec-host": "touch hello-pre-exec-" + app.Name}}}
+
+	startErr := app.Start()
+	if startErr != nil {
+		logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		assert.NoError(err)
+		t.Fatalf("app.Start() failed err=%v, logs from broken container:\n=======\n%s\n========\n", startErr, logs)
 	}
+
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
+		Service: "web",
+		Cmd:     "pwd",
+	})
+	assert.NoError(err)
+	assert.Contains(out, "/var/www/html")
+
+	assert.FileExists("hello-pre-exec-" + app.Name)
+	assert.FileExists("hello-post-exec-" + app.Name)
+	err = os.Remove("hello-pre-exec-" + app.Name)
+	assert.NoError(err)
+	err = os.Remove("hello-post-exec-" + app.Name)
+	assert.NoError(err)
+
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "web",
+		Dir:     "/usr/local",
+		Cmd:     "pwd",
+	})
+	assert.NoError(err)
+	assert.Contains(out, "/usr/local")
+
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "db",
+		Cmd:     "mysql -e 'DROP DATABASE db;'",
+	})
+	assert.NoError(err)
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "db",
+		Cmd:     "mysql information_schema -e 'CREATE DATABASE db;'",
+	})
+	assert.NoError(err)
+
+	// Make sure that exec works on non-ddev container like busybox as well
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "busybox",
+		Cmd:     "ls | grep bin",
+	})
+	assert.NoError(err)
+
+	_, stderr, err := app.Exec(&ddevapp.ExecOpts{
+		Service: "busybox",
+		Cmd:     "echo $ENVDOESNOTEXIST",
+	})
+	assert.Error(err)
+	assert.Contains(stderr, "parameter not set")
+
+	_, stderr, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "busybox",
+		Cmd:     "this is an error;",
+	})
+	assert.Error(err)
+	assert.Contains(stderr, "this: not found")
+
+	// Now kill the busybox service and make sure that responses to app.Exec are correct
+	client := dockerutil.GetDockerClient()
+	bbc, err := dockerutil.FindContainerByName(fmt.Sprintf("ddev-%s-%s", app.Name, "busybox"))
+	require.NoError(t, err)
+	err = client.StopContainer(bbc.ID, 2)
+	assert.NoError(err)
+
+	simpleOpts := ddevapp.ExecOpts{
+		Service: "busybox",
+		Cmd:     "ls",
+	}
+	_, _, err = app.Exec(&simpleOpts)
+	assert.Error(err)
+	assert.Contains(err.Error(), "not currently running")
+	assert.Contains(err.Error(), "state=exited")
+
+	err = client.RemoveContainer(docker.RemoveContainerOptions{ID: bbc.ID, Force: true})
+	assert.NoError(err)
+	_, _, err = app.Exec(&simpleOpts)
+	assert.Error(err)
+	assert.Contains(err.Error(), "not currently running")
+	assert.Contains(err.Error(), "state=doesnotexist")
+
+	runTime()
+	switchDir()
 }
 
 // TestDdevLogs tests the container log output functionality.

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -86,6 +86,18 @@ func FindContainerByName(name string) (*docker.APIContainers, error) {
 	return &containers[0], nil
 }
 
+// GetContainerStateByName returns container state for the named container
+func GetContainerStateByName(name string) (string, error) {
+	container, err := FindContainerByName(name)
+	if err != nil || container == nil {
+		return "doesnotexist", fmt.Errorf("container %s does not exist", name)
+	}
+	if container.State == "running" {
+		return container.State, nil
+	}
+	return container.State, fmt.Errorf("container %s is state=%s so can't be accessed", name)
+}
+
 // FindContainerByLabels takes a map of label names and values and returns any docker containers which match all labels.
 func FindContainerByLabels(labels map[string]string) (*docker.APIContainers, error) {
 	containers, err := FindContainersByLabels(labels)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -95,7 +95,7 @@ func GetContainerStateByName(name string) (string, error) {
 	if container.State == "running" {
 		return container.State, nil
 	}
-	return container.State, fmt.Errorf("container %s is state=%s so can't be accessed", name)
+	return container.State, fmt.Errorf("container %s is in state=%s so can't be accessed", name, container.State)
 }
 
 // FindContainerByLabels takes a map of label names and values and returns any docker containers which match all labels.


### PR DESCRIPTION
## The Problem/Issue/Bug:

On occasion, app.Exec() will try to access a container that isn't running. This can happen especially when a container has died, especially a 3rd party service container.

## How this PR Solves The Problem:

Check to see if the container exists and is running.

- [x] Need test coverage

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

