### PR TITLE
Upgrade to Blackfire agent v2 in web container

### DIFF
--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
@@ -50,7 +50,7 @@ case $1 in
     if [ ${agentstatus} -eq 0 ]; then echo "blackfire agent running"; else echo "blackfire agent not running"; fi
 
     if [ ${phpstatus} -eq 0 ]; then printf "probe version %s\n" "$(php -v | awk  -F '[ ,\~]+' '/blackfire/{ print $4; }')"; fi
-    printf "agent version %s\n" "$(blackfire version | awk '{print $2;}')"
+    printf "agent version %s\n" "$(blackfire version | awk '{print $3;}')"
     ;;
 
   *)

--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
@@ -14,17 +14,21 @@ function enable {
   fi
   phpenmod blackfire
   killall -HUP php-fpm
-  killall blackfire-agent 2>/dev/null
+  # Can't use killall here because it kills this process!
+  pid=$(ps -ef | awk '$8~/^blackfire.*/ { print $2 }' 2>/dev/null)
+  if [ "${pid}" != "" ]; then kill $pid; fi
   nohup blackfire agent:start --log-level=4 >/tmp/blackfire_nohup.out 2>&1 &
   sleep 1
-  echo "Enabled blackfire PHP extension and started blackfire-agent"
+  echo "Enabled blackfire PHP extension and started blackfire agent"
   exit
 }
 function disable {
   phpdismod blackfire
   killall -HUP php-fpm
-  killall blackfire-agent 2>/dev/null
-  echo "Disabled blackfire PHP extension and stopped blackfire-agent"
+  # Can't use killall here because it kills this process!
+  pid=$(ps -ef | awk '$8~/^blackfire.*/ { print $2 }' 2>/dev/null)
+  if [ "${pid}" != "" ]; then kill ${pid}; fi
+  echo "Disabled blackfire PHP extension and stopped blackfire agent"
   exit
 }
 
@@ -44,13 +48,13 @@ case $1 in
   status)
     php --version | grep "with blackfire" >/dev/null 2>&1
     phpstatus=$?
-    killall -0 blackfire-agent 2>/dev/null
-    agentstatus=$?
+    # Can't use killall here because it kills this process!
+    agentstatus=$(ps -ef | awk '$8~/^blackfire.*/ { print $2 }' 2>/dev/null)
+    if [ "${pid}" != "" ]; then kill $pid; fi
     if [ ${phpstatus} -eq 0 ]; then echo "blackfire PHP extension enabled"; else echo "blackfire PHP extension disabled"; fi
-    if [ ${agentstatus} -eq 0 ]; then echo "blackfire agent running"; else echo "blackfire agent not running"; fi
-
+    if [ "${agentstatus}" != "" ]; then echo "blackfire agent running"; else echo "blackfire agent not running"; fi
     if [ ${phpstatus} -eq 0 ]; then printf "probe version %s\n" "$(php -v | awk  -F '[ ,\~]+' '/blackfire/{ print $4; }')"; fi
-    printf "agent version %s\n" "$(blackfire version | awk '{print $3;}')"
+    printf "blackfire version %s\n" "$(blackfire version | awk '{print $3;}')"
     ;;
 
   *)

--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
@@ -6,7 +6,6 @@
 ## Example: "ddev blackfire" (default is "on"), "ddev blackfire off", "ddev blackfire on", "ddev blackfire status"
 
 function enable {
-  echo "step 0"
   if [ -z ${BLACKFIRE_SERVER_ID} ] || [ -z ${BLACKFIRE_SERVER_TOKEN} ]; then
     echo "BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN environment variables must be set" >&2
     echo "See docs for how to set in global or project config" >&2

--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
@@ -14,8 +14,8 @@ function enable {
   fi
   phpenmod blackfire
   killall -HUP php-fpm
-  killall blackfire-agent 2>/dev/null
-  nohup blackfire-agent --log-level=4 >/tmp/blackfire_nohup.out 2>&1 &
+  killall blackfire 2>/dev/null
+  nohup blackfire agent:start --log-level=4 >/tmp/blackfire_nohup.out 2>&1 &
   sleep 1
   echo "Enabled blackfire PHP extension and started blackfire-agent"
   exit
@@ -23,7 +23,7 @@ function enable {
 function disable {
   phpdismod blackfire
   killall -HUP php-fpm
-  killall blackfire-agent 2>/dev/null
+  killall blackfire 2>/dev/null
   echo "Disabled blackfire PHP extension and stopped blackfire-agent"
   exit
 }

--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
@@ -15,9 +15,7 @@ function enable {
   fi
   phpenmod blackfire
   killall -HUP php-fpm
-  echo "step 3"
   killall blackfire-agent 2>/dev/null
-  echo "step 4"
   nohup blackfire agent:start --log-level=4 >/tmp/blackfire_nohup.out 2>&1 &
   sleep 1
   echo "Enabled blackfire PHP extension and started blackfire-agent"
@@ -26,7 +24,7 @@ function enable {
 function disable {
   phpdismod blackfire
   killall -HUP php-fpm
-  killall blackfire 2>/dev/null
+  killall blackfire-agent 2>/dev/null
   echo "Disabled blackfire PHP extension and stopped blackfire-agent"
   exit
 }
@@ -38,9 +36,7 @@ fi
 
 case $1 in
   on|true|enable|start)
-    echo "before disable_xdebug"
     disable_xdebug
-    echo "before enable"
     enable
     ;;
   off|false|disable|stop)
@@ -55,8 +51,7 @@ case $1 in
     if [ ${agentstatus} -eq 0 ]; then echo "blackfire agent running"; else echo "blackfire agent not running"; fi
 
     if [ ${phpstatus} -eq 0 ]; then printf "probe version %s\n" "$(php -v | awk  -F '[ ,\~]+' '/blackfire/{ print $4; }')"; fi
-    printf "agent version %s\n" "$(blackfire-agent -v | awk '{print $2;}')"
-    printf "cli version %s\n" "$(blackfire version | awk '{print $2;}')"
+    printf "agent version %s\n" "$(blackfire version | awk '{print $2;}')"
     ;;
 
   *)

--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
@@ -50,7 +50,6 @@ case $1 in
     phpstatus=$?
     # Can't use killall here because it kills this process!
     agentstatus=$(ps -ef | awk '$8~/^blackfire.*/ { print $2 }' 2>/dev/null)
-    if [ "${pid}" != "" ]; then kill $pid; fi
     if [ ${phpstatus} -eq 0 ]; then echo "blackfire PHP extension enabled"; else echo "blackfire PHP extension disabled"; fi
     if [ "${agentstatus}" != "" ]; then echo "blackfire agent running"; else echo "blackfire agent not running"; fi
     if [ ${phpstatus} -eq 0 ]; then printf "probe version %s\n" "$(php -v | awk  -F '[ ,\~]+' '/blackfire/{ print $4; }')"; fi

--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
@@ -6,15 +6,20 @@
 ## Example: "ddev blackfire" (default is "on"), "ddev blackfire off", "ddev blackfire on", "ddev blackfire status"
 
 function enable {
+  echo "step 0"
   if [ -z ${BLACKFIRE_SERVER_ID} ] || [ -z ${BLACKFIRE_SERVER_TOKEN} ]; then
     echo "BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN environment variables must be set" >&2
     echo "See docs for how to set in global or project config" >&2
     echo "For example, ddev config global --web-environment=BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>"
     exit 1
   fi
+  echo "step 1"
   phpenmod blackfire
+  echo "step 2"
   killall -HUP php-fpm
+  echo "step 3"
   killall blackfire 2>/dev/null
+  echo "step 4"
   nohup blackfire agent:start --log-level=4 >/tmp/blackfire_nohup.out 2>&1 &
   sleep 1
   echo "Enabled blackfire PHP extension and started blackfire-agent"
@@ -35,7 +40,9 @@ fi
 
 case $1 in
   on|true|enable|start)
+    echo "before disable_xdebug"
     disable_xdebug
+    echo "before enable"
     enable
     ;;
   off|false|disable|stop)

--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/blackfire
@@ -13,12 +13,10 @@ function enable {
     echo "For example, ddev config global --web-environment=BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>"
     exit 1
   fi
-  echo "step 1"
   phpenmod blackfire
-  echo "step 2"
   killall -HUP php-fpm
   echo "step 3"
-  killall blackfire 2>/dev/null
+  killall blackfire-agent 2>/dev/null
   echo "step 4"
   nohup blackfire agent:start --log-level=4 >/tmp/blackfire_nohup.out 2>&1 &
   sleep 1

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -74,7 +74,7 @@ RUN mkdir /tmp/ddev && \
     fi
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
-    blackfire-agent \
+    blackfire \
     blackfire-php \
     fontconfig \
     gettext \

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.17.2" // Note that this can be overridden by make
+var WebTag = "20210502_thomasdiluccio_blackfire" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
DDEV-Local implements Blackfire agent V1 which is now deprecated and will be soon unsupported. This PR bootstrap the [upgrade to Blackfire agent V2](https://blackfire.io/docs/up-and-running/agent-upgrade#documentation).

I haven't been able to test this code and look forward to some procedures to do so.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/2970"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

