### PR TITLE
Remove Jessie keys so we can properly test for expiring keys, fixes #3004

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -14,11 +14,9 @@ ENV MYSQL_ROOT_PASSWORD root
 SHELL ["/bin/bash", "-c"]
 
 # Remove obsolete MySQL 5.5/5.6 Jessie and before keys so they don't make expiration key test stumble
-RUN if [ ${DB_TYPE} == "mysql" ] && [[ ${DB_VERSION} =~ "5\.[56]" ]] ; then \
-  for item in "75DD C3C4 A499 F1A1 8CB5  F3C8 CBF8 D6FD 518E 17E1" "126C 0D24 BD8A 2942 CC7D  F8AC 7638 D044 2B90 D010" "D211 6914 1CEC D440 F2EB  8DDA 9D6D 8F6B C857 C906" "A1BD 8E9D 78F7 FE5C 3E65  D8AF 8B48 AD62 4692 5553" "ED6D 6527 1AAC F0FF 15D1  2303 6FB2 A1C2 65FF B764"; do \
+RUN for item in "75DD C3C4 A499 F1A1 8CB5  F3C8 CBF8 D6FD 518E 17E1" "126C 0D24 BD8A 2942 CC7D  F8AC 7638 D044 2B90 D010" "D211 6914 1CEC D440 F2EB  8DDA 9D6D 8F6B C857 C906" "A1BD 8E9D 78F7 FE5C 3E65  D8AF 8B48 AD62 4692 5553" "ED6D 6527 1AAC F0FF 15D1  2303 6FB2 A1C2 65FF B764"; do \
     apt-key remove "${item}" || true; \
-  done; \
-fi
+  done;
 
 
 RUN apt-get -qq update && apt-get -qq install -y tzdata gnupg2 pv less vim wget curl lsb-release >/dev/null

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -13,11 +13,11 @@ ENV MYSQL_ROOT_PASSWORD root
 
 SHELL ["/bin/bash", "-c"]
 
-# Remove obsolete MySQL 5.5 Jessie and before keys so they don't make expiration key test stumble
-RUN if [ ${DB_TYPE} == "mysql" ] && [ ${DB_VERSION} == "5.5" ]; then \
+# Remove obsolete MySQL 5.5/5.6 Jessie and before keys so they don't make expiration key test stumble
+RUN if [ ${DB_TYPE} == "mysql" ] && [[ ${DB_VERSION} =~ "5\.[56]" ]] ; then \
   for item in "75DD C3C4 A499 F1A1 8CB5  F3C8 CBF8 D6FD 518E 17E1" "126C 0D24 BD8A 2942 CC7D  F8AC 7638 D044 2B90 D010" "D211 6914 1CEC D440 F2EB  8DDA 9D6D 8F6B C857 C906" "A1BD 8E9D 78F7 FE5C 3E65  D8AF 8B48 AD62 4692 5553" "ED6D 6527 1AAC F0FF 15D1  2303 6FB2 A1C2 65FF B764"; do \
-    apt-key remove "${item}"; \
-  done \
+    apt-key remove "${item}" || true; \
+  done; \
 fi
 
 

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -13,6 +13,14 @@ ENV MYSQL_ROOT_PASSWORD root
 
 SHELL ["/bin/bash", "-c"]
 
+# Remove obsolete MySQL 5.5 Jessie and before keys so they don't make expiration key test stumble
+RUN if [ ${DB_TYPE} == "mysql" ] && [ ${DB_VERSION} == "5.5" ]; then \
+  for item in "75DD C3C4 A499 F1A1 8CB5  F3C8 CBF8 D6FD 518E 17E1" "126C 0D24 BD8A 2942 CC7D  F8AC 7638 D044 2B90 D010" "D211 6914 1CEC D440 F2EB  8DDA 9D6D 8F6B C857 C906" "A1BD 8E9D 78F7 FE5C 3E65  D8AF 8B48 AD62 4692 5553" "ED6D 6527 1AAC F0FF 15D1  2303 6FB2 A1C2 65FF B764"; do \
+    apt-key remove "${item}"; \
+  done \
+fi
+
+
 RUN apt-get -qq update && apt-get -qq install -y tzdata gnupg2 pv less vim wget curl lsb-release >/dev/null
 
 RUN set -x; if ( ! command -v xtrabackup && ! command -v mariabackup ); then \

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -13,7 +13,7 @@ function setup {
 }
 
 @test "verify apt keys are not expiring" {
-  MAX_DAYS_BEFORE_EXPIRATION=32
+  MAX_DAYS_BEFORE_EXPIRATION=90
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi


### PR DESCRIPTION
## The Problem/Issue/Bug:

See #3004 and #3006 - Old keys were preventing us from being able to test for expiring keys. 

## How this PR Solves The Problem:

Remove the ancient Jessie keys that are expiring/expired. They were apparently only needed for upgrades to Stretch in the first place.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3030"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

