### PR TITLE
Add docker-php-ext-* helper tools for odd php extensions, fixes #2987 [skip ci][ci skip]

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -43,6 +43,10 @@ RUN curl -sSL https://raw.githubusercontent.com/netz98/n98-magerun/develop/res/a
 RUN curl -sSL https://files.magerun.net/n98-magerun2-latest.phar -o /usr/local/bin/magerun2 && chmod 777 /usr/local/bin/magerun2
 RUN curl -sSL https://raw.githubusercontent.com/netz98/n98-magerun2/develop/res/autocompletion/bash/n98-magerun2.phar.bash -o /etc/bash_completion.d/n98-magerun2.phar && chmod +x /usr/local/bin/magerun
 
+RUN set -eu -o pipefail && for item in docker-php-ext-configure docker-php-ext-enable docker-php-ext-install docker-php-source; do \
+    curl -sSL -o /usr/local/bin/${item} https://raw.githubusercontent.com/docker-library/php/master/${item} && chmod ugo+rwx /usr/local/bin/${item} ; \
+done
+
 # /usr/local/bin may need to be updated by start.sh, etc
 RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.17.6" // Note that this can be overridden by make
+var WebTag = "20210625_docker-php-ext" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

#2987 proposes adding docker-php-ext-* scripts to the web container to make it easy to add non-mainstream build-from-source php extensions.

## How this PR Solves The Problem:

Adds the scripts... but there's more to be done to make them work. And I imagine they're not useful without build-essential, which I probably wouldn't add because of size.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3071"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

