### PR TITLE
Make sure drush knows about acquia aliases

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
@@ -32,6 +32,7 @@ auth_command:
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     acli auth:login -n --key="${ACQUIA_API_KEY}" --secret="${ACQUIA_API_SECRET}"
     acli remote:aliases:download -n >/dev/null
+    drush core:init -y >/dev/null 2>&1
 
 db_pull_command:
   command: |


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noted on testing `ddev push acquia` that there was a problem with drush rsync; apparently the aliases weren't fully populated.

This adds the drush core:init command to make sure those get loaded.

