### PR TITLE
Check ENV variable first before doing a FS stat in settings.ddev.php

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -69,7 +69,7 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 const settingsIncludeStanza = `
 // Automatically generated include for settings managed by ddev.
 $ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
-if (is_readable($ddev_settings) && getenv('IS_DDEV_PROJECT') == 'true') {
+if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
   require $ddev_settings;
 }
 `


### PR DESCRIPTION
Very minor nit, but no need to check whether the file is readable if it's not a DDEV environment.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3017"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

