### PR TITLE
Windows often has first-time trouble with DNS lookups

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -19,11 +19,6 @@ set -x
 #  sleep 10
 #fi
 
-# Try to get important names cached; try twice
-for hostname in github.com raw.githubusercontent.com github-releases.githubusercontent.com; do
-  ping -c 1 $hostname 2>/dev/null || ping -c 1 $hostname 2>/dev/null || true
-done
-
 export TIMEOUT_CMD="timeout -v"
 if [ ${OSTYPE%%-*} = "linux" ]; then
   TIMEOUT_CMD="timeout"
@@ -39,6 +34,11 @@ if ! docker ps >/dev/null 2>&1 ; then
   echo "Docker is not running, exiting"
   exit 1
 fi
+
+# Try to get important names cached; try twice
+for hostname in github.com raw.githubusercontent.com github-releases.githubusercontent.com registry-1.docker.io auth.docker.io; do
+  ping -c 1 $hostname 2>/dev/null || ping -c 1 $hostname 2>/dev/null || true
+done
 
 if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
   set +x

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -36,7 +36,7 @@ if ! docker ps >/dev/null 2>&1 ; then
 fi
 
 # Try to get important names cached; try twice
-for hostname in github.com raw.githubusercontent.com github-releases.githubusercontent.com registry-1.docker.io auth.docker.io; do
+for hostname in github.com raw.githubusercontent.com github-releases.githubusercontent.com registry-1.docker.io auth.docker.io production.cloudflare.docker.com; do
   ping -c 1 $hostname 2>/dev/null || ping -c 1 $hostname 2>/dev/null || true
 done
 

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -19,6 +19,11 @@ set -x
 #  sleep 10
 #fi
 
+# Try to get important names cached; try twice
+for hostname in github.com raw.githubusercontent.com github-releases.githubusercontent.com; do
+  ping -c 1 $hostname 2>/dev/null || ping -c 1 $hostname 2>/dev/null || true
+done
+
 export TIMEOUT_CMD="timeout -v"
 if [ ${OSTYPE%%-*} = "linux" ]; then
   TIMEOUT_CMD="timeout"


### PR DESCRIPTION
## The Problem/Issue/Bug:

On Windows buildkite we often see test runs fail just because the windows machine (or docker?) fail to successfully look up a (usually github-related) DNS address.

## How this PR Solves The Problem:

Attempt to prime the pump with a ping.

This may need to be done inside a docker container.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3016"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

