### PR TITLE
Touch up Windows WSL2 hosts file support and docs, rename DRUD_INTERACTIVE, fixes #2533

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -5,7 +5,7 @@ export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
 echo "--- buildkite building ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) as USER=${USER} for OS=${OSTYPE} in ${PWD} with golang=$(go version | awk '{print $3}') docker=$(docker --version | awk '{print $3}') and docker-compose $(docker-compose --version | awk '{print $3}') ddev version=$(ddev --version | awk '{print $3}')"
 
 export GOTEST_SHORT=1
-export DRUD_NONINTERACTIVE=true
+export DDEV_NONINTERACTIVE=true
 
 set -o errexit
 set -o pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       image: ubuntu-2004:202101-01
     working_directory: ~/ddev
     environment:
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
     steps:
     - checkout
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
@@ -41,7 +41,7 @@ jobs:
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
     steps:
     - checkout
     - attach_workspace:
@@ -82,7 +82,7 @@ jobs:
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
       GOTEST_SHORT: "true"
     steps:
       - checkout
@@ -101,7 +101,7 @@ jobs:
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
       GOTEST_SHORT: "true"
     steps:
     - attach_workspace:
@@ -131,7 +131,7 @@ jobs:
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
       GOTEST_SHORT: "true"
     steps:
     - attach_workspace:
@@ -161,7 +161,7 @@ jobs:
     working_directory: ~/ddev
     environment:
       DDEV_TEST_USE_NFSMOUNT: "true"
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
       GOTEST_SHORT: "true"
     steps:
     - attach_workspace:
@@ -192,7 +192,7 @@ jobs:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
       # Experiment with only testing TYPO3 with the apache run.
       GOTEST_SHORT: 5
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
     steps:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
@@ -227,7 +227,7 @@ jobs:
       DDEV_TEST_USE_NFSMOUNT: true
       # Test only TYPO3 with the apache run.
       GOTEST_SHORT: 5
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
     steps:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,7 @@ jobs:
 
     env:
       DDEV_TEST_WEBSERVER_TYPE: ${{ matrix.webserver }}
-      DRUD_NONINTERACTIVE: "true"
+      DDEV_NONINTERACTIVE: "true"
 
     steps:
       - uses: actions/checkout@v2

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -193,6 +193,7 @@ disable
 disallowal
 distro
 distros
+dns
 dnsmasq
 docker
 docker's

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -32,7 +32,7 @@ ddev pull platform --skip-files -y`,
 func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDbArg bool, skipFilesArg bool) {
 
 	// If we're not performing the import step, we won't be deleting the existing db or files.
-	if !skipConfirmation && !skipImportArg && os.Getenv("DRUD_NONINTERACTIVE") == "" {
+	if !skipConfirmation && !skipImportArg && os.Getenv("DDEV_NONINTERACTIVE") == "" {
 		// Only warn the user about relevant risks.
 		var message string
 		if skipDbArg && skipFilesArg {

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 	}
 	log.Println("Running ddev with ddev=", DdevBin)
 
-	err := os.Setenv("DRUD_NONINTERACTIVE", "true")
+	err := os.Setenv("DDEV_NONINTERACTIVE", "true")
 	if err != nil {
 		log.Errorln("could not set noninteractive mode, failed to Setenv, err: ", err)
 	}

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -187,11 +187,11 @@ While ddev can create a webserver and a docker network infrastructure for a proj
     * This technique may not work on Windows WSL2, see below.
     * Only 10 hosts are valid on a line on traditional Windows, see [below](#windows-hosts-file-limited-to-10-hosts-per-ip-address-line); beyond that hostnames are ignored.
 
-## Windows WSL2 Name resolution on non-ddev.site hostnames or when not internet-connected
+## Windows WSL2 name resolution on non-ddev.site hostnames or when not internet-connected
 
-On Windows WSL2, there is a hosts file inside the WSL2 instance (`/etc/hosts`), and there is also one on the Windows side (`C:\Windows\system32\drivers\etc\hosts`). Most people use a browser on the Windows side, which has no idea about hostnames that may be set up in the WSL2 /etc/hosts file. So a WSL2 project which uses `*.ddev.site` works fine when accessed by a browser on the Windows side, as long as internet connectivity is available (DNS lookups of `*.ddev.site` succeed).
+On Windows WSL2, there is a hosts file inside the WSL2 instance (`/etc/hosts`), and there is also one on the Windows side (`C:\Windows\system32\drivers\etc\hosts`). Many people use a browser on the Windows side, which has no idea about hostnames that may be set up in the WSL2 /etc/hosts file. So a WSL2 project which uses `*.ddev.site` works fine when accessed by a browser on the Windows side, as long as internet connectivity is available (DNS lookups of `*.ddev.site` succeed).
 
-However, if the project uses non-ddev.site hostnames, or if not connected to the Internet, a Windows-side browser will be unable to look up project hostnames, and you'll get complaints from the browser like "<url> server IP address could not be found" or "We can’t connect to the server at <url>".  In this case, you can
+However, if the project uses non-ddev.site hostnames, or if not connected to the Internet, or if use_dns_when_possible is false in the .ddev/config.yaml, a Windows-side browser will be unable to look up project hostnames, and you'll get complaints from the browser like "<url> server IP address could not be found" or "We can’t connect to the server at <url>".  In this case, you can:
 
 1. Add the needed hostname(s) manually to the Windows hosts file. This can easily be done with the *Windows* version of ddev.exe with `sudo ddev hostname <hostname> 127.0.0.1` on *Windows* in PowerShell or Cmd or git-bash.
 2. Or run a browser within WSL2 (currently requires an X11 server like X410, but Microsoft plans to provide natively)
@@ -202,7 +202,7 @@ Some DNS servers prevent the use of DNS records that resolve to `localhost` (127
 
 In this case, you can
 
-1. Reconfigure the DNS server to allow DNS Rebinding. Many Fritzbox routers have added default DNS Rebinding disallowal, and they can be reconfigured to allow it, see [issue](https://github.com/drud/ddev/issues/2409#issuecomment-686718237).
+1. Reconfigure the DNS server to allow DNS Rebinding. Many Fritzbox routers have added default DNS Rebinding disallowal, and they can be reconfigured to allow it, see [issue](https://github.com/drud/ddev/issues/2409#issuecomment-686718237). If you have the local dnsmasq DNS server it may also be configured to disallow DNS rebinding, but it's a simple change to a configuration directive to allow it.
 2. Most computers can use most relaxed DNS resolution if they are not on corporate intranets that have non-internet DNS. So for example, the computer can be set to use 8.8.8.8 (Google) or 1.1.1.1 (Cloudflare) for DNS name resolution.
 3. If you have control of the router, you can usually change its DHCP settings to choose a DNS server to a public, relaxed DNS server as in #2.
 4. You can live with ddev trying to edit the /etc/hosts file, which it only has to do when a new name is added to a project.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -285,7 +285,7 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 
-	noninteractiveEnv := "DRUD_NONINTERACTIVE"
+	noninteractiveEnv := "DDEV_NONINTERACTIVE"
 	// nolint: errcheck
 	defer os.Setenv(noninteractiveEnv, os.Getenv(noninteractiveEnv))
 	err := os.Unsetenv(noninteractiveEnv)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1976,10 +1976,10 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 // But if it's not, try to add one.
 func addHostEntry(name string, ip string) error {
 	_, err := osexec.LookPath("sudo")
-	if (os.Getenv("DRUD_NONINTERACTIVE") != "") || err != nil {
+	if (os.Getenv("DDEV_NONINTERACTIVE") != "") || err != nil {
 		util.Warning("You must manually add the following entry to your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname %s %s'", ip, name, name, ip)
-		if os.Getenv("WSL_DISTRO") != "" {
-			util.Warning("For WSL2, execute 'sudo ddev hostname %s %s' on Windows", name, ip)
+		if nodeps.IsWSL2() {
+			util.Warning("For WSL2, if you use a Windows browser, execute 'sudo ddev hostname %s %s' on Windows", name, ip)
 		}
 		return nil
 	}
@@ -1988,8 +1988,8 @@ func addHostEntry(name string, ip string) error {
 	util.CheckErr(err)
 
 	output.UserOut.Printf("ddev needs to add an entry to your hostfile.\nIt will require administrative privileges via the sudo command, so you may be required\nto enter your password for sudo. ddev is about to issue the command:")
-	if os.Getenv("WSL_DISTRO") != "" {
-		output.UserOut.Printf("You are on WSL2, so should manually execute 'sudo ddev hostname %s %s' on Windows", name, ip)
+	if nodeps.IsWSL2() {
+		util.Warning("You are on WSL2, so should also manually execute 'sudo ddev hostname %s %s' on Windows if you use a Windows browser.", name, ip)
 	}
 
 	hostnameArgs := []string{ddevFullpath, "hostname", name, ip}
@@ -2021,7 +2021,7 @@ func (app *DdevApp) RemoveHostsEntries() error {
 		}
 
 		_, err = osexec.LookPath("sudo")
-		if os.Getenv("DRUD_NONINTERACTIVE") != "" || err != nil {
+		if os.Getenv("DDEV_NONINTERACTIVE") != "" || err != nil {
 			util.Warning("You must manually remove the following entry from your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname --remove %s %s", dockerIP, name, name, dockerIP)
 			return nil
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -215,7 +215,7 @@ func TestMain(m *testing.M) {
 
 	// Avoid having sudo try to add to /etc/hosts.
 	// This is normally done by Testsite.Prepare()
-	_ = os.Setenv("DRUD_NONINTERACTIVE", "true")
+	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")
 
 	// If GOTEST_SHORT is an integer, then use it as index for a single usage
 	// in the array. Any value can be used, it will default to just using the

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -107,6 +107,7 @@ func TestLetsEncrypt(t *testing.T) {
 	globalconfig.DdevGlobalConfig.LetsEncryptEmail = "nobody@example.com"
 	globalconfig.DdevGlobalConfig.RouterBindAllInterfaces = true
 	err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+	require.NoError(t, err)
 
 	site := TestSites[0]
 	switchDir := site.Chdir()

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -29,7 +29,7 @@ func TestServices(t *testing.T) {
 		t.Skip("skipping because unreliable on Windows")
 	}
 	assert := asrt.New(t)
-	os.Setenv("DRUD_NONINTERACTIVE", "true")
+	os.Setenv("DDEV_NONINTERACTIVE", "true")
 
 	expectedServiceCount := 3
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -79,7 +79,7 @@ func (site *TestSite) Prepare() error {
 	testDir := CreateTmpDir(site.Name)
 	site.Dir = testDir
 
-	err := os.Setenv("DRUD_NONINTERACTIVE", "true")
+	err := os.Setenv("DDEV_NONINTERACTIVE", "true")
 	util.CheckErr(err)
 
 	cachedSrcDir, _, err := GetCachedArchive(site.Name, site.Name+"_siteArchive", site.ArchiveInternalExtractionPath, site.SourceURL)

--- a/pkg/util/prompt.go
+++ b/pkg/util/prompt.go
@@ -36,10 +36,10 @@ func Prompt(prompt string, defaultValue string) string {
 }
 
 // Confirm handles the asking and interpreting of a basic yes/no question.
-// If DRUD_NONINTERACTIVE is set, Confirm() returns true. The prompt will be
+// If DDEV_NONINTERACTIVE is set, Confirm() returns true. The prompt will be
 // presented at most three times before returning false.
 func Confirm(prompt string) bool {
-	if len(os.Getenv("DRUD_NONINTERACTIVE")) > 0 {
+	if len(os.Getenv("DDEV_NONINTERACTIVE")) > 0 {
 		return true
 	}
 

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -110,7 +110,7 @@ func TestConfirm(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Unset the env var, then reset after the test
-	noninteractiveEnv := "DRUD_NONINTERACTIVE"
+	noninteractiveEnv := "DDEV_NONINTERACTIVE"
 	defer os.Setenv(noninteractiveEnv, os.Getenv(noninteractiveEnv))
 	err := os.Unsetenv(noninteractiveEnv)
 	if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2533: In the current state of WSL2, there's quite a lot of confusion in the computer about how to look up hostnames. However, ddev already has warnings to users, and it rarely matters to users who use *.ddev.site.

## How this PR Solves The Problem:

* Improved docs, minor addition to code that warns WSL2 users
* Rename DRUD_INTERACTIVE  environment variable to DDEV_INTERACTIVE

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

