### PR TITLE
move Gitpod's docker-up to a "secondary" terminal

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,8 +3,6 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - name: docker_up
-    command: sudo docker-up
   - name: make
     command: |
       # Wait for docker to come up before doing make (make requires docker)
@@ -13,6 +11,8 @@ tasks:
       done
       .githooks/linkallchecks.sh
       make
+  - name: docker_up
+    command: sudo docker-up      
 
 vscode:
   extensions:


### PR DESCRIPTION
## The Problem/Issue/Bug:
Gitpod requires `sudo docker-up` to run docker commands.
That process run indefinitely.
The other terminal that run `make` command and can show progress and becomes available for additional commands of the user is "hidden" as a second terminal.

## How this PR Solves The Problem:
Switch between the terminal order, so `sudo docker-up` is on secondary terminal, and `make` commands runs in main terminal.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

