### PR TITLE
Add ddev status as alias of ddev describe for #2195

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -12,15 +12,16 @@ import (
 
 // DescribeCommand represents the `ddev config` command
 var DescribeCommand = &cobra.Command{
-	Use:   "describe [projectname]",
-	Short: "Get a detailed description of a running ddev project.",
+	Use:     "describe [projectname]",
+	Aliases: []string{"status", "st", "desc"},
+	Short:   "Get a detailed description of a running ddev project.",
 	Long: `Get a detailed description of a running ddev project. Describe provides basic
 information about a ddev project, including its name, location, url, and status.
 It also provides details for MySQL connections, and connection information for
 additional services like MailHog and phpMyAdmin. You can run 'ddev describe' from
 a project directory to describe that project, or you can specify a project to describe by
 running 'ddev describe <projectname>.`,
-	Example: "ddev describe\nddev describe <projectname>",
+	Example: "ddev describe\nddev describe <projectname>\nddev status\nddev st",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 1 {
 			util.Failed("Too many arguments provided. Please use 'ddev describe' or 'ddev describe [projectname]'")


### PR DESCRIPTION
## The Problem/Issue/Bug:

Several people chimed in on #2195 asking for `ddev status` as an alias for `ddev describe`.

## How this PR Solves The Problem:

Adds `ddev status`, `ddev st`, `ddev desc`. Otherwise functionality is unchanged.

## Manual Testing Instructions:

* Try `ddev status` and `ddev status <projectname>`

You can test this PR at https://gitpod.io/#https://github.com/drud/ddev/pull/2955 - You can get to the base project with `cd /workspace/simpleproj` and then use `ddev describe` and `ddev status` to your heart's delight.