### PR TITLE
Add tests to check for expiring apt keys in images

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           go-version: 1.*
           
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Build and test container ${{ matrix.containers }}
         run: |
           docker version

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -37,7 +37,6 @@ jobs:
           go-version: 1.*
           
       - name: Setup tmate session
-        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
 
       - name: Build and test container ${{ matrix.containers }}

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -35,6 +35,10 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.*
+          
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
 
       - name: Build and test container ${{ matrix.containers }}
         run: |

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -14,7 +14,7 @@ function setup {
 
 @test "verify apt keys are not expiring" {
   MAX_DAYS_BEFORE_EXPIRATION=90
-  if [ "${DDEV_IGNORE_EXPIRING_KEYS}" = "true" ]; then
+  if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
   docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+# Run these tests from the repo root directory
+
+load functions.sh
+
+function setup {
+  basic_setup
+
+  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE"
+  docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+  containercheck
+}
+
+@test "verify apt keys are not expiring" {
+  MAX_DAYS_BEFORE_EXPIRATION=90
+  if [ "${DDEV_IGNORE_EXPIRING_KEYS}" = "true" ]; then
+    skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
+  fi
+  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+    dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
+    for item in ${dates}; do
+      today=$(date -I)
+      let diff=($(date +%s -d ${item})-$(date +%s -d ${today}))/86400
+      if [ ${diff} -le ${max} ]; then
+        exit 1
+      fi
+    done
+  '
+
+}

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -17,7 +17,7 @@ function setup {
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+  docker exec -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-router/test/containertest.sh
+++ b/containers/ddev-router/test/containertest.sh
@@ -83,6 +83,8 @@ else
       today=$(date -I)
       let diff=($(date +%s -d ${item})-$(date +%s -d ${today}))/86400
       if [ ${diff} -le ${max} ]; then
+        echo "An apt key is expiring in ${diff} days"
+        apt-key list
         exit 1
       fi
     done

--- a/containers/ddev-router/test/containertest.sh
+++ b/containers/ddev-router/test/containertest.sh
@@ -77,7 +77,7 @@ MAX_DAYS_BEFORE_EXPIRATION=90
 if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
   echo "Skipping test of expiring keys because DDEV_IGNORE_EXPIRING_KEYS is set"
 else
-  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -x -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-router/test/containertest.sh
+++ b/containers/ddev-router/test/containertest.sh
@@ -13,19 +13,28 @@ CONTAINER_NAME=ddev-router-test
 
 # Wait for container to be ready.
 function containercheck {
-    set +x
-	for i in {20..0};
-	do
-		# status contains uptime and health in parenthesis, sed to return health
-		status="$(docker ps --format "{{.Status}}" --filter "name=$CONTAINER_NAME" | sed  's/.*(\(.*\)).*/\1/')"
-		if [[ "$status" == "healthy" ]]
-		then
-			set -x
-			return 0
-		fi
-		sleep 1
-	done
-	return 1
+  for i in {15..0}; do
+    # fail if we can't find the container
+    if ! docker inspect ${CONTAINER_NAME} >/dev/null; then
+      break
+    fi
+
+    status="$(docker inspect ${CONTAINER_NAME} | jq -r '.[0].State.Status')"
+    if [ "${status}" != "running" ]; then
+      break
+    fi
+    health="$(docker inspect --format '{{json .State.Health }}' ${CONTAINER_NAME} | jq -r .Status)"
+    case ${health} in
+    healthy)
+      return 0
+      ;;
+    *)
+      sleep 1
+      ;;
+    esac
+  done
+  echo "# --- ddev-router FAIL -----"
+  return 1
 }
 
 function cleanup {
@@ -62,3 +71,20 @@ if [ "${OS:-$(uname)}" != "Windows_NT" ]; then
 fi
 # Make sure internal access to https is working
 docker exec -t $CONTAINER_NAME curl --fail https://127.0.0.1/healthcheck || (echo "Failed to run https healthcheck inside container" && exit 104)
+
+
+MAX_DAYS_BEFORE_EXPIRATION=90
+if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
+  echo "Skipping test of expiring keys because DDEV_IGNORE_EXPIRING_KEYS is set"
+else
+  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+    dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
+    for item in ${dates}; do
+      today=$(date -I)
+      let diff=($(date +%s -d ${item})-$(date +%s -d ${today}))/86400
+      if [ ${diff} -le ${max} ]; then
+        exit 1
+      fi
+    done
+  ' || (echo "apt keys are expiring in container" && exit 105)
+fi

--- a/containers/ddev-router/test/containertest.sh
+++ b/containers/ddev-router/test/containertest.sh
@@ -3,7 +3,6 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -x
 
 if [ "${OS:-$(uname)}" = "Windows_NT" ]; then exit; fi
 
@@ -47,6 +46,7 @@ cleanup
 
 # Make sure rootCA is created and installed on the ddev-global-cache/mkcert
 mkcert -install
+set -x
 docker run -t --rm  -v "$(mkcert -CAROOT):/mnt/mkcert" -v ddev-global-cache:/mnt/ddev-global-cache busybox sh -c "mkdir -p /mnt/ddev-global-cache/mkcert && chmod -R ugo+w /mnt/ddev-global-cache/* && cp -R /mnt/mkcert /mnt/ddev-global-cache"
 
 # Run the router alone
@@ -77,7 +77,7 @@ MAX_DAYS_BEFORE_EXPIRATION=90
 if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
   echo "Skipping test of expiring keys because DDEV_IGNORE_EXPIRING_KEYS is set"
 else
-  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -x -c '
+  docker exec -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -x -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-ssh-agent/Makefile
+++ b/containers/ddev-ssh-agent/Makefile
@@ -14,4 +14,4 @@ multi-arch:
 	echo "created multi-arch builds $(BUILD_ARCHS) for $(DOCKER_REPO)";
 
 test: container
-	true >/dev/null
+	test/test.sh $(DOCKER_REPO):$(VERSION)

--- a/containers/ddev-ssh-agent/test/functions.sh
+++ b/containers/ddev-ssh-agent/test/functions.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+function basic_setup {
+    export CONTAINER_NAME="testserver"
+    export HOSTPORT=33000
+    export MYTMPDIR="${HOME}/tmp/testserver-sh_${RANDOM}_$$"
+    export outdir="${HOME}/tmp/mariadb_testserver/output_${RANDOM}_$$"
+    export VOLUME="dbserver_test-${RANDOM}_$$"
+
+    export MOUNTUID=33
+    export MOUNTGID=33
+
+    # Homebrew mysql client realy really wants /usr/local/etc/my.cnf.d
+    if [ "${OS:-$(uname)}" != "Windows_NT" ] && [ ! -d "$(brew --prefix)/etc/my.cnf.d" ]; then
+        mkdir -p "$(brew --prefix)/etc/my.cnf.d" || sudo mkdir -p "$(brew --prefix)/etc/my.cnf.d"
+    fi
+    docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
+
+    # Initialize the volume with the correct ownership
+    docker run --rm -v "${VOLUME}:/var/lib/mysql:nocopy" busybox chown -R ${MOUNTUID}:${MOUNTGID} /var/lib/mysql
+}
+
+function teardown {
+  docker rm -f ${CONTAINER_NAME}
+  docker volume rm $VOLUME || true
+}
+
+# Wait for container to be ready.
+function containercheck {
+  for i in {15..0}; do
+    # fail if we can't find the container
+    if ! docker inspect ${CONTAINER_NAME} >/dev/null; then
+      break
+    fi
+
+    status="$(docker inspect ${CONTAINER_NAME} | jq -r '.[0].State.Status')"
+    if [ "${status}" != "running" ]; then
+      break
+    fi
+    health="$(docker inspect --format '{{json .State.Health }}' ${CONTAINER_NAME} | jq -r .Status)"
+    case ${health} in
+    healthy)
+      return 0
+      ;;
+    *)
+      sleep 1
+      ;;
+    esac
+  done
+  echo "# --- ddev-dbserver FAIL -----"
+  return 1
+}

--- a/containers/ddev-ssh-agent/test/functions.sh
+++ b/containers/ddev-ssh-agent/test/functions.sh
@@ -10,10 +10,6 @@ function basic_setup {
     export MOUNTUID=33
     export MOUNTGID=33
 
-    # Homebrew mysql client realy really wants /usr/local/etc/my.cnf.d
-    if [ "${OS:-$(uname)}" != "Windows_NT" ] && [ ! -d "$(brew --prefix)/etc/my.cnf.d" ]; then
-        mkdir -p "$(brew --prefix)/etc/my.cnf.d" || sudo mkdir -p "$(brew --prefix)/etc/my.cnf.d"
-    fi
     docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
 
     # Initialize the volume with the correct ownership

--- a/containers/ddev-ssh-agent/test/image_general.bats
+++ b/containers/ddev-ssh-agent/test/image_general.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+# Run these tests from the repo root directory
+
+load functions.sh
+
+function setup {
+  basic_setup
+
+  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE"
+  docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+  containercheck
+}
+
+@test "verify apt keys are not expiring" {
+  MAX_DAYS_BEFORE_EXPIRATION=90
+  if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
+    skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
+  fi
+  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+    dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
+    for item in ${dates}; do
+      today=$(date -I)
+      let diff=($(date +%s -d ${item})-$(date +%s -d ${today}))/86400
+      if [ ${diff} -le ${max} ]; then
+        exit 1
+      fi
+    done
+  '
+
+}

--- a/containers/ddev-ssh-agent/test/image_general.bats
+++ b/containers/ddev-ssh-agent/test/image_general.bats
@@ -7,8 +7,8 @@ load functions.sh
 function setup {
   basic_setup
 
-  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE"
-  docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+  echo "# Starting ${IMAGE}" >&3
+  docker run --rm -u "$MOUNTUID:$MOUNTGID" --name=$CONTAINER_NAME -d ${IMAGE}
   containercheck
 }
 

--- a/containers/ddev-ssh-agent/test/image_general.bats
+++ b/containers/ddev-ssh-agent/test/image_general.bats
@@ -17,7 +17,7 @@ function setup {
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+  docker exec -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-ssh-agent/test/test.sh
+++ b/containers/ddev-ssh-agent/test/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Find the directory of this script
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [ $# != 1 ]; then
+  echo "Usage: $0 <imagespec>"
+  exit 1
+fi
+export IMAGE=$1
+
+export CURRENT_ARCH=$(../get_arch.sh)
+
+# /usr/local/bin is added for git-bash, where it may not be in the $PATH.
+export PATH="/usr/local/bin:$PATH"
+bats test || (echo "bats tests failed for IMAGE=${IMAGE}" && exit 2)
+printf "Test successful for IMAGE=${IMAGE}\n\n"

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -51,7 +51,7 @@
 
 @test "verify apt keys are not expiring" {
   MAX_DAYS_BEFORE_EXPIRATION=90
-  if [ "${DDEV_IGNORE_EXPIRING_KEYS}" = "true" ]; then
+  if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
   docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -54,7 +54,7 @@
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  docker exec -it -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+  docker exec -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -16,10 +16,6 @@
 @test "enable and disable xdebug for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
     CURRENT_ARCH=$(../get_arch.sh)
 
-    if [ ${PHP_VERSION} == "5.6" ] && [ ${CURRENT_ARCH} == 'arm64' ]; then
-      skip "XDebug isn't available on arm64 PHP 5.6"
-    fi
-
     docker exec -t $CONTAINER_NAME enable_xdebug
     if [ ]${PHP_VERSION} != "8.0" ] ; then
       docker exec -t $CONTAINER_NAME php --re xdebug | grep "xdebug.remote_enable"
@@ -34,10 +30,6 @@
 
 @test "verify that xdebug is enabled by default when the image is not run with start.sh php${PHP_VERSION}" {
   CURRENT_ARCH=$(../get_arch.sh)
-
-  if [ ${PHP_VERSION} == "5.6" ] && [ ${CURRENT_ARCH} == 'arm64' ]; then
-    skip "XDebug isn't available on arm64 PHP 5.6"
-  fi
 
   docker run  -e "DDEV_PHP_VERSION=${PHP_VERSION}" --rm $DOCKER_IMAGE bash -c 'php --version | grep "with Xdebug"'
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've periodically had problems with expiring apt keys inside the container, especially the web container

## How this PR Solves The Problem:

Check during build to see that keys are no closer than 90 days from expiration.

## Manual Testing Instructions:

Tests only. 

## Automated Testing Overview:

This adds tests for each image to make sure that we're no closer than 90 days to expiration.

