### PR TITLE
Fix extraneous newline in ddev exec, fixes #3131

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -43,7 +42,7 @@ var DdevExecCmd = &cobra.Command{
 
 		app.DockerEnv()
 
-		out, _, err := app.Exec(&ddevapp.ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: serviceType,
 			Dir:     execDirArg,
 			Cmd:     strings.Join(args, " "),
@@ -53,7 +52,6 @@ var DdevExecCmd = &cobra.Command{
 		if err != nil {
 			util.Failed("Failed to execute command %s: %v", strings.Join(args, " "), err)
 		}
-		output.UserOut.Print(out)
 	},
 }
 

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -35,49 +35,41 @@ func TestCmdExec(t *testing.T) {
 	assert.NoError(err)
 
 	// Test default invocation
-	args := []string{"exec", "pwd"}
-	out, err := exec.RunCommand(DdevBin, args)
+	out, err := exec.RunHostCommand(DdevBin, "exec", "pwd")
 	assert.NoError(err)
 	assert.Contains(out, "/var/www/html")
 
 	// Test specifying service
-	args = []string{"-s", "db", "exec", "pwd"}
-	out, err = exec.RunCommand(DdevBin, args)
+	out, err = exec.RunHostCommand(DdevBin, "-s", "db", "exec", "pwd")
 	assert.NoError(err)
 	assert.Contains(out, "/")
 
 	// Test specifying working directory
-	args = []string{"exec", "-d", "/bin", "pwd"}
-	out, err = exec.RunCommand(DdevBin, args)
+	out, err = exec.RunHostCommand(DdevBin, "exec", "-d", "/bin", "pwd")
 	assert.NoError(err)
 	assert.Contains(out, "/bin")
 
 	// Test specifying service and working directory
-	args = []string{"exec", "-s", "db", "-d", "/var", "pwd"}
-	out, err = exec.RunCommand(DdevBin, args)
+	out, err = exec.RunHostCommand(DdevBin, "exec", "-s", "db", "-d", "/var", "pwd")
 	assert.NoError(err)
 	assert.Contains(out, "/var")
 
 	// Test sudo
-	args = []string{"exec", "sudo", "whoami"}
-	out, err = exec.RunCommand(DdevBin, args)
+	out, err = exec.RunHostCommand(DdevBin, "exec", "sudo", "whoami")
 	assert.NoError(err)
 	assert.Contains(out, "root")
 
 	// Test that an nonexistent working directory generates an error
-	args = []string{"exec", "-d", "/does/not/exist", "pwd"}
-	out, err = exec.RunCommand(DdevBin, args)
+	out, err = exec.RunHostCommand(DdevBin, "exec", "-d", "/does/not/exist", "pwd")
 	assert.Error(err)
 	assert.Contains(out, "no such file or directory")
 
-	args = []string{"exec", "ls >/var/www/html/TestCmdExec-${OSTYPE}.txt"}
-	_, err = exec.RunCommand(DdevBin, args)
+	_, err = exec.RunHostCommand(DdevBin, "exec", "ls >/var/www/html/TestCmdExec-${OSTYPE}.txt")
 	assert.NoError(err)
 
 	assert.FileExists(filepath.Join(site.Dir, "TestCmdExec-linux-gnu.txt"))
 
-	args = []string{"exec", "ls >/dev/null && touch /var/www/html/TestCmdExec-touch-all-in-one.txt"}
-	_, err = exec.RunCommand(DdevBin, args)
+	_, err = exec.RunHostCommand(DdevBin, "exec", "ls >/dev/null && touch /var/www/html/TestCmdExec-touch-all-in-one.txt")
 	assert.NoError(err)
 
 	// We just created in the container, must flush before looking for it on host
@@ -86,8 +78,7 @@ func TestCmdExec(t *testing.T) {
 
 	assert.FileExists(filepath.Join(site.Dir, "TestCmdExec-touch-all-in-one.txt"))
 
-	args = []string{"exec", "true", "&&", "touch", "/var/www/html/TestCmdExec-touch-separate-args.txt"}
-	_, err = exec.RunCommand(DdevBin, args)
+	_, err = exec.RunHostCommand(DdevBin, "exec", "true", "&&", "touch", "/var/www/html/TestCmdExec-touch-separate-args.txt")
 	assert.NoError(err)
 
 	err = app.MutagenSyncFlush()
@@ -97,7 +88,7 @@ func TestCmdExec(t *testing.T) {
 
 	// Make sure we can pipe things into ddev exec and have them work in stdin inside container
 	filename := t.Name() + "_junk.txt"
-	_, err = exec.RunCommand("sh", []string{"-c", fmt.Sprintf("printf 'This file was piped into ddev exec' | %s exec 'cat >/var/www/html/%s'", DdevBin, filename)})
+	_, err = exec.RunHostCommand("sh", "-c", fmt.Sprintf("printf 'This file was piped into ddev exec' | %s exec 'cat >/var/www/html/%s'", DdevBin, filename))
 	assert.NoError(err)
 	require.FileExists(t, filepath.Join(site.Dir, filename))
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

#3131 points out that there's a spare newline after `ddev exec <anything>`. 

## How this PR Solves The Problem:

Remove it. Improve test.

## Manual Testing Instructions:

`ddev exec echo hi` and see if there's an extra newline.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3133"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

