### PR TITLE
Bump images to v1.17.6 for pending release

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.17.4 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.17.6 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210502_penyaskito_xhprof" // Note that this can be overridden by make
+var WebTag = "v1.17.6" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
@@ -58,7 +58,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20210617_ddev_router_latest_nginx" // Note that this can be overridden by make
+var RouterTag = "v1.17.6" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Time for a v1.17.6 release. Tag new images for it, use latest upstream images.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3062"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

