### PR TITLE
Check available space AFTER we've already downloaded webimage

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -811,8 +811,6 @@ func (app *DdevApp) GetDBImage() string {
 func (app *DdevApp) Start() error {
 	var err error
 
-	dockerutil.CheckAvailableSpace()
-
 	app.DockerEnv()
 
 	app.DBImage = app.GetDBImage()
@@ -853,6 +851,8 @@ func (app *DdevApp) Start() error {
 	if err != nil {
 		return err
 	}
+
+	dockerutil.CheckAvailableSpace()
 
 	// Make sure that important volumes to mount already have correct ownership set
 	// Additional volumes can be added here. This allows us to run a single privileged


### PR DESCRIPTION
## The Problem/Issue/Bug:

We were checking for available docker space very early in `ddev start`, potentially before the images had been downloaded... and it uses the webimage. This could lead to a long silent pause depending on internet speed, and especially after an upgrade where we need a new image.

## How this PR Solves The Problem:

Check available space later.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3165"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

