### PR TITLE
Minor test cleanups, ignore some conflicts with mutagen on windows

### DIFF
--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -116,8 +116,8 @@ func TestComposerVersion(t *testing.T) {
 		assert.NoError(err)
 		err = os.Chdir(origDir)
 		assert.NoError(err)
-		err = os.RemoveAll(testDir)
-		assert.NoError(err)
+		// Mutagen can compete with removal, so go ahead and ignore result
+		_ = os.RemoveAll(testDir)
 	})
 
 	// Make sure base version (default) is composer v1

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -831,7 +831,7 @@ func TestExtraPackages(t *testing.T) {
 
 	// Start and make sure that the packages don't exist already
 	err = app.Start()
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	// Test db container to make sure no ncdu in there at beginning
 	_, _, err = app.Exec(&ExecOpts{
@@ -855,7 +855,7 @@ func TestExtraPackages(t *testing.T) {
 	app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-" + addedPackage}
 	app.DBImageExtraPackages = []string{"ncdu"}
 	err = app.Start()
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "web",

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2847,8 +2847,7 @@ func TestHttpsRedirection(t *testing.T) {
 		assert.NoError(err)
 		err = os.Chdir(packageDir)
 		assert.NoError(err)
-		err = os.RemoveAll(testDir)
-		assert.NoError(err)
+		_ = os.RemoveAll(testDir)
 	})
 
 	expectations := []URLRedirectExpectations{

--- a/pkg/ddevapp/providerLocalfile_test.go
+++ b/pkg/ddevapp/providerLocalfile_test.go
@@ -43,8 +43,7 @@ func TestLocalfilePull(t *testing.T) {
 		assert.NoError(err)
 
 		_ = os.Chdir(testDir)
-		err = os.RemoveAll(siteDir)
-		assert.NoError(err)
+		_ = os.RemoveAll(siteDir)
 	})
 
 	_, err = exec.Command(DdevBin).CombinedOutput()


### PR DESCRIPTION
## The Problem/Issue/Bug:

Minor test cleanups, ignore some conflicts with mutagen on windows



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3204"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

