### PR TITLE
Bump mutagen to 0.12.0-beta7

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -79,7 +79,7 @@ var DockerComposeVersion = ""
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.12.0-beta6"
+const RequiredMutagenVersion = "0.12.0-beta7"
 
 // GetVersionInfo returns a map containing the version info defined above.
 func GetVersionInfo() map[string]string {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Mutagen v0.12.0-beta7 was released, which mostly affects performance on arm64.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3228"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

