### PR TITLE
Add a test to make sure SegmentKey is working on release build

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Build DDEV executables
         run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64
 
+      - name: "Verify that SegmentKey is working (Linux amd64)"
+        if: startsWith( github.ref, 'refs/tags/v1')
+        run: |
+          echo "DDEV_NO_INSTRUMENTATION=${DDEV_NO_INSTRUMENTATION}"
+          .gotmp/bin/linux_amd64/ddev config global | grep instrumentation-opt-in=true
+          .gotmp/bin/linux_amd64/ddev config global | grep -v "SegmentKey is not available."
+
       - name: save build results to cache
         uses: actions/cache@v2
         with:
@@ -63,6 +70,14 @@ jobs:
       - name: Build chocolatey on release
         if: startsWith( github.ref, 'refs/tags/v1')
         run: make chocolatey
+
+      - name: "Verify that SegmentKey is working (Windows)"
+        if: startsWith( github.ref, 'refs/tags/v1')
+        run: |
+          echo "DDEV_NO_INSTRUMENTATION=${DDEV_NO_INSTRUMENTATION}"
+          .gotmp/bin/windows_amd64/ddev.exe config global | grep instrumentation-opt-in=true
+          .gotmp/bin/windows_amd64/ddev.exe config global | grep -v "SegmentKey is not available."
+
       - name: Cache signed binaries
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## The Problem/Issue/Bug:

We've had various build problems where SegmentKey wasn't included in the build. Might as well test for it in the build process. 

This adds an explicit test.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3037"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

