### PR TITLE
Download gsudo on demand for Windows installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ darwin_arm64_notarized: darwin_arm64_signed
 
 windows_install: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe
 
-$(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe: $(GOTMP)/bin/windows_amd64/ddev.exe $(GOTMP)/bin/windows_amd64/sudo.exe $(GOTMP)/bin/windows_amd64/sudo_license.txt $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.txt winpkg/ddev.nsi
+$(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe: $(GOTMP)/bin/windows_amd64/ddev.exe $(GOTMP)/bin/windows_amd64/sudo_license.txt $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.txt winpkg/ddev.nsi
 	ls -l .gotmp/bin/windows_amd64
 	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing ddev.exe, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows binaries..." && signtool sign ".gotmp/bin/windows_amd64/ddev.exe" ".gotmp/bin/windows_amd64/mkcert.exe" ".gotmp/bin/windows_amd64/ddev_gen_autocomplete.exe"; fi
 	@makensis -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows
@@ -248,10 +248,8 @@ $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.
 	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/mkcert.exe https://github.com/drud/mkcert/releases/download/$(MKCERT_VERSION)/mkcert-$(MKCERT_VERSION)-windows-amd64.exe
 	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/mkcert_license.txt -O https://raw.githubusercontent.com/drud/mkcert/master/LICENSE
 
-$(GOTMP)/bin/windows_amd64/sudo.exe $(GOTMP)/bin/windows_amd64/sudo_license.txt:
+$(GOTMP)/bin/windows_amd64/sudo_license.txt:
 	set -x
-	curl -sSL --create-dirs -o "$(GOTMP)/bin/windows_amd64/gsudo.zip" https://github.com/gerardog/gsudo/releases/download/$(WINDOWS_GSUDO_VERSION)/gsudo.$(WINDOWS_GSUDO_VERSION).zip
-	unzip -o -d "$(GOTMP)/bin/windows_amd64" "$(GOTMP)/bin/windows_amd64/gsudo.zip" gsudo.exe && mv "$(GOTMP)/bin/windows_amd64/gsudo.exe" "$(GOTMP)/bin/windows_amd64/sudo.exe"
 	curl --fail -sSL -o "$(GOTMP)/bin/windows_amd64/sudo_license.txt" "https://raw.githubusercontent.com/gerardog/gsudo/master/LICENSE.txt"
 
 # Best to install golangci-lint locally with "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.31.0"

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -97,6 +97,10 @@
 /**
  * Third Party Applications
  */
+!define GSUDO_NAME "gsudo"
+!define GSUDO_SETUP "sudo.exe"
+!define GSUDO_URL "https://github.com/drud/gsudo/releases/download/v0.7.3/gsudo.exe"
+
 !define WINNFSD_NAME "WinNFSd"
 !define WINNFSD_VERSION "2.4.0"
 !define WINNFSD_SETUP "WinNFSd.exe"
@@ -460,15 +464,32 @@ SectionEnd
 /**
  * sudo application install
  */
-Section "sudo" SecSudo
+Section "${GSUDO_NAME}" SecSudo
   ; Force installation
   SectionIn 1 2 3 RO
   SetOutPath "$INSTDIR"
   SetOverwrite try
 
   ; Copy files
-  File "..\.gotmp\bin\windows_amd64\sudo.exe"
   File "..\.gotmp\bin\windows_amd64\sudo_license.txt"
+
+  ; Set URL and temporary file name
+  !define GSUDO_DEST "$INSTDIR\${GSUDO_SETUP}"
+
+  ; Download installer
+  INetC::get /CANCELTEXT "Skip download" /QUESTION "" "${GSUDO_URL}" "${GSUDO_DEST}" /END
+  Pop $R0 ; return value = exit code, "OK" if OK
+
+  ; Check download result
+  ${If} $R0 != "OK"
+    ; Download failed, show message and continue
+    SetDetailsView show
+    DetailPrint "Download of `${GSUDO_NAME}` failed:"
+    DetailPrint " $R0"
+    MessageBox MB_ICONEXCLAMATION|MB_OK "Download of `${GSUDO_NAME}` has failed, please download it to the DDEV installation folder `$INSTDIR` once this installation has finished. Continue the resting installation."
+  ${EndIf}
+
+  !undef GSUDO_DEST
 SectionEnd
 
 /**
@@ -990,11 +1011,11 @@ Section Uninstall
   ; Remove installed files
   Delete "$INSTDIR\ddev_uninstall.exe"
 
-  Delete "$INSTDIR\nssm.exe"
+  Delete "$INSTDIR\${NSSM_SETUP}"
 
   Delete "$INSTDIR\windows_ddev_nfs_setup.sh"
   Delete "$INSTDIR\winnfsd_license.txt"
-  Delete "$INSTDIR\winnfsd.exe"
+  Delete "$INSTDIR\${WINNFSD_SETUP}"
 
   Delete "$INSTDIR\mkcert uninstall.lnk"
   Delete "$INSTDIR\mkcert install.lnk"
@@ -1002,7 +1023,7 @@ Section Uninstall
   Delete "$INSTDIR\mkcert.exe"
 
   Delete "$INSTDIR\sudo_license.txt"
-  Delete "$INSTDIR\sudo.exe"
+  Delete "$INSTDIR\${GSUDO_SETUP}"
 
   Delete "$INSTDIR\license.txt"
   Delete "$INSTDIR\ddev.exe"


### PR DESCRIPTION
## The Problem/Issue/Bug:
Like before with WinNFSd and NSSM, now virus tools are recognizing gsudo as malicious software and so it gets not longer bundled to the installer but downloaded on demand during the installation to avoid issues.

## How this PR Solves The Problem:
gsudo is now downloaded on demand, so only local virus scanners can complain.

## Manual Testing Instructions:
Remove the previous DDEV installation or in minimum remove the sudo.exe to see if it's correctly downloaded and installed with the new installer.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#2973

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3066"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

