### PR TITLE
Add ~/bin and /var/www/html/bin to PATH in web container

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
@@ -1,1 +1,1 @@
-export PATH="$PATH:/var/www/html/vendor/bin"
+export PATH="$PATH:/var/www/html/vendor/bin:/var/www/html/bin"

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
@@ -1,1 +1,1 @@
-export PATH="$PATH:/var/www/html/vendor/bin:/var/www/html/bin"
+export PATH="~/bin:$PATH:/var/www/html/vendor/bin:/var/www/html/bin"

--- a/docs/users/extend/in-container-configuration.md
+++ b/docs/users/extend/in-container-configuration.md
@@ -9,7 +9,7 @@ DDEV looks for the `homeadditions` directory either in `~/.ddev/homeadditions` (
 Usage examples:
 
 * If you use git inside the container, you may want to copy your ~/.gitconfig into ~/.ddev/homeadditions or the project's .ddev/homeadditions so that use of git inside the container will use your regular username and email, etc.
-* If you need to add a script or other executable component into the project, you can put it in the `bin` directory and `~/bin/<script` will be created inside the container and $HOME/bin will be added first in the $PATH. This is also useful for overriding standard scripts.
+* If you need to add a script or other executable component into the project (or global configuration), you can put it in the project or global `.ddev/homeadditions/bin` directory and `~/bin/<script` will be created inside the container. This is useful for adding a script to a project or to every project, or for overriding standard scripts, as ~/bin is first in the $PATH in the web container.
 * If you use private password-protected composer repositories with satis, for example, and use a global auth.json, you might want to `cp ~/.composer/auth.json into .ddev/homeadditions/.composer/auth.json`, but be careful that you exclude it from checking using a .gitignore or equivalent.
 * Some people have specific configuration needs for their .ssh/config. If you provide your own .ssh/config though, please make sure it includes these lines:
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210407_imagemagick" // Note that this can be overridden by make
+var WebTag = "20210415_add_exec_path" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

A number of people have their composer bin directory in /bin instead of /vendor/bin - this is fairly nonstandard, but there's no reason not to add that to the default path. 

## How this PR Solves The Problem:

Add /var/www/html/bin to path

Also adds ~/bin to front of $PATH, allows people to solve problems like this by just putting whatever they need in global homeadditions.

## Manual Testing Instructions:

`ddev exec 'echo $PATH'`

