### PR TITLE
Update xhprof-profiling.md

### DIFF
--- a/docs/users/xhprof-profiling.md
+++ b/docs/users/xhprof-profiling.md
@@ -1,6 +1,6 @@
 ## Profiling with xhprof
 
-DDEV-Local has built-in support for [xhprof](https://www.php.net/manual/en/book.xhprof.php). The official PECL xhprof extension does not support PHP5.6, but only PHP7 *and PHP8.*.
+DDEV-Local has built-in support for [xhprof](https://www.php.net/manual/en/book.xhprof.php). The official PECL xhprof extension does not support PHP5.6, but only PHP 7.\* and PHP 8.\*.
 
 ### Basic xhprof Usage
 

--- a/docs/users/xhprof-profiling.md
+++ b/docs/users/xhprof-profiling.md
@@ -1,6 +1,6 @@
 ## Profiling with xhprof
 
-DDEV-Local has built-in support for [xhprof](https://www.php.net/manual/en/book.xhprof.php). The official PECL xhprof extension does not support PHP5.6, but only PHP7.*and PHP8.*.
+DDEV-Local has built-in support for [xhprof](https://www.php.net/manual/en/book.xhprof.php). The official PECL xhprof extension does not support PHP5.6, but only PHP7 *and PHP8.*.
 
 ### Basic xhprof Usage
 


### PR DESCRIPTION
Dot after "PHP7" removed since "and PHP8" follows up

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3094"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

