### PR TITLE
Specify remote alias locations for acquia integration

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
@@ -32,7 +32,6 @@ auth_command:
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     acli auth:login -n --key="${ACQUIA_API_KEY}" --secret="${ACQUIA_API_SECRET}"
     acli remote:aliases:download -n >/dev/null
-    drush core:init -y >/dev/null 2>&1
 
 db_pull_command:
   command: |
@@ -45,10 +44,9 @@ db_pull_command:
 files_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
-    drush core:init -y --quiet
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
-    drush rsync -q -y @${project_id}:%files ./files
+    drush rsync --alias-path=~/.drush -q -y @${project_id}:%files ./files
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 db_push_command:
@@ -65,4 +63,4 @@ files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
-    drush rsync -y @self:%files @${project_id}:%files
+    drush rsync -y --alias-path=~/.drush @self:%files @${project_id}:%files

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -235,14 +235,14 @@ func TestAcquiaPush(t *testing.T) {
 
 	// Test that the database row was added
 	out, _, err := app.Exec(&ExecOpts{
-		Cmd: fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s"' | drush @%s sql-cli --extra=-N`, t.Name(), tval, acquiaTestSite),
+		Cmd: fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s"' | drush @%s --alias-path=~/.drush sql-cli --extra=-N`, t.Name(), tval, acquiaTestSite),
 	})
 	require.NoError(t, err)
 	assert.Contains(out, tval)
 
 	// Test that the file arrived there (by rsyncing it back)
 	out, _, err = app.Exec(&ExecOpts{
-		Cmd: fmt.Sprintf("drush rsync -y @%s:%%files/%s /tmp && cat /tmp/%s", acquiaTestSite, fName, fName),
+		Cmd: fmt.Sprintf("drush --alias-path=~/.drush rsync -y @%s:%%files/%s /tmp && cat /tmp/%s", acquiaTestSite, fName, fName),
 	})
 	require.NoError(t, err)
 	assert.Contains(out, tval)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Another round of getting stable Acquia. 

It turns out that `acli remote:aliases:download` puts drush aliases into ~/.drush, but drush by default doesn't load from there. acli gives a message saying you need to `drush core:init` to get it to find them, but that doesn't have anything to do with it AFAICT. What's needed is to use an `alias-path` somewhere. This PR changes to use it in the actual drush command.

