### PR TITLE
Remove trailing whitespace in config templates

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -351,7 +351,7 @@ const ConfigInstructions = `
 # In this case the user must provide all such settings.
 
 # You can inject environment variables into the web container with:
-# web_environment: 
+# web_environment:
 # - SOMEENV=somevalue
 # - SOMEOTHERENV=someothervalue
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -153,7 +153,7 @@ func WriteGlobalConfig(config GlobalConfig) error {
 # nfs_mount_enabled: true
 #
 # You can inject environment variables into the web container with:
-# web_environment: 
+# web_environment:
 # - SOMEENV=somevalue
 # - SOMEOTHERENV=someothervalue
 


### PR DESCRIPTION
Two tiny nitpicks found while doing a git-diff with white space highlighted :)

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3055"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

