### PR TITLE
Improve the command-overriding-global-command warning, fixes #3074

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -38,7 +38,11 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	projectCommandPath := app.GetConfigPath("commands")
 	// Make sure our target global command directory is empty
 	targetGlobalCommandPath := app.GetConfigPath(".global_commands")
-	_ = os.RemoveAll(targetGlobalCommandPath)
+	err = os.RemoveAll(targetGlobalCommandPath)
+	if err != nil {
+		util.Error("Unable to remove %s: %v", targetGlobalCommandPath, err)
+		return nil
+	}
 
 	err = fileutil.CopyDir(sourceGlobalCommandPath, targetGlobalCommandPath)
 	if err != nil {

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -86,7 +86,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 
 				// If command has already been added, we won't work with it again.
 				if _, ok := commandsAdded[commandName]; ok {
-					util.Warning("not adding command %s (%s) because it was already added to project %s", commandName, onHostFullPath, app.Name)
+					util.Warning("Project-level command '%s' is overriding the global '%s' command", commandName, commandName)
 					continue
 				}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3074

The error message is really misleading because it calls out project-level .ddev/.global-...

## How this PR Solves The Problem:

Improves the error message to say that project-level command is overriding the other one.

## Manual Testing Instructions:

- [x] Add a project-level override command (for example, copy ~/.ddev/commands/web/xhprof into .ddev/commands/web/xhprof). Remove the #ddev-generated. `ddev start`. Verify new warning message.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3227"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

