### PR TITLE
Add circleci-based arm64 testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,6 +319,7 @@ jobs:
   lx_arm64_container_test:
     machine:
       image: ubuntu-2004:202101-01
+    resource_class: arm.medium
     working_directory: ~/ddev
     environment:
       GOTEST_SHORT: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,9 +333,9 @@ jobs:
           name: Circle VM setup
           no_output_timeout: "40m"
 
-      - run:
-          command: ./.circleci/linux_docker_buildx_setup.sh
-          name: Docker buildx setup for multi-arch builds
+#      - run:
+#          command: ./.circleci/linux_docker_buildx_setup.sh
+#          name: Docker buildx setup for multi-arch builds
       - run:
           command: |
             . ~/.bashrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/ddev
     environment:
       DRUD_NONINTERACTIVE: "true"
@@ -37,7 +37,7 @@ jobs:
 
   lx_amd64_fpm_test:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
@@ -185,7 +185,7 @@ jobs:
 
   lx_apache_fpm_test:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
@@ -220,7 +220,7 @@ jobs:
 
   lx_nfsmount_test:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/ddev
     environment:
       DDEV_TEST_USE_NFSMOUNT: true
@@ -242,7 +242,7 @@ jobs:
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     # Run the built-in ddev tests with the executables just built.
     - run:
-        # CircleCI image ubuntu-2004:202010-01 has umask 002, which results in
+        # CircleCI image ubuntu-2004:202101-01 has umask 002, which results in
         # default perms 700 for new directories, which doesn't seem to work with NFS
         command: umask u=rwx,g=rwx,o=rx && make -s test EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: ddev tests
@@ -257,7 +257,7 @@ jobs:
 
   staticrequired:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/ddev
     environment:
     steps:
@@ -276,7 +276,7 @@ jobs:
 
   lx_container_test:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/ddev
     environment:
       GOTEST_SHORT: true
@@ -339,7 +339,7 @@ jobs:
 
   artifacts:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/ddev
     steps:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         - linux-homebrew-v23
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
-        name: NORMAL Circle VM setup - tools, docker, golang
+        name: NORMAL Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
         key: linux-homebrew-v23
@@ -58,7 +58,7 @@ jobs:
         name: Check cache contents
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
-        name: Circle VM setup - tools, docker, golang
+        name: Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
         key: linux-homebrew-v23
@@ -85,10 +85,12 @@ jobs:
       DRUD_NONINTERACTIVE: "true"
     steps:
       - checkout
+      - run: docker ps && docker run hello-world
       - run:
           command: ./.travis/linux_travis_arm64_setup.sh
           name: ARM64 VM setup
           no_output_timeout: "40m"
+      - run: docker ps && docker run hello-world
       - run:
           command: make -s test
           name: ddev tests
@@ -111,7 +113,7 @@ jobs:
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
-        name: macOS Circle VM setup - tools, docker, golang
+        name: macOS Circle VM setup
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - run:
         command: make -s test
@@ -141,7 +143,7 @@ jobs:
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
-        name: macOS Circle VM setup - tools, docker, golang
+        name: macOS Circle VM setup
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     - run:
         command: make -s test
@@ -171,7 +173,7 @@ jobs:
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
-        name: macOS Circle VM setup - tools, docker, golang
+        name: macOS Circle VM setup
     - run:
         command: make -s test
         name: ddev tests
@@ -201,7 +203,7 @@ jobs:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
-        name: Circle VM setup - tools, docker, golang
+        name: Circle VM setup
         no_output_timeout: "40m"
 
     # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
@@ -236,7 +238,7 @@ jobs:
         at: ~/
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
-        name: Circle VM setup - tools, docker, golang
+        name: Circle VM setup
         no_output_timeout: "40m"
 
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
@@ -268,7 +270,7 @@ jobs:
         - linux-v23
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
-        name: Circle VM setup - tools, docker, golang
+        name: Circle VM setup
         no_output_timeout: "40m"
     - run:
         command: source ~/.bashrc && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
@@ -289,7 +291,7 @@ jobs:
         - linux-v23
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
-        name: Circle VM setup - tools, docker, golang
+        name: Circle VM setup
         no_output_timeout: "40m"
 
     - run:
@@ -323,7 +325,7 @@ jobs:
     - checkout
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
-        name: macOS Circle VM setup - tools, docker, golang
+        name: macOS Circle VM setup
 
     - run:
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,12 +85,10 @@ jobs:
       DRUD_NONINTERACTIVE: "true"
     steps:
       - checkout
-      - run: docker ps && docker run hello-world
       - run:
           command: ./.travis/linux_travis_arm64_setup.sh
           name: ARM64 VM setup
           no_output_timeout: "40m"
-      - run: docker ps && docker run hello-world
       - run:
           command: make -s test
           name: ddev tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,7 +482,7 @@ workflows:
   version: 2
   normal_build_and_test:
     jobs:
-    - build
+#    - build
 #    - mac_container_test
 #    - lx_amd64_container_test
 #    - staticrequired
@@ -523,7 +523,6 @@ workflows:
                 - master
                 - "pull/[0-9]+"
     jobs:
-    - build
     - lx_amd64_container_test
     - lx_arm64_container_test
     - lx_amd64_fpm_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
       DRUD_NONINTERACTIVE: "true"
+      GOTEST_SHORT: "true"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ jobs:
         command: source ~/.bashrc && make staticrequired EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: staticrequired
 
-  lx_container_test:
+  lx_amd64_container_test:
     machine:
       image: ubuntu-2004:202101-01
     working_directory: ~/ddev
@@ -315,6 +315,36 @@ jobs:
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
+
+  lx_arm64_container_test:
+    machine:
+      image: ubuntu-2004:202101-01
+    working_directory: ~/ddev
+    environment:
+      GOTEST_SHORT: true
+      BUILDKIT_PROGRESS: plain
+    steps:
+      - checkout
+      - run:
+          command: ./.travis/linux_travis_arm64_setup.sh
+          name: Circle VM setup
+          no_output_timeout: "40m"
+
+      - run:
+          command: ./.circleci/linux_docker_buildx_setup.sh
+          name: Docker buildx setup for multi-arch builds
+      - run:
+          command: |
+            . ~/.bashrc
+            for dir in containers/*/
+                do pushd $dir >/dev/null
+                echo "--- Build container $dir"
+                time make container DOCKER_ARGS=--no-cache EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+                echo "--- Test container $dir"
+                time make test EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+                popd >/dev/null
+            done
+          name: linux container test
 
   mac_container_test:
     macos:
@@ -451,10 +481,11 @@ workflows:
     jobs:
     - build
 #    - mac_container_test
-#    - lx_container_test
+#    - lx_amd64_container_test
 #    - staticrequired
     - lx_amd64_fpm_test
     - lx_arm64_fpm_test
+    - lx_arm64_container_test
 #        requires:
 #        - build
 #    - mac_nginx_fpm_test:
@@ -490,7 +521,8 @@ workflows:
                 - "pull/[0-9]+"
     jobs:
     - build
-    - lx_container_test
+    - lx_amd64_container_test
+    - lx_arm64_container_test
     - lx_amd64_fpm_test
     - lx_arm64_fpm_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
         root: ~/
         paths: ddev
 
-  lx_nginx_fpm_test:
+  lx_amd64_fpm_test:
     machine:
       image: ubuntu-2004:202010-01
     working_directory: ~/ddev
@@ -74,6 +74,25 @@ jobs:
         key: linux-testcache-v23
         paths:
         - /home/circleci/.ddev/testcache
+
+  lx_arm64_fpm_test:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    working_directory: ~/ddev
+    environment:
+      DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
+      DRUD_NONINTERACTIVE: "true"
+    steps:
+      - checkout
+      - run:
+          command: ./.travis/linux_travis_arm64_setup.sh
+          name: ARM64 VM setup
+          no_output_timeout: "40m"
+      - run:
+          command: make -s test
+          name: ddev tests
+          no_output_timeout: "40m"
 
   mac_nginx_fpm_test:
     macos:
@@ -433,7 +452,8 @@ workflows:
 #    - mac_container_test
 #    - lx_container_test
 #    - staticrequired
-    - lx_nginx_fpm_test
+    - lx_amd64_fpm_test
+    - lx_arm64_fpm_test
 #        requires:
 #        - build
 #    - mac_nginx_fpm_test:
@@ -470,9 +490,8 @@ workflows:
     jobs:
     - build
     - lx_container_test
-    - lx_nginx_fpm_test:
-        requires:
-        - build
+    - lx_amd64_fpm_test
+    - lx_arm64_fpm_test
 
   release_build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,7 @@ jobs:
     environment:
       GOTEST_SHORT: true
       BUILDKIT_PROGRESS: plain
+      DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
     - checkout
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
@@ -324,6 +325,7 @@ jobs:
     environment:
       GOTEST_SHORT: true
       BUILDKIT_PROGRESS: plain
+      DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - checkout
       - run:

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -43,7 +43,7 @@ git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-c
 npm install --global markdownlint-cli
 markdownlint --version
 # readthedocs has ancient version of mkdocs in it.
-pyenv global 3.8.5 # added to make CircleCi give us pip3
+pyenv global 3.9.1 # added to make CircleCi give us pip3
 pip3 install -q yq mkdocs==0.17.5
 
 # Get the Stubs and Plugins for makensis; the linux makensis build doesn't do this.

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -57,4 +57,5 @@ fi
 docker info
 docker version
 docker-compose version
+lsb_release -a
 docker buildx create --name ddev-builder-multi --use  

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -13,7 +13,7 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
 fi
 
 sudo apt-get update -qq
-sudo rm -f /usr/local/bin/jq && sudo apt-get install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev docker-compose
+sudo rm -f /usr/local/bin/jq && sudo apt-get -qq install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev docker-compose
 
 # Copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
 sudo cp /usr/bin/docker-compose /usr/local/bin/docker-compose
@@ -40,14 +40,14 @@ EOF"
 
 sudo service nfs-kernel-server restart
 
-# Configure environment so changes are picked up when the Docker daemon is restarted after upgrading
-echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
-export DOCKER_CLI_EXPERIMENTAL=enabled
-# Upgrade to Docker CE 19.03 for BuildKit support
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo apt-get update
-sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+## Configure environment so changes are picked up when the Docker daemon is restarted after upgrading
+#echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+#export DOCKER_CLI_EXPERIMENTAL=enabled
+## Upgrade to Docker CE 19.03 for BuildKit support
+#curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+#sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+#sudo apt-get update
+#sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 # Show info to simplify debugging and create a builder
 docker info
 docker buildx create --name ddev-builder-multi --use  

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -13,10 +13,13 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
 fi
 
 sudo apt-get -qq update
-sudo rm -f /usr/local/bin/jq && sudo apt-get install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev docker-compose
+sudo rm -f /usr/local/bin/jq && sudo apt-get install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
 
-# Copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
-sudo cp /usr/bin/docker-compose /usr/local/bin/docker-compose
+# If on travis-ci copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
+if [ ! -z "${TRAVIS_BUILD_NUMBER:-}" ]; then
+  sudo apt-get install docker-compose
+  sudo cp /usr/bin/docker-compose /usr/local/bin/docker-compose
+fi
 
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -12,7 +12,7 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
   set -x
 fi
 
-sudo apt-get update -qq
+sudo apt-get -qq update
 sudo rm -f /usr/local/bin/jq && sudo apt-get -qq install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev docker-compose
 
 # Copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
@@ -50,4 +50,5 @@ sudo service nfs-kernel-server restart
 #sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 # Show info to simplify debugging and create a builder
 docker info
+docker version
 docker buildx create --name ddev-builder-multi --use  

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -15,12 +15,6 @@ fi
 sudo apt-get -qq update
 sudo rm -f /usr/local/bin/jq && sudo apt-get -qq install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
 
-# If on travis-ci copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
-if [ ! -z "${TRAVIS_BUILD_NUMBER:-}" ]; then
-  sudo apt-get -qq install docker-compose
-  sudo cp /usr/bin/docker-compose /usr/local/bin/docker-compose
-fi
-
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 
 # Without this .curlrc CircleCI linux image doesn't respect mkcert certs
@@ -44,13 +38,21 @@ EOF"
 sudo service nfs-kernel-server restart
 
 ## Configure environment so changes are picked up when the Docker daemon is restarted after upgrading
-#echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
-#export DOCKER_CLI_EXPERIMENTAL=enabled
-## Upgrade to Docker CE 19.03 for BuildKit support
-#curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-#sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-#sudo apt-get update
-#sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+if [ ! -z "${TRAVIS_BUILD_NUMBER:-}" ]; then
+  ## On Travis Upgrade to latest Docker CE BuildKit support
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  sudo apt-get update
+  sudo apt-get -qq -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
+  # Copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
+  sudo apt-get -qq install -y docker-compose
+  sudo cp /usr/bin/docker-compose /usr/local/bin/docker-compose
+fi
+
 # Show info to simplify debugging and create a builder
 docker info
 docker version

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -13,7 +13,7 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
 fi
 
 sudo apt-get -qq update
-sudo rm -f /usr/local/bin/jq && sudo apt-get -qq install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev docker-compose
+sudo rm -f /usr/local/bin/jq && sudo apt-get install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev docker-compose
 
 # Copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
 sudo cp /usr/bin/docker-compose /usr/local/bin/docker-compose

--- a/.travis/linux_travis_arm64_setup.sh
+++ b/.travis/linux_travis_arm64_setup.sh
@@ -13,11 +13,11 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
 fi
 
 sudo apt-get -qq update
-sudo rm -f /usr/local/bin/jq && sudo apt-get install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
+sudo rm -f /usr/local/bin/jq && sudo apt-get -qq install -y mysql-client zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev
 
 # If on travis-ci copy docker-compose to /usr/local/bin because Travis' pre-installed version leads to exec format error
 if [ ! -z "${TRAVIS_BUILD_NUMBER:-}" ]; then
-  sudo apt-get install docker-compose
+  sudo apt-get -qq install docker-compose
   sudo cp /usr/bin/docker-compose /usr/local/bin/docker-compose
 fi
 
@@ -54,4 +54,5 @@ sudo service nfs-kernel-server restart
 # Show info to simplify debugging and create a builder
 docker info
 docker version
+docker-compose version
 docker buildx create --name ddev-builder-multi --use  

--- a/pkg/ddevapp/providerDdevLive_test.go
+++ b/pkg/ddevapp/providerDdevLive_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -34,6 +35,9 @@ func TestDdevLivePull(t *testing.T) {
 	token := ""
 	if token = os.Getenv("DDEV_DDEVLIVE_API_TOKEN"); token == "" {
 		t.Skipf("No DDEV_DDEVLIVE_API_TOKEN env var has been set. Skipping %v", t.Name())
+	}
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Skipping because ddev-live does not yet support arm64")
 	}
 
 	// Set up tests and give ourselves a working directory.


### PR DESCRIPTION
## The Problem/Issue/Bug:

CircleCI now has arm64 testing, and it probably will be more convenient and certainly more scalable for us than Travis.

## How this PR Solves The Problem:

Add CircleCI arm64 build.

