### PR TITLE
Bump web image tag for v1.17.1

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210415_add_exec_path" // Note that this can be overridden by make
+var WebTag = "v1.17.1" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

It's time to release v1.17.1, and nice to have a simple tag for ddev-webserver

