### PR TITLE
Make sure missing USER env doesn't cause panic, fixes #2860

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -116,11 +116,9 @@ func MapKeysToArray(mapWithKeys map[string]interface{}) []string {
 // GetContainerUIDGid() returns the uid and gid (and string forms) to be used running most containers.
 func GetContainerUIDGid() (uidStr string, gidStr string, username string) {
 	curUser, err := user.Current()
-	CheckErr(err)
-
-	uidStr = curUser.Uid
-	gidStr = curUser.Gid
-	username = curUser.Username
+	if err != nil {
+		Warning("Unable to determine username, please at least set $USER environment variable: %v", err)
+	}
 	//// Windows userids are non numeric,
 	//// so we have to run as arbitrary user 1000. We may have a host uidStr/gidStr greater in other contexts,
 	//// 1000 seems not to cause file permissions issues at least on docker-for-windows.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -117,8 +117,11 @@ func MapKeysToArray(mapWithKeys map[string]interface{}) []string {
 func GetContainerUIDGid() (uidStr string, gidStr string, username string) {
 	curUser, err := user.Current()
 	if err != nil {
-		Warning("Unable to determine username, please at least set $USER environment variable: %v", err)
+		Failed("Unable to determine username and related UID, etc. Please at least set $USER environment variable: %v", err)
 	}
+	uidStr = curUser.Uid
+	gidStr = curUser.Gid
+	username = curUser.Username
 	//// Windows userids are non numeric,
 	//// so we have to run as arbitrary user 1000. We may have a host uidStr/gidStr greater in other contexts,
 	//// 1000 seems not to cause file permissions issues at least on docker-for-windows.


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2860: GetContainerUIDGid() can cause a panic.

## How this PR Solves The Problem:

Check to make sure user.Current() returns successfully.

## Manual Testing Instructions:

unset USER
ddev start

