### PR TITLE
Run mysql under mysql user if ddev-dbserver container is run as root

### DIFF
--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -48,6 +48,7 @@ fi
 
 if [ "$(id -u)" = "0" ]; then
   echo "Switching to dedicated user 'mysql'"
+  mkdir -p /home/mysql
   exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -46,6 +46,11 @@ if [ -d /mnt/ddev_config/mysql -a "$(echo /mnt/ddev_config/mysql/*.cnf)" != "/mn
   echo "!includedir /mnt/ddev_config/mysql" >/etc/mysql/conf.d/ddev.cnf
 fi
 
+if [ "$(id -u)" = "0" ]; then
+  echo "Switching to dedicated user 'mysql'"
+  exec gosu mysql "$BASH_SOURCE" "$@"
+fi
+
 export BACKUPTOOL=mariabackup
 if command -v xtrabackup; then BACKUPTOOL="xtrabackup"; fi
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

The problem is detailed in #3025.

## How this PR Solves The Problem:

It solves it according to the solution described in the above issue. This is the same way the official images do this as well.

## Manual Testing Instructions:
WIP

## Automated Testing Overview:
WIP

## Related Issue Link(s):
#3025 

## Release/Deployment notes:
This shouldn't affect any other workflows. New database docker images would be needed as part of the release.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3026"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

