### PR TITLE
Mutagen followup tweaks and docs

### DIFF
--- a/cmd/ddev/cmd/mutagen-reset.go
+++ b/cmd/ddev/cmd/mutagen-reset.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 // MutagenResetCmd implements the ddev mutagen reset command
@@ -32,7 +33,10 @@ var MutagenResetCmd = &cobra.Command{
 
 		err = app.MutagenSyncFlush()
 		if err != nil {
-			util.Failed("Failed to flush mutagen: %v", err)
+			// if the mutagen session just did not exist, continue on
+			if !strings.Contains(err.Error(), "does not exist") {
+				util.Failed("Failed to flush mutagen: %v", err)
+			}
 		}
 
 		err = ddevapp.MutagenReset(app)

--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -215,6 +215,8 @@ For example, if I want the .tarballs subdirectory of the project to be available
 * `ddev mutagen monitor` can help watch mutagen behavior. It's the same as `~/.ddev/bin/mutagen sync monitor <syncname>`
 * `ddev debug mutagen` will let you run any mutagen command using the binary in `~/.ddev/bin/mutagen`.
 * If you're working on the host and expecting things to show up immediately inside the container, you can learn a lot by running `ddev mutagen monitor` in a separate window as you work. You'll see when mutagen responds to your changes and get an idea about how much delay there is.
+* Consider `ddev stop` before massive file change operations (like moving a directory, etc.)
+* If you get in real trouble, `ddev stop`, reset your files with git, and then `ddev mutagen reset` to throw away the docker volume (which may already have incorrect files on it.)
 * If you're having trouble, we really want to hear from you to learn and try to sort it out. See the [Support channels](https://ddev.readthedocs.io/en/latest/#support-and-user-contributed-documentation).
 
 ### Mutagen Strategies and Design Considerations

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -149,6 +149,8 @@ func CreateMutagenSync(app *DdevApp) error {
 			for {
 				select {
 				case <-stopGoroutine:
+					_ = cmd.Process.Kill()
+					_, _ = cmd.Process.Wait()
 					return
 				default:
 					line, err := buf.ReadBytes('\r')

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // SetMutagenVolumeOwnership chowns the volume in use to the current user.
@@ -126,8 +127,10 @@ func CreateMutagenSync(app *DdevApp) error {
 
 	flushErr := make(chan error, 1)
 	stopGoroutine := make(chan bool, 1)
+	firstOutputReceived := make(chan bool, 1)
 	defer close(flushErr)
 	defer close(stopGoroutine)
+	defer close(firstOutputReceived)
 
 	go func() {
 		err = app.MutagenSyncFlush()
@@ -142,6 +145,7 @@ func CreateMutagenSync(app *DdevApp) error {
 		go func() {
 			previousStatus := ""
 			curStatus := ""
+			sigSent := false
 			cmd := osexec.Command(globalconfig.GetMutagenPath(), "sync", "monitor", syncName)
 			stdout, _ := cmd.StdoutPipe()
 			err = cmd.Start()
@@ -159,6 +163,14 @@ func CreateMutagenSync(app *DdevApp) error {
 					}
 					l := string(line)
 					if strings.HasPrefix(l, "Status:") {
+						// If we haven't already notified that output is coming in,
+						// then notify.
+						if !sigSent {
+							firstOutputReceived <- true
+							sigSent = true
+							_, _ = fmt.Fprintf(os.Stderr, "\n")
+						}
+
 						_, _ = fmt.Fprintf(os.Stderr, "%s", l)
 						t := strings.Replace(l, " ", "", 2)
 						c := strings.Split(t, " ")
@@ -173,11 +185,19 @@ func CreateMutagenSync(app *DdevApp) error {
 		}()
 	}
 
+	outputComing := false
 	for {
 		select {
 		// Complete when the MutagenSyncFlush() completes
 		case err = <-flushErr:
 			return err
+		case outputComing = <-firstOutputReceived:
+
+		// If we haven't yet received any "Status:" output, do a dot every second
+		case <-time.After(1 * time.Second):
+			if !outputComing {
+				_, _ = fmt.Fprintf(os.Stderr, ".")
+			}
 		}
 	}
 }

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -243,7 +243,7 @@ func (app *DdevApp) MutagenSyncFlush() error {
 		if status != "ok" || err != nil {
 			return err
 		}
-		util.Success("Flushed mutagen sync session '%s'", syncName)
+		util.Debug("Flushed mutagen sync session '%s'", syncName)
 	}
 	return nil
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

- [x] The `mutagen sync monitor` child forked to show mutagen monitor was not being killed and waited, so it zombied
- [x] Use Debug for "flush completed" message so it's not there all the time
- [x] Remove the debug info in test about showing all processes
- [x] Add a timeout for `mutagen sync flush` in case it gets stuck, see https://github.com/mutagen-io/mutagen/issues/287 (can't do, we don't know what the timeout should be)
- [x] Find out what happens after "This can take some time"
- [x] Add some dots before the first output appears
- [x] `ddev mutagen reset` should work when project is stopped
- [x] docs should mention how to get out of trouble if there's a big sync mess (big mv or whatever), use reset
- [x] docs: Consider stopping the project before a major operation like mv of massive branch. 
- [ ] Use a new session name for each start? (or use the automatic session name) (Is this possible?)
- [ ] Consider an option to always destroy the volume?


## How this PR Solves The Problem:

## Manual Testing Instructions:

- [x] Use ps to make sure that no zombies are left around after using `mutagen sync monitor`
- [x] Try flushes in several contexts (start, manual flush, composer install). Should show action with DDEV_DEBUG=true. 
- [x] Verify that the new ... before Status output works in various contexts
- [x] Try `ddev mutagen reset` both when project is running and when stopped and paused

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3176"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

