### PR TITLE
Allow disabling http/2 support in ddev-router

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -74,6 +74,12 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 		dirty = true
 	}
 
+	if cmd.Flag("disable-http2").Changed {
+		val, _ := cmd.Flags().GetBool("disable-http2")
+		globalconfig.DdevGlobalConfig.DisableHTTP2 = val
+		dirty = true
+	}
+
 	if cmd.Flag("use-letsencrypt").Changed {
 		val, _ := cmd.Flags().GetBool("use-letsencrypt")
 		globalconfig.DdevGlobalConfig.UseLetsEncrypt = val
@@ -122,6 +128,7 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 
 	output.UserOut.Printf("router-bind-all-interfaces=%v", globalconfig.DdevGlobalConfig.RouterBindAllInterfaces)
 	output.UserOut.Printf("internet-detection-timeout-ms=%v", globalconfig.DdevGlobalConfig.InternetDetectionTimeout)
+	output.UserOut.Printf("disable-http2=%v", globalconfig.DdevGlobalConfig.DisableHTTP2)
 	output.UserOut.Printf("use-letsencrypt=%v", globalconfig.DdevGlobalConfig.UseLetsEncrypt)
 	output.UserOut.Printf("letsencrypt-email=%v", globalconfig.DdevGlobalConfig.LetsEncryptEmail)
 	output.UserOut.Printf("auto-restart-containers=%v", globalconfig.DdevGlobalConfig.AutoRestartContainers)
@@ -136,6 +143,7 @@ func init() {
 	configGlobalCommand.Flags().BoolVarP(&instrumentationOptIn, "instrumentation-opt-in", "", false, "instrmentation-opt-in=true")
 	configGlobalCommand.Flags().Bool("router-bind-all-interfaces", false, "router-bind-all-interfaces=true")
 	configGlobalCommand.Flags().Int("internet-detection-timeout-ms", 750, "Increase timeout when checking internet timeout, in milliseconds")
+	configGlobalCommand.Flags().Bool("disable-http2", false, "Optionally disable http2 in ddev-router, 'ddev global --disable-http2' or `ddev global --disable-http2=false'")
 	configGlobalCommand.Flags().Bool("use-letsencrypt", false, "Enables experimental Let's Encrypt integration, 'ddev global --use-letsencrypt' or `ddev global --use-letsencrypt=false'")
 	configGlobalCommand.Flags().String("letsencrypt-email", "", "Email associated with Let's Encrypt, `ddev global --letsencrypt-email=me@example.com'")
 	configGlobalCommand.Flags().Bool("auto-restart-containers", false, "If true, automatically restart containers after a reboot or docker restart")

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -28,10 +28,15 @@ func TestCmdGlobalConfig(t *testing.T) {
 	// and then read (empty)
 	// nolint: errcheck
 	defer func() {
+		// Even though the global config is going to be deleted, make sure it's sane before leaving
+		args := []string{"config", "global", "--omit-containers", "", "--nfs-mount-enabled=true", "--disable-http2=false"}
+		globalconfig.DdevGlobalConfig.OmitContainersGlobal = nil
+		_, err := exec.RunCommand(DdevBin, args)
+		assert.NoError(err)
 		globalconfig.DdevGlobalConfig = backupConfig
 		globalconfig.DdevGlobalConfig.OmitContainersGlobal = nil
 
-		err := os.Remove(configFile)
+		err = os.Remove(configFile)
 		if err != nil {
 			t.Logf("Unable to remove %v: %v", configFile, err)
 		}
@@ -45,13 +50,13 @@ func TestCmdGlobalConfig(t *testing.T) {
 	args := []string{"config", "global"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nweb-environment=[]\nnfs-mount-enabled=false\nrouter-bind-all-interfaces=false\ninternet-detection-timeout-ms=750\nuse-letsencrypt=false\nletsencrypt-email=\nauto-restart-containers=false\nuse-hardened-images=false\nfail-on-hook-fail=false")
+	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nweb-environment=[]\nnfs-mount-enabled=false\nrouter-bind-all-interfaces=false\ninternet-detection-timeout-ms=750\ndisable-http2=false\nuse-letsencrypt=false\nletsencrypt-email=\nauto-restart-containers=false\nuse-hardened-images=false\nfail-on-hook-fail=false")
 
 	// Update a config
-	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent", "--nfs-mount-enabled=true", "--router-bind-all-interfaces=true", "--internet-detection-timeout-ms=850", "--use-letsencrypt", "--letsencrypt-email=nobody@example.com", "--auto-restart-containers=true", "--use-hardened-images=true", "--fail-on-hook-fail=true", `--web-environment="SOMEENV=some+val"`}
+	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent", "--nfs-mount-enabled=true", "--router-bind-all-interfaces=true", "--internet-detection-timeout-ms=850", "--use-letsencrypt", "--letsencrypt-email=nobody@example.com", "--auto-restart-containers=true", "--use-hardened-images=true", "--fail-on-hook-fail=true", `--disable-http2`, `--web-environment="SOMEENV=some+val"`}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]\nweb-environment=[\"SOMEENV=some+val\"]\nnfs-mount-enabled=true\nrouter-bind-all-interfaces=true\ninternet-detection-timeout-ms=850\nuse-letsencrypt=true\nletsencrypt-email=nobody@example.com\nauto-restart-containers=true\nuse-hardened-images=true\nfail-on-hook-fail=true")
+	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]\nweb-environment=[\"SOMEENV=some+val\"]\nnfs-mount-enabled=true\nrouter-bind-all-interfaces=true\ninternet-detection-timeout-ms=850\ndisable-http2=true\nuse-letsencrypt=true\nletsencrypt-email=nobody@example.com\nauto-restart-containers=true\nuse-hardened-images=true\nfail-on-hook-fail=true")
 
 	err = globalconfig.ReadGlobalConfig()
 	assert.NoError(err)
@@ -64,10 +69,5 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.True(globalconfig.DdevGlobalConfig.UseLetsEncrypt)
 	assert.True(globalconfig.DdevGlobalConfig.UseHardenedImages)
 	assert.True(globalconfig.DdevGlobalConfig.FailOnHookFailGlobal)
-
-	// Even though the global config is going to be deleted, make sure it's sane before leaving
-	args = []string{"config", "global", "--omit-containers", "", "--nfs-mount-enabled=true"}
-	globalconfig.DdevGlobalConfig.OmitContainersGlobal = nil
-	_, err = exec.RunCommand(DdevBin, args)
-	assert.NoError(err)
+	assert.True(globalconfig.DdevGlobalConfig.DisableHTTP2)
 }

--- a/containers/ddev-router/docker-entrypoint.sh
+++ b/containers/ddev-router/docker-entrypoint.sh
@@ -3,6 +3,9 @@ set -eu -o pipefail
 
 rm -f /tmp/healthy
 
+export HTTP2=http2
+if [ "${DISABLE_HTTP2}" = "true" ]; then HTTP2=""; fi
+
 # Warn if the DOCKER_HOST socket does not exist
 if [[ $DOCKER_HOST = unix://* ]]; then
 	socket_file=${DOCKER_HOST#unix://}

--- a/containers/ddev-router/gen-cert-and-nginx-config.sh.tmpl
+++ b/containers/ddev-router/gen-cert-and-nginx-config.sh.tmpl
@@ -29,7 +29,7 @@ echo "${httpsports}" >/tmp/httpsports.txt
 
 # Convert the lists into unique sets of listen directives in /tmp
 awk -F: '$0 != "" {printf "\tlisten %s default_server;\n", $1;}' /tmp/httpports.txt | sort -u >/tmp/http_ports.conf
-awk -F: '$0 != "" {printf "\tlisten %s ssl http2 default_server;\n", $1;}' /tmp/httpsports.txt | sort -u >/tmp/https_ports.conf
+awk -F: -v http2=${HTTP2} '$0 != "" {printf "\tlisten %s ssl %s default_server;\n", $1, http2;}' /tmp/httpsports.txt | sort -u >/tmp/https_ports.conf
 
 
 if [ ! -z "${USE_LETSENCRYPT:-}" ]; then

--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -245,7 +245,7 @@ server {
 
         server {
             server_name {{ $host }};
-            listen {{ $listen_port }} ssl http2 {{ $default_server }};
+            listen {{ $listen_port }} ssl {{ $.Env.HTTP2 }} {{ $default_server }};
             access_log /var/log/nginx/access.log vhost;
 
             location @brokenupstream {

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -121,6 +121,7 @@ func generateRouterCompose() (string, error) {
 		"router_bind_all_interfaces": globalconfig.DdevGlobalConfig.RouterBindAllInterfaces,
 		"compose_version":            version.DockerComposeFileFormatVersion,
 		"dockerIP":                   dockerIP,
+		"disable_http2":              globalconfig.DdevGlobalConfig.DisableHTTP2,
 		"letsencrypt":                globalconfig.DdevGlobalConfig.UseLetsEncrypt,
 		"letsencrypt_email":          globalconfig.DdevGlobalConfig.LetsEncryptEmail,
 		"AutoRestartContainers":      globalconfig.DdevGlobalConfig.AutoRestartContainers,

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -447,8 +447,9 @@ services:
       {{ if .letsencrypt }}
       - ddev-router-letsencrypt:/etc/letsencrypt:rw
       {{ end }}
-{{ if .letsencrypt }}
     environment:
+      - DISABLE_HTTP2={{ .disable_http2 }}
+{{ if .letsencrypt }}
       - LETSENCRYPT_EMAIL={{ .letsencrypt_email }}
       - USE_LETSENCRYPT={{ .letsencrypt }}
 {{ end }}

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -52,6 +52,7 @@ type GlobalConfig struct {
 	AutoRestartContainers    bool     `yaml:"auto_restart_containers"`
 	FailOnHookFailGlobal     bool     `yaml:"fail_on_hook_fail"`
 	WebEnvironment           []string `yaml:"web_environment"`
+	DisableHTTP2             bool     `yaml:"disable_http2"`
 
 	ProjectList map[string]*ProjectInfo `yaml:"project_info"`
 }
@@ -164,6 +165,9 @@ func WriteGlobalConfig(config GlobalConfig) error {
 
 # You can enable 'ddev start' to be interrupted by a failing hook with
 # fail_on_hook_fail: true
+
+# disable_http2: false
+# Disable http2 on ddev-router if true
 
 # instrumentation_user: <your_username> # can be used to give ddev specific info about who you are
 # developer_mode: true # (defaults to false) is not used widely at this time.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -58,7 +58,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.17.0" // Note that this can be overridden by make
+var RouterTag = "20210518_allow_disable_http2" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"


### PR DESCRIPTION
## The Problem/Issue/Bug:

There are situations where http/2 is not wanted; for example the Safari browser seems not to get along well with large numbers of cookies and http/2

## How this PR Solves The Problem:

*. Add `ddev global config --disable-http2` (and disable_http in global_config.yaml)
* Add support in ddev-router to respect that config

## Manual Testing Instructions:

* `ddev poweroff`, `ddev config global --disable-http2`, `ddev start`, `curl -I <site>`. The first line should show HTTP/1.1
* `ddev poweroff`, `ddev config global --disable-http2=false`, `ddev start`, `curl -I <site>`. The first line should show HTTP/2

## Automated Testing Overview:

Added to the test of global config
Added TestDisableHTTP2

## Related Issue Link(s):

https://github.com/drud/ddev/pull/2698 (which increased http2 header size) and https://github.com/drud/ddev/discussions/2697

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

