### PR TITLE
Include architecture in ddev version, fixes #2884

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -86,6 +86,7 @@ func GetVersionInfo() map[string]string {
 	versionInfo["ddev-ssh-agent"] = SSHAuthImage + ":" + SSHAuthTag
 	versionInfo["build info"] = BUILDINFO
 	versionInfo["os"] = runtime.GOOS
+	versionInfo["architecture"] = runtime.GOARCH
 	if versionInfo["docker"], err = GetDockerVersion(); err != nil {
 		versionInfo["docker"] = fmt.Sprintf("failed to GetDockerVersion(): %v", err)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

For debugging things on mac M1, it's important to have the architecture display

## How this PR Solves The Problem:

Add it to `ddev version`

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

