### PR TITLE
Use newer syntax for default network, fixes #3069

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -189,8 +189,8 @@ services:
 {{end}}
 networks:
   default:
-    external:
-      name: ddev_default
+    name: ddev_default
+    external: true
 volumes:
   {{if not .OmitDB }}
   mariadb-database:
@@ -467,8 +467,8 @@ services:
 
 networks:
   default:
-    external:
-      name: ddev_default
+    name: ddev_default
+    external: true
 volumes:
   ddev-global-cache:
     name: ddev-global-cache
@@ -510,6 +510,6 @@ services:
       timeout: 62s
 networks:
   default:
-    external:
-      name: ddev_default
+    name: ddev_default
+    external: true
 `

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -1,7 +1,8 @@
 networks:
   default:
-    external:
-      name: ddev_default
+    name: ddev_default
+    external: true
+
 services:
   web:
     container_name: TestComposeWithStreams

--- a/pkg/dockerutil/testdata/docker-compose.yml
+++ b/pkg/dockerutil/testdata/docker-compose.yml
@@ -44,5 +44,6 @@ services:
       timeout: 120s
 networks:
   default:
-    external:
-      name: ddev_default
+    name: ddev_default
+    external: true
+


### PR DESCRIPTION
## The Problem/Issue/Bug:

The syntax for using a pre-existing network has changed, and docker compose v2 complains a lot about the old syntax. 

This just updates to the new syntax. 

See https://github.com/docker/compose-cli/issues/1856#:~:text=commented-,20%20minutes%20ago,-I%20am%20the

## Manual Testing Instructions:

`ddev start` and see if you see the complaints in #3069 "network.external.name is deprecated"

## Automated Testing Overview:

No change.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3076"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

