### PR TITLE
Remove version: key from docker-compose files, fixes #3067

### DIFF
--- a/cmd/ddev/cmd/debug-compose-config_test.go
+++ b/cmd/ddev/cmd/debug-compose-config_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 var override = `
-version: '3.6'
 services:
   web:
     labels:

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -21,8 +21,6 @@ The main docker-compose file is named `.ddev/.ddev-docker-compose-base.yaml` and
 * Expose an additional port 9999 to host port 9999, in a file perhaps called `docker-compose.ports.yaml`:
 
 ```yaml
-version: '3.6'
-
 services:
   web:
     ports:

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -27,7 +27,6 @@
 * **Can different projects communicate with each other?** Yes, this is commonly required for situations like Drupal migrations. For the web container to access the db container of another project, use `ddev-<projectname>-db` as the hostname of the other project. For example, in project1, use `mysql ddev-project2-db` to access the db server of project2. For HTTP/S communication you can 1) access the web container of project2 directly with the hostname `ddev-<project2>-web` and port 80 or 443: `curl https://ddev-project2-web` or 2) Add a .ddev/docker-compose.communicate.yaml which will allow you to access the other project via the official FQDN.
 
 ```yaml
-  version: '3.6'
   services:
     web:
         external_links:

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -712,7 +712,6 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		DBPort:                    GetPort("db"),
 		DdevGenerated:             DdevFileSignature,
 		HostDockerInternalIP:      hostDockerInternalIP,
-		ComposeVersion:            version.DockerComposeFileFormatVersion,
 		DisableSettingsManagement: app.DisableSettingsManagement,
 		OmitDB:                    nodeps.ArrayContainsString(app.GetOmittedContainers(), "db"),
 		OmitDBA:                   nodeps.ArrayContainsString(app.GetOmittedContainers(), "dba") || nodeps.ArrayContainsString(app.OmitContainers, "db"),

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -119,7 +119,6 @@ func generateRouterCompose() (string, error) {
 		"router_tag":                 version.RouterTag,
 		"ports":                      exposedPorts,
 		"router_bind_all_interfaces": globalconfig.DdevGlobalConfig.RouterBindAllInterfaces,
-		"compose_version":            version.DockerComposeFileFormatVersion,
 		"dockerIP":                   dockerIP,
 		"disable_http2":              globalconfig.DdevGlobalConfig.DisableHTTP2,
 		"letsencrypt":                globalconfig.DdevGlobalConfig.UseLetsEncrypt,

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -113,7 +113,6 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 	templateVars := map[string]interface{}{
 		"ssh_auth_image":        version.SSHAuthImage,
 		"ssh_auth_tag":          version.SSHAuthTag,
-		"compose_version":       version.DockerComposeFileFormatVersion,
 		"AutoRestartContainers": globalconfig.DdevGlobalConfig.AutoRestartContainers,
 		"Username":              username,
 		"UID":                   uid,

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -2,7 +2,7 @@ package ddevapp
 
 // DDevComposeTemplate is used to create the main docker-compose file
 // file for a ddev project.
-const DDevComposeTemplate = `version: '{{ .ComposeVersion }}'
+const DDevComposeTemplate = `
 {{ .DdevGenerated }}
 services:
 {{if not .OmitDB }}
@@ -438,7 +438,7 @@ var SequelproTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>`
 
 // DdevRouterTemplate is the template for the generic router container.
-const DdevRouterTemplate = `version: '{{ .compose_version }}'
+const DdevRouterTemplate = `
 services:
   ddev-router:
     image: {{ .router_image }}:{{ .router_tag }}
@@ -478,8 +478,7 @@ volumes:
 {{ end }}
 `
 
-const DdevSSHAuthTemplate = `version: '{{ .compose_version }}'
-
+const DdevSSHAuthTemplate = `
 volumes:
   dot_ssh:
   socket_dir:

--- a/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   busybox:
     image: busybox

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.override.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.override.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   web:
     environment:

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z1.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z1.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   web:
     environment:

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   web:
     environment:

--- a/pkg/ddevapp/testdata/TestRouterConfigOverride/router-compose.override.yaml
+++ b/pkg/ddevapp/testdata/TestRouterConfigOverride/router-compose.override.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   ddev-router:
     environment:

--- a/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
+++ b/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   test-ssh-server:
     container_name: test-ssh-server

--- a/pkg/ddevapp/testdata/TestSshAuthConfigOverride/ssh-auth-compose.override.yaml
+++ b/pkg/ddevapp/testdata/TestSshAuthConfigOverride/ssh-auth-compose.override.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   ddev-ssh-agent:
     environment:

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -35,5 +35,3 @@ services:
       retries: 25
       start_period: 20s
       timeout: 120s
-
-version: '3.6'

--- a/pkg/dockerutil/testdata/docker-compose.override.yml
+++ b/pkg/dockerutil/testdata/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   foo:
     container_name: ddev-test-foo

--- a/pkg/dockerutil/testdata/docker-compose.yml
+++ b/pkg/dockerutil/testdata/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   db:
     container_name: ddev-test-db

--- a/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
@@ -2,8 +2,6 @@
 #
 # To use this in your own project: Copy this file to your project's .ddev folder.
 
-version: '3.6'
-
 services:
   beanstalk: # This is the service name used when running ddev commands accepting the --service flag
     container_name: ddev-${DDEV_SITENAME}-beanstalk # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.

--- a/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
@@ -8,8 +8,6 @@
 # 4. Optional: adjust the 'command' line below to change CLI flags sent to
 #    memcached.
 
-version: '3.6'
-
 services:
   # This is the service name used when running ddev commands accepting the
   # --service flag.

--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -21,8 +21,6 @@
 #   accessed at the URL: http://solr:8983/solr/dev (inside web container)
 #   or at http://myproject.ddev.site:8983/solr/dev (on the host)
 
-version: '3.6'
-
 services:
   solr:
     # Name of container using standard ddev convention

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -33,9 +33,6 @@ var DockerVersionConstraint = ">= 18.06.1-alpha1"
 // See https://github.com/drud/ddev/pull/738.. and regression https://github.com/drud/ddev/issues/1431
 var DockerComposeVersionConstraint = "1.21.0-alpha1 - 1.999.0"
 
-// DockerComposeFileFormatVersion is the compose version to be used
-var DockerComposeFileFormatVersion = "3.6"
-
 // WebImg defines the default web image used for applications.
 var WebImg = "drud/ddev-webserver"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#3067: docker-compose no longer requires the `version:` key in compose config files, and it has always been a bit of a mess.

## How this PR Solves The Problem:

Remove these things

## Manual Testing Instructions:

If it passes testing it should be OK.

## Automated Testing Overview:

No changes

## Release/Deployment notes:

This has dramatic changes:
* Everything on ddev-contrib will have to be updated
* The minimum docker-compose version (of the tool) will have to be changed
* Docs will need updating (I think; this may already do enough)


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3095"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

