### PR TITLE
Remove embargo on TestExtraPackages

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -794,11 +794,6 @@ func TestPHPOverrides(t *testing.T) {
 // TestExtraPackages tests to make sure that *extra_packages config.yaml directives
 // work (and are overridden by *-build/Dockerfile).
 func TestExtraPackages(t *testing.T) {
-	embargoTime := "20 AUG 21 10:00 MDT"
-	if util.IsBeforeCutoffTime(embargoTime) {
-		t.Skipf("Skipping %s until %s", t.Name(), embargoTime)
-	}
-
 	assert := asrt.New(t)
 	app := &DdevApp{}
 


### PR DESCRIPTION

## The Problem/Issue/Bug:

In 65b8151aebadeea8c716aad2389b2ea644652570 I had to embargo TestExtraPackages because the Blackfire.io packages were broken. 

This reverts that, but keeps the helper utility.
 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3175"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

