### PR TITLE
[Gitpod integration] Prepare make (with docker-up) during prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,9 +10,16 @@ tasks:
         sleep 1
       done
       .githooks/linkallchecks.sh
-      make
   - name: docker_up
     command: sudo docker-up      
+  - init: |
+      # Wait for docker to come up before doing make (make requires docker)
+      while ! docker ps; do
+        sleep 1
+      done
+      .githooks/linkallchecks.sh
+      make
+  - init: sudo docker-up &
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - name: make
+  - name: ready
     command: |
       # Wait for docker to come up before doing make (make requires docker)
       while ! docker ps; do
@@ -12,14 +12,14 @@ tasks:
       .githooks/linkallchecks.sh
   - name: docker_up
     command: sudo docker-up      
-  - init: |
+  - prebuild: |
       # Wait for docker to come up before doing make (make requires docker)
       while ! docker ps; do
         sleep 1
       done
       .githooks/linkallchecks.sh
       make
-  - init: sudo docker-up &
+  - prebuild: sudo docker-up &
 
 vscode:
   extensions:


### PR DESCRIPTION
## The Problem/Issue/Bug:
Users have to wait for make to run when starting a workspace.

## How this PR Solves The Problem:
Make (with docker-up) can run during prebuild.
A user can start workspace after make already finished running, and ready to work with `ddev`.

## Manual Testing Instructions:
Run Gitpod in this PR, and confirm you can run `ddev` in the terminal.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

