### PR TITLE
[docs only] Use fully-qualified name for service when configuring in client, fixes #2744 [skip ci][ci skip]

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -23,7 +23,7 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
 * Add a solr server at `https://<projectname>>.ddev.site/en/admin/config/search/search-api/add-server`.
     * Use the "standard" Solr connector
     * Use the "http" protocol
-    * The "solr host" should be "ddev-<projectname>-solr" **NOT the default "localhost"**, because it does not run in the same container as the webserver.
+    * The "solr host" should be "ddev-<projectname>-solr" **NOT the default "localhost"**, because it does not run in the same container as the webserver. (Note that just using "solr" will often work, and used to be recommended, but it can be ambiguous if there are more than one projects running with a solr service.)
     * The "solr core" should be named "dev" unless you customize the docker-compose.solr.yaml
     * Under "Advanced server configuration" set the "solr.install.dir" to `/opt/solr`
 * Download the config.zip provided on /admin/config/search/search-api/server/dev

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -23,7 +23,7 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
 * Add a solr server at `https://<projectname>>.ddev.site/en/admin/config/search/search-api/add-server`.
     * Use the "standard" Solr connector
     * Use the "http" protocol
-    * The "solr host" should be "solr" **NOT the default "localhost"**
+    * The "solr host" should be "ddev-<projectname>-solr" **NOT the default "localhost"**, because it does not run in the same container as the webserver.
     * The "solr core" should be named "dev" unless you customize the docker-compose.solr.yaml
     * Under "Advanced server configuration" set the "solr.install.dir" to `/opt/solr`
 * Download the config.zip provided on /admin/config/search/search-api/server/dev
@@ -56,8 +56,8 @@ This recipe adds a Memcached 1.5 container to a project. The default configurati
 #### Interacting with Memcached
 
 * The Memcached instance will listen on TCP port 11211 (the Memcached default).
-* Configure your application to access Memcached on the host:port `memcached:11211`.
-* To reach the Memcached admin interface, run `ddev ssh` to connect to the web container, then use `nc` or `telnet` to connect to the Memcached container on port 11211, i.e. `nc memcached 11211`. You can then run commands such as `stats` to see usage information.
+* Configure your application to access Memcached on the host:port `ddev-<projectname>-memcached:11211`.
+* To reach the Memcached admin interface, run `ddev ssh` to connect to the web container, then use `nc` or `telnet` to connect to the Memcached container on port 11211, i.e. `nc ddev-<projectname>-memcached 11211`. You can then run commands such as `stats` to see usage information.
 
 ### Beanstalk (Work Queue)
 
@@ -71,7 +71,7 @@ This recipe adds a [Beanstalk](https://beanstalkd.github.io/) container to a pro
 #### Interacting with the Beanstalk Queue
 
 * The Beanstalk instance will listen on TCP port 11300 (the beanstalkd default).
-* Configure your application to access Beanstalk on the host:port `beanstalk:11300`.
+* Configure your application to access Beanstalk on the host:port `ddev-<projectname>-beanstalk:11300`.
 
 ## Additional services in ddev-contrib (MongoDB, Blackfire, PostgresSQL, etc)
 

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -34,7 +34,7 @@
           - "ddev-router:project2.ddev.site"
 ```
 
-* **How do I make DDEV match my production webserver environment?** You can change the PHP major version (currently 5.6 through 7.4) and choose between nginx+fpm (default and apache+fpm and choose the MariaDB version add [extra services like solr and memcached](extend/additional-services.md). You will not be able to make every detail match your production server, but with PHP version and webserver type you'll be close.
+* **How do I make DDEV match my production webserver environment?** You can change the PHP major version (currently 5.6 through 7.4) and choose between nginx+fpm (default and apache+fpm and choose the MariaDB or MySQL version add [extra services like solr and memcached](extend/additional-services.md). You will not be able to make every detail match your production server, but with database server type and version, PHP version and webserver type you'll be close.
 
 * **How do I completely destroy a project?** Use `ddev delete <project>` to destroy a project. (Also, `ddev stop --remove-data` will do the same thing.) By default, a `ddev snapshot` of your database is taken, but you can skip this, see `ddev delete -h` for options.
 

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -34,7 +34,7 @@
           - "ddev-router:project2.ddev.site"
 ```
 
-* **How do I make DDEV match my production webserver environment?** You can change the PHP major version (currently 5.6 through 7.4) and choose between nginx+fpm (default and apache+fpm and choose the MariaDB or MySQL version add [extra services like solr and memcached](extend/additional-services.md). You will not be able to make every detail match your production server, but with database server type and version, PHP version and webserver type you'll be close.
+* **How do I make DDEV match my production webserver environment?** You can change the PHP major version and choose between nginx+fpm (default and apache+fpm and choose the MariaDB or MySQL version add [extra services like solr and memcached](extend/additional-services.md). You will not be able to make every detail match your production server, but with database server type and version, PHP version and webserver type you'll be close.
 
 * **How do I completely destroy a project?** Use `ddev delete <project>` to destroy a project. (Also, `ddev stop --remove-data` will do the same thing.) By default, a `ddev snapshot` of your database is taken, but you can skip this, see `ddev delete -h` for options.
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2744: It's possible to use ambiguous service names in client configuration. This changes the docs to suggest using names like `ddev-<projectname>-solr` instead of the default (and sometimes ambiguous) `solr`

@tgaertner I'd definitely appreciate your review of this, and would appreciate if you could re-test. I think this will fix the problem you described so clearly.