### PR TITLE
Fix broken docs sidebar, fixes #2885 [ci skip][skip ci]

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,7 @@ nav:
     - 'In-container Configuration': 'users/extend/in-container-configuration.md'
     - 'Custom TLS Certificates': 'users/extend/custom-tls-certificates.md'
   - 'Integration with Hosting Providers':
-    - 'Introduction': '/users/providers/provider-introduction.md'
+    - 'Introduction': 'users/providers/provider-introduction.md'
     - 'Acquia': 'users/providers/acquia.md'
     - 'DDEV-Live': 'users/providers/DDEV-Live.md'
     - 'Pantheon': 'users/providers/pantheon.md'


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2885: Broken left sidebar reference to provider integration intro.

