### PR TITLE
test_ddev.sh should not depend on other scripts [skip ci][ci skip]

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -12,7 +12,7 @@ assignees: ''
 If you're having trouble with ddev,
 
 1. Please use the latest stable version of DDEV-Local before reporting. Upgrading is easy.
-2. Please run a quick diagnostic and post the results as a new gist on gist.github.com (or on another pastebin-type site if you prefer). You can download [test_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/test_ddev.sh) and run it per the instructions at the top, or `curl -sSL https://raw.githubusercontent.com/drud/ddev/master/scripts/test_ddev.sh.sh | bash -s` - That will help so we don't have to ask so many questions... And it it works, it probably means there's something wrong with your project, not ddev.
+2. Please run a quick diagnostic and post the results as a new gist on gist.github.com (or on another pastebin-type site if you prefer). You can download [test_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/test_ddev.sh) and run it per the instructions at the top. That will help so we don't have to ask so many questions... And it it works, it probably means there's something wrong with your project, not ddev.
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/scripts/test_ddev.sh
+++ b/scripts/test_ddev.sh
@@ -16,17 +16,37 @@ function cleanup {
 }
 trap cleanup EXIT
 
-uname -a
+function docker_desktop_version {
+  MACOS_INFO_PATH=/Applications/Docker.app/Contents/Info.plist
+
+  if [ "${OSTYPE%%[0-9]*}" = "darwin" ] && ! command -v xq >/dev/null; then
+    printf "Please install xq, brew install python-yq, to parse macOS Info.plist"
+    exit
+  fi
+
+  if command -v powershell >/dev/null; then
+    printf "Docker Desktop for Windows "
+    powershell.exe -command '[System.Diagnostics.FileVersionInfo]::GetVersionInfo("C:\Program Files\Docker\Docker\Docker Desktop.exe").FileVersion'
+  elif [ -x /usr/libexec/PlistBuddy ] ; then
+    version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" ${MACOS_INFO_PATH})
+    build=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" ${MACOS_INFO_PATH})
+    printf "Docker Desktop for Mac %s build %s" ${version} ${build}
+  else
+    printf "Unknown Docker Desktop version"
+  fi
+}
+
+echo -n "OS Information: " && uname -a
 ddev version
-ls -l "$(which docker)"
-${BASEDIR}/docker-desktop-version.sh && echo
+echo -n "docker location: " && ls -l "$(which docker)"
+echo -n "Docker Desktop Version: " && docker_desktop_version && echo
 ddev poweroff
-docker ps -a
-docker run -it --rm busybox ls
+echo "Existing docker containers: " && docker ps -a
+docker run -it --rm busybox sh -c "echo 'docker can run busybox image'"
 mkdir -p ~/tmp/${PROJECT_NAME} && cd ~/tmp/${PROJECT_NAME}
 printf "<?php\nprint 'ddev is working. You will want to delete this project with \"ddev delete -Oy ${PROJECT_NAME}\"';\n" >index.php
 ddev config --project-type=php
-ddev start || ( \
+echo y | ddev start || ( \
   set +x && \
   ddev list && \
   printf "========= web container healthcheck ======\n" && \

--- a/scripts/test_ddev.sh
+++ b/scripts/test_ddev.sh
@@ -39,7 +39,6 @@ ddev version
 echo -n "docker location: " && ls -l "$(which docker)"
 echo -n "Docker Desktop Version: " && docker_desktop_version && echo
 ddev poweroff
-echo "result of ddev poweroff=$?"
 echo "Existing docker containers: " && docker ps -a
 docker run -it --rm busybox sh -c "echo 'docker can run busybox image'"
 mkdir -p ~/tmp/${PROJECT_NAME} && cd ~/tmp/${PROJECT_NAME}

--- a/scripts/test_ddev.sh
+++ b/scripts/test_ddev.sh
@@ -9,12 +9,10 @@
 # `ddev config global --nfs-mount-enabled=false`
 
 PROJECT_NAME=tryddevproject-${RANDOM}
-BASEDIR=$(dirname "$0")
 
 function cleanup {
   printf "\nPlease delete this project after debugging with 'ddev delete -Oy ${PROJECT_NAME}'\n"
 }
-trap cleanup EXIT
 
 function docker_desktop_version {
   MACOS_INFO_PATH=/Applications/Docker.app/Contents/Info.plist
@@ -41,11 +39,14 @@ ddev version
 echo -n "docker location: " && ls -l "$(which docker)"
 echo -n "Docker Desktop Version: " && docker_desktop_version && echo
 ddev poweroff
+echo "result of ddev poweroff=$?"
 echo "Existing docker containers: " && docker ps -a
 docker run -it --rm busybox sh -c "echo 'docker can run busybox image'"
 mkdir -p ~/tmp/${PROJECT_NAME} && cd ~/tmp/${PROJECT_NAME}
 printf "<?php\nprint 'ddev is working. You will want to delete this project with \"ddev delete -Oy ${PROJECT_NAME}\"';\n" >index.php
 ddev config --project-type=php
+trap cleanup EXIT
+
 echo y | ddev start || ( \
   set +x && \
   ddev list && \


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noticed that test_ddev.sh was depending on the docker desktop version script... but it will most often 

## How this PR Solves The Problem:

## Manual Testing Instructions:

- [ ] Run test_ddev.sh using the instructions provided in the new issue template

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

