### PR TITLE
Allow use with compose v2 when DDEV_ALLOW_COMPOSE_V2 is true

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -15,7 +15,6 @@ import (
 	"gopkg.in/segmentio/analytics-go.v3"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -35,7 +34,7 @@ Docs: https://ddev.readthedocs.io
 Support: https://ddev.readthedocs.io/en/stable/#support`,
 	Version: version.DdevVersion,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		command := strings.Join(os.Args[1:], " ")
+		command := os.Args[1]
 
 		// LogSetup() has already been done, but now needs to be done
 		// again *after* --json flag is parsed.
@@ -57,7 +56,7 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 			}
 		}
 
-		err = dockerutil.CheckDockerCompose(version.DockerComposeVersionConstraint)
+		err = dockerutil.CheckDockerCompose()
 		if err != nil {
 			if err.Error() == "no docker-compose" {
 				util.Failed("docker-compose does not appear to be installed.")

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/archive"
 	exec2 "github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -493,15 +494,20 @@ func CheckDockerVersion(versionConstraint string) error {
 
 // CheckDockerCompose determines if docker-compose is present and executable on the host system. This
 // relies on docker-compose being somewhere in the user's $PATH.
-func CheckDockerCompose(versionConstraint string) error {
+func CheckDockerCompose() error {
 	runTime := util.TimeTrack(time.Now(), "CheckDockerComposeVersion()")
 	defer runTime()
 
-	version, err := version.GetDockerComposeVersion()
+	if globalconfig.DdevAllowComposeV2 {
+		version.DockerComposeVersionConstraint = ">= 1.25.0-alpha1"
+	}
+	versionConstraint := version.DockerComposeVersionConstraint
+
+	v, err := version.GetDockerComposeVersion()
 	if err != nil {
 		return err
 	}
-	dockerComposeVersion, err := semver.NewVersion(version)
+	dockerComposeVersion, err := semver.NewVersion(v)
 	if err != nil {
 		return err
 	}
@@ -516,9 +522,11 @@ func CheckDockerCompose(versionConstraint string) error {
 		if len(errs) <= 1 {
 			// TODO: Remove these lines when docker-compose v2 starts working
 			// Probably this commit can be reverted at that time.
-			v2Constraint, _ := semver.NewConstraint("< 2.0.0")
-			if m, _ := v2Constraint.Validate(dockerComposeVersion); !m {
-				util.Error("You have docker-compose v2 and it is not yet stable enough to use with ddev.\nPlease uncheck the 'Use Docker Compose V2' experimental feature\nin Docker Desktop, or run 'docker-compose disable-v2'")
+			if !globalconfig.DdevAllowComposeV2 {
+				v2Constraint, _ := semver.NewConstraint("< 2.0.0")
+				if m, _ := v2Constraint.Validate(dockerComposeVersion); !m {
+					util.Error("You have docker-compose v2 and it is not yet stable enough to use with ddev.\nPlease uncheck the 'Use Docker Compose V2' experimental feature\nin Docker Desktop, or run 'docker-compose disable-v2'")
+				}
 			}
 			return errs[0]
 		}

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -313,7 +313,7 @@ func TestComposeWithStreams(t *testing.T) {
 func TestCheckCompose(t *testing.T) {
 	assert := asrt.New(t)
 
-	err := CheckDockerCompose(version.DockerComposeVersionConstraint)
+	err := CheckDockerCompose()
 	assert.NoError(err)
 }
 

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -22,3 +22,7 @@ var DdevDebug = (os.Getenv("DDEV_DEBUG") == "true")
 
 // DdevVerbose is set to true if the env var is set
 var DdevVerbose = (os.Getenv("DDEV_VERBOSE") == "true")
+
+// DdevAllowComposeV2 is a temporary setup that allows ddev to run even though the
+// incompatible compose-cli v2 is enabled... so we can get it working.
+var DdevAllowComposeV2 = (os.Getenv("DDEV_ALLOW_COMPOSE_V2") == "true")


### PR DESCRIPTION
## The Problem/Issue/Bug:

`export DDEV_ALLOW_COMPOSE_V2=true`

in the environment will allow running with docker-compose v2. This is for testing.


# Testing:
- [x] No variable set, docker-compose v1 (should work)
- [x] No variable set, docker-compose v2 (should fail)
- [x] Variable set, docker-compose v1 (should work)
- [x] Variable set, docker-compose v2 (should try to work but fail)

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3157"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

