### PR TITLE
Poweroff if new ddev version, fixes #1786

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -238,7 +238,7 @@ func TestLaunchCommand(t *testing.T) {
 		out, err := exec.RunCommand("bash", []string{"-c", c})
 		out = strings.Trim(out, "\n")
 		assert.NoError(err, `couldn't run "%s"", output=%s`, c, out)
-		assert.Contains(out, expect, "ouptput of %s is incorrect with app.RouterHTTPSPort=%s: %s", c, app.RouterHTTPSPort, out)
+		assert.Contains(out, expect, "output of %s is incorrect with app.RouterHTTPSPort=%s: %s", c, app.RouterHTTPSPort, out)
 	}
 }
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -784,7 +784,7 @@ func TestConfigGitignore(t *testing.T) {
 	_, err = exec.RunCommand("bash", []string{"-c", fmt.Sprintf("touch ~/.ddev/commands/web/%s ~/.ddev/homeadditions/%s", t.Name(), t.Name())})
 	assert.NoError(err)
 
-	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
 	assert.NoError(err)
 	statusOut, err := exec.RunCommand("bash", []string{"-c", "git status"})
 	assert.NoError(err)

--- a/cmd/ddev/cmd/debug-nfsmount_test.go
+++ b/cmd/ddev/cmd/debug-nfsmount_test.go
@@ -17,7 +17,7 @@ import (
 // It requires nfsd running of course.
 func TestDebugNFSMount(t *testing.T) {
 	if nodeps.IsWSL2() {
-		t.Skip("Skipping on WSL2")
+		t.Skip("Skipping on WSL2 since NFS is not used there")
 	}
 	assert := asrt.New(t)
 

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -238,7 +238,7 @@ func TestCmdDescribeMissingProjectDirectory(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
 	assert.NoError(err)
 
-	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
 	assert.NoError(err)
 
 	t.Cleanup(func() {

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -64,7 +64,7 @@ func TestHomeadditions(t *testing.T) {
 	app, err := ddevapp.GetActiveApp(site.Name)
 	require.NoError(t, err)
 
-	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
 	assert.NoError(err)
 
 	// Make sure that even though there was a global and a project-level .myscript.sh

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -23,7 +23,7 @@ func TestCmdList(t *testing.T) {
 	// This gratuitous ddev start -a repopulates the ~/.ddev/global_config.yaml
 	// project list, which has been damaged by other tests which use
 	// direct app techniques.
-	_, err := exec.RunCommand(DdevBin, []string{"start", "-a"})
+	_, err := exec.RunCommand(DdevBin, []string{"start", "-a", "-y"})
 	assert.NoError(err)
 
 	// Execute "ddev list" and harvest plain text output.
@@ -94,7 +94,7 @@ func TestCmdList(t *testing.T) {
 	t.Logf("test projects (including inactive) shown with ddev list -j: %v", siteList)
 
 	// Leave firstApp running for other tests
-	out, err = exec.RunCommand(DdevBin, []string{"start", TestSites[0].Name})
+	out, err = exec.RunCommand(DdevBin, []string{"start", "-y", TestSites[0].Name})
 	assert.NoError(err, "error runnning ddev start: %v output=%s", err, out)
 }
 

--- a/cmd/ddev/cmd/pause_test.go
+++ b/cmd/ddev/cmd/pause_test.go
@@ -82,7 +82,7 @@ func TestCmdPauseContainersMissingProjectDirectory(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
 	assert.NoError(err)
 
-	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
 	assert.NoError(err)
 
 	//nolint: errcheck

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -186,8 +186,8 @@ func instrumentationNotSetUpWarning() {
 // checkDdevVersionAndOptInInstrumentation() reads global config and checks to see if current version is different
 // from the last saved version. If it is, prompt to request anon ddev usage stats
 // and update the info.
-func checkDdevVersionAndOptInInstrumentation() error {
-	if !output.JSONOutput && semver.Compare(version.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoInstrumentation {
+func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
+	if !output.JSONOutput && semver.Compare(version.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoInstrumentation && !skipConfirmation {
 		allowStats := util.Confirm("It looks like you have a new ddev release.\nMay we send anonymous ddev usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/stable/users/cli-usage/#opt-in-usage-information\nPermission to beam up?")
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true
@@ -204,12 +204,18 @@ func checkDdevVersionAndOptInInstrumentation() error {
 			}
 		}
 	}
-	if globalconfig.DdevGlobalConfig.LastStartedVersion != version.DdevVersion {
+	if globalconfig.DdevGlobalConfig.LastStartedVersion != version.DdevVersion && !skipConfirmation {
 		globalconfig.DdevGlobalConfig.LastStartedVersion = version.DdevVersion
 		err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 		if err != nil {
 			return err
 		}
+
+		okPoweroff := util.Confirm("It looks like you have a new DDEV version. During an upgrade it's important to `ddev poweroff`. May I do `ddev poweroff` before continuing? This does no harm and loses no data.")
+		if okPoweroff {
+			powerOff()
+		}
+		return nil
 	}
 
 	return nil

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -254,6 +254,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 			}
 		})
 
+	newStartTime := time.Now().Unix()
 	// We have to do the echo technique to get past the prompt about doing a ddev poweroff
 	out, err := exec.RunCommand("bash", []string{"-c", fmt.Sprintf("echo y | %s start", DdevBin)})
 	assert.NoError(err)
@@ -273,10 +274,9 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	require.NotEmpty(t, sshC)
 	sshCreateTime := (*sshC).Created
 
-	// router and ssh-agent should have been created within the last 20 seconds
-	now := time.Now().Unix()
-	assert.Greater(routerCreateTime+20, now)
-	assert.Greater(sshCreateTime+20, now)
+	// router and ssh-agent should have been created within after we started the new project
+	assert.GreaterOrEqual(routerCreateTime, newStartTime)
+	assert.GreaterOrEqual(sshCreateTime, newStartTime)
 }
 
 // addSites runs `ddev start` on the test apps

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"os"
@@ -160,6 +161,12 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 
 			err = os.Setenv("HOME", origHome)
 			assert.NoError(err)
+
+			// Because the start will have done a poweroff (new version),
+			// make sure sites are running again.
+			for _, site := range TestSites {
+				_, _ = exec.RunCommand(DdevBin, []string{"start", "-y", site.Name})
+			}
 		})
 
 	// Make sure that the tmpDir/.ddev and tmpDir/.ddev/.update don't exist before we run ddev.
@@ -177,7 +184,8 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	assert.NoError(err)
 
 	// The .update file is only created by ddev start
-	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
+	// We have to do the echo technique to get past the prompt about doing a ddev poweroff
+	_, err = exec.RunCommand("bash", []string{"-c", fmt.Sprintf("echo y | %s start", DdevBin)})
 	assert.NoError(err)
 
 	_, err = os.Stat(tmpUpdateFilePath)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -177,7 +177,7 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	assert.NoError(err)
 
 	// The .update file is only created by ddev start
-	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
 	assert.NoError(err)
 
 	_, err = os.Stat(tmpUpdateFilePath)
@@ -196,7 +196,7 @@ func addSites() error {
 		cleanup := site.Chdir()
 		defer cleanup()
 
-		out, err := exec.RunCommand(DdevBin, []string{"start"})
+		out, err := exec.RunCommand(DdevBin, []string{"start", "-y"})
 		if err != nil {
 			log.Fatalln("Error Output from ddev start:", out, "err:", err)
 		}

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -30,8 +30,13 @@ ddev start --all`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 
+		skip, err := cmd.Flags().GetBool("skip-confirmation")
+		if err != nil {
+			util.Failed(err.Error())
+		}
+
 		// Look for version change and opt-in to instrumentation if it has changed.
-		err := checkDdevVersionAndOptInInstrumentation()
+		err = checkDdevVersionAndOptInInstrumentation(skip)
 		if err != nil {
 			util.Failed(err.Error())
 		}
@@ -67,5 +72,6 @@ ddev start --all`,
 
 func init() {
 	StartCmd.Flags().BoolVarP(&startAll, "all", "a", false, "Start all projects")
+	StartCmd.Flags().BoolP("skip-confirmation", "y", false, "Skip any confirmation steps")
 	RootCmd.AddCommand(StartCmd)
 }

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -28,7 +28,7 @@ func TestCmdStart(t *testing.T) {
 	assert.NoError(err)
 
 	// Ensure all sites are started after ddev start --all.
-	out, err := exec.RunCommand(DdevBin, []string{"start", "--all"})
+	out, err := exec.RunCommand(DdevBin, []string{"start", "--all", "-y"})
 	assert.NoError(err, "ddev start --all should succeed but failed, err: %v, output: %s", err, out)
 
 	// Confirm all sites are running.
@@ -42,7 +42,7 @@ func TestCmdStart(t *testing.T) {
 	assert.NoError(err)
 
 	// Build start command startMultipleArgs
-	startMultipleArgs := []string{"start"}
+	startMultipleArgs := []string{"start", "-y"}
 	for _, app := range apps {
 		startMultipleArgs = append(startMultipleArgs, app.GetName())
 	}
@@ -80,7 +80,7 @@ func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
 	assert.NoError(err)
 
-	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
 
 	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"stop", "-RO", projectName})
@@ -96,7 +96,7 @@ func TestCmdStartMissingProjectDirectory(t *testing.T) {
 	err = os.Rename(tmpDir, copyDir)
 	assert.NoError(err)
 
-	out, err = exec.RunCommand(DdevBin, []string{"start", projectName})
+	out, err = exec.RunCommand(DdevBin, []string{"start", "-y", projectName})
 
 	assert.Error(err, "Expected an error when starting project with no project directory")
 	assert.Contains(out, "ddev can no longer find your project files")

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -85,7 +85,7 @@ func TestCmdStopMissingProjectDirectory(t *testing.T) {
 	//nolint: errcheck
 	defer exec.RunCommand(DdevBin, []string{"stop", "-RO", projectName})
 
-	_, err = exec.RunCommand(DdevBin, []string{"start"})
+	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
 	assert.NoError(err)
 
 	_, err = exec.RunCommand(DdevBin, []string{"stop", projectName})

--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -37,7 +37,7 @@ func TestCmdXdebug(t *testing.T) {
 		_, err := exec.RunCommand(DdevBin, []string{"config", "--php-version", phpVersion})
 		require.NoError(t, err)
 
-		_, err = exec.RunCommand(DdevBin, []string{"start"})
+		_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
 		assert.NoError(err)
 
 		out, err := exec.RunCommand(DdevBin, []string{"xdebug", "status"})

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -107,6 +107,7 @@ func TestLetsEncrypt(t *testing.T) {
 	globalconfig.DdevGlobalConfig.LetsEncryptEmail = "nobody@example.com"
 	globalconfig.DdevGlobalConfig.RouterBindAllInterfaces = true
 	err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+	require.NoError(t, err)
 
 	site := TestSites[0]
 	switchDir := site.Chdir()


### PR DESCRIPTION
## The Problem/Issue/Bug:

On new ddev version, we really want people to do a poweroff, so the ddev binary isn't interacting with older/odd versions of containers. 

## How this PR Solves The Problem:

* Ask permission to poweroff if version has changed.
* `ddev start -y` to skip this, or `yes | ddev start` to automatically accept

## Manual Testing Instructions:

* Edit last_started_version in ~/.ddev/global_config.yaml
* `ddev start`
Try the same with `ddev start -y`

## Automated Testing Overview:

Added TestPoweroffOnNewVersion

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

