### PR TITLE
Update brew upgrade command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ We'll walk through these in more detail. You may prefer other techniques of inst
 16. Open the WSL2 terminal, for example `Ubuntu` from the Windows start menu.
 17. Install Homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` (See [https://brew.sh/](brew.sh).)
 18. Add brew to your path as prompted, for example, `echo 'eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)' >> ~/.profile && source ~/.profile`
-19. `brew install gcc && brew tap drud/ddev && brew install ddev`
+19. `brew install gcc && brew install drud/ddev/ddev`
 20. `sudo apt-get update && sudo apt-get install -y xdg-utils` to install the xdg-utils package that allows `ddev launch` to work.
 
 That's it! You have now installed DDEV on WSL2. If you're using WSL2 for ddev (recommended), remember to run all `ddev` commands inside the WSL2 distro.
@@ -124,7 +124,7 @@ You can also easily perform the installation or upgrade manually if preferred. D
 
 ### Installation via package managers - Linux
 
-The preferred Linux package manager is [Homebrew](http://brew.sh/) : `brew tap drud/ddev && brew install ddev`
+The preferred Linux package manager is [Homebrew](http://brew.sh/) : `brew install drud/ddev/ddev`
 
 We also currently maintain a package on [Arch Linux (AUR)](https://aur.archlinux.org/packages/ddev-bin/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ As a one-time initialization, run `mkcert -install`. Linux users may have to tak
 Later, to upgrade to a newer version of DDEV-Local, run:
 
 ```
-ddev poweroff && brew upgrade ddev
+ddev poweroff && brew upgrade drud/ddev/ddev
 ```
 
 ### Installation or Upgrade - Windows (WSL2)

--- a/docs/users/shell-completion.md
+++ b/docs/users/shell-completion.md
@@ -52,7 +52,7 @@ So follow those instructions and your zsh should be set up.
 
 ### Oh-My-Zsh Completion
 
-If you installed zsh with homebrew, ddev's completions will be automatically installed when you `brew install ddev`.
+If you installed zsh with homebrew, ddev's completions will be automatically installed when you `brew install drud/ddev/ddev`.
 
 Otherwise, Oh-My-Zsh may be set up very differently in different places, so as a power zsh user you'll need to put ddev_bash_completion.sh (see tar archive download above) where it belongs. `echo $fpath` will show you the places that it's most likely to belong. An obvious choice is ~/.oh-my-zsh/completions if that exists, so you can `mkdir -p ~/.oh-my-zsh/completions && cp ddev_zsh_completion.sh ~/.oh-my-zsh/completions/_ddev` and then `autoload -Uz compinit && compinit`.
 

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -149,7 +149,7 @@ printf "${GREEN}Download verified. Ready to place ddev and mkcert in your /usr/l
 if [ -L /usr/local/bin/ddev ] ; then
     printf "${RED}ddev already exists as a link in /usr/local/bin. Was it installed with homebrew?${RESET}\n"
     printf "${RED}Cowardly refusing to install over existing symlink${RESET}\n"
-    printf "${RED}Use 'brew unlink ddev' to remove the symlink. Or use 'brew upgrade ddev' to upgrade.${RESET}\n"
+    printf "${RED}Use 'brew unlink ddev' to remove the symlink. Or use 'brew upgrade drud/ddev/ddev' to upgrade.${RESET}\n"
     exit 101
 fi
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
Tried to update ddev with `ddev poweroff && brew upgrade ddev`to latest version and got the following error:

``` 
Formulae found in multiple taps: 
 * drud/ddev/ddev
 * drud/ddev-edge/ddev
```

## How this PR Solves The Problem:
Updated the existing upgrade command with `ddev poweroff && brew upgrade drud/ddev/ddev` to match correct package/tap.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
