### PR TITLE
Fix docs to show available PHP versions including 8.0

### DIFF
--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -4,7 +4,7 @@ ddev provides several ways in which the environment for a project using ddev can
 
 ### Changing PHP version
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4` or `8.0`. The current default is php 7.3.
+The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4` or `8.0`. The current default is php 7.4.
 
 #### Older versions of PHP
 

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -4,7 +4,7 @@ ddev provides several ways in which the environment for a project using ddev can
 
 ### Changing PHP version
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, or `7.4`. The current default is php 7.3.
+The project's `.ddev/config.yaml` file defines the PHP version to use. This can be changed, and the php_version can be set there to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4` or `8.0`. The current default is php 7.3.
 
 #### Older versions of PHP
 


### PR DESCRIPTION
The documentation should reflect the [support of PHP 8.0](https://ddev.readthedocs.io/en/stable/users/extend/config_yaml/)

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

