### PR TITLE
Increase ddev-router nginx large_client_header_buffers value for larger cookie payload

### DIFF
--- a/containers/ddev-router/etc/nginx/nginx.conf
+++ b/containers/ddev-router/etc/nginx/nginx.conf
@@ -27,10 +27,11 @@ http {
   #tcp_nopush     on;
 
   keepalive_timeout  65;
+  large_client_header_buffers 4 16k;
 
   #gzip  on;
 
-  # Double default value to accomadate larger requests (often due to big cookies)
+  # Double default value to accommodate larger requests (often due to big cookies)
   # https://github.com/drud/ddev/discussions/2697
   http2_max_header_size 32k;
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -58,7 +58,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20210518_allow_disable_http2" // Note that this can be overridden by make
+var RouterTag = "20210602_ddev_router_large_client_headers" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Some users have had trouble with huge cookie payloads and ddev-router's (nginx default) large_client_header_buffers value.

The [default value](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) is "large_client_header_buffers 4 8k;". This raises the size of the buffers to "large_client_header_buffers 4 16k;"



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3033"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

