### PR TITLE
[docs] add index.php to command for "simplest possible" [ci skip][skip ci]

### DIFF
--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -11,7 +11,7 @@ Things might go wrong! Besides the suggestions on this page don't forget about [
 * If you have customizations (PHP overrides, nginx or Apache overrides, MySQL overrides, custom services, config.yaml changes) please back them out while troubleshooting. It's important to have the simplest possible environment while troubleshooting.
 * Check your Docker disk space and memory allocation if you're using Docker Desktop on Windows or macOS.
 * Restart Docker. Consider a Docker factory reset in serious cases (this will destroy any databases you've loaded). See [Docker Troubleshooting](docker_installation.md#troubleshooting) for more.
-* Try the simplest possible ddev project to try to get it to work: `ddev poweroff && mkdir ~/tmp/testddev && cd ~/tmp/testddev && ddev config --project-type=php && ddev start`. Does that start up OK? If so, maybe something is wrong with the more complicated project you're trying to start.
+* Try the simplest possible ddev project to try to get it to work: `ddev poweroff && mkdir ~/tmp/testddev && cd ~/tmp/testddev && ddev config --project-type=php && printf "<?php\nphpinfo();\n" > index.php && ddev start`. Does that start up OK? If so, maybe something is wrong with the more complicated project you're trying to start.
 
 <a name="unable-listen"></a>
 


### PR DESCRIPTION
credit to RFay, who included this approach elsewhere for creating index.php; seems useful to add here

## The Problem/Issue/Bug:

without index.php, the ddev instance will throw errors

## How this PR Solves The Problem:

adds index.php with content

## Manual Testing Instructions:

NA

## Automated Testing Overview:

NA

## Related Issue Link(s):

NA

## Release/Deployment notes:

NA

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3118"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

