### PR TITLE
Use buildkite docker-login plugin instead of scripting `docker login`

### DIFF
--- a/.buildkite/linux-amd64.yml
+++ b/.buildkite/linux-amd64.yml
@@ -1,4 +1,8 @@
   - command: ".buildkite/test.sh"
+    plugins:
+      - docker-login#v2.0.1:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=linux"
       - "architecture=amd64"

--- a/.buildkite/linux-arm64.yml
+++ b/.buildkite/linux-arm64.yml
@@ -1,4 +1,8 @@
   - command: ".buildkite/test.sh"
+    plugins:
+      - docker-login#v2.0.1:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=linux"
       - "architecture=arm64"

--- a/.buildkite/macos-m1.yml
+++ b/.buildkite/macos-m1.yml
@@ -1,4 +1,8 @@
   - command: ".buildkite/test.sh"
+    plugins:
+      - docker-login#v2.0.1:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=macos"
       - "dockertype=dockerformac"

--- a/.buildkite/macos_container.yml
+++ b/.buildkite/macos_container.yml
@@ -1,4 +1,8 @@
   - command: ".buildkite/test_containers.sh"
+    plugins:
+      - docker-login#v2.0.1:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=macos"
       - "dockertype=dockerformac"

--- a/.buildkite/macosdockerformac.yml
+++ b/.buildkite/macosdockerformac.yml
@@ -1,4 +1,8 @@
   - command: ".buildkite/test.sh"
+    plugins:
+      - docker-login#v2.0.1:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=macos"
       - "dockertype=dockerformac"

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -40,12 +40,6 @@ for hostname in github.com raw.githubusercontent.com github-releases.githubuserc
   ping -c 1 $hostname 2>/dev/null || ping -c 1 $hostname 2>/dev/null || true
 done
 
-if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
-  set +x
-  echo "${DOCKERHUB_PULL_PASSWORD:-}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
-  set -x
-fi
-
 rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml ~/.ddev/homeadditions ~/.ddev/commands
 
 # There are discrepancies in golang hash checking in 1.11+, so kill off modcache to solve.

--- a/.buildkite/windows10_container.yml
+++ b/.buildkite/windows10_container.yml
@@ -1,4 +1,8 @@
   - command: ".buildkite/test_containers.cmd"
+    plugins:
+      - docker-login#v2.0.1:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=windows"
       - "dockertype=dockerforwindows"

--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -1,4 +1,8 @@
   - command: ".buildkite/test.cmd"
+    plugins:
+      - docker-login#v2.0.1:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=windows"
       - "dockertype=dockerforwindows"

--- a/.buildkite/wsl2.yml
+++ b/.buildkite/wsl2.yml
@@ -1,4 +1,8 @@
   - command: ".buildkite/test.sh"
+    plugins:
+      - docker-login#v2.0.1:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=wsl2"
       - "architecture=amd64"


### PR DESCRIPTION
## The Problem/Issue/Bug:
While working on my PR https://github.com/drud/ddev/pull/3039 there was a login issue with Docker so I was looking for a solution and found the docker-login plugin.

## How this PR Solves The Problem:
So far this looks to perform nice and no login issue occured.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3041"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

