### PR TITLE
Add vscode help link for launch.json

### DIFF
--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -106,7 +106,7 @@ An example configuration:
 ### Visual Studio Code (vscode) Debugging Setup
 
 1. Install the [php-debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) extension.
-2. Update the project's launch.json (.vscode/launch.json) to add "Listen for xdebug" (see [config snippet](snippets/launch.json))
+2. Update the project's [launch.json](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) (.vscode/launch.json) to add "Listen for xdebug" (see [config snippet](snippets/launch.json))
 3. Set a breakpoint in your index.php. If it isn't solid red, restart.
 4. In the menu, choose Run->Start Debugging.You may have to select "Listen for XDebug" by the green arrowhead at the top left. The bottom pane of vscode should now be orange (live) and should say "Listen for XDebug".
 5. Enable XDebug with `ddev xdebug on`

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -106,7 +106,7 @@ An example configuration:
 ### Visual Studio Code (vscode) Debugging Setup
 
 1. Install the [php-debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) extension.
-2. Update the project's [launch.json] (in `.vscode/launch.json`)  to add "Listen for xdebug" (see [config snippet](snippets/launch.json)).  For more on launch.json, see [vscode docs]((https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) )
+2. Update the project's [launch.json] (in `.vscode/launch.json`)  to add "Listen for xdebug" (see [config snippet](snippets/launch.json)).  For more on launch.json, see [vscode docs](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) )
 3. Set a breakpoint in your index.php. If it isn't solid red, restart.
 4. In the menu, choose Run->Start Debugging.You may have to select "Listen for XDebug" by the green arrowhead at the top left. The bottom pane of vscode should now be orange (live) and should say "Listen for XDebug".
 5. Enable XDebug with `ddev xdebug on`

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -106,7 +106,7 @@ An example configuration:
 ### Visual Studio Code (vscode) Debugging Setup
 
 1. Install the [php-debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) extension.
-2. Update the project's [launch.json](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) (.vscode/launch.json) to add "Listen for xdebug" (see [config snippet](snippets/launch.json))
+2. Update the project's [launch.json] (in `.vscode/launch.json`)  to add "Listen for xdebug" (see [config snippet](snippets/launch.json)).  For more on launch.json, see [vscode docs]((https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) )
 3. Set a breakpoint in your index.php. If it isn't solid red, restart.
 4. In the menu, choose Run->Start Debugging.You may have to select "Listen for XDebug" by the green arrowhead at the top left. The bottom pane of vscode should now be orange (live) and should say "Listen for XDebug".
 5. Enable XDebug with `ddev xdebug on`


### PR DESCRIPTION
Could be helpful to link to vscode launch help

## The Problem/Issue/Bug:
Docs

## How this PR Solves The Problem:
Doc help

## Manual Testing Instructions:
Read through and click link

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
n/a

## Related Issue Link(s):
n/a

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3180"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

