### PR TITLE
Enable zend assertions by default

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/mods-available/assert.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/mods-available/assert.ini
@@ -1,0 +1,2 @@
+[Assertion]
+zend.assertions = 1

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/mods-available/assert.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/mods-available/assert.ini
@@ -1,0 +1,2 @@
+[Assertion]
+zend.assertions = 1

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/mods-available/assert.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/mods-available/assert.ini
@@ -1,0 +1,2 @@
+[Assertion]
+zend.assertions = 1

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/mods-available/assert.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/mods-available/assert.ini
@@ -1,0 +1,2 @@
+[Assertion]
+zend.assertions = 1

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/mods-available/assert.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/mods-available/assert.ini
@@ -1,0 +1,2 @@
+[Assertion]
+zend.assertions = 1

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/mods-available/assert.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/mods-available/assert.ini
@@ -1,0 +1,2 @@
+[Assertion]
+zend.assertions = 1

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/mods-available/assert.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/mods-available/assert.ini
@@ -1,0 +1,2 @@
+[Assertion]
+zend.assertions = 1

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -61,6 +61,9 @@ else
   disable_xdebug
 fi
 
+# Enable assertions by default.
+phpenmod assert
+
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -31,6 +31,11 @@
     [[ "${v}" > "2." ]]
 }
 
+@test "verify that PHP assertion are enabled by default" {
+    enabled=$(docker exec $CONTAINER_NAME sh -c "php -r 'echo ini_get("'"zend.assertions"'");'")
+    [[ "${enabled}" -eq 1 ]]
+}
+
 @test "verify there aren't \"closed keepalive connection\" complaints" {
 	(docker logs $CONTAINER_NAME 2>&1 | grep -v "closed keepalive connection")  || (echo "Found unwanted closed keepalive connection messages" && exit 103)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210227_acquia_fixups" // Note that this can be overridden by make
+var WebTag = "20210226_heddn_assert_enable" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Since ddev is a development toolkit item, it would make sense to enable zend assertions by default. It was disabled.

## How this PR Solves The Problem:

This enables zend assertions.

## Manual Testing Instructions:

From the php manual:
```
// Make an assertion that should fail
assert('2 < 1');
assert('2 < 1', 'Two is less than one');
```

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
I don't think testing is needed. We're just enabling something built-in to PHP.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
PHP asserts are now enabled by default. If this is not desired, see how to override PHP directives in https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-php-configuration-phpini and set `zend.assertions` to `0` or `-1` as desired.
