### PR TITLE
Report WSL2 to segment as separate operating system

### DIFF
--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -29,7 +29,7 @@ func (n *SegmentNoopLogger) Errorf(format string, args ...interface{}) {}
 
 // ReportableEvents is the list of events that we choose to report specifically.
 // Excludes non-ddev custom commands.
-var ReportableEvents = map[string]bool{"auth": true, "composer": true, "config": true, "debug": true, "delete": true, "describe": true, "exec": true, "export-db": true, "heidisql": true, "import-db": true, "import-files": true, "launch": true, "list": true, "logs": true, "mysql": true, "pause": true, "poweroff": true, "pull": true, "restart": true, "restore-snapshot": true, "sequelace": true, "sequelpro": true, "share": true, "snapshot": true, "ssh": true, "start": true, "stop": true, "tableplus": true, "xdebug": true}
+var ReportableEvents = map[string]bool{"auth": true, "composer": true, "config": true, "debug": true, "delete": true, "describe": true, "exec": true, "export-db": true, "heidisql": true, "import-db": true, "import-files": true, "launch": true, "list": true, "logs": true, "mysql": true, "pause": true, "poweroff": true, "pull": true, "restart": true, "sequelace": true, "sequelpro": true, "share": true, "snapshot": true, "ssh": true, "start": true, "stop": true, "tableplus": true, "xdebug": true}
 
 // GetInstrumentationUser normally gets just the hashed hostID but if
 // an explicit user is provided in global_config.yaml that will be prepended.
@@ -54,6 +54,7 @@ func SetInstrumentationBaseTags() {
 		if wslDistro != "" {
 			nodeps.InstrumentationTags["isWSL"] = "true"
 			nodeps.InstrumentationTags["wslDistro"] = wslDistro
+			nodeps.InstrumentationTags["OS"] = "wsl2"
 		}
 		nodeps.InstrumentationTags["dockerVersion"] = dockerVersion
 		nodeps.InstrumentationTags["dockerToolbox"] = strconv.FormatBool(false)


### PR DESCRIPTION
## The Problem/Issue/Bug:

wsl2 is essentially an OS environment of its own. It's separately supported, etc. We need to be able to see it separately in Amplitude.

## How this PR Solves The Problem:

Report wsl2 as OS alongside Windows.

## Manual Testing Instructions:

In WSL2, do something and see how it's reported to Segment.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

