### PR TITLE
Use debian bullseye as base image for ddev-webimage, downgrades nginx to 1.18.0, fixes #3116

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -19,9 +19,10 @@ ENV CAROOT /mnt/ddev-global-cache/mkcert
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-RUN wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
-    apt-key add /tmp/nginx_signing.key && \
-    echo "deb http://nginx.org/packages/debian/ $(lsb_release -sc) nginx" > /etc/apt/sources.list.d/nginx.list
+#TODO: When upstream nginx package is ready for bullseye, use it.
+#RUN wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
+#    apt-key add /tmp/nginx_signing.key && \
+#    echo "deb http://nginx.org/packages/debian/ $(lsb_release -sc) nginx" > /etc/apt/sources.list.d/nginx.list
 
 ADD ddev-webserver-etc-skel /
 RUN /sbin/mkhomedir_helper www-data

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.17.7 as ddev-webserver-base
+FROM drud/ddev-php-base:20210714_use_bullseye as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,7 +40,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.17.7" // Note that this can be overridden by make
+var WebTag = "20210714_bullseye_web_image" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Platformsh/platform SEGV, Acquia ACLI SEGV, curl to certain hosts. Affects only Mac M1 users

* platformsh/platformsh-cli#1063
* #3116 


On macOS M1 architectures, the use of `curl` on some websites causes a SEGV in the web container, see [docker desktop 3.4.0 release notes](https://docs.docker.com/docker-for-mac/release-notes/#docker-desktop-340)

> On Apple Silicon in native arm64 containers, older versions of libssl in debian:buster, ubuntu:20.04 and centos:8 will segfault when connected to some TLS servers, for example curl https://dl.yarnpkg.com. The bug is fixed in newer versions of libssl in debian:bullseye, ubuntu:21.04 and fedora:35


## How this PR Solves The Problem:

* Upgrades base image to debian:bullseye-slim
* DOWNGRADES nginx to 1.18 from 1.20 because nginx packages for bullseye are not available. ([Request ticket for bullseye packages](https://trac.nginx.org/nginx/ticket/2217#ticket))

## Manual Testing Instructions:

People who are having SEGV trouble on Mac M1 can just add 
```
webimage: drud/ddev-webserver:20210714_bullseye_web_image
```
to their .ddev/config.yaml (or to a .ddev/config.m1.yaml)

And it should solve problems with curl, the acli program from Acquia, and the platform tool from Platform.sh

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:


* I was unable to build the upstream image in ddev-images using CircleCI - had to build and push it manually on arm64 M1 machine. Very strange.
* Because of the downgrade of nginx from 1.20 to 1.18, I don't think this can be released until those packages are available





<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3102"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

