### PR TITLE
Debian 11 Bullseye released, nginx packages available, go back to nginx 1.20, fixes #3128

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -19,10 +19,9 @@ ENV CAROOT /mnt/ddev-global-cache/mkcert
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-#TODO: When upstream nginx package is ready for bullseye, use it.
-#RUN wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
-#    apt-key add /tmp/nginx_signing.key && \
-#    echo "deb http://nginx.org/packages/debian/ $(lsb_release -sc) nginx" > /etc/apt/sources.list.d/nginx.list
+RUN wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
+    apt-key add /tmp/nginx_signing.key && \
+    echo "deb http://nginx.org/packages/debian/ $(lsb_release -sc) nginx" > /etc/apt/sources.list.d/nginx.list
 
 ADD ddev-webserver-etc-skel /
 RUN /sbin/mkhomedir_helper www-data

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -44,7 +44,7 @@ var MutagenVersionConstraint = nodeps.RequiredMutagenVersion
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210808_PHP_IDE_CONFIG" // Note that this can be overridden by make
+var WebTag = "20210817_nginx_1.20" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3128

Prerelease version of ddev v1.18.0 were using the Debian 11 Bullseye default nginx (1.18) because the official nginx debian packages were not available. Now Bullseye is officially released, and nginx has built official images, so we can go back to nginx 1.20.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3178"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

