### PR TITLE
Terminate mutagen if container not running or sync not working

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -15,7 +15,6 @@ echo "buildkite building ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) as USER
 export GOTEST_SHORT=1
 export DDEV_NONINTERACTIVE=true
 export DDEV_DEBUG=true
-export DDEV_VERBOSE=true
 
 set -o errexit
 set -o pipefail

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -14,6 +14,8 @@ echo "buildkite building ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) as USER
 
 export GOTEST_SHORT=1
 export DDEV_NONINTERACTIVE=true
+export DDEV_DEBUG=true
+export DDEV_VERBOSE=true
 
 set -o errexit
 set -o pipefail

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -66,7 +66,7 @@ func TestComposer(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 
-	_, _, err = app.Composer([]string{"install"})
+	_, _, err = app.Composer([]string{"install", "--no-progress", "--no-interaction"})
 	assert.NoError(err)
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1003,6 +1003,7 @@ func (app *DdevApp) Start() error {
 			util.Failed("Mutagen docker volume is not mounted. Please use `ddev restart`")
 		}
 		output.UserOut.Printf("Starting mutagen sync process... This can take some time.")
+		mutagenDuration := util.ElapsedDuration(time.Now())
 		err = app.GenerateMutagenYml()
 		if err != nil {
 			return err
@@ -1011,7 +1012,6 @@ func (app *DdevApp) Start() error {
 		if err != nil {
 			return err
 		}
-		mutagenDuration := util.ElapsedDuration(time.Now())
 		err = CreateMutagenSync(app)
 		if err != nil {
 			return errors.Errorf("Failed to create mutagen sync session %s. You may be able to resolve this problem with 'ddev stop %s && docker volume rm %s' (err=%v)", MutagenSyncName(app.Name), app.Name, GetMutagenVolumeName(app), err)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -315,12 +315,20 @@ func DownloadMutagen() error {
 	if runtime.GOOS == "darwin" {
 		mutagenURL = fmt.Sprintf("https://github.com/drud/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", nodeps.RequiredMutagenVersion, flavor, nodeps.RequiredMutagenVersion)
 	}
-	output.UserOut.Printf("Downloading %s", mutagenURL)
+	output.UserOut.Printf("Downloading %s ...", mutagenURL)
+
+	// Remove the existing file. This may help on macOS to prevent the Gatekeeper's
+	// caching bug from confusing with a previously downloaded file?
+	// Discussion in https://github.com/mutagen-io/mutagen/issues/290#issuecomment-906612749
+	_ = os.Remove(destFile)
+
 	_ = os.MkdirAll(globalMutagenDir, 0777)
-	err := util.DownloadFile(destFile, mutagenURL, true)
+	err := util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"))
 	if err != nil {
 		return err
 	}
+	output.UserOut.Printf("Download complete.")
+
 	err = archive.Untar(destFile, globalMutagenDir, "")
 	_ = os.Remove(destFile)
 	if err != nil {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -320,7 +320,7 @@ func DownloadMutagen() error {
 	// Remove the existing file. This may help on macOS to prevent the Gatekeeper's
 	// caching bug from confusing with a previously downloaded file?
 	// Discussion in https://github.com/mutagen-io/mutagen/issues/290#issuecomment-906612749
-	_ = os.Remove(destFile)
+	_ = os.Remove(globalconfig.GetMutagenPath())
 
 	_ = os.MkdirAll(globalMutagenDir, 0777)
 	err := util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"))

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -73,7 +73,7 @@ func TestMutagenSimple(t *testing.T) {
 	assert.Contains(stderr, "cannot access '/var/www/html/vendor'")
 
 	// Now composer install again and make sure all the stuff comes back
-	stdout, stderr, err := app.Composer([]string{"install"})
+	stdout, stderr, err := app.Composer([]string{"install", "--no-progress", "--no-interaction"})
 	assert.NoError(err)
 	t.Logf("composer install output: \nstdout: %s\n\nstderr: %s\n", stdout, stderr)
 	_, _, err = app.Exec(&ddevapp.ExecOpts{

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -30,6 +30,8 @@ func testMain(m *testing.M) int {
 
 	EnsureDdevNetwork()
 
+	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")
+
 	// prep docker container for docker util tests
 	client := GetDockerClient()
 	imageExists, err := ImageExistsLocally(version.WebImg + ":" + version.WebTag)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -194,7 +194,7 @@ func GetLiveMutagenVersion() (string, error) {
 	mutagenPath := globalconfig.GetMutagenPath()
 
 	if !fileutil.FileExists(mutagenPath) {
-		MutagenVersion = "not yet downloaded, will be automatically downloaded when needed"
+		MutagenVersion = ""
 		return MutagenVersion, nil
 	}
 	out, err := exec.Command(mutagenPath, "version").Output()


### PR DESCRIPTION
## The Problem/Issue/Bug:

There is a path where mutagen can hang forever... if you try to flush it and the container is already stopped or inaccessible (like after `ddev pause` or after docker restart.

## How this PR Solves The Problem:

* Check to see if mutagen session is connected before trying to flush it. If it's not connected, just terminate it.
* Prevent downloading mutagen multiple times in tests. This seems to have been an issue only on Windows?
* `composer install` in tests with `--no-progress`
* Don't show mutagen download progress bar in tests

## TODO
- [x] See if we can explicitly kill a running mutagen on Windows... or if we need to. I saw in tests a situation where daemon stop did not seem to work out.

## Manual Testing Instructions:

- [x] Setup: Configure a project with mutagen and start it. Then stop the web container or restart Docker. `docker stop -f ddev-<project>-web`. Then
    - [x] `ddev start` to make sure behavior is correct (it should recover and start and start a new mutagen session)
    - [x] `ddev poweroff` (after setup again), make sure it works successfully and there aren't any lingering mutagen sync sessions afterward (`ddev debug mutagen sync list`)
- [x] Verify that the multiple downloads in tests have ceased.
- [x] Verify that composer output has been lessened in tests but works normally with `ddev composer install`
- [x] Verify that the mutagen download progress bar does not show in TestMutagenSimple
- [x] Review the logic change here and make sure it's correct, consider timeout on start if it's not working, consider adding more reporting of mutagen status
- [x] Verify that mutagen/releases only gets downloaded once in a test session.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3220"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

