### PR TITLE
Update to new deb.sury.org key, fixes #2832

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -61,7 +61,7 @@ echo "--- running sanetestbot.sh"
 ./.buildkite/sanetestbot.sh
 
 # Update all images that could have changed
-( docker images | awk '/drud/ {print $1":"$2 }' | xargs -L1 docker pull ) || true
+( docker images | awk '/drud|phpmyadmin/ {print $1":"$2 }' | xargs -L1 docker pull ) || true
 
 # homebrew sometimes removes /usr/local/etc/my.cnf.d
 mkdir -p /usr/local/etc/my.cnf.d

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -99,6 +99,8 @@ RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/MailHog/releases/
 # 2021-02-24 the deb.sury.org key will expire 2021-03-17 so we need to get the new one
 RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests
+
 RUN curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus
 RUN curl -sSL -O $DDEV_LIVE_DOWNLOAD_URL && unzip ddev-live.zip && mv ddev-live /usr/local/bin && chmod +x /usr/local/bin/ddev-live && rm ddev-live.zip
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -96,6 +96,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
 ADD ddev-webserver-dev-base-files /
 RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_${MAILHOG_ARCH} -o /usr/local/bin/mailhog; 
 
+# 2021-02-24 the deb.sury.org key will expire 2021-03-17 so we need to get the new one
+RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+
 RUN curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus
 RUN curl -sSL -O $DDEV_LIVE_DOWNLOAD_URL && unzip ddev-live.zip && mv ddev-live /usr/local/bin && chmod +x /usr/local/bin/ddev-live && rm ddev-live.zip
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -491,7 +491,7 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 			assert.NoError(err)
 			out, err := exec.RunCommand("docker", []string{"logs", container.Names[0]})
 			assert.NoError(err)
-			t.Logf("DB Logs after app.Start: \n%s\n=== END DB LOGS ===", out)
+			t.Logf("DB Logs after app.Start: \n%s\n== END DB LOGS ==", out)
 		}
 
 		// ensure .ddev/docker-compose*.yaml exists inside .ddev site folder
@@ -1282,7 +1282,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		switchDir := site.Chdir()
 		defer switchDir()
 		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevFullSiteSetup", site.Name))
-		t.Logf("=== BEGIN TestDdevFullSiteSetup for %s\n", site.Name)
+		t.Logf("== BEGIN TestDdevFullSiteSetup for %s\n", site.Name)
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
 		assert.NoError(err)
@@ -1304,7 +1304,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		assert.NoError(err)
 
 		// Validate PHPMyAdmin is working and database named db is present
-		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+":8036/tbl_create.php?server=1&db=db", "Table name:")
+		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+":8036/index.php?route=/database/structure&server=1&db=db", "No tables found in database")
 		// Validate MailHog is working and "connected"
 		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+":8025/#", "Connected")
 
@@ -1614,13 +1614,13 @@ func TestDdevImportFilesDir(t *testing.T) {
 
 	for _, site := range TestSites {
 		if site.FilesTarballURL == "" && site.FilesZipballURL == "" {
-			t.Logf("=== SKIP TestDdevImportFilesDir for %s (FilesTarballURL and FilesZipballURL are not provided)\n", site.Name)
+			t.Logf("== SKIP TestDdevImportFilesDir for %s (FilesTarballURL and FilesZipballURL are not provided)\n", site.Name)
 			continue
 		}
 
 		switchDir := site.Chdir()
 		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
-		t.Logf("=== BEGIN TestDdevImportFilesDir for %s\n", site.Name)
+		t.Logf("== BEGIN TestDdevImportFilesDir for %s\n", site.Name)
 
 		testcommon.ClearDockerEnv()
 		err = app.Init(site.Dir)
@@ -1656,7 +1656,7 @@ func TestDdevImportFiles(t *testing.T) {
 
 	for _, site := range TestSites {
 		if site.FilesTarballURL == "" && site.FilesZipballURL == "" && site.FullSiteTarballURL == "" {
-			t.Logf("=== SKIP TestDdevImportFiles for %s (FilesTarballURL and FilesZipballURL are not provided)\n", site.Name)
+			t.Logf("== SKIP TestDdevImportFiles for %s (FilesTarballURL and FilesZipballURL are not provided)\n", site.Name)
 			continue
 		}
 
@@ -1708,7 +1708,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
 		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
-		t.Logf("=== BEGIN TestDdevImportFilesCustomUploadDir for %s\n", site.Name)
+		t.Logf("== BEGIN TestDdevImportFilesCustomUploadDir for %s\n", site.Name)
 
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
@@ -2121,7 +2121,7 @@ func TestDdevDescribe(t *testing.T) {
 		healthcheck, inspectErr := exec.RunCommandPipe("sh", []string{"-c", fmt.Sprintf("docker inspect ddev-%s-web|jq -r '.[0].State.Health.Log[-1]'", app.Name)})
 		assert.NoError(inspectErr)
 
-		t.Fatalf("app.StartAndWait(%s) failed: %v, \nweb container healthcheck='%s', \n=== web container logs=\n%s\n=== END web container logs ===", site.Name, err, healthcheck, out)
+		t.Fatalf("app.StartAndWait(%s) failed: %v, \nweb container healthcheck='%s', \n== web container logs=\n%s\n== END web container logs ==", site.Name, err, healthcheck, out)
 	}
 
 	desc, err := app.Describe(false)
@@ -2558,7 +2558,7 @@ func TestHttpsRedirection(t *testing.T) {
 			if startErr != nil {
 				appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 				assert.NoError(getLogsErr)
-				t.Fatalf("app.StartAndWait failure; err=%v \n===== container logs ===\n%s\n", startErr, appLogs)
+				t.Fatalf("app.StartAndWait failure; err=%v \n===== container logs ==\n%s\n", startErr, appLogs)
 			}
 			// Test for directory redirects under https and http
 			for _, parts := range expectations {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.16.6" // Note that this can be overridden by make
+var WebTag = "v1.16.7" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2832: deb.sury.org's key is going to expire, which will wreak havoc on people who use `webimage_extra_packages` after 2021-03-17. 

## How this PR Solves The Problem:

Get the new key into ddev-webserver image.

## Manual Testing Instructions:

`docker run --rm drud/ddev-webserver:v1.16.7 apt-key list` and check the expiration of deb.sury.org key (last one)

