### PR TITLE
Killing and restarting docker doesn't work on latest docker for mac

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -13,11 +13,11 @@ set -o nounset
 set -x
 
 # On macOS, restart docker to avoid bugs where containers can't be deleted
-if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
-  killall Docker || true
-  nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
-  sleep 10
-fi
+#if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
+#  killall Docker || true
+#  nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended &
+#  sleep 10
+#fi
 
 export TIMEOUT_CMD="timeout -v"
 if [ ${OSTYPE%%-*} = "linux" ]; then


### PR DESCRIPTION
## The Problem/Issue/Bug:

For some time the buildkite script has killed and restarted docker... but that doesn't work on latest docker desktop 3.3.0 for mac M1. So removing that stanza.

