### PR TITLE
Ensure monitoring is accessible also with basic authentication

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/monitoring.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/monitoring.conf
@@ -1,5 +1,6 @@
     ## provide a health check endpoint
     location /healthcheck {
+        auth_basic off;
         access_log off;
         stub_status     on;
         keepalive_timeout 0;    # Disable HTTP keepalive
@@ -7,6 +8,7 @@
     }
 
     location ~ ^/phpstatus$ {
+        auth_basic off;
         access_log off;
         stub_status     on;
         keepalive_timeout 0;    # Disable HTTP keepalive

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
@@ -8,3 +8,4 @@ stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 exitcodes=0,1
+startsecs=0 # See https://github.com/Supervisor/supervisor/issues/212#issuecomment-47933372

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
@@ -1,11 +1,14 @@
 [program:apache2]
 stopwaitsecs = 20
 startretries=10
-stopsignal = WINCH
-command=/usr/sbin/apache2ctl -k restart -D "FOREGROUND"
+stopsignal = TERM
+command=/usr/sbin/apache2ctl -D "FOREGROUND"
+# Great hints at https://advancedweb.hu/supervisor-with-docker-lessons-learned/
+killasgroup=true
+stopasgroup=true
 priority=6
 stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 exitcodes=0,1
-startsecs=0 # See https://github.com/Supervisor/supervisor/issues/212#issuecomment-47933372
+startsecs=1 # Must stay up 1 sec

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/conf.d/supervisor.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/conf.d/supervisor.conf
@@ -1,7 +1,7 @@
 [supervisord]
 logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
-pidfile=//var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=false               ; (start in foreground if true;default false)
 
 [eventlistener:child_exit_monitor]

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import signal
@@ -15,10 +15,10 @@ def main():
    while 1:
        write_stdout('READY\n')
        line = sys.stdin.readline()
-       write_stdout('This line kills supervisor: ' + line);
+       write_stdout('This line kills supervisor: ' + line)
        try:
                pidfile = open('/var/run/supervisord.pid','r')
-               pid = int(pidfile.readline());
+               pid = int(pidfile.readline())
                os.kill(pid, signal.SIGQUIT)
        except Exception as e:
                write_stdout('Could not kill supervisor: ' + e.strerror + '\n')

--- a/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/apache.conf
@@ -8,3 +8,4 @@ stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 exitcodes=0,1
+startsecs=0 # See https://github.com/Supervisor/supervisor/issues/212#issuecomment-47933372

--- a/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/apache.conf
@@ -11,4 +11,4 @@ stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 exitcodes=0,1
-startsecs=0 # See https://github.com/Supervisor/supervisor/issues/212#issuecomment-47933372
+startsecs=1 # Must stay up 1 sec

--- a/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/apache.conf
@@ -1,8 +1,11 @@
 [program:apache2]
 stopwaitsecs = 20
 startretries=10
-stopsignal = WINCH
-command=/usr/sbin/apache2ctl -k restart -D "FOREGROUND"
+stopsignal = TERM
+command=/usr/sbin/apache2ctl -D "FOREGROUND"
+# Great hints at https://advancedweb.hu/supervisor-with-docker-lessons-learned/
+killasgroup=true
+stopasgroup=true
 priority=6
 stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0

--- a/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/conf.d/supervisor.conf
+++ b/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/conf.d/supervisor.conf
@@ -1,7 +1,7 @@
 [supervisord]
 logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
-pidfile=//var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=false               ; (start in foreground if true;default false)
 
 [eventlistener:child_exit_monitor]

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -127,3 +127,28 @@
   run docker exec -t $CONTAINER_NAME disable_xdebug
   run docker exec -t $CONTAINER_NAME disable_xhprof
 }
+
+@test "verify htaccess doesn't break ${WEBSERVER_TYPE} php${PHP_VERSION}" {
+  docker cp tests/ddev-webserver/testdata/nginx/auth.conf ${CONTAINER_NAME}:/etc/nginx/common.d
+  docker cp tests/ddev-webserver/testdata/nginx/junkpass ${CONTAINER_NAME}:/tmp
+  docker cp tests/ddev-webserver/testdata/apache/auth.conf ${CONTAINER_NAME}:/etc/apache2/conf-enabled
+  # Reload everything
+  docker exec ${CONTAINER_NAME} kill -HUP 1
+  sleep 4
+  # Make sure we can hit /phpstatus without auth
+  run curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$HOST_HTTP_PORT/phpstatus
+  echo "# phpstatus status=$output"
+  [ "$status" = 0 ]
+  [ "$output" = "200" ]
+  curl --fail -s http://127.0.0.1:$HOST_HTTP_PORT/phpstatus | egrep "idle processes|php is working"
+  # Make sure the auth requirement is actually working
+  curlstmt="curl --fail -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$HOST_HTTP_PORT/test/phptest.php"
+  run ${curlstmt}
+  [ "$output" = "401" ]
+
+  # Make sure it works with auth when hitting phptest.php
+  AUTH=$(echo -ne "junk:junk" | base64)
+  curl --fail --header "Authorization: Basic $AUTH" 127.0.0.1:$HOST_HTTP_PORT/test/phptest.php
+  docker exec ${CONTAINER_NAME} rm /etc/nginx/common.d/auth.conf /etc/apache2/conf-enabled/auth.conf
+  docker exec ${CONTAINER_NAME} kill -HUP 1
+}

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -132,9 +132,13 @@
   docker cp tests/ddev-webserver/testdata/nginx/auth.conf ${CONTAINER_NAME}:/etc/nginx/common.d
   docker cp tests/ddev-webserver/testdata/nginx/junkpass ${CONTAINER_NAME}:/tmp
   docker cp tests/ddev-webserver/testdata/apache/auth.conf ${CONTAINER_NAME}:/etc/apache2/conf-enabled
-  # Reload everything
-  docker exec ${CONTAINER_NAME} kill -HUP 1
-  sleep 4
+  # Reload webserver
+  if [ "${WEBSERVER_TYPE}" = "apache-fpm" ]; then
+    docker exec ${CONTAINER_NAME} apache2ctl -k graceful
+  else
+    docker exec ${CONTAINER_NAME} nginx -s reload
+  fi
+  sleep 2
   # Make sure we can hit /phpstatus without auth
   run curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$HOST_HTTP_PORT/phpstatus
   echo "# phpstatus status=$output"

--- a/containers/ddev-webserver/tests/ddev-webserver/testdata/apache/auth.conf
+++ b/containers/ddev-webserver/tests/ddev-webserver/testdata/apache/auth.conf
@@ -1,0 +1,8 @@
+<Directory /var/www/html>
+AuthType Basic
+AuthName "Restricted Files"
+# (Following line optional)
+AuthBasicProvider file
+AuthUserFile "/tmp/junkpass"
+Require valid-user
+</Directory>

--- a/containers/ddev-webserver/tests/ddev-webserver/testdata/nginx/auth.conf
+++ b/containers/ddev-webserver/tests/ddev-webserver/testdata/nginx/auth.conf
@@ -1,2 +1,2 @@
-auth_basic   "auth test DDEV";
+auth_basic   "Restricted Files";
 auth_basic_user_file    "/tmp/junkpass";

--- a/containers/ddev-webserver/tests/ddev-webserver/testdata/nginx/auth.conf
+++ b/containers/ddev-webserver/tests/ddev-webserver/testdata/nginx/auth.conf
@@ -1,0 +1,2 @@
+auth_basic   "auth test DDEV";
+auth_basic_user_file    "/tmp/junkpass";

--- a/containers/ddev-webserver/tests/ddev-webserver/testdata/nginx/junkpass
+++ b/containers/ddev-webserver/tests/ddev-webserver/testdata/nginx/junkpass
@@ -1,0 +1,1 @@
+junk:$apr1$NvBN0a6P$lqw25K4bRP.JmyyD1DKUA/

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210910_mutagen_state_neighboring" // Note that this can be overridden by make
+var WebTag = "20210916_supervisor_fixes" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210916_supervisor_fixes" // Note that this can be overridden by make
+var WebTag = "20210916_gilbertsoft_phpstatus" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:
With Nginx if basic authentication is enabled the monitoring endpoints are not longer accessible and this cannot be changed in a custom configuration because the locations are already defined.

For Apache this is not an issue because an alias is used for `/phpstatus`.

In addition, this need uncovered problems in how apache is run via supervisord, and those had to be fixed. This was originally https://github.com/drud/ddev/pull/3249 but for practicality had to be rolled in here. 



## How this PR Solves The Problem:

* To avoid this problem this patch sets `auth_basic` always to `off` for phpstatus
* Fix a bug from #3249 where `child_exit_monitor entered FATAL state, too many start retries too quickly` showed up in the logs at startup in v1.18 (using nonexistent python (python2) in /usr/local/bin/kill_supervisor.py)
* Fix a bug where reloads/restarts of apache were not successful when done by supervisord

## Manual Testing Instructions:
Enable auth_basic with a custom config `.ddev/nginx/auth.conf`:

```
auth_basic		"auth test DDEV";
auth_basic_user_file	/mnt/ddev_config/nginx/htpasswd;
```

Create a `.ddev/nginx/htpasswd` file using apache2-utils see https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basic-authentication/.

Access the webroot with `ddev launch` and an authentication dialog should be shown, abort the authentication. Now check the two monitoring end points to be accessible without authentication. ATTENTION: the browser remembers a basic auth so once authenticated you are not able to log off without closing the browser.

Also check the logs for errors with `ddev logs`.

## Automated Testing Overview:

Added a full extra stanza to container testing for this situation, which covers both apache and nginx.

## Related Issue Link(s):

Some of what gets fixed here was first attempted in #3249, but unfortunately they were too closely related to keep them separate.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3247"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

