### PR TITLE
Stop reporting anything but start to segment

### DIFF
--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -29,7 +29,7 @@ func (n *SegmentNoopLogger) Errorf(format string, args ...interface{}) {}
 
 // ReportableEvents is the list of events that we choose to report specifically.
 // Excludes non-ddev custom commands.
-var ReportableEvents = map[string]bool{"auth": true, "composer": true, "config": true, "debug": true, "delete": true, "describe": true, "exec": true, "export-db": true, "heidisql": true, "import-db": true, "import-files": true, "launch": true, "list": true, "logs": true, "mysql": true, "pause": true, "poweroff": true, "pull": true, "restart": true, "sequelace": true, "sequelpro": true, "share": true, "snapshot": true, "ssh": true, "start": true, "stop": true, "tableplus": true, "xdebug": true}
+var ReportableEvents = map[string]bool{"start": true}
 
 // GetInstrumentationUser normally gets just the hashed hostID but if
 // an explicit user is provided in global_config.yaml that will be prepended.


### PR DESCRIPTION
## The Problem/Issue/Bug:

Segment costs > $100/month, and we have no funding, so it makes no sense to spend that money. We have switched to the free plan, which allows a far smaller number of packets.

## How this PR Solves The Problem:

Only report `ddev start` to segment.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3020"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

