### PR TITLE
Revert "Latest docker (version 20) (#2897) [skip ci][ci skip]"

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,8 +1,6 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
-RUN sudo apt-get update -y && sudo apt-get upgrade docker -y
-
 RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc


### PR DESCRIPTION
## The Problem/Issue/Bug:

This reverts commit 9e5228aae47443e87b803c19338598f336a9ba11, #2897 

It turns out that while 20.04 works for building images... you can use ddev or anything else useful.

