### PR TITLE
Remove Gitpod badge from PR comments

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,7 +27,7 @@ github:
     # add a check to pull requests (defaults to true)
     addCheck: true
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: true
+    addComment: false
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: true
     # add a label once the prebuild is ready to pull requests (defaults to false)


### PR DESCRIPTION
## The Problem/Issue/Bug:
There's already a Gitpod badge in the PR description, the badge in comments is redundant and confusing.

## How this PR Solves The Problem:
Remove the badge from PR comments (but keep it in PR description)

## Manual Testing Instructions:
Confirm that there's only 1 Gitpod badge in this PR, and no badge in this PR's comments 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3122"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

