### PR TITLE
Blackfire packages are currently broken, embargo TestExtraPackages, force image removal

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -794,6 +794,11 @@ func TestPHPOverrides(t *testing.T) {
 // TestExtraPackages tests to make sure that *extra_packages config.yaml directives
 // work (and are overridden by *-build/Dockerfile).
 func TestExtraPackages(t *testing.T) {
+	embargoTime := "20 AUG 21 10:00 MDT"
+	if util.IsBeforeCutoffTime(embargoTime) {
+		t.Skipf("Skipping %s until %s", t.Name(), embargoTime)
+	}
+
 	assert := asrt.New(t)
 	app := &DdevApp{}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -364,7 +364,7 @@ func TestDdevStart(t *testing.T) {
 	for _, imageName := range []string{webBuilt, dbBuilt} {
 		exists, err = dockerutil.ImageExistsLocally(imageName)
 		assert.NoError(err)
-		assert.False(exists, "image %s should not have existed but still exists (while testing %s)", app.Name)
+		assert.False(exists, "image %s should not have existed but still exists (while testing %s)", imageName, app.Name)
 	}
 
 	runTime()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -852,12 +852,13 @@ func GetHostDockerInternalIP() (string, error) {
 	return hostDockerInternal, nil
 }
 
-// RemoveImage removes an image
+// RemoveImage removes an image with force
 func RemoveImage(tag string) error {
 	client := GetDockerClient()
-	err := client.RemoveImage(tag)
+	err := client.RemoveImageExtended(tag, docker.RemoveImageOptions{Force: true})
+
 	if err == nil {
-		util.Success("Deleting docker image %s", tag)
+		util.Success("Deleted docker image %s", tag)
 	} else {
 		util.Warning("Unable to delete %s: %v", tag, err)
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -226,3 +226,17 @@ func FormatDuration(d time.Duration) string {
 	}
 	return fmt.Sprintf("%dm%ds", minutes, seconds)
 }
+
+// IsBeforeCutoffTime returns true if the current time is before
+// the cutoff time, in format "01 Jan 21 10:00 UTC"
+func IsBeforeCutoffTime(cutoff string) bool {
+	cutoffTime, err := time.Parse(time.RFC822, cutoff)
+	if err != nil {
+		output.UserErr.Printf("Failed to parse cutoffTime %s: %v", cutoffTime, err)
+	}
+	currentTime := time.Now()
+	if currentTime.Before(cutoffTime) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Blackfire.io's Debian repositories are currently refusing `apt-get update`, see https://twitter.com/randyfay/status/1426535913094467584
* Image removal is not currently forced. I think it will do no harm to force removal

## How this PR Solves The Problem:

* Embargo the TestExtraPackages test until 20 AUG 21 10:00 MDT, meaning we won't test it until then, but tests will resume then.
* Change dockerutil.RemoveImage() to force removal. This fixes a random test failure that was identified at the same time as the Blackfire problem.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3169"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

