### PR TITLE
gitpod: Move make into init in .gitpod.yml

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,6 +3,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN sudo apt-get update && sudo apt-get install -y netcat telnet
 RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
+RUN npm install -g markdownlint-cli
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       export DDEV_NONINTERACTIVE=true
       make
-      mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --router-http-port=8080 --router-https-port=8443 && cp ~/bin/gitpod-setup-ddev.sh .ddev && .ddev/gitpod-setup-ddev.sh
+      mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && .ddev/gitpod-setup-ddev.sh
   - name: terminal
     command: |
       sudo docker-up >/dev/null 2>&1 &

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,12 +7,12 @@ tasks:
       sudo docker-up >/dev/null 2>&1 &
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       make
-      mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && ddev start
+      mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && ddev start -y
   - name: terminal
     command: |
       sudo docker-up >/dev/null 2>&1 &
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
-      ddev start simpleproj
+      ddev start -y simpleproj
 vscode:
   extensions:
     - premparihar.gotestexplorer@0.1.10:jvUM8akrQ67vQxfjaxCgCg==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,8 +9,10 @@ tasks:
       export DDEV_NONINTERACTIVE=true
       make
       mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && .ddev/gitpod-setup-ddev.sh
+      gp sync-done make
   - name: terminal
     command: |
+      gp sync-await make
       sudo docker-up >/dev/null 2>&1 &
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       ddev start -y simpleproj

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,14 +1,13 @@
-
 image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - init: |
-    sudo docker-up >/dev/null 2>&1 &
-    while ! docker ps >/dev/null 2>&1; do sleep 1; done
-    make
-    .githooks/linkallchecks.sh
-    mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && ddev start
+  - name: prebuild
+    prebuild: |
+      sudo docker-up >/dev/null 2>&1 &
+      while ! docker ps >/dev/null 2>&1; do sleep 1; done
+      make
+      mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && ddev start
   - name: terminal
     command: |
       sudo docker-up >/dev/null 2>&1 &

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,17 +3,17 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - name: make
+  - init: |
+    sudo docker-up >/dev/null 2>&1 &
+    while ! docker ps >/dev/null 2>&1; do sleep 1; done
+    make
+    .githooks/linkallchecks.sh
+    mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && ddev start
+  - name: terminal
     command: |
-      # Wait for docker to come up before doing make (make requires docker)
-      while ! docker ps; do
-        sleep 1
-      done
-      .githooks/linkallchecks.sh
-      make
-  - name: docker_up
-    command: sudo docker-up      
-
+      sudo docker-up >/dev/null 2>&1 &
+      while ! docker ps >/dev/null 2>&1; do sleep 1; done
+      ddev start simpleproj
 vscode:
   extensions:
     - premparihar.gotestexplorer@0.1.10:jvUM8akrQ67vQxfjaxCgCg==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,10 +5,12 @@ tasks:
   - name: prebuild
     prebuild: |
       sudo docker-up >/dev/null 2>&1 &
+      DOCKERPID=$!
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       export DDEV_NONINTERACTIVE=true
       make
       mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && .ddev/gitpod-setup-ddev.sh
+      sudo kill $DOCKERPID
   - name: terminal
     command: |
       sudo docker-up >/dev/null 2>&1 &

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,11 +8,9 @@ tasks:
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       export DDEV_NONINTERACTIVE=true
       make
-      mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && .ddev/gitpod-setup-ddev.sh
-      gp sync-done make
+      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && .ddev/gitpod-setup-ddev.sh
   - name: terminal
     command: |
-      gp sync-await make
       sudo docker-up >/dev/null 2>&1 &
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       ddev start -y simpleproj

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       export DDEV_NONINTERACTIVE=true
       make
-      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && .ddev/gitpod-setup-ddev.sh
+      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && printf "<?php\nphpinfo();\n" >index.php &&.ddev/gitpod-setup-ddev.sh
       sudo kill $DOCKERPID
   - name: terminal
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,8 +6,9 @@ tasks:
     prebuild: |
       sudo docker-up >/dev/null 2>&1 &
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
+      export DDEV_NONINTERACTIVE=true
       make
-      mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --auto && ddev start -y
+      mkdir -p ~/tmp/simpleproj && cd ~/tmp/simpleproj && ddev config --router-http-port=8080 --router-https-port=8443 && cp ~/bin/gitpod-setup-ddev.sh .ddev && .ddev/gitpod-setup-ddev.sh
   - name: terminal
     command: |
       sudo docker-up >/dev/null 2>&1 &


### PR DESCRIPTION
## The Problem/Issue/Bug:

The gitpod check is likely not running because there is no init.

With the latest gitpod as of yesterday, there's no need to delay the make and ddev start

## How this PR Solves The Problem:

Add an init that does basic make and setup.

See also #2935

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

