### PR TITLE
Colors for warning and error and fail were lost, fixes #3233

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -28,6 +28,7 @@ func init() {
 
 // Failed will print a red error message and exit with failure.
 func Failed(format string, a ...interface{}) {
+	format = ColorizeText(format, "red")
 	if a != nil {
 		//output.UserOut.Fatalf(format, a...)
 		output.UserErr.Fatalf(format, a...)
@@ -40,6 +41,7 @@ func Failed(format string, a ...interface{}) {
 
 // Error will print a red error message but will not exit.
 func Error(format string, a ...interface{}) {
+	format = ColorizeText(format, "red")
 	if a != nil {
 		output.UserErr.Errorf(format, a...)
 	} else {
@@ -49,6 +51,7 @@ func Error(format string, a ...interface{}) {
 
 // Warning will present the user with warning text.
 func Warning(format string, a ...interface{}) {
+	format = ColorizeText(format, "yellow")
 	if a != nil {
 		output.UserErr.Warnf(format, a...)
 	} else {


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3233

It seems that the upstream coloring for Output.UserOut got lost, but it had been added back for util.Success. This adds it for util.Fail() and util.Error() and util.Warn

Not entirely sure why the upstream technique doesn't work any more. 

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3234"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

