### PR TITLE
Fix homebrew and AUR release push failures [skip ci][ci skip]

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -217,7 +217,7 @@ jobs:
           bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_STABLE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
 
       - name: "Push AUR ddev-edge-bin"
-        if: env.AUR_SSH_PRIVATE_KEY != '' && startsWith( github.ref, 'refs/tags/v1') && contains( github.ref, '-')
+        if: env.AUR_SSH_PRIVATE_KEY != '' && startsWith( github.ref, 'refs/tags/v1')
         run: |
           echo GITHUB_REF=${GITHUB_REF}
           .ci-scripts/bump_aur.sh ddev-edge-bin ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -207,7 +207,7 @@ jobs:
           args: ${{ github.workspace }}/artifacts/*
 
       - name: "Bump homebrew edge release"
-        if: env.DDEV_GITHUB_TOKEN != '' && startsWith( github.ref, 'refs/tags/v1') && contains( github.ref, '-')
+        if: env.DDEV_GITHUB_TOKEN != '' && startsWith( github.ref, 'refs/tags/v1')
         run: |
           bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_EDGE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

We failed to get homebrew (edge) or AUR pushes in v1.17.3

AUR was partly a result of not having the right ssh key configured in secrets.

homebrew edge was due to a logic error. 

I'm manually pushed homebrew edge, and still have to do AUR manually.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3036"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

