### PR TITLE
Use container ID for beta in sync session, fixes #3161

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -519,22 +519,6 @@ func (app *DdevApp) GetHostnames() []string {
 func (app *DdevApp) WriteDockerComposeYAML() error {
 	var err error
 
-	// Because of move from docker-compose.yaml as base file to .ddev-docker-compose-base.yaml
-	// remove old ddev-managed docker-compose.yaml
-	oldDockerCompose := filepath.Join(app.AppConfDir(), "docker-compose.yaml")
-	if fileutil.FileExists(oldDockerCompose) {
-		found, err := fileutil.FgrepStringInFile(oldDockerCompose, DdevFileSignature)
-		if err != nil {
-			return err
-		}
-		if found {
-			err = os.Remove(oldDockerCompose)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	f, err := os.Create(app.DockerComposeYAMLPath())
 	if err != nil {
 		return err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -243,8 +243,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 	}
 	appDesc["hostname"] = app.GetHostname()
 	appDesc["hostnames"] = app.GetHostnames()
-	appDesc["nfs_mount_enabled"] = app.NFSMountEnabled || app.NFSMountEnabledGlobal
-	appDesc["mutagen_enabled"] = app.MutagenEnabled || app.MutagenEnabledGlobal
+	appDesc["nfs_mount_enabled"] = (app.NFSMountEnabled || app.NFSMountEnabledGlobal) && !(app.MutagenEnabled || app.MutagenEnabledGlobal)
 	appDesc["fail_on_hook_fail"] = app.FailOnHookFail || app.FailOnHookFailGlobal
 	httpURLs, httpsURLs, allURLs := app.GetAllURLs()
 	appDesc["httpURLs"] = httpURLs

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -238,6 +238,9 @@ func (app *DdevApp) MutagenSyncFlush() error {
 func MutagenSyncExists(app *DdevApp) bool {
 	syncName := MutagenSyncName(app.Name)
 
+	if !fileutil.FileExists(globalconfig.GetMutagenPath()) {
+		return false
+	}
 	_, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list", syncName)
 	return err == nil
 }

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -62,20 +62,18 @@ func TerminateMutagenSync(app *DdevApp) error {
 
 // SyncAndTerminateMutagenSession syncs and terminates the mutagen sync session
 func SyncAndTerminateMutagenSession(app *DdevApp) error {
-	if app.MutagenEnabled || app.MutagenEnabledGlobal {
-		syncName := MutagenSyncName(app.Name)
+	syncName := MutagenSyncName(app.Name)
 
-		if !MutagenSyncExists(app) {
-			return errors.Errorf("Sync session '%v' does nto exist", syncName)
-		}
-		err := app.MutagenSyncFlush()
-		if err != nil {
-			util.Error("Error on 'mutagen sync flush %s': %v", syncName, err)
-		}
-		err = TerminateMutagenSync(app)
-		if err != nil {
-			return err
-		}
+	if !MutagenSyncExists(app) {
+		return nil
+	}
+	err := app.MutagenSyncFlush()
+	if err != nil {
+		util.Error("Error on 'mutagen sync flush %s': %v", syncName, err)
+	}
+	err = TerminateMutagenSync(app)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -105,7 +103,12 @@ func CreateMutagenSync(app *DdevApp) error {
 	if err != nil {
 		return err
 	}
-	args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker://ddev-%s-web/var/www/html", app.Name), "--no-global-configuration", "--name", syncName}
+	container, err := dockerutil.FindContainerByName(fmt.Sprintf("ddev-%s-web", app.Name))
+	if err != nil {
+		return err
+	}
+
+	args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker://%s/var/www/html", container.ID), "--no-global-configuration", "--name", syncName}
 	if configFile != "" {
 		args = append(args, fmt.Sprintf(`--configuration-file=%s`, configFile))
 	}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -47,13 +47,11 @@ func MutagenSyncName(name string) string {
 // TerminateMutagenSync terminates the mutagen sync
 // It is not an error if the sync session does not exist
 func TerminateMutagenSync(app *DdevApp) error {
-	if app.MutagenEnabled || app.MutagenEnabledGlobal {
-		syncName := MutagenSyncName(app.Name)
-		if MutagenSyncExists(app) {
-			_, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "terminate", syncName)
-			if err != nil {
-				return err
-			}
+	syncName := MutagenSyncName(app.Name)
+	if MutagenSyncExists(app) {
+		_, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "terminate", syncName)
+		if err != nil {
+			return err
 		}
 		util.Success("Terminated mutagen sync session '%s'", syncName)
 	}

--- a/scripts/test_ddev.sh
+++ b/scripts/test_ddev.sh
@@ -35,6 +35,12 @@ echo -n "docker location: " && ls -l "$(which docker)"
 if [ ${OSTYPE%-*} != "linux" ]; then
   echo -n "Docker Desktop Version: " && docker_desktop_version && echo
 fi
+
+echo "======= Mutagen Info ========="
+if [ -f ~/.ddev/bin/mutagen ]; then
+  echo "Mutagen is installed in ddev, version=$(~/.ddev/bin/mutagen version)"
+  ~/.ddev/bin/mutagen sync list
+fi
 if command -v mutagen >/dev/null ; then
   echo "mutagen additionally installed in PATH at $(command -v mutagen), version $(mutagen version)"
 fi
@@ -42,6 +48,8 @@ if killall -0 mutagen 2>/dev/null; then
   echo "mutagen is running on this system:"
   ps -ef | grep mutagen
 fi
+
+echo "======= Docker Info ========="
 
 echo "Docker disk space:" && docker run --rm busybox df -h / && echo
 ddev poweroff


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3161 

## How this PR Solves The Problem:

1. Use container ID instead of name for the Beta in mutagen sync session
2. Unconditionally stop a mutagen session of the appropriate name even if mutagen is not currently enabled.

## Manual Testing Instructions:

- [x] `ddev start` with mutagen enabled and verify that the beta is the container id (`ddev mutagen status --verbose`)
- [x] `ddev config --mutagen-enabled=false`
- [x] `ddev stop` 
- [x] Use `mutagen sync list` to verify that the sync session was removed even though ddev was configured for no mutagen.
- [x] Verify that `ddev stop` and `ddev restart` cause no harm if mutagen is not enabled at all (or even downloaded)

## Automated Testing Overview:

## Related Issue Link(s):


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3162"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

