### PR TITLE
Bump golang build to v1.16.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ BUILD_OS = $(shell go env GOHOSTOS)
 BUILD_ARCH = $(shell go env GOHOSTARCH)
 VERSION_LDFLAGS=$(foreach v,$(VERSION_VARIABLES),-X '$(PKG)/pkg/version.$(v)=$($(v))')
 LDFLAGS=-extldflags -static $(VERSION_LDFLAGS)
-BUILD_IMAGE ?= drud/golang-build-container:v1.16.0
+BUILD_IMAGE ?= drud/golang-build-container:v1.16.5
 DOCKERBUILDCMD=docker run -t --rm -u $(shell id -u):$(shell id -g) \
 	-v "/$(PWD)://workdir$(DOCKERMOUNTFLAG)" \
 	-e GOPATH="//workdir/$(GOTMP)" \


### PR DESCRIPTION
Bump golang build to v1.16.5

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3063"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

