### PR TITLE
Fix Debian 11 bullseye problems with supervisord

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
@@ -8,3 +8,4 @@ stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 exitcodes=0,1
+startsecs=0 # See https://github.com/Supervisor/supervisor/issues/212#issuecomment-47933372

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/conf.d/supervisor.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/conf.d/supervisor.conf
@@ -1,7 +1,7 @@
 [supervisord]
 logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
-pidfile=//var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=false               ; (start in foreground if true;default false)
 
 [eventlistener:child_exit_monitor]

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import signal
@@ -15,10 +15,10 @@ def main():
    while 1:
        write_stdout('READY\n')
        line = sys.stdin.readline()
-       write_stdout('This line kills supervisor: ' + line);
+       write_stdout('This line kills supervisor: ' + line)
        try:
                pidfile = open('/var/run/supervisord.pid','r')
-               pid = int(pidfile.readline());
+               pid = int(pidfile.readline())
                os.kill(pid, signal.SIGQUIT)
        except Exception as e:
                write_stdout('Could not kill supervisor: ' + e.strerror + '\n')

--- a/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/apache.conf
@@ -8,3 +8,4 @@ stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 exitcodes=0,1
+startsecs=0 # See https://github.com/Supervisor/supervisor/issues/212#issuecomment-47933372

--- a/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/conf.d/supervisor.conf
+++ b/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/conf.d/supervisor.conf
@@ -1,7 +1,7 @@
 [supervisord]
 logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
-pidfile=//var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=false               ; (start in foreground if true;default false)
 
 [eventlistener:child_exit_monitor]

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210910_mutagen_state_neighboring" // Note that this can be overridden by make
+var WebTag = "20210916_supervisor_fixes" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

There were a couple of problems with the startup of the web container with Debian 11 Bullseye. They weren't really obvious if you weren't watching the logs.

1. `child_exit_monitor entered FATAL state, too many start retries too quickly`
2. A reload of supervisord reported a failure (but error 0) restarting apache

## How this PR Solves The Problem:

1. The problem with `child_exit_monitor` was that the script used for this (/usr/local/bin/kill_supervisord.py) was set to use `#!/usr/bin/env python` and that referenced python2, which is gone from Debian Bullseye. This changes that to `#!/usr/bin/env python3`
2. Apache restart (when doing `kill -1 1` to get supervisord to restart did not work because it returns right away, so this changes to `startsecs=0` to allow `apachectl` to return right away. This was almost certainly this way since the beginning of apache support in ddev.

## Manual Testing Instructions:

- [ ] `ddev start` and watch `ddev logs`. There shouldn't be failures of child_exit_monitor
- [ ] After starting with apache-fpm, `ddev exec kill -1 1` to reload supervisord, you should see it reload with no errors

## Automated Testing Overview:

I'm not sure this needs any particular automated testing

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3249"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

