### PR TITLE
Update cli-usage.md

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -171,7 +171,7 @@ ddev composer create "drupal/recommended-project"
 ddev composer require drush/drush
 ddev drush site:install -y
 ddev drush uli
-ddev drush launch
+ddev launch
 ```
 
 #### Drupal 9 Git Clone Example


### PR DESCRIPTION
Changed  line 174 "ddev drush launch"  to "ddev launch"

Joanne + Ian (New to DDEV and issue queue)

## The Problem/Issue/Bug:
"ddev drush launch"  is not a valid command and will error 

## How this PR Solves The Problem:
"ddev launch"  is the required command

## Manual Testing Instructions:
Run through the D9 quickstart installation instructions, it should complete correctly.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Not sure how to automate a test for this

## Related Issue Link(s):
N/A

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
Unknown
