### PR TITLE
Skip TestGetLocalHTTPResponse on mac m1 - fails always

### DIFF
--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -59,6 +59,11 @@ func IsWSL2() bool {
 	return GetWSLDistro() != ""
 }
 
+// IsMacM1 returns true if running on mac M1
+func IsMacM1() bool {
+	return runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
+}
+
 // GetWSLDistro returns the WSL2 distro name if on Linux
 func GetWSLDistro() string {
 	wslDistro := ""

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -136,8 +136,8 @@ func TestValidTestSite(t *testing.T) {
 
 // TestGetLocalHTTPResponse() brings up a project and hits a URL to get the response
 func TestGetLocalHTTPResponse(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on Windows as we always seem to have port conflicts")
+	if runtime.GOOS == "windows" || nodeps.IsMacM1() {
+		t.Skip("Skipping on Windows/Mac M1 as we always seem to have port conflicts")
 	}
 	// We have to get globalconfig read so CA is known and installed.
 	err := globalconfig.ReadGlobalConfig()


### PR DESCRIPTION
## The Problem/Issue/Bug:

TestGetLocalHTTPResponse is one of the (many) tests that fail perpetually on mac M1, only occasionally succeed. And this one prevents the next set of tests from running, and doesn't have anything special for M1.

Skip it. Let the later tests fail on M1. 

See https://github.com/docker/for-mac/issues/5407

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3177"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

