### PR TITLE
Don't try to build chocolatey on interim revisions

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
         run: |
           if [ "${DDEV_WINDOWS_SIGN}" != "true" ]; then echo "DDEV_WINDOWS_SIGN is not true, exiting" && exit 1; fi
-          make windows_install chocolatey
+          make windows_install
       - name: Show github.ref
         run: echo ${{ github.ref }}
       - name: Build chocolatey on release

--- a/Makefile
+++ b/Makefile
@@ -237,8 +237,12 @@ chocolatey: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1
 	perl -pi -e 's/REPLACE_GITHUB_ORG/$(GITHUB_ORG)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1 #GITHUB_ORG is for testing, for example when the binaries are on rfay acct
 	perl -pi -e "s/REPLACE_INSTALLER_CHECKSUM/$$(cat $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe.sha256.txt | awk '{ print $$1; }')/g" $(GOTMP)/bin/windows_amd64/chocolatey/tools/*
-	docker run --rm -v "/$(PWD)/$(GOTMP)/bin/windows_amd64/chocolatey:/tmp/chocolatey" -w "//tmp/chocolatey" linuturk/mono-choco pack ddev.nuspec
-	@echo "chocolatey package is in $(GOTMP)/bin/windows_amd64/chocolatey"
+	if [[ "$(NO_V_VERSION)" =~ -g[0-9a-f]+ ]]; then \
+  		echo "Skipping chocolatey build on interim version"; \
+	else \
+		docker run --rm -v "/$(PWD)/$(GOTMP)/bin/windows_amd64/chocolatey:/tmp/chocolatey" -w "//tmp/chocolatey" linuturk/mono-choco pack ddev.nuspec; \
+		@echo "chocolatey package is in $(GOTMP)/bin/windows_amd64/chocolatey"; \
+	fi
 
 $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.txt:
 	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/mkcert.exe  https://github.com/drud/mkcert/releases/download/$(MKCERT_VERSION)/mkcert-$(MKCERT_VERSION)-windows-amd64.exe


### PR DESCRIPTION
## The Problem/Issue/Bug:

The new github builds try to build chocolatey on interim revisions, and it blows sky-hi because choco can't accept something like 1.17.2-12-g7a20a436

## How this PR Solves The Problem:

Don't try to build chocolatey in that situation.

## Manual Testing Instructions:

## Release/Deployment notes:


After this goes in we can re-add CHOCOLATEY_API_KEY to the repository


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3012"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

