### PR TITLE
gitpod: Install docker buildx so we can build images

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
-RUN sudo apt-get update && sudo apt-get install -y file netcat telnet
+RUN sudo apt-get update && sudo apt-get install -y file mysql-client netcat telnet
 RUN brew update && brew install bash-completion bats-core drud/ddev/ddev golangci-lint
 RUN npm install -g markdownlint-cli
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
 RUN sudo apt-get update && sudo apt-get install -y file netcat telnet
-RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
+RUN brew update && brew install bash-completion bats-core drud/ddev/ddev golangci-lint
 RUN npm install -g markdownlint-cli
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
-RUN sudo apt-get update && sudo apt-get install -y netcat telnet
+RUN sudo apt-get update && sudo apt-get install -y file netcat telnet
 RUN brew update && brew install bash-completion drud/ddev/ddev golangci-lint
 RUN npm install -g markdownlint-cli
 
@@ -12,6 +12,12 @@ RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
 
 RUN curl -o ~/bin/gitpod-setup-ddev.sh --fail -lLs https://raw.githubusercontent.com/shaal/ddev-gitpod/main/.ddev/gitpod-setup-ddev.sh && chmod +x ~/bin/gitpod-setup-ddev.sh
 RUN mkcert -install
+
+ENV BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64"
+
+RUN mkdir -p ~/.docker/cli-plugins && curl --output ~/.docker/cli-plugins/docker-buildx \
+    --silent --show-error --location --fail --retry 3 \
+    "$BUILDX_BINARY_URL" && chmod a+x ~/.docker/cli-plugins/docker-buildx
 
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,7 +16,7 @@ tasks:
       sudo docker-up >/dev/null 2>&1 &
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       cd /workspace/simpleproj && .ddev/gitpod-setup-ddev.sh
-      gp await-port 8080 && gp preview $(gp url 8080)
+      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 vscode:
   extensions:
     - premparihar.gotestexplorer@0.1.10:jvUM8akrQ67vQxfjaxCgCg==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,13 +9,18 @@ tasks:
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       export DDEV_NONINTERACTIVE=true
       make
-      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && printf "<?php\nphpinfo();\n" >index.php &&.ddev/gitpod-setup-ddev.sh
+      ddev version | awk '/(drud|phpmyadmin)\// {print $2;}' >/tmp/images.txt
+      for item in $(cat /tmp/images.txt); do
+        docker pull $item
+      done
+
       sudo kill $DOCKERPID
   - name: terminal
     command: |
       sudo docker-up >/dev/null 2>&1 &
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
-      ddev start -y simpleproj
+      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && printf "<?php\nphpinfo();\n" >index.php &&.ddev/gitpod-setup-ddev.sh
+      cd /workspace/simpleproj && ddev start -y
 vscode:
   extensions:
     - premparihar.gotestexplorer@0.1.10:jvUM8akrQ67vQxfjaxCgCg==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,18 +9,14 @@ tasks:
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
       export DDEV_NONINTERACTIVE=true
       make
-      ddev version | awk '/(drud|phpmyadmin)\// {print $2;}' >/tmp/images.txt
-      for item in $(cat /tmp/images.txt); do
-        docker pull $item
-      done
-
+      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && printf "<?php\nphpinfo();\n" >index.php && .ddev/gitpod-setup-ddev.sh
       sudo kill $DOCKERPID
   - name: terminal
     command: |
       sudo docker-up >/dev/null 2>&1 &
       while ! docker ps >/dev/null 2>&1; do sleep 1; done
-      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && printf "<?php\nphpinfo();\n" >index.php &&.ddev/gitpod-setup-ddev.sh
-      cd /workspace/simpleproj && ddev start -y
+      cd /workspace/simpleproj && .ddev/gitpod-setup-ddev.sh
+      gp await-port 8080 && gp preview $(gp url 8080)
 vscode:
   extensions:
     - premparihar.gotestexplorer@0.1.10:jvUM8akrQ67vQxfjaxCgCg==

--- a/docs/developers/building-contributing.md
+++ b/docs/developers/building-contributing.md
@@ -21,7 +21,29 @@ Gitpod.io provides a quick preconfigured ddev experience in the browser, so you 
 To just open and work on ddev you can use the button below.
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/drud/ddev)
 
-If you want to run a project in there, the easy way to set it up based on [ddev-gitpod](https://github.com/shaal/ddev-gitpod) is to `ddev config` and then `cd .ddev && cp ~/bin/gitpod-setup-ddev.sh . && ./gitpod-setup-ddev.sh`. This sets up ports for the project that are compatible with gitpod, etc.
+If you want to run a project in there, the easy way to set it up in `/workspace/<yourproject>` based on [ddev-gitpod](https://github.com/shaal/ddev-gitpod) is to `ddev config` and then `cd .ddev && cp ~/bin/gitpod-setup-ddev.sh . && ./gitpod-setup-ddev.sh`. This sets up ports for the project that are compatible with gitpod, etc.
+
+A dummy project for gitpod is also provided already set up in /workspace/simpleproj.
+
+## Making changes to ddev images
+
+If you need to make a change to one of the ddev images, you can make the change but then it has to be built with a specific tag, and the tag has to be updated in pkg/version/version.go. So for example, make a change to containers/ddev-webserver/Dockerfile, then built it:
+
+```bash
+cd containers/ddev-webserver
+make VERSION=20210424_fix_dockerfile
+```
+
+Then edit pkg/version/version.go to set `var WebTag = "20210424_fix_dockerfile"` and
+
+```bash
+cd /workspace/ddev
+make
+```
+
+`ddev version` should show you that you are using the correct webtag, and `ddev start` will show it.
+
+It's easiest to do this using gitpod (see above) because gitpod already has `docker buildx` all set up for you and the built ddev is in the $PATH.
 
 ## Pull Requests and PR Preparation
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Routine gitpod maintenance. Since gitpod does not have docker 20.10, we need to install the buildx extension

## Release/Deployment notes:

When gitpod supports 20.10, this should be removable.
