### PR TITLE
docker-desktop-version.sh mistakenly insisted on installation of xq

### DIFF
--- a/scripts/docker-desktop-version.sh
+++ b/scripts/docker-desktop-version.sh
@@ -2,11 +2,6 @@
 
 MACOS_INFO_PATH=/Applications/Docker.app/Contents/Info.plist
 
-if [ "${OSTYPE%%[0-9]*}" = "darwin" ] && ! command -v xq >/dev/null; then
-  printf "Please install xq, brew install python-yq, to parse macOS Info.plist"
-  exit
-fi
-
 if command -v powershell >/dev/null; then
   printf "Docker Desktop for Windows "
   powershell.exe -command '[System.Diagnostics.FileVersionInfo]::GetVersionInfo("C:\Program Files\Docker\Docker\Docker Desktop.exe").FileVersion'


### PR DESCRIPTION
## The Problem/Issue/Bug:

docker-desktop-version.sh mistakenly insisted on installation of xq

Affects only macOS buildkite builds.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3045"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

