### PR TITLE
TestPoweroffOnNewVersion : Try to get a reasonable behavior for start time, fixes #2979

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -36,9 +36,11 @@ if ! docker ps >/dev/null 2>&1 ; then
 fi
 
 # Try to get important names cached; try twice
-for hostname in github.com raw.githubusercontent.com github-releases.githubusercontent.com registry-1.docker.io auth.docker.io production.cloudflare.docker.com; do
-  ping -c 1 $hostname 2>/dev/null || ping -c 1 $hostname 2>/dev/null || true
-done
+docker run --rm alpine sh -c '
+  for hostname in github.com raw.githubusercontent.com github-releases.githubusercontent.com registry-1.docker.io auth.docker.io production.cloudflare.docker.com; do
+    nslookup $hostname >/dev/null 2>&1 || nslookup $hostname >/dev/null 2>&1 || true
+  done
+'
 
 if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
   set +x


### PR DESCRIPTION
## The Problem/Issue/Bug:

Multiple attempts to solve #2979 on Windows. There seems to be some time difference in docker (or an error in behavior that I don't understand on Windows). 

If this doesn't solve it, maybe will just disable the test on traditional Windows. 

But if that is required, careful manual testing will be required first.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3043"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

