### PR TITLE
Make more robust and flexible options for how importing works in `ddev pull`

### DIFF
--- a/docs/users/providers/provider-introduction.md
+++ b/docs/users/providers/provider-introduction.md
@@ -15,8 +15,10 @@ Each provider recipe is a yaml file that can be named any way you want to name i
 Each provider recipe is a file named `<provider>.yaml` and consists of several mostly-optional stanzas:
 
 * `environment_variables`: Environment variables will be created in the web container for each of these during pull or push operations. They're used to provide context (project id, environment name, etc.) for each of the other stanzas.
-* `db_pull_command`: A script that determines how ddev should pull a database. It's job is to create a gzipped database dump in /var/www/html/.ddev/.downloads/db.sql.gz.
-* `files_pull_command`: A script that determines how ddev can get user-generated files from upstream. Its job is to copy the files from upstream to  /var/www/html/.ddev/.downloads/files.
+* `db_pull_command`: A script that determines how ddev should pull a database.
+   If `skip_import` (boolean, default `false`) is `true`, the command handles downloading and inserting data into the project. Else, its job is to create a gzipped database dump in /var/www/html/.ddev/.downloads/db.sql.gz.
+* `files_pull_command`: A script that determines how ddev can get user-generated files from upstream.
+   If `skip_import` (boolean, default `false`) is `true`, the command handles downloading and inserting data into the project. Else, its job is to copy the files from upstream to  /var/www/html/.ddev/.downloads/files.
 * `db_push_command`: A script that determines how ddev should push a database. It's job is to take a  gzipped database dump from /var/www/html/.ddev/.downloads/db.sql.gz and load it on the hosting provider.
 * `files_push_command`: A script that determines how ddev push user-generated files to upstream. Its job is to copy the files from the project's user-files directory ($DDEV_FILES_DIR) to the correct place on the upstream provider.
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -15,11 +15,13 @@ import (
 
 // ProviderCommand defines the shell command to be run for one of the commands (db pull, etc.)
 type ProviderCommand struct {
-	Command string `yaml:"command"`
-	Service string `yaml:"service,omitempty"`
+	Command    string `yaml:"command"`
+	Service    string `yaml:"service,omitempty"`
+	SkipImport bool   `yaml:"skip_import"`
 }
 
 // ProviderInfo defines the provider
+// @todo: CodePullCommand unused
 type ProviderInfo struct {
 	EnvironmentVariables map[string]string `yaml:"environment_variables"`
 	AuthCommand          ProviderCommand   `yaml:"auth_command"`
@@ -91,11 +93,10 @@ func (app *DdevApp) Pull(provider *Provider, skipDbArg bool, skipFilesArg bool, 
 			return err
 		}
 
-		output.UserOut.Printf("Database downloaded to: %s", fileLocation)
-
-		if skipImportArg {
-			output.UserOut.Println("Skipping database import.")
+		if skipImportArg || provider.DBPullCommand.SkipImport {
+			output.UserOut.Println("Skipping default database import.")
 		} else {
+			output.UserOut.Printf("Database downloaded to: %s", fileLocation)
 			output.UserOut.Println("Importing database...")
 			err = app.ImportDB(fileLocation, importPath, true, false, "db")
 			if err != nil {
@@ -118,11 +119,10 @@ func (app *DdevApp) Pull(provider *Provider, skipDbArg bool, skipFilesArg bool, 
 			return err
 		}
 
-		output.UserOut.Printf("Files downloaded to: %s", fileLocation)
-
-		if skipImportArg {
-			output.UserOut.Println("Skipping files import.")
+		if skipImportArg || provider.FilesPullCommand.SkipImport {
+			output.UserOut.Println("Skipping default file locations import.")
 		} else {
+			output.UserOut.Printf("Files downloaded to: %s", fileLocation)
 			output.UserOut.Println("Importing files...")
 			err = app.ImportFiles(fileLocation, importPath)
 			if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:
Previously it was not possible to disable automatic imports by configuration.

## How this PR Solves The Problem:
This adds a <provider>.yaml option `skip_import` (bool).
When `false` (default), "ddev pull" automatically imports downloaded artefacts
from `.ddev/.downloads/`.
When `true`, "ddev pull" will not act upon artefacts. In that case it is the
command's responsibility to take all necessary steps to make them available
in the ddev environment.

Setting this for both `files_pull_command` and `db_pull_command` is functionally
equivalent to using "ddev pull ... --skip-import".

This also changes when the message "... downloaded to: ..." is shown:
If either the command line argument "--skip-import" has been given or any of the
newly introduced <provider>.yaml options are set, the message is not shown.

## Manual Testing Instructions:
```
cat > .ddev/providers/test.yaml <<EOF
db_pull_command:
  command: |
    echo | gzip > /var/www/html/.ddev/.downloads/db.sql.gz
    echo "[db with default] After this message is shown, ddev will output 'Database downloaded to: ...' and 'Importing database...'"

files_pull_command:
  skip_import: true
  command: |
    echo "[files with skip_import:true] After this message is shown, ddev will output 'Skipping default file locations import.'"EOF
EOF

ddev pull test -y
```

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Sorry, none so far. 

## Related Issue Link(s):
#3216

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
none


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3223"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

