### PR TITLE
Fix bug in webserver Makefile where prod image can overwrite dev image

### DIFF
--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -9,9 +9,9 @@ DOCKER_BUILDKIT=1
 
 BUILD_ARCHS=linux/amd64,linux/arm64
 
-include ../containers_shared.mak
+build: images
 
-container build: images
+include ../containers_shared.mak
 
 images: $(DEFAULT_IMAGES)
 
@@ -29,8 +29,8 @@ multi-arch:
 		echo "created multi-arch builds $(BUILD_ARCHS) for $(DOCKER_ORG)/$$item"; \
 	done
 
-ddev-webserver ddev-webserver-dev-base ddev-webserver-prod-base ddev-webserver-prod:
-	docker buildx build -o type=docker --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+$(DEFAULT_IMAGES):
+	 docker buildx build -o type=docker --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 
 test: images

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.17.4" // Note that this can be overridden by make
+var WebTag = "20210614_fix_build_no_overwrite" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

I discovered that when doing a local `make` in ddev-webserver, the ddev-webserver-prod ended up overwriting the ddev-webserver build. It was very confusing.

## How this PR Solves The Problem:

Make it build with the right target. This only affects local builds, not push. also, `make VERSION=xxx DEFAULT_IMAGES=ddev-webserver` now will build just ddev-webserver, saving some dev time.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3049"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

