### PR TITLE
Change pantheon pull to use terminus backup:get

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -54,3 +54,9 @@ GHR_RELEASE="v0.13.0"
 curl -fsL -o /tmp/ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/${GHR_RELEASE}/ghr_${GHR_RELEASE}_linux_amd64.tar.gz
 sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/ghr.tar.gz ghr_${GHR_RELEASE}_linux_amd64/ghr
 ghr -v
+
+# Show info to simplify debugging
+docker info
+docker version
+docker-compose version
+lsb_release -a

--- a/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
@@ -4,34 +4,36 @@
 # but can be adapted for other CMSs supported by Pantheon
 
 # To use this configuration:
-# 
+#
 # 1. Get your Pantheon.io machine token:
 #    a. Login to your Pantheon Dashboard, and [Generate a Machine Token](https://pantheon.io/docs/machine-tokens/) for ddev to use.
 #    b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml
-# 
+#
 #    ```
 #    web_environment:
 #    - TERMINUS_MACHINE_TOKEN=abcdeyourtoken`
 #    ```
-# 
-# 2. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>, the site ID is 009a2cda-2c22-4eee-8f9d-96f017321555.
-# 
-# 3. Make sure your public ssh key is configured in Pantheon (Account->SSH Keys)
-# 
-# 4. Check out project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
-# 
-# 5. Verify that drush is installed in your project, `ddev composer require drush/drush`
-# 
-# 6. Configure the local checkout for ddev using `ddev config`
-# 
-# 7. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the "project" under `environment_variables` (change it from `yourproject.dev`). If you want to use a different environment than "dev", change `dev` to the name of the environment.
-# 
-# 8. `ddev restart`
-# 
-# 9. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
-# 
-# 10. Optionally use `ddev push pantheon` to push local files and database to DDEV-Live. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
-# 
+#
+# 2. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site uuid, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>, the site ID is 009a2cda-2c22-4eee-8f9d-96f017321555.
+#
+# 3. On the pantheon dashboard, make sure that at least one backup has been created. (When you need to refresh what you pull, do a new backup.)
+#
+# 4. Make sure your public ssh key is configured in Pantheon (Account->SSH Keys)
+#
+# 5. Check out project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
+#
+# 6. Verify that drush is installed in your project, `ddev composer require drush/drush`
+#
+# 7. Configure the local checkout for ddev using `ddev config`
+#
+# 8. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the "project" under `environment_variables` (change it from `yourproject.dev`). If you want to use a different environment than "dev", change `dev` to the name of the environment.
+#
+# 9. `ddev restart`
+#
+# 10. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
+#
+# 11. Optionally use `ddev push pantheon` to push local files and database to DDEV-Live. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+#
 
 # Debugging: Use `ddev exec terminus auth:whoami` to see what terminus knows about
 # `ddev exec terminus site:list` will show available sites
@@ -51,14 +53,16 @@ db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    drush @${project} sql-dump --gzip >/var/www/html/.ddev/.downloads/db.sql.gz
+    pushd /var/www/html/.ddev/.downloads >/dev/null
+    terminus backup:get ${project} --element=db --to=db.sql.gz
 
 files_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
-    ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
+    ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
-    drush rsync -y @${project}:%files/ /var/www/html/.ddev/.downloads/files/
+    terminus backup:get ${project} --element=files --to=files.tgz
+    mkdir -p files && tar --strip-components=1 -C files -zxf files.tgz
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 db_push_command:

--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -19,18 +19,20 @@ If you have ddev installed, and have an active Pantheon account with an active s
 
 2. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>, the site ID is 009a2cda-2c22-4eee-8f9d-96f017321555.
 
-3. Make sure your public ssh key is configured in Pantheon (Account->SSH Keys)
+3. On the pantheon dashboard for the site, make sure that at least one backup has been created. (When you need to refresh what you pull, create a new backup.)
 
-4. Check out project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
+4. Make sure your public ssh key is configured in Pantheon (Account->SSH Keys)
 
-5. If using Drupal 8+, verify that drush is installed in your project, `ddev composer require drush/drush`. If using Drupal 6 or 7, drush8 is already provided in the web container's /usr/local/bin/drush, so you can skip this step.
+5. Check out the project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
 
 6. Configure the local checkout for ddev using `ddev config`
 
-7. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the `project_id` and `environment_name`.
+7. If using Drupal 8+, verify that drush is installed in your project, `ddev composer require drush/drush`. If using Drupal 6 or 7, drush8 is already provided in the web container's /usr/local/bin/drush, so you can skip this step.
 
-8. `ddev restart`
+8. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the `project` environment variable under `environment_variables`. It will be in the format `<projectname>.<environment>`, for example `yourprojectname.dev` or (in cases of ambiguity) `<project_uuid>.<environment>`, for example `009a2cda-2c22-4eee-8f9d-96f017321555.dev`.
 
-9. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
+9. `ddev restart`
 
-10. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+10. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
+
+11. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1480,6 +1480,9 @@ func (app *DdevApp) StartAndWait(extraSleep int) error {
 	if err != nil {
 		return err
 	}
+	if extraSleep > 0 {
+		time.Sleep(time.Duration(extraSleep) * time.Second)
+	}
 	return nil
 }
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -743,13 +743,17 @@ func GetExposedContainerPorts(containerID string) ([]string, error) {
 		return nil, err
 	}
 
-	ports := []string{}
+	portMap := map[string]bool{}
 	for _, portMapping := range inspectInfo.NetworkSettings.Ports {
 		if portMapping != nil && len(portMapping) > 0 {
 			for _, item := range portMapping {
-				ports = append(ports, item.HostPort)
+				portMap[item.HostPort] = true
 			}
 		}
+	}
+	ports := []string{}
+	for k := range portMap {
+		ports = append(ports, k)
 	}
 	sort.Slice(ports, func(i, j int) bool {
 		return ports[i] < ports[j]


### PR DESCRIPTION
## The Problem/Issue/Bug:

The previous (drush rsync) technique for pulling a backup from Pantheon was just way too tedious, and could even fail due to connection timeouts

## How this PR Solves The Problem:

Use `terminus backup:get`. command and require that a backup already exists.

## Manual Testing Instructions:

Use the "pull" sections of the new strategy with your site and see if it works.

