### PR TITLE
Add project-name arg to ddev logs, fixes #3203

### DIFF
--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -30,7 +30,7 @@ ddev logs -s db [projectname]`,
 
 		projects, err := getRequestedProjects(args, false)
 		if err != nil {
-			util.Failed("Failed to retrieve logs for project(s): %v", err)
+			util.Failed("GetRequestedProjects() failed:  %v", err)
 		}
 		project := projects[0]
 

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -16,23 +16,29 @@ var (
 
 // DdevLogsCmd contains the "ddev logs" command
 var DdevLogsCmd = &cobra.Command{
-	Use:   "logs",
+	Use:   "logs [projectname]",
 	Short: "Get the logs from your running services.",
 	Long:  `Uses 'docker logs' to display stdout from the running services.`,
 	Example: `ddev logs
 ddev logs -f
-ddev logs -s db`,
+ddev logs -s db
+ddev logs -s db [projectname]`,
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := ddevapp.GetActiveApp("")
-		if err != nil {
-			util.Failed("Failed to retrieve logs: %v", err)
+		if len(args) > 1 {
+			util.Failed("Too many arguments provided. Please use 'ddev logs' or 'ddev logs [projectname]'")
 		}
 
-		if strings.Contains(app.SiteStatus(), ddevapp.SiteStopped) {
+		projects, err := getRequestedProjects(args, false)
+		if err != nil {
+			util.Failed("Failed to retrieve logs for project(s): %v", err)
+		}
+		project := projects[0]
+
+		if strings.Contains(project.SiteStatus(), ddevapp.SiteStopped) {
 			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 
-		err = app.Logs(serviceType, follow, timestamp, tail)
+		err = project.Logs(serviceType, follow, timestamp, tail)
 		if err != nil {
 			util.Failed("Failed to retrieve logs for %s: %v", app.GetName(), err)
 		}

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -40,7 +40,7 @@ ddev logs -s db [projectname]`,
 
 		err = project.Logs(serviceType, follow, timestamp, tail)
 		if err != nil {
-			util.Failed("Failed to retrieve logs for %s: %v", app.GetName(), err)
+			util.Failed("Failed to retrieve logs for %s: %v", project.GetName(), err)
 		}
 	},
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

The logs command doesn't support `project-name` passed as an argument.

## How this PR Solves The Problem:

Tries to add support for `[project-name]` passed to the logs command.

## Related Issue Link(s):

https://github.com/drud/ddev/issues/3203

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3206"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

