### PR TITLE
Exclude .DS_Store from mutagen syncing

### DIFF
--- a/pkg/ddevapp/mutagen_config_assets/mutagen.yml
+++ b/pkg/ddevapp/mutagen_config_assets/mutagen.yml
@@ -17,6 +17,7 @@ sync:
       - "/.tarballs"
       - "/.ddev/db_snapshots"
       - "/.ddev/.importdb*"
+      - ".DS_Store"
       # For example /var/www/html/var does not need to sync in TYPO3
       # - "/var"
       # vcs like .git can be ignored for safety, but then some


### PR DESCRIPTION
## The Problem/Issue/Bug:

.DS_Store is a macOS-only side file that should never be synced into the container.

Exclude it in mutagen.yml.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3236"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

