### PR TITLE
Make sure mutagen sync name begins with letter, fixes #3265

### DIFF
--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // SetMutagenVolumeOwnership chowns the volume in use to the current user.
@@ -42,7 +43,11 @@ func SetMutagenVolumeOwnership(app *DdevApp) error {
 // See restrictions on sync name at https://mutagen.io/documentation/introduction/names-labels-identifiers
 // The input must be a valid DNS name (valid ddev project name)
 func MutagenSyncName(name string) string {
-	return strings.ReplaceAll(name, ".", "")
+	name = strings.ReplaceAll(name, ".", "")
+	if unicode.IsNumber(rune(name[0])) {
+		name = "a" + name
+	}
+	return name
 }
 
 // TerminateMutagenSync terminates the mutagen sync


### PR DESCRIPTION
## The Problem/Issue/Bug:

A project name beginning with numeric chars can't work, even though it's a valid hostname. 

## How this PR Solves The Problem:

Related problems (dots) had already been dealt with in MutagenSyncName() but not this one. 

## Manual Testing Instructions:

Try to create a mutagen-enabled project named 123project.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3266"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

