### PR TITLE
Reduce how much circleci gets used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ workflows:
 #    - staticrequired
     - lx_amd64_fpm_test
     - lx_arm64_fpm_test
-    - lx_arm64_container_test
+#    - lx_arm64_container_test
 #        requires:
 #        - build
 #    - mac_nginx_fpm_test:
@@ -524,8 +524,8 @@ workflows:
                 - "pull/[0-9]+"
     jobs:
     - lx_amd64_container_test
-    - lx_arm64_container_test
-    - lx_amd64_fpm_test
+#    - lx_arm64_container_test
+#    - lx_amd64_fpm_test
     - lx_arm64_fpm_test
 
   release_build:


### PR DESCRIPTION
## The Problem/Issue/Bug:

Trying to reduce cost of CircleCI and decrease redundancy with github workflow. 

## How this PR Solves The Problem:

Use less in the normal build and also in the nightly.

The fundamental value of CircleCI at this point is

1. Testing on arm64
2. Testing forked PRs with (throwaway) secrets. Github can't do that.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3010"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

