### PR TITLE
Force restart if mutagen volume did not get mounted

### DIFF
--- a/cmd/ddev/cmd/mutagen-cmd_test.go
+++ b/cmd/ddev/cmd/mutagen-cmd_test.go
@@ -30,6 +30,8 @@ func TestCmdMutagen(t *testing.T) {
 
 	app, err := ddevapp.GetActiveApp("")
 	require.NoError(t, err)
+	err = app.Stop(true, false)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		err = app.Stop(true, false)
@@ -53,7 +55,8 @@ func TestCmdMutagen(t *testing.T) {
 	_, err = exec.RunHostCommand(DdevBin, "config", "--mutagen-enabled=true")
 	assert.NoError(err)
 
-	app, err = ddevapp.NewApp("", false)
+	// Have to reload the app, since we just changed the config
+	app, err = ddevapp.GetActiveApp("")
 	require.NoError(t, err)
 
 	// Make sure it got turned on

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -944,6 +944,13 @@ func (app *DdevApp) Start() error {
 	}
 
 	if app.MutagenEnabled || app.MutagenEnabledGlobal {
+		mounted, err := IsMutagenVolumeMounted(app)
+		if err != nil {
+			return err
+		}
+		if !mounted {
+			util.Failed("Mutagen docker volume is not mounted. Please use `ddev restart`")
+		}
 		output.UserOut.Printf("Starting mutagen sync process... This can take some time.")
 		err = app.GenerateMutagenYml()
 		if err != nil {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -604,6 +604,9 @@ func TestDdevStartUnmanagedSettings(t *testing.T) {
 
 // TestDdevNoProjectMount tests running without the app file mount.
 func TestDdevNoProjectMount(t *testing.T) {
+	if nodeps.MutagenEnabledDefault == true {
+		t.Skip("Skipping because this doesn't make sense with mutagen")
+	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
 	"golang.org/x/term"
 	"os"
@@ -368,3 +369,27 @@ func (app *DdevApp) GenerateMutagenYml() error {
 	err = fileutil.TemplateStringToFile(content, map[string]interface{}{"SymlinkMode": symlinkMode}, mutagenYmlPath)
 	return err
 }
+
+// IsMutagenVolumeMounted checks to see if the mutagen volume is mounted
+func IsMutagenVolumeMounted(app *DdevApp) (bool, error) {
+	client := dockerutil.GetDockerClient()
+	container, err := dockerutil.FindContainerByName("ddev-" + app.Name + "-web")
+	if err != nil {
+		return false, err
+	}
+	inspect, err := client.InspectContainerWithOptions(docker.InspectContainerOptions{
+		ID: container.ID,
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, m := range inspect.Mounts {
+		if m.Name == app.Name+"_project_mutagen" {
+			return true, nil
+		}
+	}
+	return false, nil
+
+}
+
+

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -96,7 +96,7 @@ func CreateMutagenSync(app *DdevApp) error {
 	syncName := MutagenSyncName(app.Name)
 	configFile := GetMutagenConfigFile(app)
 	if configFile != "" {
-		util.Success("Using mutagen config file %s", configFile)
+		util.Debug("Using mutagen config file %s", configFile)
 	}
 
 	util.Debug("Terminating mutagen sync if session already exists")

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -391,5 +391,3 @@ func IsMutagenVolumeMounted(app *DdevApp) (bool, error) {
 	return false, nil
 
 }
-
-

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -90,9 +92,20 @@ func TestMutagenSimple(t *testing.T) {
 
 	// Make sure we can stop the daemon
 	ddevapp.StopMutagenDaemon()
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		out, err := exec.RunHostCommand("bash", "-c", "ps -ef | grep mutagen")
+		assert.NoError(err)
+		t.Logf("mutagen processes after StopMutagenDaemon: \n=====\n%s====\n", out)
+	}
+
 	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list")
 	assert.NoError(err)
 	assert.Contains(out, "Started Mutagen daemon in background")
+	if !strings.Contains(out, "Started Mutagen daemon in background") && (runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
+		out, err := exec.RunHostCommand("bash", "-c", "ps -ef | grep mutagen")
+		assert.NoError(err)
+		t.Logf("current mutagen processes: \n=====\n%s====\n", out)
+	}
 
 	err = app.Start()
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

A bug was described by a @TXChetG:

-  Project running nfs, never had mutagen before
-  Configure mutagen while running
- ddev start, downloads mutagen
- Long pause before download (because restarting daemon?)
- Then comes up and it's actually mutagen-syncing to nfs

## How this PR Solves The Problem:

On Start, make sure that the mutagen volume is mounted. If it is not, insist on a `ddev restart`

## Manual Testing Instructions:

1. Start a project with NFS only
2. While project is running, `ddev config --mutagen-enabled`
3. `ddev start`
4. It should insist on a `ddev restart`

@TXChetG I'd love it if you could review this (especially manually testing)

## Automated Testing Overview:

This is an odd edge case; it might deserve a test. Not sure.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3167"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

