### PR TITLE
proposed Gitpod pre-build config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,6 +11,7 @@ RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
 
 RUN curl -o ~/bin/gitpod-setup-ddev.sh --fail -lLs https://raw.githubusercontent.com/shaal/ddev-gitpod/main/.ddev/gitpod-setup-ddev.sh && chmod +x ~/bin/gitpod-setup-ddev.sh
 RUN mkcert -install
+RUN npm install -g markdownlint-cli
 
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,16 +3,19 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
+  - name: docker_up
+    before: sudo docker-up & echo $! > /tmp/docker.pid && fg
   - name: make
-    command: |
+    init: |
       # Wait for docker to come up before doing make (make requires docker)
       while ! docker ps; do
         sleep 1
       done
       .githooks/linkallchecks.sh
       make
-  - name: docker_up
-    command: sudo docker-up      
+      gp sync-done make
+  - name: docker_down
+    prebuild: gp sync-await make && sudo kill $(cat /tmp/docker.pid)
 
 vscode:
   extensions:


### PR DESCRIPTION
I played around a bit with your Gitpod setup. This is the result
- pre-install `markdownlint` in the dockerfile as it's required by the build
- run `docker-up` as `before` task as it's needed in all scenarios. Save its PID in a tempfile
- run the `make build` as an `init` task
- add a `prebuild` task that waits for `make` to finish and tears down docker using the saved PID, otherwise pre-builds won't terminate