### PR TITLE
pin jsmin to PR #34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ GitPython==3.1.14
 htmlmin==0.1.12
 Jinja2==2.11.3
 joblib==1.0.1
-jsmin==2.2.2
+git+https://github.com/serenecloud/jsmin@6467320#egg=jsmin
 livereload==2.6.3
 lunr==0.5.8
 Markdown==3.3.4


### PR DESCRIPTION
Fixes #3232

Fixes breaking readthedocs builds due to removal of Python 2 support in setuptools 58.

PR: https://github.com/tikitu/jsmin/pull/34


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3235"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

