### PR TITLE
Replace archived golint with revive and update errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
         # Optional: working directory, useful for monorepos
         # working-directory: somedir
 
-        args: --disable-all --enable=gofmt --enable=govet --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode
+        args: --disable-all --enable=gofmt --enable=govet --enable=revive --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode
 
         # Optional: show only new issues if it's a pull request. The default value is `false`.
         # only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.39
+        version: v1.40
 
         # Optional: working directory, useful for monorepos
         # working-directory: somedir

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"
 SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
 
-GOLANGCI_LINT_ARGS ?= --out-format=line-number --disable-all --enable=gofmt --enable=govet --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode
+GOLANGCI_LINT_ARGS ?= --out-format=line-number --disable-all --enable=gofmt --enable=govet --enable=revive --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode
 
 WINDOWS_GSUDO_VERSION=v0.7.3
 WINNFSD_VERSION=2.4.0

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -20,6 +20,7 @@ import (
 
 var composerCreateYesFlag bool
 
+// ComposerCreateCmd handles ddev composer create
 var ComposerCreateCmd = &cobra.Command{
 	Use: "create [args] [flags]",
 	FParseErrWhitelist: cobra.FParseErrWhitelist{
@@ -175,6 +176,8 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 	},
 }
 
+// ComposerCreateProjectCmd just sends people to the right thing
+// when they try ddev composer create-project
 var ComposerCreateProjectCmd = &cobra.Command{
 	Use: "create-project",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 )
 
+// ComposerCmd handles ddev composer
 var ComposerCmd = &cobra.Command{
 	Use:   "composer [command]",
 	Short: "Executes a composer command within the web container",

--- a/cmd/ddev/cmd/flags.go
+++ b/cmd/ddev/cmd/flags.go
@@ -161,7 +161,7 @@ func (v *nameValue) validate(longOptions *map[nameValue]bool) error {
 // validate checks a shorthandValue for uniqueness and containing one ASCII
 // character only.
 func (v *shorthandValue) validate(shortOptions *map[shorthandValue]nameValue, name nameValue) error {
-	var errors string = ""
+	var errors string
 
 	// Check shorthand does not already exist
 	if flagOfShorthand, found := (*shortOptions)[*v]; found {

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// DdevSnapshotRestoreCommand handles ddev snapshot restore
 var DdevSnapshotRestoreCommand = &cobra.Command{
 	Use:   "restore [snapshot_name]",
 	Short: "Restore a project's database to the provided snapshot version.",

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -150,6 +150,7 @@ func writeBackdropDdevSettingsFile(settings *BackdropSettings, filePath string) 
 	}
 	defer util.CheckClose(file)
 
+	//nolint: revive
 	if err := tmpl.Execute(file, settings); err != nil {
 		return err
 	}
@@ -235,6 +236,7 @@ func backdropImportFilesAction(app *DdevApp, importPath, extPath string) error {
 		return nil
 	}
 
+	//nolint: revive
 	if err := fileutil.CopyDir(importPath, destPath); err != nil {
 		return err
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -41,7 +41,7 @@ var containerWaitTimeout = 61
 // SiteRunning defines the string used to denote running sites.
 const SiteRunning = "running"
 
-// SiteStarting
+// SiteStarting is the string for a project that is starting
 const SiteStarting = "starting"
 
 // SiteStopped defines the string used to denote a site where the containers were not found/do not exist, but the project is there.
@@ -115,7 +115,7 @@ type DdevApp struct {
 	ComposeYaml map[string]interface{} `yaml:"-"`
 }
 
-// List() provides the functionality for `ddev list`
+// List provides the functionality for `ddev list`
 // activeOnly if true only shows projects that are currently docker containers
 // continuous if true keeps requesting and outputting continuously
 // continuousSleepTime is the time between reports
@@ -666,6 +666,7 @@ func (app *DdevApp) ImportFiles(importPath string, extPath string) error {
 		return err
 	}
 
+	//nolint: revive
 	if err := app.ProcessHooks("post-import-files"); err != nil {
 		return err
 	}
@@ -1471,7 +1472,7 @@ func (app *DdevApp) WaitByLabels(labels map[string]string) error {
 	return nil
 }
 
-// StartAndWait() is primarily for use in tests.
+// StartAndWait is primarily for use in tests.
 // It does app.Start() but then waits for extra seconds
 // before returning.
 // extraSleep arg in seconds is the time to wait if > 0
@@ -1729,7 +1730,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	return nil
 }
 
-// Stops and Removes the docker containers for the project in current directory.
+// Stop stops and Removes the docker containers for the project in current directory.
 func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	app.DockerEnv()
 	var err error
@@ -1817,7 +1818,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	return nil
 }
 
-// RemoveGlobalProjectInfo() deletes the project from ProjectList
+// RemoveGlobalProjectInfo deletes the project from ProjectList
 func (app *DdevApp) RemoveGlobalProjectInfo() {
 	_ = globalconfig.RemoveProjectInfo(app.Name)
 }
@@ -1864,7 +1865,7 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 	return httpURLs, httpsURLs, append(httpsURLs, httpURLs...)
 }
 
-// GetPrimaryURL() returns the primary URL that can be used, https or http
+// GetPrimaryURL returns the primary URL that can be used, https or http
 func (app *DdevApp) GetPrimaryURL() string {
 	httpURLs, httpsURLs, _ := app.GetAllURLs()
 	urlList := httpsURLs
@@ -2177,12 +2178,12 @@ func (app *DdevApp) GetWorkingDir(service string, dir string) string {
 	return app.DefaultWorkingDirMap()[service]
 }
 
-// Returns the docker volume name of the nfs mount volume
+// GetNFSMountVolName returns the docker volume name of the nfs mount volume
 func (app *DdevApp) GetNFSMountVolName() string {
 	return strings.ToLower("ddev-" + app.Name + "_nfsmount")
 }
 
-// StartAppIfNotRunning() is intended to replace much-duplicated code in the commands.
+// StartAppIfNotRunning is intended to replace much-duplicated code in the commands.
 func (app *DdevApp) StartAppIfNotRunning() error {
 	var err error
 	if app.SiteStatus() != SiteRunning {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -359,6 +359,7 @@ func writeDrupal8DdevSettingsFile(settings *DrupalSettings, filePath string) err
 	}
 	defer util.CheckClose(file)
 
+	//nolint: revive
 	if err := tmpl.Execute(file, settings); err != nil {
 		return err
 	}
@@ -601,6 +602,7 @@ func drupal8PostStartAction(app *DdevApp) error {
 		return err
 	}
 
+	//nolint: revive
 	if err := drupalEnsureWritePerms(app); err != nil {
 		return err
 	}
@@ -772,6 +774,7 @@ func drupalImportFilesAction(app *DdevApp, importPath, extPath string) error {
 		return nil
 	}
 
+	//nolint: revive
 	if err := fileutil.CopyDir(importPath, destPath); err != nil {
 		return err
 	}

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -21,7 +21,7 @@ import (
 
 var hashedHostID string
 
-// Define a no-op logger to prevent Segment log messages from being emitted
+// SegmentNoopLogger defines a no-op logger to prevent Segment log messages from being emitted
 type SegmentNoopLogger struct{}
 
 func (n *SegmentNoopLogger) Logf(format string, args ...interface{})   {}

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -7,7 +7,9 @@ import (
 )
 
 const (
-	WarnTypeAbsent        = iota
+	// WarnTypeAbsent warns if type is absent
+	WarnTypeAbsent = iota
+	// WarnTypeNotConfigured warns if type not configured
 	WarnTypeNotConfigured = iota
 )
 

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -106,6 +106,7 @@ func magentoImportFilesAction(app *DdevApp, importPath, extPath string) error {
 		return nil
 	}
 
+	//nolint: revive
 	if err := fileutil.CopyDir(importPath, destPath); err != nil {
 		return err
 	}

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -215,7 +215,7 @@ func (p *Provider) GetBackup(backupType string) (string, string, error) {
 	return filePath, importPath, nil
 }
 
-// UploadDB() is used by Push to push the database to hosting provider
+// UploadDB is used by Push to push the database to hosting provider
 func (p *Provider) UploadDB() error {
 	_ = os.RemoveAll(p.getDownloadDir())
 	_ = os.Mkdir(p.getDownloadDir(), 0755)
@@ -241,7 +241,7 @@ func (p *Provider) UploadDB() error {
 	return nil
 }
 
-// UploadFiles() is used by Push to push the user-generated files to the hosting provider
+// UploadFiles is used by Push to push the user-generated files to the hosting provider
 func (p *Provider) UploadFiles() error {
 	_ = os.RemoveAll(p.getDownloadDir())
 	_ = os.Mkdir(p.getDownloadDir(), 0755)

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -60,6 +60,7 @@ func shopware6ImportFilesAction(app *DdevApp, importPath, extPath string) error 
 		return nil
 	}
 
+	//nolint: revive
 	if err := fileutil.CopyDir(importPath, destPath); err != nil {
 		return err
 	}

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -201,6 +201,7 @@ func typo3ImportFilesAction(app *DdevApp, importPath, extPath string) error {
 		return nil
 	}
 
+	//nolint: revive
 	if err := fileutil.CopyDir(importPath, destPath); err != nil {
 		return err
 	}

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -259,6 +259,7 @@ func CreateGitIgnore(targetDir string, ignores ...string) error {
 		IgnoredItems: generatedIgnores,
 	}
 
+	//nolint: revive
 	if err = tmpl.Execute(file, parms); err != nil {
 		return err
 	}

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -252,6 +252,7 @@ func writeWordpressSettingsFile(wordpressConfig *WordpressConfig, filePath strin
 	}
 	defer util.CheckClose(file)
 
+	//nolint: revive
 	if err = tmpl.Execute(file, wordpressConfig); err != nil {
 		return err
 	}
@@ -296,6 +297,7 @@ func writeWordpressDdevSettingsFile(config *WordpressConfig, filePath string) er
 	}
 	defer util.CheckClose(file)
 
+	//nolint: revive
 	if err = tmpl.Execute(file, config); err != nil {
 		return err
 	}
@@ -367,6 +369,7 @@ func wordpressImportFilesAction(app *DdevApp, importPath, extPath string) error 
 		return nil
 	}
 
+	//nolint: revive
 	if err := fileutil.CopyDir(importPath, destPath); err != nil {
 		return err
 	}

--- a/pkg/ddevhosts/ddevhosts.go
+++ b/pkg/ddevhosts/ddevhosts.go
@@ -30,7 +30,7 @@ func (h DdevHosts) GetIPPosition(ip string) int {
 	return -1
 }
 
-// New() is a simple wrapper on goodhosts.NewHosts()
+// New is a simple wrapper on goodhosts.NewHosts()
 func New() (*DdevHosts, error) {
 	h, err := goodhosts.NewHosts()
 	if err != nil {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -211,7 +211,7 @@ func ContainerWait(waittime int, labels map[string]string) (string, error) {
 	return "", fmt.Errorf("inappropriate break out of for loop in ContainerWait() waiting for container labels %v", labels)
 }
 
-// ContainesrWait provides a wait loop to check for multiple containers in "healthy" status.
+// ContainersWait provides a wait loop to check for multiple containers in "healthy" status.
 // waittime is in seconds.
 // Returns logoutput, error, returns error if not "healthy"
 func ContainersWait(waittime int, labels map[string]string) error {
@@ -684,7 +684,7 @@ func RemoveContainer(id string, timeout uint) error {
 	return err
 }
 
-// RemoveContainersByLabels() removes all containers that match a set of labels
+// RemoveContainersByLabels removes all containers that match a set of labels
 func RemoveContainersByLabels(labels map[string]string) error {
 	client := GetDockerClient()
 	containers, err := FindContainersByLabels(labels)
@@ -812,7 +812,7 @@ func CreateVolume(volumeName string, driver string, driverOpts map[string]string
 	return volume, err
 }
 
-// GetHostDockerInternalIP() returns either "host.docker.internal"
+// GetHostDockerInternalIP returns either "host.docker.internal"
 // (for docker-for-mac and Win10 Docker-for-windows) or a usable IP address
 func GetHostDockerInternalIP() (string, error) {
 	hostDockerInternal := ""

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -233,13 +233,14 @@ func ReplaceStringInFile(searchString string, replaceString string, origPath str
 
 	output := bytes.Replace(input, []byte(searchString), []byte(replaceString), -1)
 
+	// nolint: revive
 	if err = ioutil.WriteFile(destPath, output, 0666); err != nil {
 		return err
 	}
 	return nil
 }
 
-// IsSameFile() determines whether two paths refer to the same file/dir
+// IsSameFile determines whether two paths refer to the same file/dir
 func IsSameFile(path1 string, path2 string) (bool, error) {
 	path1fi, err := os.Stat(path1)
 	if err != nil {
@@ -261,7 +262,7 @@ func ReadFileIntoString(path string) (string, error) {
 	return string(bytes), err
 }
 
-// AppendStirngtoFile takes a path to a file and a string to append
+// AppendStringToFile takes a path to a file and a string to append
 // and it appends it, returning err
 func AppendStringToFile(path string, appendString string) error {
 	f, err := os.OpenFile(path,
@@ -281,7 +282,7 @@ type XSymContents struct {
 	LinkTarget   string
 }
 
-// FindSimulatedXsymSymlinks() searches the basePath provided for files
+// FindSimulatedXsymSymlinks searches the basePath provided for files
 // whose first line is XSym, which is used in cifs filesystem for simulated
 // symlinks.
 func FindSimulatedXsymSymlinks(basePath string) ([]XSymContents, error) {
@@ -314,7 +315,7 @@ func FindSimulatedXsymSymlinks(basePath string) ([]XSymContents, error) {
 	return symLinks, err
 }
 
-// ReplaceSimulatedXsymSymlinks() walks a list of XSymContents and makes real symlinks
+// ReplaceSimulatedXsymSymlinks walks a list of XSymContents and makes real symlinks
 // in their place. This is only valid on Windows host, only works with Docker for Windows
 // (cifs filesystem)
 func ReplaceSimulatedXsymSymlinks(links []XSymContents) error {
@@ -345,7 +346,7 @@ func CanCreateSymlinks() bool {
 	return true
 }
 
-// ReplaceSimulatedLinks() walks the path provided and tries to replace XSym links with real ones.
+// ReplaceSimulatedLinks walks the path provided and tries to replace XSym links with real ones.
 func ReplaceSimulatedLinks(path string) {
 	links, err := FindSimulatedXsymSymlinks(path)
 	if err != nil {

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -56,7 +56,7 @@ type GlobalConfig struct {
 	ProjectList map[string]*ProjectInfo `yaml:"project_info"`
 }
 
-// GetGlobalConfigPath() gets the path to global config file
+// GetGlobalConfigPath gets the path to global config file
 func GetGlobalConfigPath() string {
 	return filepath.Join(GetGlobalDdevDir(), DdevGlobalConfigName)
 }
@@ -70,7 +70,7 @@ func ValidateGlobalConfig() error {
 	return nil
 }
 
-// ReadGlobalConfig() reads the global config file into DdevGlobalConfig
+// ReadGlobalConfig reads the global config file into DdevGlobalConfig
 func ReadGlobalConfig() error {
 	globalConfigFile := GetGlobalConfigPath()
 
@@ -268,7 +268,7 @@ func GetValidOmitContainers() []string {
 	return s
 }
 
-// HostPortIsAllocated returns the project name that has allocated
+// HostPostIsAllocated returns the project name that has allocated
 // the port, or empty string.
 func HostPostIsAllocated(port string) string {
 	for project, item := range DdevGlobalConfig.ProjectList {
@@ -279,7 +279,7 @@ func HostPostIsAllocated(port string) string {
 	return ""
 }
 
-// Check GlobalDdev UsedHostPorts to see if requested ports are available.
+// CheckHostPortsAvailable checks GlobalDdev UsedHostPorts to see if requested ports are available.
 func CheckHostPortsAvailable(projectName string, ports []string) error {
 	for _, port := range ports {
 		allocatedProject := HostPostIsAllocated(port)
@@ -327,7 +327,7 @@ func GetFreePort(localIPAddr string) (string, error) {
 
 }
 
-// ReservePorts() adds the ProjectInfo if necessary and assigns the reserved ports
+// ReservePorts adds the ProjectInfo if necessary and assigns the reserved ports
 func ReservePorts(projectName string, ports []string) error {
 	// If the project doesn't exist, add it.
 	_, ok := DdevGlobalConfig.ProjectList[projectName]
@@ -339,7 +339,7 @@ func ReservePorts(projectName string, ports []string) error {
 	return err
 }
 
-// SetProjectAppRoot() sets the approot in the ProjectInfo of global config
+// SetProjectAppRoot sets the approot in the ProjectInfo of global config
 func SetProjectAppRoot(projectName string, appRoot string) error {
 	// If the project doesn't exist, add it.
 	_, ok := DdevGlobalConfig.ProjectList[projectName]
@@ -368,7 +368,7 @@ func GetProject(projectName string) *ProjectInfo {
 	return project
 }
 
-// RemoveProjectInfo() removes the ProjectInfo line for a project
+// RemoveProjectInfo removes the ProjectInfo line for a project
 func RemoveProjectInfo(projectName string) error {
 	_, ok := DdevGlobalConfig.ProjectList[projectName]
 	if ok {
@@ -381,12 +381,12 @@ func RemoveProjectInfo(projectName string) error {
 	return nil
 }
 
-// GetGlobalProjectList() returns the global project list map
+// GetGlobalProjectList returns the global project list map
 func GetGlobalProjectList() map[string]*ProjectInfo {
 	return DdevGlobalConfig.ProjectList
 }
 
-// GetCAROOT() is just a wrapper on global config
+// GetCAROOT is just a wrapper on global config
 func GetCAROOT() string {
 	return DdevGlobalConfig.MkcertCARoot
 }
@@ -437,7 +437,10 @@ func fileExists(name string) bool {
 	return true
 }
 
+// IsInternetActiveAlreadyChecked just flags whether it's been checked
 var IsInternetActiveAlreadyChecked = false
+
+// IsInternetActiveResult is the result of the check
 var IsInternetActiveResult = false
 
 // IsInternetActiveNetResolver wraps the standard DNS resolver.
@@ -447,7 +450,7 @@ var IsInternetActiveNetResolver interface {
 	LookupHost(ctx context.Context, host string) (addrs []string, err error)
 } = net.DefaultResolver
 
-//IsInternetActive() checks to see if we have a viable
+//IsInternetActive checks to see if we have a viable
 // internet connection. It just tries a quick DNS query.
 // This requires that the named record be query-able.
 // This check will only be made once per command run.

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -8,11 +8,17 @@ const (
 	DBAContainer          = "dba"
 )
 
+// ValidOmitContainers is the valid omit's that can be done in for a project
 var ValidOmitContainers = map[string]bool{
 	DdevSSHAgentContainer: true,
 	DBAContainer:          true,
 }
 
+// DdevNoInstrumentation is set to true if the env var is set
 var DdevNoInstrumentation = os.Getenv("DDEV_NO_INSTRUMENTATION") == "true"
+
+// DdevDebug is set to true if the env var is set
 var DdevDebug = (os.Getenv("DDEV_DEBUG") == "true")
+
+// DdevVerbose is set to true if the env var is set
 var DdevVerbose = (os.Getenv("DDEV_VERBOSE") == "true")

--- a/pkg/nodeps/instrumentation.go
+++ b/pkg/nodeps/instrumentation.go
@@ -1,3 +1,4 @@
 package nodeps
 
+// InstrumentationTags contains the tags to be sent to Segment
 var InstrumentationTags = map[string]string{}

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -5,6 +5,7 @@ package nodeps
 // MariaDBDefaultVersion is the default MariaDB version
 const MariaDBDefaultVersion = MariaDB103
 
+// ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
 	MariaDB55:  true,
 	MariaDB100: true,

--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -3,6 +3,7 @@ package nodeps
 // MariaDBDefaultVersion is the default MariaDB version
 const MariaDBDefaultVersion = MariaDB103
 
+// ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
 	MariaDB101: true,
 	MariaDB102: true,

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -3,6 +3,7 @@ package nodeps
 // MariaDBDefaultVersion is the default MariaDB version
 const MariaDBDefaultVersion = MariaDB103
 
+// ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
 	MariaDB101: true,
 	MariaDB102: true,

--- a/pkg/nodeps/mysql_values.go
+++ b/pkg/nodeps/mysql_values.go
@@ -2,6 +2,7 @@
 
 package nodeps
 
+// ValidMySQLVersions is the versions of MySQL that are valid
 var ValidMySQLVersions = map[string]bool{
 	MySQL55: true,
 	MySQL56: true,

--- a/pkg/nodeps/mysql_values_darwin_arm64.go
+++ b/pkg/nodeps/mysql_values_darwin_arm64.go
@@ -1,5 +1,6 @@
 package nodeps
 
+// ValidMySQLVersions is the versions of MySQL that are valid
 var ValidMySQLVersions = map[string]bool{}
 
 // Oracle MySQL versions

--- a/pkg/nodeps/mysql_values_linux_arm64.go
+++ b/pkg/nodeps/mysql_values_linux_arm64.go
@@ -1,5 +1,6 @@
 package nodeps
 
+// ValidMySQLVersions is the versions of MySQL that are valid
 var ValidMySQLVersions = map[string]bool{}
 
 // Oracle MySQL versions

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -39,6 +39,7 @@ func RemoveItemFromSlice(slice []string, item string) []string {
 }
 
 // From https://www.calhoun.io/creating-random-strings-in-go/
+//nolint: revive
 var seededRand *rand.Rand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
 
@@ -53,7 +54,7 @@ func RandomString(length int) string {
 	return string(b)
 }
 
-// IsWSL2() returns true if running WSL2
+// IsWSL2 returns true if running WSL2
 func IsWSL2() bool {
 	return GetWSLDistro() != ""
 }

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -30,6 +30,7 @@ const (
 	WebserverApacheFPM = "apache-fpm"
 )
 
+// ValidOmitContainers is the list of things that can be omitted
 var ValidOmitContainers = map[string]bool{
 	DBContainer:           true,
 	DdevSSHAgentContainer: true,

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -9,6 +9,7 @@ import (
 var (
 	// UserOut is the customized logrus log used for direct user output
 	UserOut = log.New()
+	// UserErr is the customized logrus log used for direct user stderr
 	UserErr = log.New()
 	// UserOutFormatter is the specialized formatter for UserOut
 	UserOutFormatter = new(TextFormatter)
@@ -44,6 +45,7 @@ func LogSetUp() {
 	log.SetLevel(logLevel)
 }
 
+// ErrorWriter allows writing stderr
 // Splitting to stderr approach from
 // https://huynvk.dev/blog/4-tips-for-logging-on-gcp-using-golang-and-logrus
 type ErrorWriter struct{}

--- a/pkg/util/capture.go
+++ b/pkg/util/capture.go
@@ -61,7 +61,7 @@ func CaptureStdOut() func() string {
 	}
 }
 
-// CaptureStdOutToFile captures Stdout to a string. Capturing starts when it is called. It returns an anonymous function that when called, will return a string
+// CaptureOutputToFile captures Stdout to a string. Capturing starts when it is called. It returns an anonymous function that when called, will return a string
 // containing the output during capture, and revert once again to the original value of os.StdOut.
 func CaptureOutputToFile() (func() string, error) {
 	oldStdout := os.Stdout // keep backup of the real stdout

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -113,7 +113,7 @@ func MapKeysToArray(mapWithKeys map[string]interface{}) []string {
 	return result
 }
 
-// GetContainerUIDGid() returns the uid and gid (and string forms) to be used running most containers.
+// GetContainerUIDGid returns the uid and gid (and string forms) to be used running most containers
 func GetContainerUIDGid() (uidStr string, gidStr string, username string) {
 	curUser, err := user.Current()
 	if err != nil {
@@ -154,6 +154,8 @@ func GetFirstWord(s string) string {
 	return arr[0]
 }
 
+// FindWindowsBashPath returns the PATH to bash on Windows
+// preferring git-bash
 // On Windows we'll need the path to bash to execute anything.
 // Returns empty string if not found, path if found
 func FindWindowsBashPath() string {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -60,8 +60,10 @@ var RouterImage = "drud/ddev-router"
 // RouterTag defines the tag used for the router.
 var RouterTag = "v1.17.0" // Note that this can be overridden by make
 
+// SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
+// SSHAuthTag is ssh-agent auth tag
 var SSHAuthTag = "v1.17.0"
 
 // BUILDINFO is information with date and context, supplied by make


### PR DESCRIPTION
## The Problem/Issue/Bug:

golangci-lint has started complaining about golint being deprecated

## How this PR Solves The Problem:

Start using the replacement "revive" instead



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3007"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

