### PR TITLE
Update Pantheon provider instructions to match yaml.

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
@@ -24,7 +24,7 @@
 # 
 # 6. Configure the local checkout for ddev using `ddev config`
 # 
-# 7. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the `project_id` and `environment_name`.
+# 7. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit `yourproject`. If you want to use a different enviornment than dev, update `dev` to the name of the environment.
 # 
 # 8. `ddev restart`
 # 

--- a/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
@@ -24,7 +24,7 @@
 # 
 # 6. Configure the local checkout for ddev using `ddev config`
 # 
-# 7. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit `yourproject`. If you want to use a different enviornment than dev, update `dev` to the name of the environment.
+# 7. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the "project" under `environment_variables` (change it from `yourproject.dev`). If you want to use a different environment than "dev", change `dev` to the name of the environment.
 # 
 # 8. `ddev restart`
 # 
@@ -75,4 +75,3 @@ files_push_command:
     # set -x   # You can enable bash debugging output by uncommenting
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
     drush rsync -y @self:%files @${project}:%files
-


### PR DESCRIPTION
## The Problem/Issue/Bug:
The instructions in the pantheon.yaml.example file say to:
In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the `project_id` and `environment_name`.

There is no `project_id`or `environment_name` in the file. Instead, `yourproject.dev` must be defined.

## How this PR Solves The Problem:
Updates the instructions to match the yaml.

## Manual Testing Instructions:
Review the PR and test locally.

As an example, updating `yourproject` to the name of a Pantheon site and changing `dev` to `live` works for me.

## Automated Testing Overview:
N/A

## Related Issue Link(s):
N/A

## Release/Deployment notes:
N/A

