### PR TITLE
Don't allow docker-compose v2 to be used

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 * [Docker](https://www.docker.com/products/docker-desktop) version 18.06 or higher. Linux users make sure you upgrade docker-compose and do the [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
 
-* docker-compose 1.21.0 and higher (bundled with Docker in Docker Desktop for Mac and Docker Desktop for Windows)
+* docker-compose 1.21.0 and higher (bundled with Docker in Docker Desktop for Mac and Docker Desktop for Windows). docker-compose 2.x is not yet compatible with the features of docker-compose v1. However, the not-yet-compatible docker-compose v2 is being pushed to some users in Docker Desktop 3.5+ as an experimental feeature. If this is pushed to you, you can uncheck "Use Docker Compose V2" in "Experimental Features" of Docker Desktop, or issue the command `docker-compose disable-v2`.
 * OS Support
     * macOS Mojave and higher (macOS 10.14 and higher; it should run anywhere Docker Desktop for Mac runs (Current Docker Desktop has deprecated macOS 10.13 High Sierra, but Docker Desktop versions prior to  can still work with DDEV-Local on High Sierra.)
     * Linux: Most Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 16.04+, Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -515,7 +515,7 @@ func CheckDockerCompose(versionConstraint string) error {
 		if len(errs) <= 1 {
 			// TODO: Remove these lines when docker-compose v2 starts working
 			// Probably this commit can be reverted at that time.
-			v2Constraint, _ := semver.NewConstraint("> 1.999.0")
+			v2Constraint, _ := semver.NewConstraint("< 2.0.0")
 			if m, _ := v2Constraint.Validate(dockerComposeVersion); !m {
 				util.Error("You have docker-compose v2 and it is not yet stable enough to use with ddev.\nPlease uncheck the 'Use Docker Compose V2' experimental feature\nin Docker Desktop, or run 'docker-compose disable-v2'")
 			}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -513,6 +513,12 @@ func CheckDockerCompose(versionConstraint string) error {
 	match, errs := constraint.Validate(dockerComposeVersion)
 	if !match {
 		if len(errs) <= 1 {
+			// TODO: Remove these lines when docker-compose v2 starts working
+			// Probably this commit can be reverted at that time.
+			v2Constraint, _ := semver.NewConstraint("> 1.999.0")
+			if m, _ := v2Constraint.Validate(dockerComposeVersion); !m {
+				util.Error("You have docker-compose v2 and it is not yet stable enough to use with ddev.\nPlease uncheck the 'Use Docker Compose V2' experimental feature\nin Docker Desktop, or run 'docker-compose disable-v2'")
+			}
 			return errs[0]
 		}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -31,7 +31,7 @@ var DockerVersionConstraint = ">= 18.06.1-alpha1"
 // REMEMBER TO CHANGE docs/index.md if you touch this!
 // The constraint MUST HAVE a -pre of some kind on it for successful comparison.
 // See https://github.com/drud/ddev/pull/738.. and regression https://github.com/drud/ddev/issues/1431
-var DockerComposeVersionConstraint = ">= 1.21.0-alpha1"
+var DockerComposeVersionConstraint = "1.21.0-alpha1 - 1.999.0"
 
 // DockerComposeFileFormatVersion is the compose version to be used
 var DockerComposeFileFormatVersion = "3.6"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -149,14 +149,6 @@ func GetDockerComposeVersion() (string, error) {
 		return "", fmt.Errorf("no docker-compose")
 	}
 
-	// Temporarily fake the docker-compose check on macOS because of
-	// the slow docker-compose problem in https://github.com/docker/compose/issues/6956
-	// This can be removed when that's resolved.
-	if runtime.GOOS != "darwin" {
-		DockerComposeVersion = "1.25.0-rc4"
-		return DockerComposeVersion, nil
-	}
-
 	out, err := exec.Command(path, "version", "--short").Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## The Problem/Issue/Bug:

Currently there are so many bugs on docker-compose v2 beta that it's unusable for most ddev purposes.

This PR checks for compose v2 and refuses to use it, and gives instruction. 

For a current list of incompatibilities and problems, see https://github.com/drud/ddev/pull/3083#issuecomment-873060929

## How this PR Solves The Problem:

Improve the version constraint to disallow v2
Add an extra error message explaining about v2

## Manual Testing Instructions:

With compose v2 enabled, `ddev start`. It should fail, explaining why.
Then `docker-compose disable-v2` and `ddev start`. It should work. 


## Release/Deployment notes:

Hopefully we can revert this when compose v2 is fully functional and compatible.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3086"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

