### PR TITLE
Encourage use of expose instead of ports in docker-compose.*.yaml

### DIFF
--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -24,9 +24,24 @@ The main docker-compose file is named `.ddev/.ddev-docker-compose-base.yaml` and
 version: '3.6'
 
 services:
-  web:
+  someservice:
     ports:
       - "9999:9999"
+```
+
+That approach usually isn't sustainable because two projects might want to use the same port, so we *expose* the additional port (to the docker network) and then use the ddev-router to bind it to the host. This works only for services with an http API, but results in having both http and https ports (9998 and 9999).
+
+```yaml
+version: '3.6'
+
+services:
+  someservice:
+    expose: 
+      - 9999
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=9998:9999
+      - HTTPS_EXPOSE=9999:9999
 ```
 
 ### Confirming docker-compose configurations

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -172,7 +172,7 @@ services:
       com.ddev.approot: $DDEV_APPROOT
     links:
       - db:db
-    ports:
+    expose:
       - "80"
     hostname: {{ .Name }}-dba
     environment:

--- a/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
@@ -9,7 +9,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-beanstalk # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
     image: schickling/beanstalkd:latest
     restart: "no"
-    ports:
+    expose:
     - 11300 # beanstalk is available at this port inside the container (default port for beanstalkd)
     labels:
       # These labels ensure this service is discoverable by ddev

--- a/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
@@ -20,7 +20,7 @@ services:
     image: memcached:1.5
     restart: "no"
     # memcached is available at this port inside the container.
-    ports:
+    expose:
       - 11211
     # These labels ensure this service is discoverable by ddev.
     labels:

--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -34,7 +34,7 @@ services:
     image: solr:8
     restart: "no"
     # Solr is served from this port inside the container.
-    ports:
+    expose:
       - 8983
     # These labels ensure this service is discoverable by ddev.
     labels:


### PR DESCRIPTION
## The Problem/Issue/Bug:

There were places in the docs where `ports` was used and it's not a very good habit, as things can collide. Encourage use of `expose` instead, which just works inside the docker network.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3151"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

