### PR TITLE
Fix `ddev pull` with mutagen enabled, fixes #3237

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ jobs:
           - /home/linuxbrew
     - run: echo "$(docker --version) $(docker-compose --version)"
     - run:
+        name: ddev tests - TestPull and TetsDdevFullSiteSetup
         command: make -s testpkg TESTARGS='-run "(TestDdevFullSite.*|Test.*Pull)"' EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
-        name: ddev tests
         no_output_timeout: "40m"
     - store_test_results:
         path: /tmp/testresults
@@ -85,6 +85,7 @@ jobs:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
       DDEV_NONINTERACTIVE: "true"
       GOTEST_SHORT: "true"
+      DDEV_TEST_USE_MUTAGEN: "true"
     steps:
       - checkout
       - run:

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -257,12 +257,7 @@ func (app *DdevApp) PostStartAction() error {
 // ImportFilesAction executes the relevant import files workflow for each app type.
 func (app *DdevApp) ImportFilesAction(importPath, extPath string) error {
 	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.importFilesAction != nil {
-		err := appFuncs.importFilesAction(app, importPath, extPath)
-		if err != nil {
-			return err
-		}
-		err = app.MutagenSyncFlush()
-		return err
+		return appFuncs.importFilesAction(app, importPath, extPath)
 	}
 
 	return fmt.Errorf("this project type (%s) does not support import-files", app.Type)

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -257,7 +257,13 @@ func (app *DdevApp) PostStartAction() error {
 // ImportFilesAction executes the relevant import files workflow for each app type.
 func (app *DdevApp) ImportFilesAction(importPath, extPath string) error {
 	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.importFilesAction != nil {
-		return appFuncs.importFilesAction(app, importPath, extPath)
+		err := appFuncs.importFilesAction(app, importPath, extPath)
+		if err != nil {
+			return err
+		} else {
+			err = app.MutagenSyncFlush()
+			return err
+		}
 	}
 
 	return fmt.Errorf("this project type (%s) does not support import-files", app.Type)

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -260,10 +260,9 @@ func (app *DdevApp) ImportFilesAction(importPath, extPath string) error {
 		err := appFuncs.importFilesAction(app, importPath, extPath)
 		if err != nil {
 			return err
-		} else {
-			err = app.MutagenSyncFlush()
-			return err
 		}
+		err = app.MutagenSyncFlush()
+		return err
 	}
 
 	return fmt.Errorf("this project type (%s) does not support import-files", app.Type)

--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
@@ -29,6 +29,7 @@ environment_variables:
 
 auth_command:
   command: |
+    set -eu -o pipefail
     if [ -z "${ACQUIA_API_KEY:-}" ] || [ -z "${ACQUIA_API_SECRET:-}" ]; then echo "Please make sure you have set ACQUIA_API_KEY and ACQUIA_API_SECRET in ~/.ddev/global_config.yaml" && exit 1; fi
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
@@ -38,6 +39,7 @@ auth_command:
 db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null
     acli remote:drush -n ${project_id} -- sql-dump --extra-dump=--no-tablespaces >db.sql
@@ -46,6 +48,7 @@ db_pull_command:
 files_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
     drush -r docroot rsync --alias-path=~/.drush -q -y @${project_id}:%files ./files
@@ -54,6 +57,7 @@ files_pull_command:
 db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
     acli remote:drush -n ${project_id} -- sql-drop -y
@@ -64,5 +68,6 @@ db_push_command:
 files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
     drush rsync -y --alias-path=~/.drush @self:%files @${project_id}:%files

--- a/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example
@@ -16,9 +16,13 @@ environment_variables:
   PROJECT_ROOT: /full/path/to/project/root
 
 db_pull_command:
-  command: cp ~/Dropbox/db.sql.gz ${PROJECT_ROOT}/.ddev/.downloads
+  command: |
+    set -eu -o pipefail
+    cp ~/Dropbox/db.sql.gz ${PROJECT_ROOT}/.ddev/.downloads
   service: host
 
 files_pull_command:
-  command: tar -zxf ~/Dropbox/files.tar.gz -C ${PROJECT_ROOT}/.ddev/.downloads/files
+  command: |
+    set -eu -o pipefail
+    tar -zxf ~/Dropbox/files.tar.gz -C ${PROJECT_ROOT}/.ddev/.downloads/files
   service: host

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -43,6 +43,7 @@ environment_variables:
 
 auth_command:
   command: |
+    set -eu -o pipefail
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     if [ -z "${TERMINUS_MACHINE_TOKEN:-}" ]; then echo "Please make sure you have set TERMINUS_MACHINE_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
@@ -52,6 +53,7 @@ auth_command:
 db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null
     terminus backup:get ${project} --element=db --to=db.sql.gz
@@ -59,6 +61,7 @@ db_pull_command:
 files_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
     terminus backup:get ${project} --element=files --to=files.tgz
@@ -68,6 +71,7 @@ files_pull_command:
 db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
     terminus remote:drush ${project} -- sql-drop -y
@@ -77,5 +81,6 @@ db_push_command:
 files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
     drush rsync -y @self:%files @${project}:%files

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml.example
@@ -26,17 +26,20 @@ environment_variables:
 
 auth_command:
   command: |
+    set -eu -o pipefail
     if [ -z "${PLATFORMSH_CLI_TOKEN:-}" ]; then echo "Please make sure you have set PLATFORMSH_CLI_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
 
 db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     platform db:dump --yes --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${project_id}" --environment="${environment}"
 
 files_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     platform mount:download --yes --quiet --project="${project_id}" --environment="${environment}" --mount=web/sites/default/files --target=/var/www/html/.ddev/.downloads/files
 
@@ -45,6 +48,7 @@ files_pull_command:
 db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
     gzip -dc db.sql.gz | platform db:sql --project="${project_id}" --environment="${environment}"
@@ -53,5 +57,6 @@ db_push_command:
 files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls "${DDEV_FILES_DIR}" >/dev/null # This just refreshes stale NFS if possible
     platform mount:upload --yes --quiet --project="${project_id}" --environment="${environment}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files

--- a/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example
@@ -24,17 +24,20 @@ environment_variables:
 
 auth_command:
   command: |
+    set -eu -o pipefail
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
 
 db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     rsync -az "${dburl}" /var/www/html/.ddev/.downloads
   service: web
 
 files_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null
     rm -f files.tar.gz
@@ -49,6 +52,7 @@ files_pull_command:
 db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     mysqldump db | gzip >/var/www/html/.ddev/.downloads/db_push.sql.gz
     rsync -avz /var/www/html/.ddev/.downloads/db_push.sql.gz "${dburl}"
@@ -56,4 +60,5 @@ db_push_command:
 files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
     rsync -az "${DDEV_FILES_DIR}/" "${filesurl}/"

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -96,6 +96,10 @@ func (app *DdevApp) Pull(provider *Provider, skipDbArg bool, skipFilesArg bool, 
 		if skipImportArg {
 			output.UserOut.Println("Skipping database import.")
 		} else {
+			err = app.MutagenSyncFlush()
+			if err != nil {
+				return err
+			}
 			output.UserOut.Println("Importing database...")
 			err = app.ImportDB(fileLocation, importPath, true, false, "db")
 			if err != nil {
@@ -318,7 +322,11 @@ func (p *Provider) getDatabaseBackup() (filename string, error error) {
 	if s == "" {
 		s = "web"
 	}
-	err := p.app.ExecOnHostOrService(s, p.injectedEnvironment()+"; "+p.DBPullCommand.Command)
+	err := p.app.MutagenSyncFlush()
+	if err != nil {
+		return "", err
+	}
+	err = p.app.ExecOnHostOrService(s, p.injectedEnvironment()+"; "+p.DBPullCommand.Command)
 	if err != nil {
 		return "", fmt.Errorf("Failed to exec %s on %s: %v", p.DBPullCommand.Command, s, err)
 	}

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -241,6 +241,10 @@ func (p *Provider) UploadDB() error {
 	if err != nil {
 		return err
 	}
+	err = p.app.MutagenSyncFlush()
+	if err != nil {
+		return err
+	}
 
 	s := p.DBPushCommand.Service
 	if s == "" {

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -269,5 +269,8 @@ func isPullSiteValid(siteURL string, siteExpectation string) bool {
 		return false
 	}
 	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
 	return strings.Contains(string(body), siteExpectation)
 }

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -75,7 +75,6 @@ func TestAcquiaPull(t *testing.T) {
 
 	app.Name = t.Name()
 	app.Type = nodeps.AppTypeDrupal9
-	app.ComposerVersion = "2"
 
 	_ = app.Stop(true, false)
 	err = app.WriteConfig()
@@ -100,6 +99,8 @@ func TestAcquiaPull(t *testing.T) {
 	err = os.WriteFile(app.GetConfigPath("providers/acquia.yaml"), []byte(x), 0666)
 	assert.NoError(err)
 	err = app.WriteConfig()
+	require.NoError(t, err)
+	err = app.MutagenSyncFlush()
 	require.NoError(t, err)
 
 	provider, err := app.GetProvider("acquia")

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -25,6 +25,8 @@ import (
  */
 
 const pantheonTestSiteID = "ddev-test-site-do-not-delete.dev"
+const pantheonSiteURL = "https://dev-ddev-test-site-do-not-delete.pantheonsite.io/"
+const pantheonSiteExpectation = "DDEV DRUPAL8 TEST SITE"
 
 // TestPantheonPull ensures we can pull from pantheon.
 func TestPantheonPull(t *testing.T) {
@@ -41,6 +43,8 @@ func TestPantheonPull(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
+
+	require.True(t, isPullSiteValid(pantheonSiteURL, pantheonSiteExpectation), "pantheonSiteURL %s isn't working right", pantheonSiteURL)
 
 	webEnvSave := globalconfig.DdevGlobalConfig.WebEnvironment
 	globalconfig.DdevGlobalConfig.WebEnvironment = []string{"TERMINUS_MACHINE_TOKEN=" + token}
@@ -137,6 +141,8 @@ func TestPantheonPush(t *testing.T) {
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
+
+	require.True(t, isPullSiteValid(pantheonSiteURL, pantheonSiteExpectation), "pantheonSiteURL %s isn't working right", pantheonSiteURL)
 
 	webEnvSave := globalconfig.DdevGlobalConfig.WebEnvironment
 	globalconfig.DdevGlobalConfig.WebEnvironment = []string{"TERMINUS_MACHINE_TOKEN=" + token}

--- a/pkg/ddevapp/providerPlatform_test.go
+++ b/pkg/ddevapp/providerPlatform_test.go
@@ -29,6 +29,9 @@ import (
 var platformTestSiteID = "lago3j23xu2w6"
 var platformTestSiteEnvironment = "master"
 
+const platformSiteURL = "https://master-7rqtwti-lago3j23xu2w6.eu-3.platformsh.site/"
+const platformSiteExpectation = "Super easy vegetarian pasta"
+
 // TestPlatformPull ensures we can pull backups from platform.sh for a configured environment.
 func TestPlatformPull(t *testing.T) {
 	var token string
@@ -37,6 +40,8 @@ func TestPlatformPull(t *testing.T) {
 	}
 	assert := asrt.New(t)
 	var err error
+
+	require.True(t, isPullSiteValid(platformSiteURL, platformSiteExpectation), "platformSiteURL %s isn't working right", platformSiteURL)
 
 	webEnvSave := globalconfig.DdevGlobalConfig.WebEnvironment
 
@@ -108,6 +113,8 @@ func TestPlatformPush(t *testing.T) {
 
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
+
+	require.True(t, isPullSiteValid(platformSiteURL, platformSiteExpectation), "platformSiteURL %s isn't working right", platformSiteURL)
 
 	webEnvSave := globalconfig.DdevGlobalConfig.WebEnvironment
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3237


## How this PR Solves The Problem:

* Make sure mutagen gets synced after db is downloaded
* Make sure there's test coverage (CircleCI) for pull with mutagen

## Manual Testing Instructions:

- [x] Manually use `ddev pull`
- [x] Manually use `ddev push`
- [ ] Make sure TestAcquiaPull and TestAcquiaPush work with mutagen enabled

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3238"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

