### PR TITLE
Clarify usage of the "solr path" setting in implementation details

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -25,6 +25,7 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
     * Use the "http" protocol
     * The "solr host" should be `ddev-<projectname>-solr` **NOT the default "localhost"**, because it does not run in the same container as the webserver. (Note that just using "solr" will often work, and used to be recommended, but it can be ambiguous if there are more than one projects running with a solr service.)
     * The "solr core" should be named "dev" unless you customize the docker-compose.solr.yaml
+    * Systems that use the Solr API v1 should use the "solr path" value of "/solr", while systems that use the Solr API v2 should use "/", otherwise they won't be able to connect to the Solr server.
     * Under "Advanced server configuration" set the "solr.install.dir" to `/opt/solr`
 * Download the config.zip provided on /admin/config/search/search-api/server/dev
 * Unzip the config.zip into .ddev/solr/conf. For example, `cd .ddev/solr/conf && unzip ~/Downloads/solr_8.x-config.zip`


### PR DESCRIPTION
## The Problem/Issue/Bug:
Different systems use Solr API v1 and others use v2.

## How this PR Solves The Problem:
Noted that the "Solr path" setting must be set to "/solr" when using Solr API v1 and just "/" when using Solr API v2.

## Manual Testing Instructions:

## Automated Testing Overview:

## Related Issue Link(s):
https://drupal.slack.com/archives/C5TQRQZRR/p1632433128297900

## Release/Deployment notes:


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3261"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

