### PR TITLE
Make ssh-auth volume name explicit on creation, fixes #3075

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -483,6 +483,7 @@ const DdevSSHAuthTemplate = `version: '{{ .compose_version }}'
 volumes:
   dot_ssh:
   socket_dir:
+    name: ddev-ssh-agent_socket_dir
 
 services:
   ddev-ssh-agent:


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev auth ssh` didn't work with docker-compose v2, see #3075 

## How this PR Solves The Problem:

The problem turns out to be that docker-compose v2 uses a different default name for the volume

## Manual Testing Instructions:

Normal testing for `ddev auth ssh`

* `ddev auth ssh` and add some keys
* `ddev exec ssh-add -l` should show your keys



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3077"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

