### PR TITLE
Bump upstream Dockerfile again to get composer 2.1.1

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.17.3.1 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.17.4 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -223,6 +223,7 @@ func TestDisableHTTP2(t *testing.T) {
 
 	// Verify that http2 is on by default
 	out, err := exec.RunCommand("bash", []string{"-c", "curl -k -s -I " + app.GetPrimaryURL() + "| head -1"})
+	assert.NoError(err, "failed to curl, err=%v out=%v", err, out)
 	assert.Equal("HTTP/2 200 \r\n", out)
 
 	// Now turn it off and verify

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.17.3" // Note that this can be overridden by make
+var WebTag = "v1.17.4" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* composer 2.1.1 was released; it may solve some problems with 2.1.0



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3038"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

