### PR TITLE
Document how to restore DDEV management to a file

### DIFF
--- a/docs/users/topics/cms_specific_help.md
+++ b/docs/users/topics/cms_specific_help.md
@@ -11,3 +11,20 @@
 ### Running any PHP App with DDEV
 
 Nearly any PHP app will run fine with DDEV, and lots of others. If your project type is not one of the explicitly supported project types, that's fine. Just set the project type to 'php' and go about setting up settings files or .env as you normally would.
+
+### DDEV-managed Files
+
+These files created by DDEV are also updated and managed by DDEV by default.  If this is changed, you will receive the message "settings.ddev.php already exists and is managed by the user."
+
+If you wish to return it to being managed by DDEV, you can restore DDEV management by adding `#ddev-generated` in a comment at the top of the file, like so:
+
+```php
+<?php
+
+/**
+ * @file
+ * #ddev-generated: Automatically generated Drupal settings file.
+ * ddev manages this file and may delete or overwrite the file unless this
+ * comment is removed.  It is recommended that you leave this file alone.
+ */
+```


### PR DESCRIPTION
## The Problem/Issue/Bug:

DDEV warns you when a file is not managed by it anymore but does not indicate how to restore management, with the exception of a closed issue https://github.com/drud/ddev/issues/468 indicating how to take a file *out* of DDEV management.

## How this PR Solves The Problem:

Adds documentation (so searching for the message will bring you to a documentation page) but does *not*, as yet, add a link in the `ddev start` messages.

## Manual Testing Instructions:

N/A documentation only.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

N/A documentation only.

## Related Issue Link(s):

https://github.com/drud/ddev/issues/468

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3213"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

