### PR TITLE
[docs] Windows WSL2 offline usage (windows-side hosts file) [skip ci][ci skip]

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -751,7 +751,7 @@ In `.ddev/config.yaml` `project_tld: example.com` (or any other domain) can set 
 
 You can also set up a local DNS server like dnsmasq (Linux and macOS, `brew install dnsmasq`) or ([unbound](https://github.com/NLnetLabs/unbound) or many others on Windows) in your own host environment that serves the project_tld that you choose, and DNS resolution will work just fine. You'll likely want a wildcard A record pointing to 127.0.0.1 (on most ddev installations). If you use dnsmasq you must configure it to allow DNS rebinding.
 
-If you're using a browser on Windows, accessing a DDEV project in WSL2, Windows will attempt to resolve the site name via DNS. If you do not have an internet connect, this will fail. To resolve this, update your `C:\Windows\System32\drivers\etc\hosts` file.
+If you're using a browser on Windows, accessing a DDEV project in WSL2, Windows will attempt to resolve the site name via DNS. If you do not have an internet connection, this will fail. To resolve this, update your `C:\Windows\System32\drivers\etc\hosts` file.
 
 ```
 127.0.0.1 example.ddev.site

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -750,3 +750,10 @@ In `.ddev/config.yaml` `use_dns_when_possible: false` will make ddev never try t
 In `.ddev/config.yaml` `project_tld: example.com` (or any other domain) can set ddev to use a project that could never be looked up in DNS. You can also use `ddev config --project-tld=example.com`
 
 You can also set up a local DNS server like dnsmasq (Linux and macOS, `brew install dnsmasq`) or ([unbound](https://github.com/NLnetLabs/unbound) or many others on Windows) in your own host environment that serves the project_tld that you choose, and DNS resolution will work just fine. You'll likely want a wildcard A record pointing to 127.0.0.1 (on most ddev installations). If you use dnsmasq you must configure it to allow DNS rebinding.
+
+If you're using a browser on Windows, accessing a DDEV project in WSL2, Windows will attempt to resolve the sitename via DNS. If you do not have an internet connect, this will fail. To resolve this, update your `C:\Windows\System32\drivers\etc\hosts` file.
+```
+127.0.0.1 example.ddev.site
+```
+- Note: You must have administrative privilages to save this file.
+- See [Windows Hosts File limited to 10 hosts per IP address line](https://ddev.readthedocs.io/en/stable/users/troubleshooting/#windows-hosts-file-limited-to-10-hosts-per-ip-address-line) for additional troubleshooting.

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -751,9 +751,9 @@ In `.ddev/config.yaml` `project_tld: example.com` (or any other domain) can set 
 
 You can also set up a local DNS server like dnsmasq (Linux and macOS, `brew install dnsmasq`) or ([unbound](https://github.com/NLnetLabs/unbound) or many others on Windows) in your own host environment that serves the project_tld that you choose, and DNS resolution will work just fine. You'll likely want a wildcard A record pointing to 127.0.0.1 (on most ddev installations). If you use dnsmasq you must configure it to allow DNS rebinding.
 
-If you're using a browser on Windows, accessing a DDEV project in WSL2, Windows will attempt to resolve the sitename via DNS. If you do not have an internet connect, this will fail. To resolve this, update your `C:\Windows\System32\drivers\etc\hosts` file.
+If you're using a browser on Windows, accessing a DDEV project in WSL2, Windows will attempt to resolve the site name via DNS. If you do not have an internet connect, this will fail. To resolve this, update your `C:\Windows\System32\drivers\etc\hosts` file.
 ```
 127.0.0.1 example.ddev.site
 ```
-- Note: You must have administrative privilages to save this file.
+- Note: You must have administrative privileges to save this file.
 - See [Windows Hosts File limited to 10 hosts per IP address line](https://ddev.readthedocs.io/en/stable/users/troubleshooting/#windows-hosts-file-limited-to-10-hosts-per-ip-address-line) for additional troubleshooting.

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -752,8 +752,11 @@ In `.ddev/config.yaml` `project_tld: example.com` (or any other domain) can set 
 You can also set up a local DNS server like dnsmasq (Linux and macOS, `brew install dnsmasq`) or ([unbound](https://github.com/NLnetLabs/unbound) or many others on Windows) in your own host environment that serves the project_tld that you choose, and DNS resolution will work just fine. You'll likely want a wildcard A record pointing to 127.0.0.1 (on most ddev installations). If you use dnsmasq you must configure it to allow DNS rebinding.
 
 If you're using a browser on Windows, accessing a DDEV project in WSL2, Windows will attempt to resolve the site name via DNS. If you do not have an internet connect, this will fail. To resolve this, update your `C:\Windows\System32\drivers\etc\hosts` file.
+
 ```
 127.0.0.1 example.ddev.site
 ```
-- Note: You must have administrative privileges to save this file.
-- See [Windows Hosts File limited to 10 hosts per IP address line](https://ddev.readthedocs.io/en/stable/users/troubleshooting/#windows-hosts-file-limited-to-10-hosts-per-ip-address-line) for additional troubleshooting.
+
+* Note: You must have administrative privileges to save this file.
+
+* See [Windows Hosts File limited to 10 hosts per IP address line](https://ddev.readthedocs.io/en/stable/users/troubleshooting/#windows-hosts-file-limited-to-10-hosts-per-ip-address-line) for additional troubleshooting.


### PR DESCRIPTION
## The Problem/Issue/Bug:
Recently, my network was offline and I was unable to access the internet. No problems, I though, I develop locally in WSL. Unfortunately, I was getting DNS errors when attempting to access my site from Windows. I looked in the DDEV documents but couldn't see an obvious reference to my problem.

Once I found a solution, I did a search of the docs for `hosts`, but didn't see anything. 

## How this PR Solves The Problem:
- adds specific instructions for Windows browsers, to a WSL DDEV website when Windows is offline.

## Automated Testing Overview:
NA


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

