### PR TITLE
Check for adequate disk space in docker, fixes #863

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -428,6 +428,7 @@ func (app *DdevApp) GetWebserverType() string {
 // ImportDB takes a source sql dump and imports it to an active site's database container.
 func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDrop bool, targetDB string) error {
 	app.DockerEnv()
+	dockerutil.CheckAvailableSpace()
 	if targetDB == "" {
 		targetDB = "db"
 	}
@@ -805,6 +806,8 @@ func (app *DdevApp) GetDBImage() string {
 // Start initiates docker-compose up
 func (app *DdevApp) Start() error {
 	var err error
+
+	dockerutil.CheckAvailableSpace()
 
 	app.DockerEnv()
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/archive"
 	exec2 "github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -947,4 +949,14 @@ func Exec(containerID string, command string) (string, string, error) {
 	}
 
 	return stdout.String(), stderr.String(), execErr
+}
+
+// CheckAvailableSpace outputs a warning if docker space is low
+func CheckAvailableSpace() {
+	_, out, _ := RunSimpleContainer(version.GetWebImage(), "", []string{"sh", "-c", `df -h / | awk '/overlay/ {print $5;}'`}, []string{}, []string{}, []string{"testnfsmount" + ":/nfsmount"}, "", true, false, nil)
+	out = strings.Trim(out, "% \n")
+	spacePercent, _ := strconv.Atoi(out)
+	if spacePercent < nodeps.MinimumDockerSpaceWarning {
+		util.Error("Your docker installation has less than %d%% available space. Please increase it!", nodeps.MinimumDockerSpaceWarning)
+	}
 }

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -89,6 +89,7 @@ const (
 	DdevDefaultTLD                  = "ddev.site"
 	InternetDetectionTimeoutDefault = 750
 	RequiredMutagenVersion          = "0.12.0-beta4"
+	MinimumDockerSpaceWarning       = 15
 )
 
 // IsValidPHPVersion is a helper function to determine if a PHP version is valid, returning


### PR DESCRIPTION
## The Problem/Issue/Bug:

On macOS, there's a specifically limited disk allocation in Docker Desktop, and when you run out very bad things happen.

* #863 

## How this PR Solves The Problem:

On Start and Import-db, check to see if we're in trouble on disk (defined as over 85% usage) and gives a warning.

## Manual Testing Instructions:

This is hard to test without compiling. I changed the value in nodeps and ran it to test. 

## Automated Testing Overview:

No automated testing; not sure it's possible



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3110"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

