### PR TITLE
Do not trim quotes in findDirectivesInScriptCommand (#3051)

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -296,7 +296,7 @@ func findDirectivesInScriptCommand(script string) map[string]string {
 		if strings.HasPrefix(line, "## ") && strings.Contains(line, ":") {
 			line = strings.Replace(line, "## ", "", 1)
 			parts := strings.SplitN(line, ":", 2)
-			parts[1] = strings.Trim(parts[1], " \"'")
+			parts[1] = strings.Trim(parts[1], " ")
 			directives[parts[0]] = parts[1]
 		}
 	}

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -296,7 +296,11 @@ func findDirectivesInScriptCommand(script string) map[string]string {
 		if strings.HasPrefix(line, "## ") && strings.Contains(line, ":") {
 			line = strings.Replace(line, "## ", "", 1)
 			parts := strings.SplitN(line, ":", 2)
-			parts[1] = strings.Trim(parts[1], " ")
+			if parts[0] == "Example" {
+				parts[1] = strings.Trim(parts[1], " ")
+			} else {
+				parts[1] = strings.Trim(parts[1], " \"'")
+			}
 			directives[parts[0]] = parts[1]
 		}
 	}

--- a/cmd/ddev/cmd/global_dotddev_assets/commands/host/heidisql
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/host/heidisql
@@ -5,7 +5,7 @@
 ## Usage: heidisql
 ## Example: "ddev heidisql"
 ## OSTypes: windows,wsl2
-## HostBinaryExists: "/mnt/c/Program Files/HeidiSQL/heidisql.exe,C:\Program Files\HeidiSQL\Heidisql.exe"
+## HostBinaryExists: /mnt/c/Program Files/HeidiSQL/heidisql.exe,C:\Program Files\HeidiSQL\Heidisql.exe
 
 arguments="--host=127.0.0.1 --port=${DDEV_HOST_DB_PORT} --user=root --password=root --description=${DDEV_SITENAME}"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
https://github.com/drud/ddev/issues/3051

## How this PR Solves The Problem:
In 2ff4f0b17, triming was added for readability of file paths but the code
does not actually depend on quotes around paths. It only cares for
commas to differentiate multiple paths in a given directive.

This partially reverts:
```
    commit 2ff4f0b178734f602a4f26013fb48fb528ac0f30
    Author: Andreas Hager <3351175+andreashager@users.noreply.github.com>
    Date:   Tue Dec 29 05:47:40 2020 +0100

        Create new HeidiSQL command for Windows and WSL2 (#2679)
```

## Manual Testing Instructions:
Call `ddev drush --help` or any command help in `cmd/ddev/cmd/global_dotddev_assets/commands/web/`

## Automated Testing Overview:
NA

## Related Issue Link(s):
https://github.com/drud/ddev/issues/3051

## Release/Deployment notes:
I can't test on Windows, which was the focus of the original commit

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3057"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

