### PR TITLE
[tests only] only listen on localhost for xdebug test

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -718,7 +718,8 @@ func TestDdevXdebugEnabled(t *testing.T) {
 		}
 
 		// Start a listener on port 9000 of localhost (where PHPStorm or whatever would listen)
-		listener, err := net.Listen("tcp", ":9000")
+		// Use localhost listening to not trigger firewall on macOS Big Sur+
+		listener, err := net.Listen("tcp", "127.0.0.1:9000")
 		require.NoError(t, err)
 
 		// Curl to the project's index.php or anything else

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -654,6 +654,13 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 	testcommon.ClearDockerEnv()
 
+	// On macOS we want to just listen on localhost port, so as to not trigger
+	// firewall block. On other systems, just listen on all interfaces
+	listenPort := ":9000"
+	if runtime.GOOS == "darwin" {
+		listenPort = "127.0.0.1:9000"
+	}
+
 	site := TestSites[0]
 	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
 
@@ -718,8 +725,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 		}
 
 		// Start a listener on port 9000 of localhost (where PHPStorm or whatever would listen)
-		// Use localhost listening to not trigger firewall on macOS Big Sur+
-		listener, err := net.Listen("tcp", "127.0.0.1:9000")
+		listener, err := net.Listen("tcp", listenPort)
 		require.NoError(t, err)
 
 		// Curl to the project's index.php or anything else


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noticed that the firewall was triggering on one of the tests on the M1 test runner. 

https://apple.stackexchange.com/questions/3271/how-to-get-rid-of-firewall-accept-incoming-connections-dialog pointed out that this can happen when you try to listen on something other than localhost.

So adding. I didn't find any other places that were likely to have this problem.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3061"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

