### PR TITLE
Add project type and docroot to describe

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -137,7 +137,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 
 			// Get extra info for web container
 			if k == "web" {
-				extraInfo = append(extraInfo, fmt.Sprintf("PHP %s %s", desc["php_version"], desc["webserver_type"]))
+				extraInfo = append(extraInfo, fmt.Sprintf("%s PHP%s\n%s docroot:'%s'", desc["type"], desc["php_version"], desc["webserver_type"], desc["docroot"]))
 				if desc["nfs_mount_enabled"].(bool) {
 					extraInfo = append(extraInfo, fmt.Sprintf("NFS Enabled"))
 				}

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -137,7 +137,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 
 			// Get extra info for web container
 			if k == "web" {
-				extraInfo = append(extraInfo, fmt.Sprintf("%s PHP%s\n%s docroot:'%s'", desc["type"], desc["php_version"], desc["webserver_type"], desc["docroot"]))
+				extraInfo = append(extraInfo, fmt.Sprintf("%s PHP%s\n%s\ndocroot:'%s'", desc["type"], desc["php_version"], desc["webserver_type"], desc["docroot"]))
 				if desc["nfs_mount_enabled"].(bool) {
 					extraInfo = append(extraInfo, fmt.Sprintf("NFS Enabled"))
 				}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -188,6 +188,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 	appDesc["name"] = app.GetName()
 	appDesc["status"] = app.SiteStatus()
 	appDesc["approot"] = app.GetAppRoot()
+	appDesc["docroot"] = app.GetDocroot()
 	appDesc["shortroot"] = shortRoot
 	appDesc["httpurl"] = app.GetHTTPURL()
 	appDesc["httpsurl"] = app.GetHTTPSURL()


### PR DESCRIPTION
## The Problem/Issue/Bug:

In testing for v1.18, it was discovered that neither docroot nor project type was reported in `ddev describe`

## How this PR Solves The Problem:

Add them in.

## Manual Testing Instructions:

With a variety of projects, `ddev describe` and make sure project type and docroot are obvious.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3258"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

