### PR TITLE
Make sure windows path is set with git-bash first [skip ci][ci skip]

### DIFF
--- a/docs/developers/scripts/windows_buildkite_start.ps1
+++ b/docs/developers/scripts/windows_buildkite_start.ps1
@@ -13,6 +13,8 @@ Set-Timezone -Id "Mountain Standard Time"
 # Enable developer mode feature
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"
 
+setx /M PATH "C:\Program Files\Git\bin;%PATH%"
+
 # Install WSL2 and VirtualMachinePlatform
 dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
 dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all

--- a/docs/developers/scripts/windows_buildkite_start.ps1
+++ b/docs/developers/scripts/windows_buildkite_start.ps1
@@ -13,7 +13,7 @@ Set-Timezone -Id "Mountain Standard Time"
 # Enable developer mode feature
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"
 
-setx /M PATH "C:\Program Files\Git\bin;%PATH%"
+cmd /c "setx /M PATH ""C:\Program Files\Git\bin;%PATH%"""
 
 # Install WSL2 and VirtualMachinePlatform
 dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart


### PR DESCRIPTION
## The Problem/Issue/Bug:

I was having trouble with the docker-login buildkite extension on a few Windows test runners. Found that the problem was that the Windows bash.exe was earlier in the PATH than the git-bash that we need to be running those scripts.

## How this PR Solves The Problem:

Add to PATH as we install



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3058"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

