### PR TITLE
Reverse broken backwards minimum disk space warning

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -956,7 +956,7 @@ func CheckAvailableSpace() {
 	_, out, _ := RunSimpleContainer(version.GetWebImage(), "", []string{"sh", "-c", `df -h / | awk '/overlay/ {print $5;}'`}, []string{}, []string{}, []string{"testnfsmount" + ":/nfsmount"}, "", true, false, nil)
 	out = strings.Trim(out, "% \n")
 	spacePercent, _ := strconv.Atoi(out)
-	if spacePercent < nodeps.MinimumDockerSpaceWarning {
-		util.Error("Your docker installation has less than %d%% available space. Please increase it!", nodeps.MinimumDockerSpaceWarning)
+	if (100 - spacePercent) < nodeps.MinimumDockerSpaceWarning {
+		util.Error("Your docker installation has less than %d%% available space (%d%% used). Please increase disk image size.", nodeps.MinimumDockerSpaceWarning, spacePercent)
 	}
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

In https://github.com/drud/ddev/pull/3110 I added checking for available docker (or other) disk space. 

I reversed the logic, so it showed the warning when you have LOTS of disk space.

This turns it back.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3132"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

