### PR TITLE
`sudo docker-up` is no longer needed in Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -24,3 +24,7 @@ RUN mkdir -p ~/.docker/cli-plugins && curl --output ~/.docker/cli-plugins/docker
 # RUN brew install bastet
 #
 # More information: https://www.gitpod.io/docs/config-docker/
+
+###
+### Initiate a rebuild of Gitpod's image by updating this comment #1
+###

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,12 +2,11 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - name: prebuild
+  - name: terminal
     prebuild: |
       export DDEV_NONINTERACTIVE=true
       make
       mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && printf "<?php\nphpinfo();\n" >index.php && .ddev/gitpod-setup-ddev.sh
-  - name: terminal
     command: |
       cd /workspace/simpleproj && .ddev/gitpod-setup-ddev.sh
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,17 +4,11 @@ image:
 tasks:
   - name: prebuild
     prebuild: |
-      sudo docker-up >/dev/null 2>&1 &
-      DOCKERPID=$!
-      while ! docker ps >/dev/null 2>&1; do sleep 1; done
       export DDEV_NONINTERACTIVE=true
       make
       mkdir -p /workspace/simpleproj && cd /workspace/simpleproj && ddev config --auto && cp ~/bin/gitpod-setup-ddev.sh .ddev && printf "<?php\nphpinfo();\n" >index.php && .ddev/gitpod-setup-ddev.sh
-      sudo kill $DOCKERPID
   - name: terminal
     command: |
-      sudo docker-up >/dev/null 2>&1 &
-      while ! docker ps >/dev/null 2>&1; do sleep 1; done
       cd /workspace/simpleproj && .ddev/gitpod-setup-ddev.sh
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 vscode:


### PR DESCRIPTION
## The Problem/Issue/Bug:
Gitpod runs docker daemon by default.
`sudo docker-up` is no longer needed to run docker commands in Gitpod.

## How this PR Solves the Problem:
This PR removes all related commands from `.gitpod.yml`

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Open this PR in gitpod, confirm that ddev runs as usual.

## Related Issue Link(s):
https://github.com/shaal/ddev-gitpod/pull/36

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/2984"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

