### PR TITLE
Use large_client_header_buffers instead of http2_max_header_size for nginx config

### DIFF
--- a/containers/ddev-router/etc/nginx/nginx.conf
+++ b/containers/ddev-router/etc/nginx/nginx.conf
@@ -31,10 +31,6 @@ http {
 
   #gzip  on;
 
-  # Double default value to accommodate larger requests (often due to big cookies)
-  # https://github.com/drud/ddev/discussions/2697
-  http2_max_header_size 32k;
-
   include /etc/nginx/conf.d/*.conf;
 }
 daemon off;

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
@@ -128,10 +128,6 @@ http {
     https on;
   }
 
-  # Double default value to accomadate larger requests (often due to big cookies)
-  # https://github.com/drud/ddev/discussions/2697
-  http2_max_header_size 32k;
-
   # Double the default value for large_client_header_buffers - large cookie payloads
   large_client_header_buffers 4 16k;
 

--- a/pkg/ddevapp/webserver_config_assets/apache-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/apache-site-php.conf
@@ -33,6 +33,10 @@
     # following line enables the CGI configuration for this host only
     # after it has been globally disabled with "a2disconf".
     #Include conf-available/serve-cgi-bin.conf
+
+    # Increase allowed field size for large cookies header.
+    LimitRequestFieldSize 16380
+
     # Simple ddev technique to get a phpstatus
     Alias "/phpstatus" "/var/www/phpstatus.php"
 
@@ -67,6 +71,9 @@
 
     ErrorLog /dev/stdout
     CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    # Increase allowed field size for large cookies header.
+    LimitRequestFieldSize 16380
 
     # For most configuration files from conf-available/, which are
     # enabled or disabled at a global level, it is possible to

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "2021_nicohaase_phive" // Note that this can be overridden by make
+var WebTag = "20210615_use_large_header_buffers" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
@@ -58,7 +58,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.17.3" // Note that this can be overridden by make
+var RouterTag = "20210615_use_large_header_buffers" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noticed this error in the ddev-webserver log:

> the "http2_max_header_size" directive is obsolete, use the "large_client_header_buffers" directive instead in /etc/nginx/nginx.conf:133

So somewhere in our doubling of the http2_max_header_size journey we did/did not switch to the new format. 

This switches to the new format in ddev-webserver and ddev-router.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3053"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

