### PR TITLE
Use explicit db hostname, fixes #3065

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -101,8 +101,8 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			output = output + "\n" + "MySQL/MariaDB Credentials\n-------------------------\n" + `Username: "db", Password: "db", Default database: "db"` + "\n"
 			output = output + "\n" + `or use root credentials when needed: Username: "root", Password: "root"` + "\n\n"
 
-			output = output + "Database hostname and port INSIDE container: db:3306\n"
-			output = output + fmt.Sprintf("To connect to db server inside container or in project settings files: \nmysql --host=db --user=db --password=db --database=db\n")
+			output = output + fmt.Sprintf("Database hostname and port INSIDE container: %s:3306\n", ddevapp.GetDBHostname(app))
+			output = output + fmt.Sprintf("To connect to db server inside container or in project settings files: \nmysql --host=%s --user=db --password=db --database=db\n", ddevapp.GetDBHostname(app))
 
 			output = output + fmt.Sprintf("Database hostname and port from HOST: %s:%d\n", dockerIP, dbinfo["published_port"])
 			output = output + fmt.Sprintf("To connect to mysql from your host machine, \nmysql --host=%s --port=%d --user=db --password=db --database=db\n", dockerIP, dbinfo["published_port"])

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -495,7 +495,7 @@ You can also see more detailed information about a project by running `ddev desc
 
 ```
 NAME        TYPE     LOCATION                URL                           STATUS
-d8composer  drupal8  ~/workspace/d8composer  https://d8composer.ddev.site  running
+d9composer  drupal8  ~/workspace/d9composer  https://d9composer.ddev.site  running
 
 Project Information
 -------------------
@@ -504,9 +504,9 @@ MariaDB version 10.3
 
 URLs
 ----
-https://d8composer.ddev.site
+https://d9composer.ddev.site
 https://127.0.0.1:33232
-http://d8composer.ddev.site
+http://d9composer.ddev.site
 http://127.0.0.1:33233
 
 MySQL/MariaDB Credentials
@@ -515,19 +515,19 @@ Username: "db", Password: "db", Default database: "db"
 
 or use root credentials when needed: Username: "root", Password: "root"
 
-Database hostname and port INSIDE container: db:3306
+Database hostname and port INSIDE container: ddev-d9-db:3306
 To connect to db server inside container or in project settings files:
-mysql --host=db --user=db --password=db --database=db
+mysql --host=ddev-d9-dbcomposer --user=db --password=db --database=db
 Database hostname and port from HOST: 127.0.0.1:33231
 To connect to mysql from your host machine,
 mysql --host=127.0.0.1 --port=33231 --user=db --password=db --database=db
 
 Other Services
 --------------
-MailHog (https):    https://d8composer.ddev.site:8026
-MailHog:            http://d8composer.ddev.site:8025
-phpMyAdmin (https): https://d8composer.ddev.site:8037
-phpMyAdmin:         http://d8composer.ddev.site:8036
+MailHog (https):    https://d9composer.ddev.site:8026
+MailHog:            http://d9composer.ddev.site:8025
+phpMyAdmin (https): https://d9composer.ddev.site:8037
+phpMyAdmin:         http://d9composer.ddev.site:8036
 
 DDEV ROUTER STATUS: healthy
 ssh-auth status: healthy

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -39,7 +39,7 @@ func NewBackdropSettings(app *DdevApp) *BackdropSettings {
 		DatabaseName:     "db",
 		DatabaseUsername: "db",
 		DatabasePassword: "db",
-		DatabaseHost:     "db",
+		DatabaseHost:     "ddev-" + app.Name + "-db",
 		DatabaseDriver:   "mysql",
 		DatabasePort:     GetPort("db"),
 		DatabasePrefix:   "",

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2243,3 +2243,8 @@ func (app *DdevApp) StartAppIfNotRunning() error {
 
 	return err
 }
+
+// GetDBHostname gets the in-container hostname of the DB container
+func GetDBHostname(app *DdevApp) string {
+	return "ddev-" + app.Name + "-db"
+}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -269,7 +269,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 			dbinfo["username"] = "db"
 			dbinfo["password"] = "db"
 			dbinfo["dbname"] = "db"
-			dbinfo["host"] = "db"
+			dbinfo["host"] = GetDBHostname(app)
 			dbPublicPort, err := app.GetPublishedPort("db")
 			util.CheckErr(err)
 			dbinfo["dbPort"] = GetPort("db")

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -49,7 +49,7 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 		DatabaseName:     "db",
 		DatabaseUsername: "db",
 		DatabasePassword: "db",
-		DatabaseHost:     "db",
+		DatabaseHost:     "ddev-" + app.Name + "-db",
 		DatabaseDriver:   "mysql",
 		DatabasePort:     GetPort("db"),
 		DatabasePrefix:   "",

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -49,7 +49,7 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 		DatabaseName:     "db",
 		DatabaseUsername: "db",
 		DatabasePassword: "db",
-		DatabaseHost:     "ddev-" + app.Name + "-db",
+		DatabaseHost:     GetDBHostname(app),
 		DatabaseDriver:   "mysql",
 		DatabasePort:     GetPort("db"),
 		DatabasePrefix:   "",

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -8,7 +8,6 @@ import (
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -54,7 +53,8 @@ func createMagentoSettingsFile(app *DdevApp) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		err = ioutil.WriteFile(app.SiteSettingsPath, content, 0644)
+		templateVars := map[string]interface{}{"DBHostname": GetDBHostname(app)}
+		err = fileutil.TemplateStringToFile(string(content), templateVars, app.SiteSettingsPath)
 		if err != nil {
 			return "", err
 		}
@@ -154,7 +154,9 @@ func createMagento2SettingsFile(app *DdevApp) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		err = ioutil.WriteFile(app.SiteSettingsPath, content, 0644)
+
+		templateVars := map[string]interface{}{"DBHostname": GetDBHostname(app)}
+		err = fileutil.TemplateStringToFile(string(content), templateVars, app.SiteSettingsPath)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/ddevapp/magento_assets/env.php
+++ b/pkg/ddevapp/magento_assets/env.php
@@ -15,7 +15,7 @@ return [
         'table_prefix' => '',
         'connection' => [
             'default' => [
-                'host' => 'db',
+                'host' => '{{ .DBHostname }}',
                 'dbname' => 'db',
                 'username' => 'db',
                 'password' => 'db',

--- a/pkg/ddevapp/magento_assets/local.xml
+++ b/pkg/ddevapp/magento_assets/local.xml
@@ -46,7 +46,7 @@ ddev to ignore this file and not regenerate it.
             </db>
             <default_setup>
                 <connection>
-                    <host><![CDATA[db]]></host>
+                    <host><![CDATA[{{ .DBHostname }}]]></host>
                     <username><![CDATA[db]]></username>
                     <password><![CDATA[db]]></password>
                     <dbname><![CDATA[db]]></dbname>

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -82,7 +82,7 @@ func getShopwareUploadDir(app *DdevApp) string {
 func shopware6PostStartAction(app *DdevApp) error {
 	envFile := filepath.Join(app.AppRoot, ".env")
 	var addOnConfig string
-	expectedDatabaseURL := `DATABASE_URL="mysql://db:db@db:3306/db"`
+	expectedDatabaseURL := fmt.Sprintf(`DATABASE_URL="mysql://db:db@%s:3306/db"`, GetDBHostname(app))
 	expectedPrimaryURL := fmt.Sprintf(`APP_URL="%s"`, app.GetPrimaryURL())
 	expectedMailerURL := `MAILER_URL="smtp://localhost:1025?encryption=&auth_mode="`
 

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -2,8 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-	"io/ioutil"
-
 	"os"
 	"path/filepath"
 
@@ -29,7 +27,7 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
                 'Connections' => [
                     'Default' => [
                         'dbname' => 'db',
-                        'host' => 'db',
+                        'host' => '{{ .DBHostname }}',
                         'password' => 'db',
                         'port' => '3306',
                         'user' => 'db',
@@ -111,16 +109,11 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 		}
 	}
 
-	file, err := os.Create(filePath)
+	templateVars := map[string]interface{}{"DBHostname": GetDBHostname(app)}
+	err := fileutil.TemplateStringToFile(typo3AdditionalConfigTemplate, templateVars, filePath)
 	if err != nil {
 		return err
 	}
-	contents := []byte(typo3AdditionalConfigTemplate)
-	err = ioutil.WriteFile(filePath, contents, 0644)
-	if err != nil {
-		return err
-	}
-	util.CheckClose(file)
 	return nil
 }
 

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -45,7 +45,7 @@ func NewWordpressConfig(app *DdevApp, absPath string) *WordpressConfig {
 		DatabaseName:     "db",
 		DatabaseUsername: "db",
 		DatabasePassword: "db",
-		DatabaseHost:     "db",
+		DatabaseHost:     "ddev-" + app.Name + "-db",
 		DeployURL:        app.GetPrimaryURL(),
 		Docroot:          "/var/www/html/docroot",
 		TablePrefix:      "wp_",


### PR DESCRIPTION
## The Problem/Issue/Bug:

The hostname "db" is potentially ambiguous, see previous issues

TODO:
- [x] Drupal
- [x] WordPress
- [x] TYPO3
- [x] Magento
- [x] Magento2
- [x] Shopware6
- [x] Docs
- [x] `ddev describe` 

## How this PR Solves The Problem:

Everywhere that we used to use "db" for inside-docker hostname, use `ddev-<project>-db`, which is explicit.

## Manual Testing Instructions:

`ddev start` on each project type and inspect the additional settings (like settings.ddev.php). You should see the explicit database hostname.

## Automated Testing Overview:

Regular TestDdevFullSiteSetup (on CircleCI) should check all this.

## Related Issue Link(s):

## Release/Deployment notes:

This should be added to the release notes, but as the old usage should work forever, it's not a big deal.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3111"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

