### PR TITLE
Kill off ddev-router if it's not running, fixes #2981

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -57,6 +57,16 @@ func StopRouterIfNoContainers() error {
 
 // StartDdevRouter ensures the router is running.
 func StartDdevRouter() error {
+	// If the router is not healthy/running, we'll kill it so it
+	// starts over again.
+	router, err := FindDdevRouter()
+	if router != nil && err == nil && router.State != "running" {
+		err = dockerutil.RemoveContainer(nodeps.RouterContainer, 0)
+		if err != nil {
+			return err
+		}
+	}
+
 	routerComposeFullPath, err := generateRouterCompose()
 	if err != nil {
 		return err


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2981 - a docker restart or system reboot could leave the ddev-router in "stopped" state, where it seems lots of things can go wrong.

Related upstream problem on macOS amd64 and arm64: https://github.com/docker/for-mac/issues/5649

## How this PR Solves The Problem:

If `ddev start` finds the router in a state other than "running", it kills it off and thus restarts it.

## Manual Testing Instructions:

Follow the recreation instructions in #2981

## Automated Testing Overview:

No new tests



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/2985"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

