### PR TITLE
Use the real ddev-live latest binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
         paths:
           - /home/linuxbrew
     - run:
-        command: make -s testpkg TESTARGS='-run "(TestDdevFullSite.*)"' EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
+        command: make -s testpkg TESTARGS='-run "(TestDdevFullSite.*|Test.*Pull)"' EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: ddev tests
         no_output_timeout: "40m"
     - store_test_results:

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -105,8 +105,7 @@ RUN curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(c
 RUN curl -sSL https://github.com/platformsh/platformsh-cli/releases/download/$(curl --silent "https://api.github.com/repos/platformsh/platformsh-cli/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/platform.phar --output /usr/local/bin/platform && chmod 777 /usr/local/bin/platform
 RUN curl -sSL --output /usr/local/bin/acli https://github.com/acquia/cli/releases/latest/download/acli.phar && chmod 777 /usr/local/bin/acli
 
-# Temporary hack 20210319 until ddev-live has arm64 binaries
-RUN source /tmp/ddev/vars && curl -fsSL -o ddev-live.zip https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/ddev-live_${DDEV_LIVE_ARCH}.zip && unzip ddev-live.zip && mv ddev-live /usr/local/bin && chmod 777 /usr/local/bin/ddev-live && rm ddev-live.zip
+RUN source /tmp/ddev/vars && curl -fsSL -o ddev-live.zip https://downloads.ddev.com/ddev-live-cli/latest/linux_${DDEV_LIVE_ARCH}/ddev-live.zip && unzip ddev-live.zip && mv ddev-live /usr/local/bin && chmod 777 /usr/local/bin/ddev-live && rm ddev-live.zip
 
 RUN curl -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.17.0-rc1" // Note that this can be overridden by make
+var WebTag = "20210330_ddev-live" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

ddev-live binary is now available for arm64 from the canonical source. Use it.

