### PR TITLE
Update acquia.yaml.example

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
@@ -21,7 +21,7 @@
 # 9. Use `ddev pull acquia` to pull the project database and files.
 # 10. Optionally use `ddev push acquia` to push local files and database to Aquia. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
-# Debugging: Use `ddev exec acli command` and `ddev exec acli auth:info`
+# Debugging: Use `ddev exec acli command` and `ddev exec acli auth:login`
 # Make sure you remembered to `ddev auth ssh`
 
 environment_variables:
@@ -35,6 +35,8 @@ auth_command:
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     acli auth:login -n --key="${ACQUIA_API_KEY}" --secret="${ACQUIA_API_SECRET}"
     acli remote:aliases:download -n >/dev/null
+    drush core:init -y   # make aliases available to Drush
+    source ~/.bashrc
 
 db_pull_command:
   command: |
@@ -42,8 +44,7 @@ db_pull_command:
     set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null
-    acli remote:drush -n ${project_id} -- sql-dump --extra-dump=--no-tablespaces >db.sql
-    gzip db.sql
+    drush @${project_id} sql-dump -n --extra-dump=--no-tablespaces --gzip >db.sql.gz
 
 files_pull_command:
   command: |
@@ -51,7 +52,7 @@ files_pull_command:
     set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
-    drush -r docroot rsync --alias-path=~/.drush -q -y @${project_id}:%files ./files
+    drush -r docroot rsync --exclude-paths='styles:css:js' --alias-path=~/.drush -q -y @${project_id}:%files ./files
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 db_push_command:

--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
@@ -35,8 +35,6 @@ auth_command:
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     acli auth:login -n --key="${ACQUIA_API_KEY}" --secret="${ACQUIA_API_SECRET}"
     acli remote:aliases:download -n >/dev/null
-    drush core:init -y   # make aliases available to Drush
-    source ~/.bashrc
 
 db_pull_command:
   command: |
@@ -44,7 +42,7 @@ db_pull_command:
     set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null
-    drush @${project_id} sql-dump -n --extra-dump=--no-tablespaces --gzip >db.sql.gz
+    drush @${project_id} sql-dump -n --alias-path=~/.drush --extra-dump=--no-tablespaces --gzip >db.sql.gz
 
 files_pull_command:
   command: |


### PR DESCRIPTION
We noticed the ddev pull acquia was significantly slower than a direct ddev blt drupal:sync, but drupal:sync started failing.  Two suggested optimizations:
1.  In the db pull, we switched from acli remote:drush to the local drush (using it for the files pull), which allows using the --gzip option and downloads directly into db.sql.gz.  On our relatively large DB (about 300 mb) this change reduced the time from about 23 minutes to 15 minutes (using Linux time command)
2.  In the files_pull, we added an --exclude-paths='styles:css:js' to not bother with what are usually Drupal's aggregation temporaries.  We actually added a project specific directory with PDFs to reduce transfer size.  This change reduce the time from about 66 minutes to 43 minutes (there are A LOT of files in the project).  A better optimization would be to not copy the files into the .ddev/.downloads directory then have ddev copy it into the Drupal site directory, but instead do a direct rsync to the Drupal site directory which would avoid a lot of files being copied after the first time but that would require changes to the Golang.....  When we tested that option outside of the pull the rsync time went down to 15 minutes.

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3209"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

