### PR TITLE
Revert macos_ddev_nfs_setup script because docker mac m1 has gone back to old networking

### DIFF
--- a/scripts/macos_ddev_nfs_setup.sh
+++ b/scripts/macos_ddev_nfs_setup.sh
@@ -35,28 +35,11 @@ echo ""
 
 ddev poweroff || true
 
-ARCH="$(uname -m)"
 echo "\n\n== Setting up nfs... You may be asked for your sudo password and for permission to administer your computer..."
 # Share home directory. If the projects are elsewhere the /etc/exports will need
 # to be adapted.
 SHAREDIR=${HOME}
-
-case ${ARCH} in
-  x86_64)
-    LINE="${SHAREDIR} -alldirs -mapall=$(id -u):$(id -g) localhost"
-    ;;
-  arm64)
-    # For mac m1, the source address from NFS driver is different. Gather from the internal
-    # ip of host.docker.internal
-    NET=$(docker run -it --rm busybox sh -c 'ping -c1 host.docker.internal | awk "/PING/ { gsub(/[\(\):]/, \"\"); print \$3 }"')
-    LINE="${SHAREDIR} -alldirs -mapall=$(id -u):$(id -g) -network=${NET%.[0-9]*}.0 -mask 255.255.255.0"
-    ;;
-  *)
-    echo "Unrecognized architecture '${ARCH}" && exit 2
-    ;;
-esac
-
-
+LINE="${SHAREDIR} -alldirs -mapall=$(id -u):$(id -g) localhost"
 FILE=/etc/exports
 sudo bash -c "echo >> $FILE" || ( echo "Unable to edit /etc/exports, need Full Disk Access on Mojave and later" && exit 103 )
 grep -qF -- "$LINE" "$FILE" || ( sudo echo "$LINE" | sudo tee -a $FILE > /dev/null )


### PR DESCRIPTION
## The Problem/Issue/Bug:

The latest Docker for Mac M1 tech preview has changed its networking again... to an easier model that doesn't require special handling for mac M1. 

## How this PR Solves The Problem:

Revert the special architecture-based handling.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

