### PR TITLE
Bump required mutagen version to v0.12.0-beta12 and move RequiredMutagenVersion to version.go

### DIFF
--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -9,7 +9,6 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -307,13 +306,13 @@ func DownloadMutagen() error {
 	flavor := runtime.GOOS + "_" + runtime.GOARCH
 	globalMutagenDir := filepath.Dir(globalconfig.GetMutagenPath())
 	destFile := filepath.Join(globalMutagenDir, "mutagen.tgz")
-	mutagenURL := fmt.Sprintf("https://github.com/mutagen-io/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", nodeps.RequiredMutagenVersion, flavor, nodeps.RequiredMutagenVersion)
+	mutagenURL := fmt.Sprintf("https://github.com/mutagen-io/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", version.RequiredMutagenVersion, flavor, version.RequiredMutagenVersion)
 	// Temporary workaround to get signed/notarized binaries for macOS.
 	// See https://github.com/drud/mutagen/releases/tag/v0.12.0-beta5 and
 	// https://github.com/mutagen-io/mutagen/issues/290
 	// TODO: Remove this when mutagen has signed releases
 	if runtime.GOOS == "darwin" {
-		mutagenURL = fmt.Sprintf("https://github.com/drud/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", nodeps.RequiredMutagenVersion, flavor, nodeps.RequiredMutagenVersion)
+		mutagenURL = fmt.Sprintf("https://github.com/drud/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", version.RequiredMutagenVersion, flavor, version.RequiredMutagenVersion)
 	}
 	output.UserOut.Printf("Downloading %s ...", mutagenURL)
 
@@ -363,7 +362,7 @@ func DownloadMutagenIfNeeded(app *DdevApp) error {
 		return nil
 	}
 	curVersion, err := version.GetLiveMutagenVersion()
-	if err != nil || curVersion != nodeps.RequiredMutagenVersion {
+	if err != nil || curVersion != version.RequiredMutagenVersion {
 		err = DownloadMutagen()
 		if err != nil {
 			return err

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -92,8 +92,8 @@ const (
 	// DdevDefaultTLD is the top-level-domain used by default, can be overridden
 	DdevDefaultTLD                  = "ddev.site"
 	InternetDetectionTimeoutDefault = 750
-	RequiredMutagenVersion          = "0.12.0-beta5"
-	MinimumDockerSpaceWarning       = 15
+
+	MinimumDockerSpaceWarning = 15
 )
 
 // IsValidPHPVersion is a helper function to determine if a PHP version is valid, returning

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -76,8 +76,10 @@ var DockerVersion = ""
 // DockerComposeVersion is filled with the version we find for docker-compose
 var DockerComposeVersion = ""
 
-// MutagenVersion is filled with the version we find for mutagen
+// MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
+
+const RequiredMutagenVersion = "0.12.0-beta6"
 
 // GetVersionInfo returns a map containing the version info defined above.
 func GetVersionInfo() map[string]string {
@@ -99,7 +101,7 @@ func GetVersionInfo() map[string]string {
 	if versionInfo["docker-compose"], err = GetDockerComposeVersion(); err != nil {
 		versionInfo["docker-compose"] = fmt.Sprintf("failed to GetDockerComposeVersion(): %v", err)
 	}
-	versionInfo["mutagen"] = nodeps.RequiredMutagenVersion
+	versionInfo["mutagen"] = RequiredMutagenVersion
 
 	if runtime.GOOS == "windows" {
 		versionInfo["docker type"] = "Docker Desktop For Windows"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Mutagen version v0.12.0-beta12 is out, with special accommodations for ddev (Not trying to sync if it's impossible)

## Manual testing

- [x] Use the same tests as in https://github.com/drud/ddev/pull/3220 - set up situation where beta is gone or inaccessible and see what the behavior is.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3224"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

