### PR TITLE
Declare gsudo as dependency in chocolatey

### DIFF
--- a/winpkg/chocolatey/ddev.nuspec
+++ b/winpkg/chocolatey/ddev.nuspec
@@ -21,6 +21,7 @@
     <description>ddev allows developers to use both nginx and apache, and many versions of PHP, with no host configurations. It works for most web apps, but has a bias toward TYPO3 and Drupal and Wordpress.</description>
     <releaseNotes>See https://github.com/drud/ddev/releases/tag/vREPLACE_DDEV_VERSION</releaseNotes>
   <dependencies>
+      <dependency id="gsudo" />
       <dependency id="ngrok" />
       <dependency id="mkcert" />
       <dependency id="nssm" />


### PR DESCRIPTION
## The Problem/Issue/Bug:

In attempting to get out of virus detection hell on Chocolatey, declare gsudo as a dependency, so it won't be scaneed.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3080"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

