### PR TITLE
Use 'drush -r docroot' in acquia provider as acquia seems to require it now

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
@@ -48,7 +48,7 @@ files_pull_command:
     # set -x   # You can enable bash debugging output by uncommenting
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
-    drush rsync --alias-path=~/.drush -q -y @${project_id}:%files ./files
+    drush -r docroot rsync --alias-path=~/.drush -q -y @${project_id}:%files ./files
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 db_push_command:

--- a/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/acquia.yaml.example
@@ -21,6 +21,8 @@
 # 9. Use `ddev pull acquia` to pull the project database and files.
 # 10. Optionally use `ddev push acquia` to push local files and database to Aquia. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
+# Warning for Apple M1 Users: There is currently a bug in the linux acli command (or its dependencies) which causes it to SEGFAULT in normal use. As a result, you can't run `ddev pull acquia` on an M1 machine at this time.
+
 # Debugging: Use `ddev exec acli command` and `ddev exec acli auth:info`
 # Make sure you remembered to `ddev auth ssh`
 

--- a/cmd/ddev/cmd/dotddev_assets/providers/platform.yaml.example
+++ b/cmd/ddev/cmd/dotddev_assets/providers/platform.yaml.example
@@ -16,6 +16,9 @@
 # 5. In your project's .ddev/providers directory, copy platform.yaml.example to platform.yaml and edit the `project_id` and `environment_name`.
 # 6. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 # 7. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+
+# Warning for Apple M1 Users: There is currently a bug in the linux `platform` command (or its dependencies) which causes it to SEGFAULT in normal use. As a result, you can't run `ddev pull platform` on an M1 machine at this time.
+
 # Debugging: Use `ddev exec platform` to see what platform.sh knows about
 # your configuration and whether it's working correctly.
 

--- a/docs/users/providers/acquia.md
+++ b/docs/users/providers/acquia.md
@@ -26,6 +26,8 @@ ddev's Acquia integration pulls database and files from an existing project into
 9. Use `ddev pull acquia` to pull the project database and files.
 10. Optionally use `ddev push acquia` to push local files and database to Aquia. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
+**Warning for Apple M1 Users:** There is currently a bug in the linux `acli` command (or its dependencies) which causes it to SEGFAULT in normal use on the M1. As a result, you can't run `ddev pull acquia` on an M1 machine at this time.
+
 ### Usage
 
 `ddev pull acquia` will connect to the Acquia Cloud Platform to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.

--- a/docs/users/providers/platform.md
+++ b/docs/users/providers/platform.md
@@ -22,6 +22,8 @@ ddev's Platform.sh integration pulls database and files from an existing Platfor
 6. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 7. Optionally use `ddev push platform` to push local files and database to Platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
+**Warning for Apple M1 Users:** There is currently a bug in the linux `platform` command (or its dependencies) which causes it to SEGFAULT in normal use. As a result, you can't run `ddev pull platform` on an M1 machine at this time.
+
 ### Usage
 
 `ddev pull platform` will connect to Platform.sh to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -179,7 +179,7 @@ func TestAcquiaPush(t *testing.T) {
 	})
 
 	app.Name = t.Name()
-	app.Type = nodeps.AppTypeDrupal8
+	app.Type = nodeps.AppTypeDrupal9
 	app.Hooks = map[string][]YAMLTask{"post-push": {{"exec-host": "touch hello-post-push-" + app.Name}}, "pre-push": {{"exec-host": "touch hello-pre-push-" + app.Name}}}
 	_ = app.Stop(true, false)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

The TestAcquiaPull test started failing. Debugging led to minor change in the suggested acquia config.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3100"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

