### PR TITLE
Mutagen commands should not hard-fail when not enabled, fixes #3269

### DIFF
--- a/cmd/ddev/cmd/mutagen-monitor.go
+++ b/cmd/ddev/cmd/mutagen-monitor.go
@@ -25,7 +25,8 @@ var MutagenMonitorCmd = &cobra.Command{
 			util.Failed("Failed to get active project: %v", err)
 		}
 		if !(app.IsMutagenEnabled()) {
-			util.Failed("Mutagen is not enabled on project %s", app.Name)
+			util.Warning("Mutagen is not enabled on project %s", app.Name)
+			return
 		}
 		ddevapp.MutagenMonitor(app)
 	},

--- a/cmd/ddev/cmd/mutagen-reset.go
+++ b/cmd/ddev/cmd/mutagen-reset.go
@@ -28,7 +28,8 @@ var MutagenResetCmd = &cobra.Command{
 			util.Failed("Failed to get active project: %v", err)
 		}
 		if !(app.IsMutagenEnabled()) {
-			util.Failed("Mutagen is not enabled on project %s", app.Name)
+			util.Warning("Mutagen is not enabled on project %s", app.Name)
+			return
 		}
 
 		err = app.MutagenSyncFlush()

--- a/cmd/ddev/cmd/mutagen-status.go
+++ b/cmd/ddev/cmd/mutagen-status.go
@@ -31,7 +31,8 @@ var MutagenStatusCmd = &cobra.Command{
 			util.Failed("Failed to get active project: %v", err)
 		}
 		if !(app.IsMutagenEnabled()) {
-			util.Failed("Mutagen is not enabled on project %s", app.Name)
+			util.Warning("Mutagen is not enabled on project %s", app.Name)
+			return
 		}
 		status, shortResult, longResult, _ := app.MutagenStatus()
 

--- a/cmd/ddev/cmd/mutagen-sync.go
+++ b/cmd/ddev/cmd/mutagen-sync.go
@@ -31,7 +31,8 @@ var MutagenSyncCmd = &cobra.Command{
 			util.Failed("Failed to get active project: %v", err)
 		}
 		if !(app.IsMutagenEnabled()) {
-			util.Failed("Mutagen is not enabled on project %s", app.Name)
+			util.Warning("Mutagen is not enabled on project %s", app.Name)
+			return
 		}
 
 		err = app.MutagenSyncFlush()

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/yarn
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/yarn
@@ -5,4 +5,4 @@
 ## Example: "ddev yarn install" or "ddev yarn add learna" or "ddev yarn --cwd web/core add learna"
 
 ddev exec yarn "$@"
-ddev mutagen sync
+ddev mutagen sync 2>/dev/null


### PR DESCRIPTION
## The Problem/Issue/Bug:

There's no reason for an actual failure return on `ddev mutagen sync` and related commands if mutagen is not enabled.

* Return a warning and zero exit
* Make `ddev yarn` not show the output anyway.

## Manual Testing Instructions:

- [x] `ddev mutagen sync` with mutagen disabled should just show warning
- [x] `ddev yarn` should not show the mutagen sync at all with or without mutagen enabled.

## Automated Testing Overview:

No additions.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3260"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

