### PR TITLE
Add MariaDB 10.6, solve problems with unsupported 5.5-10.1 versions, fixes #3093

### DIFF
--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.10.6
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.10.6
@@ -1,0 +1,4 @@
+name: callme10.6
+type: php
+docroot: ""
+mariadb_version: "10.6"

--- a/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.6
+++ b/cmd/ddev/cmd/testdata/TestConfigMariaDBVersion/config.yaml.imagespec.10.6
@@ -1,0 +1,4 @@
+name: imagespec10.6
+type: php
+docroot: ""
+dbimage: somerandomdbimg-mariadb-10.6

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -19,6 +19,10 @@ RUN for item in "75DD C3C4 A499 F1A1 8CB5  F3C8 CBF8 D6FD 518E 17E1" "126C 0D24 
     apt-key remove "${item}" || true; \
   done;
 
+# Older versions of mariadb have been removed from
+# the mariadb apt repository, so we don't want to
+# look there when doing apt-get update. And we don't use new packages from there.
+RUN rm -f /etc/apt/sources.list.d/mariadb.list
 
 RUN apt-get -qq update && apt-get -qq install -y tzdata gnupg2 pv less vim wget curl lsb-release >/dev/null
 

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,9 +10,9 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64_8.0.22
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_amd64 mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64_8.0.22
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
-	echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
+	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \
 	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test"; \
   	fi )

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,23 +10,21 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_amd64 mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64_8.0.22
+BUILD_TARGETS=mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_amd64 mysql_8.0_amd64_8.0.22
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
-	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
+	echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \
-	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test"; \
+	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test"; \
   	fi )
 
 container: build
 build: $(BUILD_TARGETS)
 
-mariadb_5.5: mariadb_5.5_amd64
-mariadb_10.0: mariadb_10.0_amd64
-mariadb_10.1: mariadb_10.1_amd64
 mariadb_10.2: mariadb_10.2_both
 mariadb_10.3: mariadb_10.3_both
 mariadb_10.4: mariadb_10.4_both
 mariadb_10.5: mariadb_10.5_both
+mariadb_10.6: mariadb_10.6_both
 
 mysql_5.5: mysql_5.5_amd64
 mysql_5.6: mysql_5.6_amd64

--- a/containers/ddev-dbserver/test/custom_config.bats
+++ b/containers/ddev-dbserver/test/custom_config.bats
@@ -13,9 +13,9 @@ function setup {
   containercheck
 }
 
-@test "test with mysql/utf.cnf override ${DB_TYPE} ${DB_VERSION}" {
-  docker exec $CONTAINER_NAME sh -c 'grep collation-server /mnt/ddev_config/mysql/utf.cnf'
-  mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$HOSTPORT -e "SHOW GLOBAL VARIABLES like \"collation_server\";" | grep "utf8_general_ci"
+@test "test with mysql/collation.cnf override ${DB_TYPE} ${DB_VERSION}" {
+  docker exec $CONTAINER_NAME sh -c 'grep collation-server /mnt/ddev_config/mysql/collation.cnf'
+  mysql --user=root --password=root --skip-column-names --host=127.0.0.1 --port=$HOSTPORT -e "SHOW GLOBAL VARIABLES like \"collation_server\";" | grep "latin1_swedish_ci"
 }
 
 

--- a/containers/ddev-dbserver/test/testdata/mysql/collation.cnf
+++ b/containers/ddev-dbserver/test/testdata/mysql/collation.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+collation-server = latin1_swedish_ci
+character-set-server = latin1

--- a/containers/ddev-dbserver/test/testdata/mysql/utf.cnf
+++ b/containers/ddev-dbserver/test/testdata/mysql/utf.cnf
@@ -1,3 +1,0 @@
-[mysqld]
-collation-server = utf8_general_ci
-character-set-server = utf8

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -724,7 +724,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 
 	require.NoError(t, startErr, "app.StartAndWait() did not succeed: output:\n=====\n%s\n===== logs:\n========= logs =======\n%s\n========\n", stdout, logs)
 
-	assert.Contains(stdout, "utf.cnf")
+	assert.Contains(stdout, "collation.cnf")
 	assert.Contains(stdout, "my-php.ini")
 
 	switch app.WebserverType {

--- a/pkg/ddevapp/testdata/TestConfigOverrideDetection/.ddev/mysql/collation.cnf
+++ b/pkg/ddevapp/testdata/TestConfigOverrideDetection/.ddev/mysql/collation.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+collation-server = latin1_swedish_ci
+character-set-server = latin1

--- a/pkg/ddevapp/testdata/TestConfigOverrideDetection/.ddev/mysql/utf.cnf
+++ b/pkg/ddevapp/testdata/TestConfigOverrideDetection/.ddev/mysql/utf.cnf
@@ -1,3 +1,0 @@
-[mysqld]
-collation-server = utf8_general_ci
-character-set-server = utf8

--- a/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/dbimage-10.6/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/dbimage-10.6/.ddev/config.yaml
@@ -1,0 +1,1 @@
+dbimage: somedbimage:10.6

--- a/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/mariadb-version-10.6/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestPkgConfigMariaDBVersion/mariadb-version-10.6/.ddev/config.yaml
@@ -1,0 +1,1 @@
+mariadb_version: 10.6

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -7,13 +7,11 @@ const MariaDBDefaultVersion = MariaDB103
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
-	MariaDB55:  true,
-	MariaDB100: true,
-	MariaDB101: true,
 	MariaDB102: true,
 	MariaDB103: true,
 	MariaDB104: true,
 	MariaDB105: true,
+	MariaDB106: true,
 }
 
 // MariaDB Versions
@@ -25,4 +23,5 @@ const (
 	MariaDB103 = "10.3"
 	MariaDB104 = "10.4"
 	MariaDB105 = "10.5"
+	MariaDB106 = "10.6"
 )

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -7,6 +7,9 @@ const MariaDBDefaultVersion = MariaDB103
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
+	MariaDB55:  true,
+	MariaDB100: true,
+	MariaDB101: true,
 	MariaDB102: true,
 	MariaDB103: true,
 	MariaDB104: true,

--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -5,11 +5,11 @@ const MariaDBDefaultVersion = MariaDB103
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
-	MariaDB101: true,
 	MariaDB102: true,
 	MariaDB103: true,
 	MariaDB104: true,
 	MariaDB105: true,
+	MariaDB106: true,
 }
 
 // MariaDB Versions
@@ -21,4 +21,5 @@ const (
 	MariaDB103 = "10.3"
 	MariaDB104 = "10.4"
 	MariaDB105 = "10.5"
+	MariaDB106 = "10.6"
 )

--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -5,6 +5,7 @@ const MariaDBDefaultVersion = MariaDB103
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
+	MariaDB101: true,
 	MariaDB102: true,
 	MariaDB103: true,
 	MariaDB104: true,

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -21,4 +21,5 @@ const (
 	MariaDB103 = "10.3"
 	MariaDB104 = "10.4"
 	MariaDB105 = "10.5"
+	MariaDB106 = "10.6"
 )

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -5,11 +5,11 @@ const MariaDBDefaultVersion = MariaDB103
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
-	MariaDB101: true,
 	MariaDB102: true,
 	MariaDB103: true,
 	MariaDB104: true,
 	MariaDB105: true,
+	MariaDB106: true,
 }
 
 // MariaDB Versions

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -5,6 +5,7 @@ const MariaDBDefaultVersion = MariaDB103
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
+	MariaDB101: true,
 	MariaDB102: true,
 	MariaDB103: true,
 	MariaDB104: true,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -46,7 +46,7 @@ var WebTag = "v1.17.7" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.17.7"
+var BaseDBTag = "20210709_mariadb_versions"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

MariaDB 10.6 has been released to GA, see #3093
Unfortunately, in doing it they removed all the unsupported versions from their apt repositories, so we now can't build MariaDB 5.5, 10.0, or 10.1 :( so those are removed.

I opened https://jira.mariadb.org/browse/MDEV-26122 with MariaDB about the disappeared repositories. 

This PR does an end-run by removing the /etc/apt/sources.list.d/mariadb.list file, so `apt-get update` doesn't find it and freak out.

## Manual Testing Instructions:

Build a project with MariaDB 10.6

## Automated Testing Overview:

The tests are driven by the ValidMariaDBVersions, so should be extended properly

## Related Issue Link(s):

## Release/Deployment notes:

This deserves a notice, but it shouldn't affect much else.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3096"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

