### PR TITLE
Check for environment variable DDEV_ALLOW_PUSH before allowing provider push

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
@@ -19,7 +19,7 @@
 # 7. Your project must include drush; `ddev composer require drush/drush` if it isn't there already.
 # 8. `ddev restart`
 # 9. Use `ddev pull acquia` to pull the project database and files.
-# 10. Optionally use `ddev push acquia` to push local files and database to Aquia. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+# 10. Optionally use `ddev push acquia` to push local files and database to Aquia. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended. If you want to enable push, you must set the environment variable DDEV_ALLOW_PUSH=true in your .ddev/config.yaml or ~/.ddev/global_config.yaml.
 
 # Debugging: Use `ddev exec acli command` and `ddev exec acli auth:info`
 # Make sure you remembered to `ddev auth ssh`

--- a/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/pantheon.yaml.example
@@ -32,7 +32,7 @@
 #
 # 10. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
 #
-# 11. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+# 11. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended. If you want to enable push, you must set the environment variable DDEV_ALLOW_PUSH=true in your .ddev/config.yaml or ~/.ddev/global_config.yaml.
 #
 
 # Debugging: Use `ddev exec terminus auth:whoami` to see what terminus knows about

--- a/cmd/ddev/cmd/dotddev_assets/providers/platform.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/platform.yaml.example
@@ -15,7 +15,8 @@
 # 4. Obtain your project id with `ddev exec platform`. The platform tool should show you all the information about your account and project.
 # 5. In your project's .ddev/providers directory, copy platform.yaml.example to platform.yaml and edit the `project_id` and `environment_name`.
 # 6. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
-# 7. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+# 7. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended. If you want to enable push, you must set the environment variable DDEV_ALLOW_PUSH=true in your .ddev/config.yaml or ~/.ddev/global_config.yaml.
+
 # Debugging: Use `ddev exec platform` to see what platform.sh knows about
 # your configuration and whether it's working correctly.
 

--- a/docs/users/providers/acquia.md
+++ b/docs/users/providers/acquia.md
@@ -24,7 +24,7 @@ ddev's Acquia integration pulls database and files from an existing project into
 7. Your project must include drush; `ddev composer require drush/drush` if it isn't there already.
 8. `ddev restart`
 9. Use `ddev pull acquia` to pull the project database and files.
-10. Optionally use `ddev push acquia` to push local files and database to Aquia. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+10. Optionally use `ddev push acquia` to push local files and database to Aquia. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended. If you want to enable push, you must set the environment variable DDEV_ALLOW_PUSH=true in your .ddev/config.yaml or ~/.ddev/global_config.yaml.
 
 ### Usage
 

--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -35,4 +35,4 @@ If you have ddev installed, and have an active Pantheon account with an active s
 
 10. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
 
-11. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+11. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended. If you want to enable push, you must set the environment variable DDEV_ALLOW_PUSH=true in your .ddev/config.yaml or ~/.ddev/global_config.yaml.

--- a/docs/users/providers/platform.md
+++ b/docs/users/providers/platform.md
@@ -20,7 +20,7 @@ ddev's Platform.sh integration pulls database and files from an existing Platfor
 4. Obtain your project id with `ddev exec platform`. The platform tool should show you all the information about your account and project.
 5. In your project's .ddev/providers directory, copy platform.yaml.example to platform.yaml and edit the `project_id` and `environment_name`.
 6. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
-7. Optionally use `ddev push platform` to push local files and database to Platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+7. Optionally use `ddev push platform` to push local files and database to Platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended. If you want to enable push, you must set the environment variable DDEV_ALLOW_PUSH=true in your .ddev/config.yaml or ~/.ddev/global_config.yaml.
 
 ### Usage
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -226,7 +226,7 @@ func (p *Provider) UploadDB() error {
 	}
 
 	if os.Getenv("DDEV_ALLOW_PUSH") != "true" {
-		util.Warning("You must set the enviorement DDEV_ALLOW_PUSH=true to allow DB push")
+		util.Warning("You must set the environment variable DDEV_ALLOW_PUSH=true to allow DB push")
 		return nil
 	}
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"github.com/drud/ddev/pkg/output"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -226,8 +227,7 @@ func (p *Provider) UploadDB() error {
 	}
 
 	if os.Getenv("DDEV_ALLOW_PUSH") != "true" {
-		util.Warning("You must set the environment variable DDEV_ALLOW_PUSH=true to allow DB push")
-		return nil
+		return errors.Errorf("You must set the environment variable DDEV_ALLOW_PUSH=true to allow DB push")
 	}
 
 	err := p.app.ExportDB(p.app.GetConfigPath(".downloads/db.sql.gz"), true, "")
@@ -257,8 +257,7 @@ func (p *Provider) UploadFiles() error {
 	}
 
 	if os.Getenv("DDEV_ALLOW_PUSH") != "true" {
-		util.Warning("You must set the enviorement DDEV_ALLOW_PUSH=true to allow Files push")
-		return nil
+		return errors.Errorf("You must set the enviorement DDEV_ALLOW_PUSH=true to allow Files push")
 	}
 
 	s := p.FilesPushCommand.Service
@@ -267,7 +266,7 @@ func (p *Provider) UploadFiles() error {
 	}
 	err := p.app.ExecOnHostOrService(s, p.injectedEnvironment()+"; "+p.FilesPushCommand.Command)
 	if err != nil {
-		util.Failed("Failed to exec %s on %s: %v", p.FilesPushCommand.Command, s, err)
+		return errors.Errorf("Failed to exec %s on %s: %v", p.FilesPushCommand.Command, s, err)
 	}
 	return nil
 }

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -225,6 +225,11 @@ func (p *Provider) UploadDB() error {
 		return nil
 	}
 
+	if os.Getenv("DDEV_ALLOW_PUSH") == "true" {
+		util.Warning("You must set the enviorement DDEV_ALLOW_PUSH=true to allow DB push")
+		return nil
+	}
+
 	err := p.app.ExportDB(p.app.GetConfigPath(".downloads/db.sql.gz"), true, "")
 	if err != nil {
 		return err
@@ -248,6 +253,11 @@ func (p *Provider) UploadFiles() error {
 
 	if p.FilesPullCommand.Command == "" {
 		util.Warning("No FilesPushCommand is defined for provider %s", p.ProviderType)
+		return nil
+	}
+
+	if os.Getenv("DDEV_ALLOW_PUSH") == "true" {
+		util.Warning("You must set the enviorement DDEV_ALLOW_PUSH=true to allow Files push")
 		return nil
 	}
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -225,7 +225,7 @@ func (p *Provider) UploadDB() error {
 		return nil
 	}
 
-	if os.Getenv("DDEV_ALLOW_PUSH") == "true" {
+	if os.Getenv("DDEV_ALLOW_PUSH") != "true" {
 		util.Warning("You must set the enviorement DDEV_ALLOW_PUSH=true to allow DB push")
 		return nil
 	}
@@ -256,7 +256,7 @@ func (p *Provider) UploadFiles() error {
 		return nil
 	}
 
-	if os.Getenv("DDEV_ALLOW_PUSH") == "true" {
+	if os.Getenv("DDEV_ALLOW_PUSH") != "true" {
 		util.Warning("You must set the enviorement DDEV_ALLOW_PUSH=true to allow Files push")
 		return nil
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Allow the dangerous push of DB or files only after an env is set

## How this PR Solves The Problem:


## Related Issue Link(s):

https://github.com/drud/ddev/pull/2963#pullrequestreview-644054303


I've never written in Go, so this is just a naive (and so far untested) implementation.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/2966"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

