### PR TITLE
Remove github sponsors from docs/index.md [skip ci][ci skip]

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -183,5 +183,3 @@ We love to hear from our users and help them be successful with DDEV. Support op
 * [ddev-contrib](https://github.com/drud/ddev-contrib) repo provides a number of vetted user-contributed recipes for extending and using DDEV. Your contributions are welcome.
 * [awesome-ddev](https://github.com/drud/awesome-ddev) repo has loads of external resources, blog posts, recipes, screencasts, and the like. Your contributions are welcome.
 * [Twitter with tag #ddev](https://twitter.com/search?q=%23ddev&src=typd&f=live) will get to us, but it's not as good for interactive support, but we'll answer anywhere.
-
-<iframe src="https://github.com/sponsors/drud/button" title="Sponsor DDEV-Local" height="35" width="116" style="border: 0;"></iframe>


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've opted out of GitHub Sponsors. Remove doc pointing to it.

