### PR TITLE
Bump images to 1.17.7 in preparation for release

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.17.6 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.17.7 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,13 +40,13 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210703_improve_xhprof" // Note that this can be overridden by make
+var WebTag = "v1.17.7" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20210628_lang_utf8"
+var BaseDBTag = "v1.17.7"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Bump new image names
* All tests on macOS amd64 will use docker-compose v2 to make sure that's all sorted out



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3081"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

