### PR TITLE
Test push only on one test system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
         paths:
           - /home/linuxbrew
     - run:
-        command: make -s testpkg TESTARGS='-run "(TestDdevLivePull|TestPantheonPull|TestPlatformPull|TestAcquiaPull|TestLocalfilePull|TestDdevFullSite.*)"' EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+        command: make -s testpkg TESTARGS='-run "(TestDdevFullSite.*)"' EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: ddev tests
         no_output_timeout: "40m"
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
         paths:
           - /home/linuxbrew
     - run:
-        command: make -s testpkg TESTARGS='-run "(TestDdevLive.*|TestPantheon.*|TestPlatform.*|TestAcquia*|TestFlat*|Test*Pull|TestDdevFullSite.*)"' EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+        command: make -s testpkg TESTARGS='-run "(TestDdevLivePull|TestPantheonPull|TestPlatformPull|TestAcquiaPull|TestLocalfilePull|TestDdevFullSite.*)"' EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: ddev tests
         no_output_timeout: "40m"
     - store_test_results:


### PR DESCRIPTION
## The Problem/Issue/Bug:

Since all the push tests have (significant) side-effects, we should only be doing them in one place. With this change we'll do them only in CircleCI's arm64 test.

