### PR TITLE
[DOCS] Rename AdditionalSettings.php to AdditionalConfiguration.php

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -347,7 +347,7 @@ const ConfigInstructions = `
 
 # disable_settings_management: false
 # If true, ddev will not create CMS-specific settings files like
-# Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalSettings.php
+# Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalConfiguration.php
 # In this case the user must provide all such settings.
 
 # You can inject environment variables into the web container with:


### PR DESCRIPTION
## The Problem/Issue/Bug:
The TYPO3 internal file `AdditionalConfiguration.php` was sometimes mistakenly referred as `AdditionalSettings.php`.

## How this PR Solves The Problem:
Rename all occurrences of AdditionalSettings.php to AdditionalConfiguration.php.

## Manual Testing Instructions:
It is only about documentation in comments and test data.

## Automated Testing Overview:
It is only about documentation in comments and test data. No tests required.

## Related Issue Link(s):
None.

## Release/Deployment notes:
No.

