### PR TITLE
Add gitpod support to ddev [skip ci][ci skip]

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,10 @@
+FROM gitpod/workspace-full
+SHELL ["/bin/bash", "-c"]
+# Install ddev
+RUN brew update && brew install golangci-lint
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,7 +8,7 @@ RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
 
-RUN curl -o ~/bin/gitpod-setup-ddev.sh --fail -lLs https://raw.githubusercontent.com/shaal/ddev-gitpod/main/.ddev/gitpod-setup-ddev.sh && chown +x ~/bin/gitpod-setup-ddev.sh
+RUN curl -o ~/bin/gitpod-setup-ddev.sh --fail -lLs https://raw.githubusercontent.com/shaal/ddev-gitpod/main/.ddev/gitpod-setup-ddev.sh && chmod +x ~/bin/gitpod-setup-ddev.sh
 RUN mkcert -install
 
 # Install custom tools, runtimes, etc.

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,6 +5,8 @@ RUN brew update && brew install golangci-lint bash-completion
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"' >>~/.bash_profile
 
+RUN ln -s ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev
+
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:
 # RUN brew install bastet

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,7 +3,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
 
-RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"' >>~/.bash_profile; fi
+RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bash_profile
 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bash_profile && mkdir -p ~/bin
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,11 +1,11 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 # Install ddev
-RUN brew update && brew install golangci-lint bash-completion
+RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"' >>~/.bash_profile
 
-RUN ln -s ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev
+RUN brew unlink ddev && ln -sf ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev && chmod 777 /usr/local/bin/ddev
 
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,6 +8,7 @@ RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
 
+RUN curl -o ~/bin/gitpod-setup-ddev.sh --fail -lLs https://raw.githubusercontent.com/shaal/ddev-gitpod/main/.ddev/gitpod-setup-ddev.sh && chown +x ~/bin/gitpod-setup-ddev.sh
 RUN mkcert -install
 
 # Install custom tools, runtimes, etc.

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,11 +1,11 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
-# Install ddev
-RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
+
+RUN brew update && brew install bash-completion golangci-lint
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"' >>~/.bash_profile
 
-RUN brew unlink ddev && ln -sf ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev && chmod 777 /usr/local/bin/ddev
+RUN ln -sf ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev && chmod 777 /usr/local/bin/ddev
 
 RUN mkcert -install
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,11 +1,12 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
-RUN brew update && brew install bash-completion golangci-lint
+RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"' >>~/.bash_profile
 
-RUN ln -sf ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev && chmod 777 /usr/local/bin/ddev
+RUN echo 'export PATH=~/bin:$PATH' >>~/.bash_profile && mkdir -p ~/bin
+RUN ln -sf ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
 
 RUN mkcert -install
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,9 +3,9 @@ SHELL ["/bin/bash", "-c"]
 
 RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
 
-RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bash_profile
+RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc
 
-RUN echo 'export PATH=~/bin:$PATH' >>~/.bash_profile && mkdir -p ~/bin
+RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
 
 RUN mkcert -install

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,9 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 # Install ddev
-RUN brew update && brew install golangci-lint
+RUN brew update && brew install golangci-lint bash-completion
+
+RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"' >>~/.bash_profile
 
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,6 +7,8 @@ RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" 
 
 RUN brew unlink ddev && ln -sf ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev && chmod 777 /usr/local/bin/ddev
 
+RUN mkcert -install
+
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:
 # RUN brew install bastet

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,10 +3,10 @@ SHELL ["/bin/bash", "-c"]
 
 RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
 
-RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"' >>~/.bash_profile
+RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"' >>~/.bash_profile; fi
 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bash_profile && mkdir -p ~/bin
-RUN ln -sf ~/workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
+RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
 
 RUN mkcert -install
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,6 @@
-image: gitpod/workspace-full
+
+image:
+  file: .gitpod.Dockerfile
 
 tasks:
   - name: docker_up
@@ -9,6 +11,7 @@ tasks:
       while ! docker ps; do
         sleep 1
       done
+      .githooks/linkallchecks.sh
       make
 
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,15 @@
 image: gitpod/workspace-full
 
 tasks:
-  - init: go get -v -t -d ./...
-  - make
+  - name: docker_up
+    command: sudo docker-up
+  - name: make
+    command: |
+      # Wait for docker to come up before doing make (make requires docker)
+      while ! docker ps; do
+        sleep 1
+      done
+      make
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,3 +7,22 @@ tasks:
 vscode:
   extensions:
     - premparihar.gotestexplorer@0.1.10:jvUM8akrQ67vQxfjaxCgCg==
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image: gitpod/workspace-full
+
+tasks:
+  - init: go get -v -t -d ./...
+  - make
+
+vscode:
+  extensions:
+    - premparihar.gotestexplorer@0.1.10:jvUM8akrQ67vQxfjaxCgCg==

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The general workflow for contributing to this project is outlined in this docume
 
 ## Create an Issue
 
-If you find a bug in this project, have trouble following the documentation, or have a question about the project, create an issue! There’s nothing to it and whatever issue you’re having, you’re likely not the only one, so others will find your issue helpful, too. For more information on how issues work, check out GitHub's [Issues guide](http://guides.github.com/features/issues).
+If you find a bug in this project, have trouble following the documentation, or have a question about the project, create an issue! There’s nothing to it and whatever issue you’re having, you’re likely not the only one, so others will find your issue helpful, too. For more information on how issues work, check out GitHub's [Issues guide](http://guides.github.com/features/issues). Or there are lots of [other places for immediate support](https://ddev.readthedocs.io/en/stable/#support-and-user-contributed-documentation).
 
 ### Issues Pro Tips
 
@@ -60,3 +60,7 @@ The rules:
 9. Even though we call these "rules" above, they are actually just guidelines. Since you've read all the rules, you now know that.
 
 If you are having trouble getting into the mood of idiomatic Go, we recommend reading through [Effective Go](https://golang.org/doc/effective_go.html). The [Go Blog](https://blog.golang.org) is also a great resource. Drinking the kool-aid is a lot easier than going thirsty.
+
+## Using Gitpod.io to test PRs
+
+[Gitpod.io](https://www.gitpod.io/) is integrated with DDEV-Local so you don't have to set up a development environment to work on bugs or features. You can just spin up a gitpod instance and go. There's a link on every PR build in the checks to let you do it.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ddev
 
 [![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) [![Go Report Card](https://goreportcard.com/badge/github.com/drud/ddev)](https://goreportcard.com/report/github.com/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2021.svg)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/drud/ddev)
 
 ![ddev logo](images/ddev_logo.png)
 

--- a/docs/developers/building-contributing.md
+++ b/docs/developers/building-contributing.md
@@ -1,5 +1,9 @@
 # Building, Testing, and Contributing
 
+## Open in Gitpod
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/drud/ddev)
+
 ## Pull Requests and PR Preparation
 
 When preparing your pull request, please use a branch name like "2020_<your_username>_short_description" so that it's easy to track to you.


### PR DESCRIPTION
## The Problem/Issue/Bug:

Gitpod is pretty cool. Add gitpod support so that people can use build and test ddev.

## How this PR Solves The Problem:

* Add gitpod.yml for golang setup
- [x] Needs docs in developer area about how to use it. Maybe add to readme. Add a CONTRIBUTING doc.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

