### PR TITLE
Remove developer docs from index [skip ci][ci skip]

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,5 +64,3 @@ nav:
     - 'DDEV-Live': 'users/providers/DDEV-Live.md'
     - 'Pantheon': 'users/providers/pantheon.md'
     - 'Platform.sh': 'users/providers/platform.md'
-  - 'Developer Documentation':
-    - 'Building, Testing, and Contributing': 'developers/building-contributing.md'


### PR DESCRIPTION
## The Problem/Issue/Bug:

There's no reason for the "developer docs" to be in ddev.readthedocs.io

## How this PR Solves The Problem:

Remove them from the index.

