### PR TITLE
Pick up new php-imagick build from upstream, fixes #2934

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod (for DDEV-Live)
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.17.0 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.17.1-alpha1 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod (for DDEV-Live)
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.17.1-alpha1 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.17.1-alpha4 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -2,9 +2,10 @@
 
 @test "Verify required binaries are installed in normal image" {
     if [ "${IS_HARDENED}" == "true" ]; then skip "Skipping because IS_HARDENED==true"; fi
-    COMMANDS="composer ddev-live drush git magerun magerun2 mkcert node npm platform sudo terminus wp"
+    COMMANDS="composer ddev-live drush8 git magerun magerun2 mkcert node npm platform sudo terminus wp"
     for item in $COMMANDS; do
-       docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"
+#      echo "# looking for $item" >&3
+      docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"
     done
 }
 

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -86,6 +86,8 @@
   7.[01])
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring mysqli pgsql readline soap sqlite3 uploadprogress xml xmlrpc zip"
     ;;
+  8.0)
+    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 xml xmlrpc zip"
   esac
 
   run docker exec -t $CONTAINER_NAME enable_xdebug

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -74,3 +74,27 @@
 @test "verify that test/phptest.php is interpreted ($project_type)" {
 	curl --fail 127.0.0.1:$HOST_HTTP_PORT/test/phptest.php
 }
+
+@test "verify key php extensions are loaded on PHP${PHP_VERSION}" {
+  if [ "${WEBSERVER_TYPE}" = "apache-fpm" ]; then skip "Skipping on apache-fpm because we don't have to do this twice"; fi
+
+  extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xml xmlrpc zip"
+  case ${PHP_VERSION} in
+  5.6)
+    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring mysql pgsql readline soap sqlite3 uploadprogress xml xmlrpc zip"
+    ;;
+  7.[01])
+    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring mysqli pgsql readline soap sqlite3 uploadprogress xml xmlrpc zip"
+    ;;
+  esac
+
+  run docker exec -t $CONTAINER_NAME enable_xdebug
+  run docker exec -t $CONTAINER_NAME bash -c "php -r \"print_r(get_loaded_extensions());\" 2>/dev/null | tr -d '\r\n'"
+  loaded="${output}"
+  # echo "# loaded=${output}" >&3
+  for item in $extensions; do
+#    echo "# extension: $item on PHP${PHP_VERSION}" >&3
+    grep -q "=> $item " <<< ${loaded} || (echo "# extension ${item} not loaded" >&3 && false)
+  done
+  run docker exec -t $CONTAINER_NAME disable_xdebug
+}

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -7,8 +7,8 @@ set -o nounset
 if [ $# != "1" ]; then echo "docker image spec must be \$1"; exit 1; fi
 DOCKER_IMAGE=$1
 export IS_HARDENED=false
-DOCKER_REPO=${DOCKER_IMAGE##:*}
-if [ ${DOCKER_REPO%_prod} ]; then
+DOCKER_REPO=${DOCKER_IMAGE%:*}
+if [[ "${DOCKER_REPO}" == "*prod*" ]]; then
   IS_HARDENED=true
 fi
 
@@ -31,20 +31,28 @@ docker run -t --rm  -v "$(mkcert -CAROOT):/mnt/mkcert" -v ddev-global-cache:/mnt
 
 # Wait for container to be ready.
 function containerwait {
-	for i in {60..0};
+	for i in {20..0};
 	do
-		# status contains uptime and health in parenthesis, sed to return health
-		status="$(docker ps --format "{{.Status}}" --filter "name=$CONTAINER_NAME" | sed  's/.*(\(.*\)).*/\1/')"
-		if [[ "$status" == "healthy" ]]
-		then
-			return 0
-		fi
-		sleep 1
+		status="$(docker inspect $CONTAINER_NAME | jq -r '.[0].State.Status')"
+    health="$(docker inspect $CONTAINER_NAME | jq -r '.[0].State.Health.Status')"
+
+		case $status in
+		running)
+      if [ ${health} = "healthy" ]; then
+		    return 0
+      else
+        sleep 1
+      fi
+		  ;;
+		exited)
+		  echo "# --- container exited"
+		  return 1
+		  ;;
+		*)
+  		sleep 1
+		esac
 	done
-	echo "# --- ddev-webserver containerwait failed: information:"
-	docker ps -a
-	docker logs $CONTAINER_NAME
-	docker inspect $CONTAINER_NAME
+	echo "# --- containerwait failed: information:"
 	return 1
 }
 
@@ -83,7 +91,7 @@ for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0; do
 done
 
 for project_type in backdrop drupal6 drupal7 drupal8 drupal9 laravel magento magento2 typo3 wordpress default; do
-	export PHP_VERSION="7.3"
+	export PHP_VERSION="7.4"
     export project_type
 	if [ "$project_type" == "drupal6" ]; then
 	  PHP_VERSION="5.6"
@@ -99,7 +107,7 @@ for project_type in backdrop drupal6 drupal7 drupal8 drupal9 laravel magento mag
     cleanup
 done
 
-docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=7.3" --mount "type=bind,src=$PWD/tests/ddev-webserver/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache -d --name $CONTAINER_NAME -d $DOCKER_IMAGE >/dev/null
+docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=7.4" --mount "type=bind,src=$PWD/tests/ddev-webserver/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache -d --name $CONTAINER_NAME -d $DOCKER_IMAGE >/dev/null
 containerwait
 
 bats tests/ddev-webserver/custom_config.bats

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.17.0" // Note that this can be overridden by make
+var WebTag = "20210407_imagemagick" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* v1.17.0 didn't have php7.*-imagick enabled or installed, see #2934 
* uploadprogress was also missing I think
* Adds php8.0-xmlrpc

## How this PR Solves The Problem:

Add those from upstream

## Manual Testing Instructions:

php -i and look for the missing items

## Automated Testing Overview:

Added a new container test to look for key php extensions.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

