### PR TITLE
Use stable nginx as upstream image for ddev-router

### DIFF
--- a/containers/ddev-router/Dockerfile
+++ b/containers/ddev-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.18
+FROM nginx:stable
 
 ENV MKCERT_VERSION=v1.4.6
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -58,7 +58,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20210615_use_large_header_buffers" // Note that this can be overridden by make
+var RouterTag = "20210617_ddev_router_latest_nginx" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"


### PR DESCRIPTION
## The Problem/Issue/Bug:

I happened to notice when looking at headers that ddev-router was using an older version of nginx (v1.18) rather than current stable (v1.20)

## How this PR Solves The Problem:

Update

## Manual Testing Instructions:

`curl -I <projecturl>` and see headers.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3059"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

