### PR TITLE
Don't use a full path for source of bind mount, for #3130 (WSL2 PhpStorm integration)

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -539,6 +539,10 @@ func (app *DdevApp) WriteDockerComposeYAML() error {
 	if err != nil {
 		return err
 	}
+	// Replace `docker-compose config`'s full-path usage with relative pathing
+	// for https://youtrack.jetbrains.com/issue/WI-61976 - PhpStorm
+	// This is an ugly an shortsighted approach, but otherwise we'd have to parse the yaml.
+	fullContents = strings.Replace(fullContents, fmt.Sprintf("source: %s\n", app.AppRoot), "source: ../\n", -1)
 	fullHandle, err := os.Create(app.DockerComposeFullRenderedYAMLPath())
 	if err != nil {
 		return err


### PR DESCRIPTION

## The Problem/Issue/Bug:

In studying how to use PhpStorm with full integration in tests in https://github.com/drud/ddev/issues/3130#issuecomment-890608424 

we found that in reality on WSL2 and current PhpStorm you can't have a full path listed as a bind-mount or it confuses PhpStorm, which then can't access the container properly.

See https://youtrack.jetbrains.com/issue/WI-61976

Unfortunately, `docker-compose config`, which we use in the final phase of outputting the docker-compose config, switches everything to rooted paths.

This PR tries to find that one mount and rewrite it as a relative path.


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

