### PR TITLE
Use working_dir in generated compose instead of always overriding, fixes #3158

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -265,12 +265,13 @@ func (app *DdevApp) ImportFilesAction(importPath, extPath string) error {
 
 // DefaultWorkingDirMap returns the app type's default working directory map.
 func (app *DdevApp) DefaultWorkingDirMap() map[string]string {
+	_, _, username := util.GetContainerUIDGid()
 	// Default working directory values are defined here.
 	// Services working directories can be overridden by app types if needed.
 	defaults := map[string]string{
 		"web": "/var/www/html/",
-		"db":  "/home",
-		"dba": "/home",
+		"db":  "/home/" + username,
+		"dba": "/root",
 	}
 
 	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.defaultWorkingDirMap != nil {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -657,6 +657,7 @@ type composeYAMLVars struct {
 	FailOnHookFail            bool
 	WebWorkingDir             string
 	DBWorkingDir              string
+	DBAWorkingDir             string
 	WebEnvironment            []string
 }
 
@@ -731,6 +732,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		FailOnHookFail:        app.FailOnHookFail || app.FailOnHookFailGlobal,
 		WebWorkingDir:         app.GetWorkingDir("web", ""),
 		DBWorkingDir:          app.GetWorkingDir("db", ""),
+		DBAWorkingDir:         app.GetWorkingDir("dba", ""),
 		WebEnvironment:        webEnvironment,
 	}
 	if app.NFSMountEnabled || app.NFSMountEnabledGlobal {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -655,6 +655,8 @@ type composeYAMLVars struct {
 	GID                       string
 	AutoRestartContainers     bool
 	FailOnHookFail            bool
+	WebWorkingDir             string
+	DBWorkingDir              string
 	WebEnvironment            []string
 }
 
@@ -727,6 +729,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		DBBuildDockerfile:     "../.dbimageBuild/Dockerfile",
 		AutoRestartContainers: globalconfig.DdevGlobalConfig.AutoRestartContainers,
 		FailOnHookFail:        app.FailOnHookFail || app.FailOnHookFailGlobal,
+		WebWorkingDir:         app.GetWorkingDir("web", ""),
+		DBWorkingDir:          app.GetWorkingDir("db", ""),
 		WebEnvironment:        webEnvironment,
 	}
 	if app.NFSMountEnabled || app.NFSMountEnabledGlobal {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1141,8 +1141,8 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	}
 
 	args := []string{"exec"}
-	if workingDir := app.GetWorkingDir(opts.Service, opts.Dir); workingDir != "" {
-		args = append(args, "-w", workingDir)
+	if opts.Dir != "" {
+		args = append(args, "-w", opts.Dir)
 	}
 
 	if !isatty.IsTerminal(os.Stdin.Fd()) || !opts.Tty {
@@ -1169,7 +1169,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	errcheck := "set -eu"
 	args = append(args, shell, "-c", errcheck+` && ( `+opts.Cmd+`)`)
 
-	files, err := app.ComposeFiles()
+	files := []string{app.DockerComposeFullRenderedYAMLPath()}
 	if err != nil {
 		return "", "", err
 	}
@@ -1213,8 +1213,8 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 	}
 
 	args := []string{"exec"}
-	if workingDir := app.GetWorkingDir(opts.Service, opts.Dir); workingDir != "" {
-		args = append(args, "-w", workingDir)
+	if opts.Dir != "" {
+		args = append(args, "-w", opts.Dir)
 	}
 
 	args = append(args, opts.Service)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -18,7 +18,7 @@ services:
         gid: '{{ .GID }}'
     image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
     stop_grace_period: 60s
-    working_dir: "{{ .WebWorkingDir }}"
+    working_dir: "{{ .DBWorkingDir }}"
     volumes:
       - type: "volume"
         source: mariadb-database
@@ -167,6 +167,7 @@ services:
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
+    working_dir: "{{ .DBAWorkingDir }}"
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -18,6 +18,7 @@ services:
         gid: '{{ .GID }}'
     image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
     stop_grace_period: 60s
+    working_dir: "{{ .WebWorkingDir }}"
     volumes:
       - type: "volume"
         source: mariadb-database
@@ -75,6 +76,7 @@ services:
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
     cap_add:
       - SYS_PTRACE
+    working_dir: "{{ .WebWorkingDir }}"
     volumes:
       {{ if not .NoProjectMount }}
       - type: {{ .MountType }}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3158 

#3158 points out that we could more efficiently do working_dir with the docker-compose yaml instead of only passing it on the docker-compose command line. 

## How this PR Solves The Problem:

Put working_dir in the generated `.ddev/.ddev-docker-compose-*.yaml`

## Manual Testing Instructions:

- [x] Use `ddev exec` and `ddev ssh` both with and without the `-d` flag, make sure it works all those ways.
- [x] Change working_dir in the .ddev/config.yaml and make sure that it becomes the default

## Automated Testing Overview:

I'm hoping the existing tests are adequate.

The behavior shouldn't change.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3160"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

