### PR TITLE
Make PHP_IDE_CONFIG available in 'ddev drush'.

### DIFF
--- a/cmd/ddev/cmd/global_dotddev_assets/commands/web/drush
+++ b/cmd/ddev/cmd/global_dotddev_assets/commands/web/drush
@@ -6,6 +6,9 @@
 ## Example: "ddev drush uli" or "ddev drush sql-cli" or "ddev drush --version"
 ## ProjectTypes: drupal7,drupal8,drupal9,backdrop
 
+# Set up variable needed for debugging.
+source /etc/bash.php-ide-config
+
 if ! command -v drush >/dev/null; then
   echo "drush is not available. You may need to 'ddev composer require drush/drush'"
   exit 1

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
@@ -56,4 +56,4 @@ fi
 
 export HISTFILE=/mnt/ddev-global-cache/bashhistory/${HOSTNAME}/bash_history
 
-export PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}
+source /etc/bash.php-ide-config

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.php-ide-config
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.php-ide-config
@@ -1,0 +1,2 @@
+# To be sourced in interactive mode and from select non-interactive scripts like drush.
+export PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -44,7 +44,7 @@ var MutagenVersionConstraint = nodeps.RequiredMutagenVersion
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210729_cspitzlay_mysql_history" // Note that this can be overridden by make
+var WebTag = "20210805_cspitzlay_phpideconfig_in_drush" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The PHP_IDE_CONFIG variable is not set when drush is started from the host machine via `ddev drush`.
As a result breakpoints in phpstorm do not work for code started that way.

## How this PR Solves The Problem:
It moves the line that sets the variable into a separate file that is included both in interactive shells, e.g. when running `ddev ssh` and from the drush wrapper script.

Just sourcing ~/.bashrc instead would not have worked because the line that sets the variable is after a check for interactive mode.  From /etc/bash.bashrc:
```
# If not running interactively, don't do anything
[ -z "$PS1" ] && return
```
In the drush script that variable is not set so the rest of the script ist not executed.

## Manual Testing Instructions:
- In ~/.ddev/commands/web/drush, remove the #ddev-generated
- Put `export | grep PHP_IDE_CONFIG` before and after the line that sources the new file
- You will see the line with the variable only once.

## Related Issue Link(s):
See also https://github.com/drud/ddev/issues/2998


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3143"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

