### PR TITLE
Store ddev binary artifacts separately for download

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,67 +45,13 @@ jobs:
       - name: Build DDEV executables
         run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 windows_amd64 windows_install
 
-      - name: Generate artifacts
-        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
-
-      - name: Upload artifacts
+      - name: Upload macos-amd64 binary
         uses: actions/upload-artifact@v2
         with:
-          name: ddev-executables
-          path: ${{ github.workspace }}/artifacts/*
-          # 90 retention days are overkill for this
-          retention-days: 7
-
-  tests:
-    defaults:
-      run:
-        shell: bash
-
-    strategy:
-      matrix:
-        webserver: [apache-fpm, nginx-fpm]
-        tests: [testpkg, testcmd, testfullsitesetup]
-        os: [ ubuntu-20.04 ]
-      fail-fast: false
-
-#    name: ${{ matrix.os[0] }} - ${{ matrix.webserver }} - make ${{ matrix.tests }}
-    runs-on: ${{ matrix.os }}
-
-    env:
-      DDEV_TEST_WEBSERVER_TYPE: ${{ matrix.webserver }}
-      DRUD_NONINTERACTIVE: "true"
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: GOTEST_SHORT setup - use "true" except for testfullsitesetup
-        run: |
-          if [ "${{ matrix.tests }}" != "testfullsitesetup" ]; then
-            echo "GOTEST_SHORT=true" >> $GITHUB_ENV
-          fi
-
-      - name: Install Docker and deps (Linux)
-        if: matrix.os == 'ubuntu-20.04'
-        run: ./.github/workflows/linux-setup.sh
-      
-#      - name: Install Docker and deps (macOS)
-#        if: matrix.os == 'macos-latest'
-#        run: ./.github/workflows/macos-setup.sh
-
-      - uses: actions/setup-go@v2
-        if: matrix.os == 'ubuntu-20.04'
-        with:
-          go-version: 1.*
-
-#      - name: Clean up self-hosted runners if necessary
-#        if: matrix.os[1] == 'self-hosted'
-#        run: .github/workflows/selfhosted-maintenance.sh
-
-      - name: DDEV tests
-        run: make ${{ matrix.tests }}
-
-      - name: Store test results
+          name: ddev-macos-amd64
+          path: .gotmp/bin/darwin_amd64/ddev
+      - name: Upload macos-arm64 binary
         uses: actions/upload-artifact@v2
         with:
-          name: ddev-test-results-${{ matrix.webserver }}
-          path: /tmp/testresults/
+          name: ddev-macos-arm64
+          path: .gotmp/bin/darwin_arm64/ddev


### PR DESCRIPTION
## The Problem/Issue/Bug:

Artifacts for download on github actions are all bundled into a huge zipball, which makes it awkward to download and use

Experiment with separate uploads for each.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

