### PR TITLE
TestNFSMount can fail on Windows because of NFS failure, make it more resilient

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3316,7 +3316,9 @@ func verifyNFSMount(t *testing.T, app *ddevapp.DdevApp) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     "ln -s  .ddev nfscontainerlinked_ddev",
+		// symlink creation on windows can seem to fail with mysterious i/o error, when it actually worked
+		// so give it a second chance with the ls.
+		Cmd: "ln -s  .ddev nfscontainerlinked_ddev || ls nfscontainerlinked_ddev",
 	})
 	assert.NoError(err)
 
@@ -3330,7 +3332,9 @@ func verifyNFSMount(t *testing.T, app *ddevapp.DdevApp) {
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Dir:     "/var/www/html",
-		Cmd:     "ln -s  .ddev/config.yaml nfscontainerlinked_config.yaml",
+		// symlink creation on windows can fail... but actually succeed. We give it a second
+		// chance with the ls
+		Cmd: "ln -s  .ddev/config.yaml nfscontainerlinked_config.yaml || ls nfscontainerlinked_config.yaml",
 	})
 	assert.NoError(err)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Tests only: I don't know why, but TestNFSMount fails to create symlinks inside the container. But if you wait and do an ls, it works.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3166"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

