### PR TITLE
Use the correct variable name for Pantheon token

### DIFF
--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -10,8 +10,11 @@ If you have ddev installed, and have an active Pantheon account with an active s
 
 1. Get your Pantheon.io machine token:
    a. Login to your Pantheon Dashboard, and [Generate a Machine Token](https://pantheon.io/docs/machine-tokens/) for ddev to use.
-   b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml, `- DDEV_PANTHEON_API_TOKEN=abcdeyourtoken`
-
+   b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml
+   ```
+   web_environment:
+   - TERMINUS_MACHINE_TOKEN=abcdeyourtoken`
+   ```
 2. Choose a Pantheon site and environment you want to use with ddev. You'll need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321627#dev/>, the site ID is 009a2cda-2c22-4eee-8f9d-96f017321627.
 
 3. Create a new backup of the Pantheon site. This can be done by navigating to Backups->Backup Log->Create New Backup. _Note: this must be done every time you want the latest state of your Pantheon environment provisioned locally._

--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -11,10 +11,12 @@ If you have ddev installed, and have an active Pantheon account with an active s
 1. Get your Pantheon.io machine token:
    a. Login to your Pantheon Dashboard, and [Generate a Machine Token](https://pantheon.io/docs/machine-tokens/) for ddev to use.
    b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml
+
    ```
    web_environment:
    - TERMINUS_MACHINE_TOKEN=abcdeyourtoken`
    ```
+
 2. Choose a Pantheon site and environment you want to use with ddev. You'll need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321627#dev/>, the site ID is 009a2cda-2c22-4eee-8f9d-96f017321627.
 
 3. Create a new backup of the Pantheon site. This can be done by navigating to Backups->Backup Log->Create New Backup. _Note: this must be done every time you want the latest state of your Pantheon environment provisioned locally._


### PR DESCRIPTION
## The Problem/Issue/Bug:
Documentation is different than the instructions in `.ddev/providers/pantheon.yaml.example`
I confirmed this syntax is working.