### PR TITLE
Remove PHP_IDE_CONFIG in php-fpm instead of trying to add it elsewhere, replaces #3143, fixes #2998, fixes #3106

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
@@ -55,5 +55,3 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
 fi
 
 export HISTFILE=/mnt/ddev-global-cache/bashhistory/${HOSTNAME}/bash_history
-
-export PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/php-fpm.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/php-fpm.conf
@@ -1,5 +1,5 @@
 [program:php-fpm]
-command = bash -c "unset PHP_IDE_CONFIG && exec /usr/sbin/php-fpm --nodaemonize --force-stderr"
+command = /usr/sbin/php-fpm --nodaemonize --force-stderr --allow-to-run-as-root
 priority=5
 stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/php-fpm.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/php-fpm.conf
@@ -1,5 +1,5 @@
 [program:php-fpm]
-command = /usr/sbin/php-fpm --nodaemonize --force-stderr --allow-to-run-as-root
+command = bash -c "unset PHP_IDE_CONFIG && exec /usr/sbin/php-fpm --nodaemonize --force-stderr"
 priority=5
 stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -88,4 +88,7 @@ mkcert -install
 CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev_default
 echo 'Server started'
 
+# We don't want the various daemons to know about PHP_IDE_CONFIG
+unset PHP_IDE_CONFIG
+
 exec /usr/bin/supervisord -n -c "/etc/supervisor/supervisord-${DDEV_WEBSERVER_TYPE}.conf"

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -87,4 +87,7 @@ mkcert -install
 CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev_default
 echo 'Server started'
 
+# We don't want the various daemons to know about PHP_IDE_CONFIG
+unset PHP_IDE_CONFIG
+
 exec /usr/bin/supervisord -n -c "/etc/supervisor/supervisord-${DDEV_WEBSERVER_TYPE}.conf"

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -138,6 +138,7 @@ services:
       - IS_DDEV_PROJECT=true
       - LINES
       - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history
+      - PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}
       - SSH_AUTH_SOCK=/home/.ssh-agent/socket
       - TZ={{ .Timezone }}
       - VIRTUAL_HOST=${DDEV_HOSTNAME}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -44,7 +44,7 @@ var MutagenVersionConstraint = nodeps.RequiredMutagenVersion
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210810_mrbaileys_xhprof" // Note that this can be overridden by make
+var WebTag = "20210808_PHP_IDE_CONFIG" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* For PhpStorm zero-configuration debugging to work, PHP_IDE_CONFIG must not exist (for php-fpm)
* For command-line debugging, PHP_IDE_CONFIG must be set

After discovering this problem, the attempt was to *add* PHP_IDE_CONFIG only for login sessions, but people didn't like that for a variety of reasons (doesn't work then for `ddev exec` or `ddev drush`)

## How this PR Solves The Problem:

Instead of trying to ADD PHP_IDE_CONFIG for the command-line, instead add it everywhere (via docker-compose.yaml) and *hide* it from php-fpm by unsetting it before php-fpm or even supervisord is started

Thanks to @cspitzlay for pushing me to try another time!

## Manual Testing Instructions:

This testing is critical:

* `docker pull  drud/ddev-webserver:20210808_PHP_IDE_CONFIG` to make sure you have the latest
* Start a project with this ddev (you can use gitpod per the links here)
* Remove any existing "Server" from the "PHP" section in PhpStorm
* Use the regular instructions for [zero-configuration xdebug](https://ddev.readthedocs.io/en/stable/users/step-debugging/#phpstorm) for PhpStorm.  You should get a popup that lets you choose a mapping. Verify that this works. (This also creates a new server/mapping). Verify that debugging a web app works now.
* Now go to the server/mapping in "PHP" and make sure the root of the project is mapped to /var/www/html
* Set a breakpoint and turn on xdebug and use `ddev drush` or `ddev exec someotherphp` to verify that debugging also works on the command line.

## Automated Testing Overview:
This is so PhpStorm fiddly that I didn't try adding anything.

## Related Issue Link(s):

* #3143
* #2998 
* #3106
* #2427
* #2424


## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3149"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

