### PR TITLE
Implement -d argument to ddev composer to specify relative dir, fixes #1699

### DIFF
--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -8,6 +8,8 @@ import (
 	"os"
 )
 
+var execDir = ""
+
 var ComposerCmd = &cobra.Command{
 	Use:   "composer [command]",
 	Short: "Executes a composer command within the web container",
@@ -17,7 +19,8 @@ the command with 'ddev'.`,
 	Example: `ddev composer install
 ddev composer require <package>
 ddev composer outdated --minor-only
-ddev composer create drupal/recommended-project`,
+ddev composer create drupal/recommended-project
+ddev composer -d docroot install`,
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil {
@@ -30,7 +33,7 @@ ddev composer create drupal/recommended-project`,
 			}
 		}
 
-		stdout, stderr, err := app.Composer(args)
+		stdout, stderr, err := app.Composer(execDir, args)
 		if err != nil {
 			util.Failed("composer %v failed, %v. stderr=%v", args, err, stderr)
 		}
@@ -41,5 +44,6 @@ ddev composer create drupal/recommended-project`,
 
 func init() {
 	RootCmd.AddCommand(ComposerCmd)
+	ComposerCmd.Flags().StringVarP(&execDir, "dir", "d", "", "The relative directory  where composer will be run, defaults to empty, the project root")
 	ComposerCmd.Flags().SetInterspersed(false)
 }

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -15,10 +16,15 @@ import (
 func TestComposerCmd(t *testing.T) {
 	assert := asrt.New(t)
 
+	// This often fails on Windows with NFS
+	// It appears to be something about composer itself, or could be stale nfs
+	// Might be fixable with `ls` in the directory before taking action
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows because it always seems to fail on windows nfs")
+	}
+
 	oldDir, err := os.Getwd()
 	assert.NoError(err)
-	// nolint: errcheck
-	defer os.Chdir(oldDir)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
 	err = os.Chdir(tmpDir)
@@ -38,30 +44,35 @@ func TestComposerCmd(t *testing.T) {
 	// Get an app just so we can do waits
 	app, err := ddevapp.NewApp(tmpDir, true)
 	assert.NoError(err)
-	//nolint: errcheck
-	defer app.Stop(true, false)
+
+	t.Cleanup(func() {
+		err = os.Chdir(oldDir)
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		err = os.RemoveAll(tmpDir)
+		assert.NoError(err)
+	})
 
 	// Test create-project
 	// These two often fail on Windows with NFS
 	// It appears to be something about composer itself?
 
-	if !(runtime.GOOS == "windows" && (app.NFSMountEnabled || app.NFSMountEnabledGlobal)) {
-		// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
-		args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0"}
-		out, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
-		assert.Contains(out, "Created project in ")
-		assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
+	// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
+	args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
+	assert.Contains(out, "Created project in ")
+	assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
 
-		err = app.StartAndWait(5)
-		assert.NoError(err)
-		// ddev composer create --prefer-dist--no-dev --no-install psr/log:1.1.0
-		args = []string{"composer", "create", "--prefer-dist", "--no-dev", "--no-install", "psr/log:1.1.0"}
-		out, err = exec.RunCommand(DdevBin, args)
-		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
-		assert.Contains(out, "Created project in ")
-		assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
-	}
+	err = app.StartAndWait(5)
+	assert.NoError(err)
+	// ddev composer create --prefer-dist--no-dev --no-install psr/log:1.1.0
+	args = []string{"composer", "create", "--prefer-dist", "--no-dev", "--no-install", "psr/log:1.1.0"}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
+	assert.Contains(out, "Created project in ")
+	assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
 
 	// Test a composer require, with passthrough args
 	args = []string{"composer", "require", "sebastian/version", "--no-plugins", "--ansi"}
@@ -75,4 +86,19 @@ func TestComposerCmd(t *testing.T) {
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 	assert.Contains(out, "Generating autoload files")
 	assert.False(fileutil.FileExists(filepath.Join(tmpDir, "vendor/sebastian")))
+
+	// Verify that we can target a composer.json in another directory
+	cDir := filepath.Join(app.AppRoot, "composerdir")
+	err = os.MkdirAll(cDir, 0755)
+	assert.NoError(err)
+	args = []string{"composer", "-d", "composerdir", "init", "-q", "--name=j/j"}
+	_, err = exec.RunCommand(DdevBin, args)
+	require.NoError(t, err)
+	args = []string{"composer", "-d", "composerdir", "require", "sebastian/version", "--no-plugins", "--ansi"}
+	_, err = exec.RunCommand(DdevBin, args)
+	require.NoError(t, err)
+	rv, err := fileutil.FgrepStringInFile(filepath.Join(cDir, "composer.json"), "sebastian/version")
+	assert.NoError(err)
+	assert.True(rv)
+	assert.True(fileutil.FileExists(filepath.Join(cDir, "vendor/sebastian")))
 }

--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -5,12 +5,13 @@ import (
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/mattn/go-isatty"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
 
 // Composer runs composer commands in the web container, managing pre- and post- hooks
-func (app *DdevApp) Composer(args []string) (string, string, error) {
+func (app *DdevApp) Composer(dir string, args []string) (string, string, error) {
 	err := app.ProcessHooks("pre-composer")
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to process pre-composer hooks: %v", err)
@@ -18,7 +19,7 @@ func (app *DdevApp) Composer(args []string) (string, string, error) {
 
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "web",
-		Dir:     "/var/www/html",
+		Dir:     filepath.Join("/var/www/html", dir),
 		Cmd:     fmt.Sprintf("composer %s", strings.Join(args, " ")),
 		Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 	})

--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -5,7 +5,7 @@ import (
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/mattn/go-isatty"
 	"os"
-	"path/filepath"
+	"path"
 	"runtime"
 	"strings"
 )
@@ -19,7 +19,7 @@ func (app *DdevApp) Composer(dir string, args []string) (string, string, error) 
 
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "web",
-		Dir:     filepath.Join("/var/www/html", dir),
+		Dir:     path.Join("/var/www/html", dir),
 		Cmd:     fmt.Sprintf("composer %s", strings.Join(args, " ")),
 		Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 	})

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/stretchr/testify/require"
 	"os"
+	"path/filepath"
 	"testing"
 
 	asrt "github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestComposer(t *testing.T) {
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 
-	// Use drupal8 only for this test, just need a little composer action
+	// Use drupal9 only for this test, just need a little composer action
 	site := FullTestSites[8]
 	// If running this with GOTEST_SHORT we have to create the directory, tarball etc.
 	if site.Dir == "" || !fileutil.FileExists(site.Dir) {
@@ -29,29 +30,35 @@ func TestComposer(t *testing.T) {
 		err := site.Prepare()
 		require.NoError(t, err)
 		// nolint: errcheck
-		defer os.RemoveAll(site.Dir)
+		t.Cleanup(func() {
+			err = os.RemoveAll(site.Dir)
+			assert.NoError(err)
+		})
 	}
 
-	testDir, _ := os.Getwd()
-	// nolint: errcheck
-	defer os.Chdir(testDir)
-	_ = os.Chdir(site.Dir)
-
+	origDir, _ := os.Getwd()
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
-	app.ComposerVersion = "2"
 	assert.NoError(err)
 	app.Hooks = map[string][]ddevapp.YAMLTask{"post-composer": {{"exec-host": "touch hello-post-composer-" + app.Name}}, "pre-composer": {{"exec-host": "touch hello-pre-composer-" + app.Name}}}
 	// Make sure we get rid of this for other uses
-	defer func() {
+
+	t.Cleanup(func() {
 		app.Hooks = nil
 		app.ComposerVersion = ""
-		_ = app.WriteConfig()
-		_ = app.Stop(true, false)
-	}()
+		err = app.WriteConfig()
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+	})
+
+	err = os.Chdir(app.AppRoot)
+	require.NoError(t, err)
 	err = app.Start()
 	require.NoError(t, err)
-	_, _, err = app.Composer([]string{"install"})
+	_, _, err = app.Composer("", []string{"install"})
 	assert.NoError(err)
 	assert.FileExists("hello-pre-composer-" + app.Name)
 	assert.FileExists("hello-post-composer-" + app.Name)
@@ -59,6 +66,19 @@ func TestComposer(t *testing.T) {
 	assert.NoError(err)
 	err = os.Remove("hello-post-composer-" + app.Name)
 	assert.NoError(err)
+
+	// Make sure that composer targeted to a different directory works ok
+	cDir := filepath.Join(app.AppRoot, "composerdir")
+	err = os.MkdirAll(cDir, 0755)
+	assert.NoError(err)
+	_, _, err = app.Composer("composerdir", []string{"init", "-q", "--name=j/j"})
+	require.NoError(t, err)
+	_, _, err = app.Composer("composerdir", []string{"require", "sebastian/version", "--no-plugins", "--ansi"})
+	require.NoError(t, err)
+	rv, err := fileutil.FgrepStringInFile(filepath.Join(cDir, "composer.json"), "sebastian/version")
+	assert.NoError(err)
+	assert.True(rv)
+	assert.True(fileutil.FileExists(filepath.Join(cDir, "vendor/sebastian")))
 }
 
 // TestComposerVersion tests to make sure that composer_version setting
@@ -84,14 +104,14 @@ func TestComposerVersion(t *testing.T) {
 		assert.NoError(err)
 	})
 
-	// Make sure base version (default) is composer v1
+	// Make sure base version (default) is composer v2
 	err = app.Start()
 	require.NoError(t, err)
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})
 	assert.NoError(err)
 	assert.Contains(stdout, "Composer version 2")
 
-	// Make sure it does the right thing with latest 2.x
+	// Make sure it does the right thing with latest 1.x
 	app.ComposerVersion = "1"
 	err = app.Start()
 	require.NoError(t, err)
@@ -108,7 +128,7 @@ func TestComposerVersion(t *testing.T) {
 	assert.Contains(stdout, "Composer version 2")
 
 	// With explicit version, we should get that version
-	app.ComposerVersion = "2.0.1"
+	app.ComposerVersion = "2.0.10"
 	err = app.Start()
 	require.NoError(t, err)
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})

--- a/pkg/ddevapp/task.go
+++ b/pkg/ddevapp/task.go
@@ -96,7 +96,7 @@ func (c ExecHostTask) Execute() error {
 // and returns stdout, stderr, err
 func (c ComposerTask) Execute() error {
 	components := strings.Split(c.exec, " ")
-	_, _, err := c.app.Composer(components[0:])
+	_, _, err := c.app.Composer("", components[0:])
 
 	return err
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

Despite the convention of having composer.json in the root of the project, some projects and some people have it elsewhere.

## How this PR Solves The Problem:

Add `ddev composer -d`  to identify the target directory

## Manual Testing Instructions:

```
mkdir junk
ddev composer -d junk composer init
ddev composer -d junk require drush/drush
```
Verify the composer.json in the junk directory has reasonable content with drush.

## Automated Testing Overview:

Added to TestComposerCmd and TestComposer to cover this case

## Related Issue Link(s):

Fixes #1699

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

