### PR TITLE
Make windows_install build on Windows

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -76,6 +76,6 @@ fi
 echo "--- Running tests..."
 make test
 RV=$?
-echo "build.sh completed with status=$RV"
+echo "test.sh completed with status=$RV"
 ddev poweroff || true
 exit $RV

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ TEST_TIMEOUT=150m
 BUILD_ARCH = $(shell go env GOARCH)
 
 DDEVNAME=ddev
-SHASUM="shasum -a 256"
+SHASUM=shasum -a 256
 ifeq ($(BUILD_OS),windows)
 	DDEVNAME=ddev.exe
 	SHASUM=sha256sum

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ MKCERT_VERSION=v1.4.6
 
 GOTESTSUM_FORMAT ?= short-verbose
 TESTTMP=/tmp/testresults
-DOWNLOADTMP=$(HOME)/tmp
 
 # This repo's root import path (under GOPATH).
 PKG := github.com/drud/ddev
@@ -156,7 +155,6 @@ testfullsitesetup: $(DEFAULT_BUILD) setup
 setup:
 	@mkdir -p $(GOTMP)/{src,pkg/mod/cache,.cache}
 	@mkdir -p $(TESTTMP)
-	@mkdir -p $(DOWNLOADTMP)
 
 # Required static analysis targets used in circleci - these cause fail if they don't work
 staticrequired: setup golangci-lint markdownlint mkdocs pyspelling
@@ -244,11 +242,11 @@ $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.
 	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/mkcert.exe  https://github.com/drud/mkcert/releases/download/$(MKCERT_VERSION)/mkcert-$(MKCERT_VERSION)-windows-amd64.exe
 	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/mkcert_license.txt -O https://raw.githubusercontent.com/drud/mkcert/master/LICENSE
 
-https://github.com/gerardog/gsudo/releases/download/v0.7.3/gsudo.v0.7.3.zip
 $(GOTMP)/bin/windows_amd64/sudo.exe $(GOTMP)/bin/windows_amd64/sudo_license.txt:
-	curl  -sSL --create-dirs -o $(DOWNLOADTMP)/gsudo.zip  https://github.com/gerardog/gsudo/releases/download/$(WINDOWS_GSUDO_VERSION)/gsudo.$(WINDOWS_GSUDO_VERSION).zip
-	unzip -o -d $(GOTMP)/bin/windows_amd64 $(DOWNLOADTMP)/gsudo.zip && mv $(GOTMP)/bin/windows_amd64/gsudo.exe $(GOTMP)/bin/windows_amd64/sudo.exe
-	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/sudo_license.txt https://raw.githubusercontent.com/gerardog/gsudo/master/LICENSE.txt
+	set -x
+	curl  -sSL --create-dirs -o "$(GOTMP)/bin/windows_amd64/gsudo.zip"  https://github.com/gerardog/gsudo/releases/download/$(WINDOWS_GSUDO_VERSION)/gsudo.$(WINDOWS_GSUDO_VERSION).zip
+	unzip -o -d "$(GOTMP)/bin/windows_amd64" "$(GOTMP)/bin/windows_amd64/gsudo.zip" gsudo.exe && mv "$(GOTMP)/bin/windows_amd64/gsudo.exe" "$(GOTMP)/bin/windows_amd64/sudo.exe"
+	curl --fail -sSL -o "$(GOTMP)/bin/windows_amd64/sudo_license.txt" "https://raw.githubusercontent.com/gerardog/gsudo/master/LICENSE.txt"
 
 $(GOTMP)/bin/windows_amd64/nssm.exe $(GOTMP)/bin/windows_amd64/winnfsd_license.txt $(GOTMP)/bin/windows_amd64/winnfsd.exe :
 	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/winnfsd.exe  https://github.com/winnfsd/winnfsd/releases/download/$(WINNFSD_VERSION)/WinNFSd.exe

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ linux_arm64: $(GOTMP)/bin/linux_arm64/ddev
 linux_arm: $(GOTMP)/bin/linux_arm/ddev
 darwin_amd64: $(GOTMP)/bin/darwin_amd64/ddev
 darwin_arm64: $(GOTMP)/bin/darwin_arm64/ddev
-windows_amd64: $(GOTMP)/bin/windows_amd64/ddev.exe
+windows_amd64: windows_install
 windows_arm64: $(GOTMP)/bin/windows_arm64/ddev.exe
 
 TARGETS=$(GOTMP)/bin/linux_amd64/ddev $(GOTMP)/bin/linux_arm64/ddev $(GOTMP)/bin/linux_arm/ddev $(GOTMP)/bin/darwin_amd64/ddev $(GOTMP)/bin/darwin_arm64/ddev $(GOTMP)/bin/windows_amd64/ddev.exe

--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,10 @@ TEST_TIMEOUT=150m
 BUILD_ARCH = $(shell go env GOARCH)
 
 DDEVNAME=ddev
+SHASUM="shasum -a 256"
 ifeq ($(BUILD_OS),windows)
 	DDEVNAME=ddev.exe
+	SHASUM=sha256sum
 endif
 
 DDEV_BINARY_FULLPATH=$(PWD)/$(GOTMP)/bin/$(BUILD_OS)_$(BUILD_ARCH)/$(DDEVNAME)
@@ -224,7 +226,7 @@ $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe:  $(GOTMP)/bin/
 
 	@makensis -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows
 	@if [ -z "$(DDEV_WINDOWS_SIGNING_PASSWORD)" ] ; then echo "Skipping signing ddev_windows_installer, no DDEV_WINDOWS_SIGNING_PASSWORD provided"; else echo "Signing windows installer binary..."&& mv $@ $@.unsigned && osslsigncode sign -pkcs12 certfiles/drud_cs.p12  -n "DDEV-Local Installer" -i https://ddev.com -in $@.unsigned -out $@ -t http://timestamp.digicert.com -pass $(DDEV_WINDOWS_SIGNING_PASSWORD); fi
-	shasum -a 256 $@ >$@.sha256.txt
+	$(SHASUM) $@ >$@.sha256.txt
 
 no_v_version:
 	@echo $(NO_V_VERSION)

--- a/docs/developers/scripts/windows_buildkite_setup.sh
+++ b/docs/developers/scripts/windows_buildkite_setup.sh
@@ -50,3 +50,5 @@ nssm.exe status buildkite-agent || true
 winpty docker run -it --rm -p 80 busybox ls
 
 bash "/c/Program Files/ddev/windows_ddev_nfs_setup.sh"
+
+bash "scripts/windows_postinstall.sh"

--- a/docs/developers/scripts/windows_postinstall.sh
+++ b/docs/developers/scripts/windows_postinstall.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Install NSIS on test machines, any other post-install
+# This should be run with administrative privileges.
+
+set -eu -o pipefail
+set -x
+
+NSIS_VERSION=3.06.1
+NSIS_HOME="/c/Program Files (x86)/NSIS"
+
+# Note that this is not a silent NSIS install because the silent install
+# does not install the default Plugins and Stubs
+curl -sSL -o /tmp/nsis-setup.exe https://prdownloads.sourceforge.net/nsis/nsis-${NSIS_VERSION}-setup.exe?download && chmod +x /tmp/nsis-setup.exe
+/tmp/nsis-setup.exe
+
+# Get the Plugins for NSIS
+curl -fsSL -o /tmp/EnVar-Plugin.zip https://github.com/GsNSIS/EnVar/releases/latest/download/EnVar-Plugin.zip && unzip -o -d "${NSIS_HOME}" /tmp/EnVar-Plugin.zip
+curl -fsSL -o /tmp/INetC.zip https://github.com/DigitalMediaServer/NSIS-INetC-plugin/releases/latest/download/INetC.zip && unzip -o -d "${NSIS_HOME}/Plugins" /tmp/INetC.zip

--- a/docs/developers/scripts/windows_postinstall.sh
+++ b/docs/developers/scripts/windows_postinstall.sh
@@ -17,3 +17,5 @@ curl -sSL -o /tmp/nsis-setup.exe https://prdownloads.sourceforge.net/nsis/nsis-$
 # Get the Plugins for NSIS
 curl -fsSL -o /tmp/EnVar-Plugin.zip https://github.com/GsNSIS/EnVar/releases/latest/download/EnVar-Plugin.zip && unzip -o -d "${NSIS_HOME}" /tmp/EnVar-Plugin.zip
 curl -fsSL -o /tmp/INetC.zip https://github.com/DigitalMediaServer/NSIS-INetC-plugin/releases/latest/download/INetC.zip && unzip -o -d "${NSIS_HOME}/Plugins" /tmp/INetC.zip
+
+echo "You must now add to the system path C:\Program Files (x86)\NSIS\bin, which for some reason is not added by the installer"

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -11,9 +11,7 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
 #### Installation
 
 1. Copy [docker-compose.solr.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml) to the .ddev folder for your project.
-2. Solr version can be changed by updating this line `image: solr:8` in `docker-compose.solr.yaml` file, but the recipe here assumes solr:8 and it may not work with other versions. Acquia and Pantheon.io hosting seem to require versions from 3 to 7, and you'll want to see the [contributed recipe](https://github.com/drud/
-
-contrib/tree/master/docker-compose-services/solr-5) for those older versions of solr.
+2. Solr version can be changed by updating this line `image: solr:8` in `docker-compose.solr.yaml` file, but the recipe here assumes solr:8 and it may not work with other versions. Acquia and Pantheon.io hosting seem to require versions from 3 to 7, and you'll want to see the [contributed recipes](https://github.com/drud/ddev-contrib) for older versions of solr.
 3. Create the folder path .ddev/solr/conf.
     * If needed, you may copy/extract the Solr configuration files for your project into `.ddev/solr/conf`. Ensure that the configuration files are present before running `ddev start`.
 4. Run `ddev start` or `ddev restart` if your project is already running.


### PR DESCRIPTION
## The Problem/Issue/Bug:

Ironically, we can't `make windows_install` on Windows :) This makes it harder to move signing to a windows machine. Working on it. 

Currently the result of `make windows_install` is 

```
λ make windows_install
building .gotmp/bin/windows_amd64/ddev.exe from ./cmd/... ./pkg/...
Signing windows ddev.exe...
Succeeded
Command line defined: "VERSION=v1.17.2-6-ge7e3ae63"
Processing config: C:\Program Files (x86)\NSIS\nsisconf.nsh
Processing script file: "winpkg/ddev.nsi" (ACP)
Plugin directories:
  C:\Program Files (x86)\NSIS\Plugins\x86-unicode
Plugin not found, cannot call INetC::get
Error in script "winpkg/ddev.nsi" on line 415 -- aborting creation process
make: *** [Makefile:224: .gotmp/bin/windows_amd64/ddev_windows_installer.v1.17.2-6-ge7e3ae63.exe] Error 1
```

The contents of C:\Program Files (X86)\NSIS  are listed in [nsisfiles.txt](https://github.com/drud/ddev/files/6446758/nsisfiles.txt)

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/2994"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

