### PR TITLE
Include memory consumption by default in xhprof output.

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/xhprof_prepend.php
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/xhprof_prepend.php
@@ -7,7 +7,7 @@ if (!empty($_SERVER) && array_key_exists('REQUEST_URI', $_SERVER)) {
 
 // Enable xhprof profiling if we're not on an xhprof page
 if (extension_loaded('xhprof') && strpos($uri, '/xhprof') === false) {
-    xhprof_enable();
+    xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);
     register_shutdown_function('xhprof_completion');
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -44,7 +44,7 @@ var MutagenVersionConstraint = nodeps.RequiredMutagenVersion
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210729_cspitzlay_mysql_history" // Note that this can be overridden by make
+var WebTag = "20210810_mrbaileys_xhprof" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

When enabling xhprof, the output in the UI does not contain information about memory consumption.

## How this PR Solves The Problem:

Enable profiling of memory consumption alongside CPU profiling by adding the XHPROF_FLAGS_MEMORY when xhprof_enable is called.

## Manual Testing Instructions:

This can be tested using gitpod: https://gitpod.io/#https://github.com/drud/ddev/pull/3154

Enable xhprof (ddev xhprof on).
Visit at least one page on your site.
Visit /xhprof and view the profiling output, it should contain information on memory consumption.

## Automated Testing Overview:
Not sure if (or how) this can be included in automated testing. Happy to add testing to this PR if someones points me in the right direction.

## Related Issue Link(s):

## Release/Deployment notes:




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3154"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

