### PR TITLE
Restore windows symlink scanning and recreation, fixes #3254

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -75,8 +76,8 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		}
 
 		for _, o := range objs {
-			// Preserve .ddev/
-			if o == ".ddev" || o == ".git" {
+			// Preserve .ddev, .git. .tarballs
+			if o == ".ddev" || o == ".git" || o == ".tarballs" {
 				continue
 			}
 
@@ -133,6 +134,9 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		err = app.Restart()
 		if err != nil {
 			util.Warning("Failed to restart project after composer create: %v", err)
+		}
+		if runtime.GOOS == "windows" {
+			fileutil.ReplaceSimulatedLinks(app.AppRoot)
 		}
 	},
 }

--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -45,6 +45,22 @@ If your composer.json is not in the project root, you'll need to provide the `-d
 
 Note: if you run `ddev composer global require`, (or run `composer global require` inside the web container) the global packages will be installed in the in-container user's home directory ( ~/.composer) and will disappear on the next container restart, requiring rerun of the command. You may need an additional step of synchronizing created composer configuration and installed packages with the DDEV's [homeadditions folder](extend/in-container-configuration.md) on the host.
 
+<a name="windows-os-and-ddev-composer"></a>
+
+#### Windows OS and `ddev composer`
+
+Both composer and some configurations of Docker Desktop for Windows introduce quite complex filesystem workarounds. DDEV attempts to help you with each of them.
+
+You generally don't have to worry about any of this, but it does keep things cleaner. Mostly just a few of the more complex TYPO3 projects have been affected.
+
+* On some configurations of Docker Desktop for Windows, symlinks are created in the container as "simulated symlinks", or XSym files. These are special text files that behave as symlinks inside the container (on CIFS filesystem), but appear as simple text files on the Windows host. (on the CIFS filesystem used by Docker for Windows inside the container there is no capability to create real symlinks, even though Windows now has this capability.)
+* DDEV-Local attempts to clean up for this situation. Since Windows 10+ (in developer mode) can create real symlinks, DDEV-Local scans your repository after a `ddev composer` command and attempts to convert XSym files into real symlinks. It can only do this if your Windows 10 host is set to Developer Mode.
+* On Windows 10+, to set your computer to developer mode, search for "developer" in settings. Screenshots are below.
+
+![finding developer mode](images/developer_mode_1.png)
+
+![setting developer mode](images/developer_mode_2.png)
+
 #### Limitations with `ddev composer`
 
 * Using `ddev composer --version` or `ddev composer -V` will not work, since `ddev` tries to utilize the command for itself. Use `ddev exec composer --version` instead.

--- a/docs/users/extend/custom-commands.md
+++ b/docs/users/extend/custom-commands.md
@@ -60,7 +60,7 @@ tail -f /opt/solr/server/logs/solr.log
 
 ### Global commands
 
-Global commands work exactly the same as project-level commands, you just have to put them in your global .ddev directory. Your home directory has a .ddev/commands in it; there you can add host or web or db commands. 
+Global commands work exactly the same as project-level commands, you just have to put them in your global .ddev directory. Your home directory has a .ddev/commands in it; there you can add host or web or db commands.
 
 ### Environment variables provided
 

--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -2,8 +2,10 @@ package ddevapp
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/mattn/go-isatty"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -28,6 +30,9 @@ func (app *DdevApp) Composer(args []string) (string, string, error) {
 	err = app.MutagenSyncFlush()
 	if err != nil {
 		return stdout, stderr, err
+	}
+	if runtime.GOOS == "windows" {
+		fileutil.ReplaceSimulatedLinks(app.AppRoot)
 	}
 	err = app.ProcessHooks("post-composer")
 	if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

In #3226 the support for Windows symlink scanning and conversion was removed. This is currently unnecessary for current Docker Desktop running WSL2, but it may still be necessary for some Windows systems using the old Hyper-V Docker Desktop setting.

## How this PR Solves The Problem:

Roll back symlink setup and docs for this feature

## Manual Testing Instructions:

- [x] On Windows with Hyper-V try `ddev composer create` and `ddev composer install`
- [x] On Windows with WSL2/plain try `ddev composer create` and `ddev composer install`
- [x] On Windows with WSL2/NFS try `ddev composer create` and `ddev composer install`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3255"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

