### PR TITLE
Update ddev-dbserver images for v1.18 release

### DIFF
--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -31,7 +31,7 @@ mysql_5.6: mysql_5.6_amd64
 mysql_5.7: mysql_5.7_amd64
 # Mysql 8.0 often must be pinned because xtrabackup is not ready for latest 8.0
 # So check whether xtrabackup is available for latest 8.0 before changing pin
-mysql_8.0: mysql_8.0_amd64_8.0.22
+mysql_8.0: mysql_8.0_amd64_8.0.26
 
 
 # Examples:

--- a/containers/ddev-dbserver/files/etc/my.cnf
+++ b/containers/ddev-dbserver/files/etc/my.cnf
@@ -70,7 +70,7 @@ table-open-cache               = 4096
 # innodb-flush-method            = O_DIRECT
 innodb-log-files-in-group      = 2
 ; 48M is chosen here only to work around xtrabackup bug
-; for mariadb 5.5, https://bugs.launchpad.net/percona-xtrabackup/+bug/1527081
+; for mariadb 5.5, https://jira.percona.com/browse/PXB-450
 innodb-log-file-size           = 48M
 innodb-flush-log-at-trx-commit = 2
 innodb-file-per-table          = 1

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -47,7 +47,7 @@ var WebTag = "20210916_gilbertsoft_phpstatus" // Note that this can be overridde
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20210729_cspitzlay_mysql_history"
+var BaseDBTag = "20210917_update_images"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -59,13 +59,13 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.17.6" // Note that this can be overridden by make
+var RouterTag = "20210917_update_images" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.17.0"
+var SSHAuthTag = "20210917_update_images"
 
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"


### PR DESCRIPTION
## The Problem/Issue/Bug:

It's time to update images for upcoming release. This gets mysql 8.0.26 and latest of everything else

## Manual Testing
- [x] Make sure snapshot and snapshot restore work on mysql 8.0 particularly. Automated tests should catch any problems, but manual is good.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3251"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

