### PR TITLE
Use upstream hostname instead of IP for upstream in ddev-router, resolves #2805

### DIFF
--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -1,14 +1,9 @@
 
 {{ define "upstream" }}
     {{ if .Address }}
-        {{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
-        {{ if and .Container.Node.ID .Address.HostPort }}
-            # {{ .Container.Node.Name }}/{{ .Container.Name }}
-            server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
-        {{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
-        {{ else if .Network }}
+        {{ if .Network }}
             # Container={{ .Container.Name }} {{ .Network.IP }}:{{ .Address.Port }}
-            server {{ .Network.IP }}:{{ .Address.Port }};
+            server {{ .Container.Name }}:{{ .Address.Port }};
         {{ end }}
     {{ else if .Network }}
             # Container={{ .Container.Name }} (down)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -58,7 +58,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.17.0-rc1" // Note that this can be overridden by make
+var RouterTag = "20210330_router_use_name" // Note that this can be overridden by make
 
 var SSHAuthImage = "drud/ddev-ssh-agent"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

This experimental PR might solve #2805, where some (mostly WSl2?) IP addresses get resolved wrong. Maybe.

## How this PR Solves The Problem:

Use the name of the container, instead of using its IP address.

## Manual Testing Instructions:

Manual testing is not likely to recreate the bug, but general testing should be extensive, but it should at least be tested on WSL2.

- [x] Inspect the generated ddev-router:/etc/nginx/conf.d/ddev.conf
- [x] Run several projects at the same time, verify behavior on each on the main URL and others (especially phpmyadmin)
- [x] Stop and start projects and verify behavior.

