### PR TITLE
Remove remnants of Docker Toolbox support from Windows Installer

### DIFF
--- a/containers/containers_shared.mak
+++ b/containers/containers_shared.mak
@@ -12,4 +12,4 @@ container-name:
 	@echo "container: $(DOCKER_REPO):$(VERSION)"
 
 push:
-	docker buildx build --push --platform $(BUILD_ARCHS) -t $(DOCKER_REPO):$(VERSION) --label "build-info=$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always) built $$(date) by $$(id -un) on $$(hostname)" --label "maintainer=DDEV <rfay@ddev.com>" $(DOCKER_ARGS) .
+	docker buildx build --push --platform $(BUILD_ARCHS) -t $(DOCKER_REPO):$(VERSION) --label "build-info=$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always) built $$(date) by $$(id -un) on $$(hostname)" --label "maintainer=DDEV <randy@randyfay.com>" $(DOCKER_ARGS) .

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -508,7 +508,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 
 	// The perl manipulation removes statements like CREATE DATABASE and USE, which
 	// throw off imports. This is a scary manipulation, as it must not match actual content
-	// as has actually happened with https://www.ddev.com/ddev-local/ddev-local-database-management/
+	// as has actually happened with https://www.ddevhq.org/ddev-local/ddev-local-database-management/
 	// and in https://github.com/drud/ddev/issues/2787
 	// The backtick after USE is inserted via fmt.Sprintf argument because it seems there's
 	// no way to escape a backtick in a string literal.

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -972,13 +972,6 @@ Function checkDocker
 
         DockerDesktopSelect:
           StrCpy $DockerSelected "1"
-        ${Else}
-          MessageBox MB_ICONQUESTION|MB_YESNOCANCEL "`${DOCKER_TOOLBOX_NAME}` is not installed, but it is required for $(^Name) to function. Would you like to go to the download page of `${DOCKER_TOOLBOX_NAME}`? Cancel will not show this message again." IDYES DockerToolboxDownload IDCANCEL CheckDockerIgnore
-          Goto CheckDockerEnd
-
-        DockerToolboxDownload:
-          ExecShell "open" "${DOCKER_TOOLBOX_URL}"
-        ${EndIf}
 
         Goto CheckDockerEnd
 

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -67,7 +67,7 @@
 !define PRODUCT_PUBLISHER "Drud Technology LLC"
 
 !define PRODUCT_WEB_SITE "${PRODUCT_NAME} Website"
-!define PRODUCT_WEB_SITE_URL "https://www.ddev.com"
+!define PRODUCT_WEB_SITE_URL "https://ddev.readthedocs.io"
 
 !define PRODUCT_DOCUMENTATION "${PRODUCT_NAME} Documentation"
 !define PRODUCT_DOCUMENTATION_URL "https://ddev.readthedocs.io"

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -972,6 +972,7 @@ Function checkDocker
 
         DockerDesktopSelect:
           StrCpy $DockerSelected "1"
+        ${EndIf}
 
         Goto CheckDockerEnd
 

--- a/winpkg/include/docker.nsh
+++ b/winpkg/include/docker.nsh
@@ -76,9 +76,6 @@
   !define DOCKER_DESKTOP_URL `https://download.docker.com/win/stable/Docker%20Desktop%20Installer.exe`
   !define DOCKER_DESKTOP_SETUP `Docker Desktop Installer.exe`
 
-  !define DOCKER_TOOLBOX_NAME `Docker Toolbox`
-  !define DOCKER_TOOLBOX_URL `https://github.com/docker/toolbox/releases/latest`
-
   ; Macros
   !macro _DockerDesktopIsInstallable _a _b _t _f
     !insertmacro _LOGICLIB_TEMP


### PR DESCRIPTION
## The Problem/Issue/Bug:

I happened to notice that there were some remnants of Docker Toolbox support in the Windows Installer

## How this PR Solves The Problem:

Remove them

## Manual Testing Instructions:

Use the installer and verify that it behaves.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3079"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

