### PR TITLE
Change testdata for db backup to env var for ddev-live

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
@@ -27,7 +27,6 @@ environment_variables:
 
 auth_command:
   command: |
-    # set -x   # You can enable bash debugging output by uncommenting
     if [ -z "${ACQUIA_API_KEY:-}" ] || [ -z "${ACQUIA_API_SECRET:-}" ]; then echo "Please make sure you have set ACQUIA_API_KEY and ACQUIA_API_SECRET in ~/.ddev/global_config.yaml" && exit 1; fi
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )

--- a/cmd/ddev/cmd/dotddev_assets/providers/ddev-live.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/ddev-live.yaml.example
@@ -52,12 +52,13 @@ db_push_command:
     # set -x   # You can enable bash debugging output by uncommenting
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
-    restore=$(ddev-live push database ${project_id} -o json db.sql.gz | jq -r .databaseRestore)
+    restore=${project_id%/*}/$(ddev-live push database ${project_id} -o json db.sql.gz | jq -r .databaseRestore)
     while true; do
-        restore_status=$(ddev-live describe restore database "${project_id%/*}/$restore" -o json | jq -r .status)
+        restore_status=$(ddev-live describe restore database "${restore}" -o json | jq -r .status)
         if [ "${restore_status}" = "ImportOpFinished" ]; then break; fi
         sleep 1
     done
+    ddev-live delete backup db -y ${restore}
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 files_push_command:
@@ -65,9 +66,10 @@ files_push_command:
     # set -x   # You can enable bash debugging output by uncommenting
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
     pushd $DDEV_FILES_DIR >/dev/null;
-    restore=$(ddev-live push files ${project_id} -o json . 2>/dev/null | jq -r .filesRestore)
+    restore=${project_id%/*}/$(ddev-live push files ${project_id} -o json . 2>/dev/null | jq -r .filesRestore)
     while true; do
-        restore_status=$(ddev-live describe restore files "${project_id%/*}/${restore}" -o json | jq -r .complete)
+        restore_status=$(ddev-live describe restore files "${restore}" -o json | jq -r .complete)
         if [ "${restore_status}" = "Completed" ]; then break; fi
         sleep 1
     done
+    ddev-live delete backup files -y ${restore}

--- a/cmd/ddev/cmd/dotddev_assets/providers/ddev-live.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/ddev-live.yaml.example
@@ -27,14 +27,12 @@ environment_variables:
 
 auth_command:
   command: |
-    # set -x   # You can enable bash debugging output by uncommenting
-    #if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     if [ -z "${DDEV_LIVE_API_TOKEN:-}" ]; then echo "Please make sure you have set DDEV_LIVE_API_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
     ddev-live auth --token="${DDEV_LIVE_API_TOKEN}"
 
 db_pull_command:
   command: |
-    # set -x   # You can enable bash debugging output by uncommenting
+    set -x   # You can enable bash debugging output by uncommenting
     pushd /var/www/html/.ddev/.downloads >/dev/null
     filename=$(ddev-live pull database -o json ${database_backup} | jq -r .filename)
     mv ${filename} db.sql.gz

--- a/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
@@ -41,7 +41,6 @@ environment_variables:
 
 auth_command:
   command: |
-    # set -x   # You can enable bash debugging output by uncommenting
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     if [ -z "${TERMINUS_MACHINE_TOKEN:-}" ]; then echo "Please make sure you have set TERMINUS_MACHINE_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi

--- a/cmd/ddev/cmd/dotddev_assets/providers/rsync.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/rsync.yaml.example
@@ -27,11 +27,14 @@ auth_command:
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
 
 db_pull_command:
-  command: rsync -az "${dburl}" /var/www/html/.ddev/.downloads
+  command: |
+    # set -x   # You can enable bash debugging output by uncommenting
+    rsync -az "${dburl}" /var/www/html/.ddev/.downloads
   service: web
 
 files_pull_command:
   command: |
+    # set -x   # You can enable bash debugging output by uncommenting
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null
     rm -f files.tar.gz

--- a/pkg/ddevapp/providerDdevLive_test.go
+++ b/pkg/ddevapp/providerDdevLive_test.go
@@ -26,8 +26,7 @@ import (
  * A valid site (with backups) must be present which matches the test site and environment name
  * defined in the constants below.
  */
-const ddevliveTestSite = "ddev-live-test-no-delete"
-const ddevLiveOrg = "ddltest"
+const ddevliveTestSite = "ddltest/ddev-live-test-no-delete"
 
 var ddevLiveDBBackupName = ""
 
@@ -94,8 +93,9 @@ func TestDdevLivePull(t *testing.T) {
 	// Build our ddev-live.yaml from the example file
 	s, err := ioutil.ReadFile(app.GetConfigPath("providers/ddev-live.yaml.example"))
 	require.NoError(t, err)
-	x := strings.Replace(string(s), "project_id:", fmt.Sprintf("project_id: %s/%s\n#project_id:", ddevLiveOrg, ddevliveTestSite), -1)
-	x = strings.Replace(x, "database_backup:", fmt.Sprintf("database_backup: %s/%s\n#database_backup: ", ddevLiveOrg, ddevLiveDBBackupName), -1)
+	x := strings.Replace(string(s), "project_id:", fmt.Sprintf("project_id: %s\n#project_id:", ddevliveTestSite), -1)
+	x = strings.Replace(x, "database_backup:", fmt.Sprintf("database_backup: %s\n#database_backup: ", ddevLiveDBBackupName), -1)
+	x = strings.Replace(x, "# set -x", "set -x", -1)
 	err = ioutil.WriteFile(app.GetConfigPath("providers/ddev-live.yaml"), []byte(x), 0666)
 	require.NoError(t, err)
 	err = app.WriteConfig()
@@ -178,8 +178,8 @@ func TestDdevLivePush(t *testing.T) {
 	// Build our ddev-live.yaml from the example file
 	s, err := ioutil.ReadFile(app.GetConfigPath("providers/ddev-live.yaml.example"))
 	require.NoError(t, err)
-	x := strings.Replace(string(s), "project_id:", fmt.Sprintf("project_id: %s/%s\n#project_id:", ddevLiveOrg, ddevliveTestSite), -1)
-	x = strings.Replace(x, "database_backup:", fmt.Sprintf("database_backup: %s/%s\n#database_backup: ", ddevLiveOrg, ddevLiveDBBackupName), -1)
+	x := strings.Replace(string(s), "project_id:", fmt.Sprintf("project_id: %s\n#project_id:", ddevliveTestSite), -1)
+	x = strings.Replace(x, "database_backup:", fmt.Sprintf("database_backup: %s\n#database_backup: ", ddevLiveDBBackupName), -1)
 	err = ioutil.WriteFile(app.GetConfigPath("providers/ddev-live.yaml"), []byte(x), 0666)
 	assert.NoError(err)
 	err = app.WriteConfig()
@@ -219,7 +219,7 @@ func TestDdevLivePush(t *testing.T) {
 
 	// Test that the file arrived there (by execing a cat of it)
 	out, _, err := app.Exec(&ExecOpts{
-		Cmd: fmt.Sprintf(`ddev-live exec %s/%s -- cat %s `, ddevLiveOrg, ddevliveTestSite, path.Join("sites/default/files", fName)),
+		Cmd: fmt.Sprintf(`ddev-live exec %s -- cat %s `, ddevliveTestSite, path.Join("sites/default/files", fName)),
 	})
 	require.NoError(t, err)
 	assert.Contains(out, tval)

--- a/pkg/ddevapp/providerDdevLive_test.go
+++ b/pkg/ddevapp/providerDdevLive_test.go
@@ -28,13 +28,17 @@ import (
  */
 const ddevliveTestSite = "ddev-live-test-no-delete"
 const ddevLiveOrg = "ddltest"
-const ddevLiveDBBackupName = "ddev-live-test-no-delete-gg5pt"
+
+var ddevLiveDBBackupName = ""
 
 // TestDdevLivePull ensures we can pull backups from DDEV-Live
 func TestDdevLivePull(t *testing.T) {
 	token := ""
 	if token = os.Getenv("DDEV_DDEVLIVE_API_TOKEN"); token == "" {
 		t.Skipf("No DDEV_DDEVLIVE_API_TOKEN env var has been set. Skipping %v", t.Name())
+	}
+	if ddevLiveDBBackupName = os.Getenv("DDEV_DDEVLIVE_PULL_BACKUP"); ddevLiveDBBackupName == "" {
+		t.Skipf("No DDEV_DDEVLIVE_PULL_BACKUP env var has been set. Skipping %v", t.Name())
 	}
 
 	// Set up tests and give ourselves a working directory.
@@ -120,6 +124,9 @@ func TestDdevLivePush(t *testing.T) {
 	token := ""
 	if token = os.Getenv("DDEV_DDEVLIVE_API_TOKEN"); token == "" {
 		t.Skipf("No DDEV_DDEVLIVE_API_TOKEN env var has been set. Skipping %v", t.Name())
+	}
+	if ddevLiveDBBackupName = os.Getenv("DDEV_DDEVLIVE_PULL_BACKUP"); ddevLiveDBBackupName == "" {
+		t.Skipf("No DDEV_DDEVLIVE_PULL_BACKUP env var has been set. Skipping %v", t.Name())
 	}
 
 	// Set up tests and give ourselves a working directory.


### PR DESCRIPTION
## The Problem/Issue/Bug:

* The `ddev-live push ddev-live` (and as a result TestPushDdevLive) were creating a backup every time, because that's what ddev-live does.
* As a result we hit the backup quota and everything broke

## How this PR Solves The Problem:

* Change the example to delete its backup after pushing 
* Change the test to use a configurable db backup (environment variable)

