### PR TITLE
Remove commented line in platform example [skip ci][ci skip]

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/providers/platform.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/platform.yaml.example
@@ -26,7 +26,6 @@ environment_variables:
 auth_command:
   command: |
     if [ -z "${PLATFORMSH_CLI_TOKEN:-}" ]; then echo "Please make sure you have set PLATFORMSH_CLI_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
-    # ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
 
 db_pull_command:
   command: |


### PR DESCRIPTION
## The Problem/Issue/Bug:

This just removes a spurious commented-out line in the platform.yaml.example

