### PR TITLE
Enabling develop mode in xdebug so we get the pretty stack trace outputs

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/commands/web/xdebug
+++ b/cmd/ddev/cmd/dotddev_assets/commands/web/xdebug
@@ -23,7 +23,7 @@ case $1 in
   case ${xdebug_version} in
   v3*)
     status=$(php -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
-    if [ "${status}" = "debug" ]; then
+    if [[ "${status}" =~ .*"debug".* ]]; then
       result="xdebug enabled"
     else
       result="xdebug disabled"

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/mods-available/xdebug.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/mods-available/xdebug.ini
@@ -1,5 +1,5 @@
 zend_extension=xdebug.so
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9000
-xdebug.mode=debug
+xdebug.mode=debug,develop
 xdebug.start_with_request=yes

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/mods-available/xdebug.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/mods-available/xdebug.ini
@@ -1,5 +1,5 @@
 zend_extension=xdebug.so
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9000
-xdebug.mode=debug
+xdebug.mode=debug,develop
 xdebug.start_with_request=yes

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/mods-available/xdebug.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/mods-available/xdebug.ini
@@ -1,5 +1,5 @@
 zend_extension=xdebug.so
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9000
-xdebug.mode=debug
+xdebug.mode=debug,develop
 xdebug.start_with_request=yes

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/mods-available/xdebug.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/mods-available/xdebug.ini
@@ -1,5 +1,5 @@
 zend_extension=xdebug.so
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9000
-xdebug.mode=debug
+xdebug.mode=debug,develop
 xdebug.start_with_request=yes

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -706,7 +706,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 		}
 		// PHP 7.2 through 8.0 gets xdebug 3.0+
 		if app.PHPVersion == nodeps.PHP72 || app.PHPVersion == nodeps.PHP73 || app.PHPVersion == nodeps.PHP74 || app.PHPVersion == nodeps.PHP80 {
-			assert.Contains(stdout, "xdebug.mode => debug => debug", "xdebug is not enabled for %s", v)
+			assert.Contains(stdout, "xdebug.mode => debug,develop => debug,develop", "xdebug is not enabled for %s", v)
 		} else {
 			assert.Contains(stdout, "xdebug support => enabled", "xdebug is not enabled for %s", v)
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210226_heddn_assert_enable" // Note that this can be overridden by make
+var WebTag = "20210318_graham_xdebug_mode" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:
After running `ddev xdebug on`, the error are not "pretty" stack traces like I was expecting. 

They looked like this: 
![image](https://user-images.githubusercontent.com/6642498/111622885-98730c00-87e1-11eb-9f6e-8bcf4435916f.png)

What I was expecting was an output more like this: 
![image](https://user-images.githubusercontent.com/6642498/111623006-c22c3300-87e1-11eb-95e3-a8253a717773.png)


## How this PR Solves The Problem:
Xdebug.ini config changes to enable stack trace outputs. 

## Manual Testing Instructions:
- Turn on xdebug. 
- Cause an error.

## Release/Deployment notes:
I don't think this affects anything else. 
