### PR TITLE
Force github actions to use actual merge commit in pr build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           # We need to get all branches and tags for git describe to work properly
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Find out info about how github is getting the hash
       - run: "git describe --tags --always --dirty"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Force github actions pr_build to use the actual hash of the commit, instead of some merge commit that we don't understand.

