### PR TITLE
Increase ddev-webserver apache/nginx limit request field size for large cookie payloads

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/sites-enabled/apache-site.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/sites-enabled/apache-site.conf
@@ -35,6 +35,9 @@
     # Simple ddev technique to get a phpstatus
     Alias "/phpstatus" "/var/www/phpstatus.php"
 
+    # Double the default LimitRequestFieldSize for large header payloads
+    LimitRequestFieldSize 16380
+
 </VirtualHost>
 
 <VirtualHost *:443>
@@ -75,6 +78,9 @@
     #Include conf-available/serve-cgi-bin.conf
     # Simple ddev technique to get a phpstatus
     Alias "/phpstatus" "/var/www/phpstatus.php"
+
+    # Double the default LimitRequestFieldSize for large header payloads
+    LimitRequestFieldSize 16380
 
 </VirtualHost>
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
@@ -132,6 +132,9 @@ http {
   # https://github.com/drud/ddev/discussions/2697
   http2_max_header_size 32k;
 
+  # Double the default value for large_client_header_buffers - large cookie payloads
+  large_client_header_buffers 4 16k;
+
   # Include files in the sites-enabled folder.
   include /etc/nginx/sites-enabled/*.conf;
 }

--- a/pkg/ddevapp/testdata/TestConfigOverrideDetection/.ddev/apache/apache-site.conf
+++ b/pkg/ddevapp/testdata/TestConfigOverrideDetection/.ddev/apache/apache-site.conf
@@ -32,6 +32,9 @@
 	# Simple ddev technique to get a phpstatus
 	Alias "/phpstatus" "/var/www/phpstatus.php"
 
+    # Double the default LimitRequestFieldSize for large header payloads
+    LimitRequestFieldSize 16380
+
 </VirtualHost>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210502_thomasdiluccio_blackfire" // Note that this can be overridden by make
+var WebTag = "20210602_ddev_webserver_apache_LimitRequestFieldSize" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Some users have run into trouble with huge cookie payloads, both in nginx and apache. This doubles the relevant [nginx default value](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) is "large_client_header_buffers 4 8k;". This raises the size of the nginx buffers to "large_client_header_buffers 4 16k;"

Apache LimitRequestFieldSize  is doubled to 16380.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3034"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

