### PR TITLE
Turn off DOCKER_SCAN_SUGGEST to get rid of synk advertising

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1363,6 +1363,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_ROUTER_HTTPS_PORT":     app.RouterHTTPSPort,
 		"DDEV_XDEBUG_ENABLED":        strconv.FormatBool(app.XdebugEnabled),
 		"DDEV_PRIMARY_URL":           app.GetPrimaryURL(),
+		"DOCKER_SCAN_SUGGEST":        "false",
 		"IS_DDEV_PROJECT":            "true",
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Docker-compose in 1.29.0 started saying this when building:
```
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```

It's really annoying. DOCKER_SCAN_SUGGEST=false gets rid of it.

See https://github.com/docker/compose-cli/issues/1517
This is partially fixed in https://github.com/docker/compose-cli/pull/1532

But we don't ever need this advertising.

## How this PR Solves The Problem:

set environment DOCKER_SCAN_SUGGEST=false

## Manual Testing Instructions:

`ddev start` with docker-compose v1.29.0. You should not see the annoying message.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

