### PR TITLE
readthedocs: Go back to using published jsmin [skip ci]

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,9 +28,6 @@ plugins:
     - git-revision-date-localized:
         type: timeago
         locale: en
-google_analytics:
-  - 'UA-105593079-2'
-  - 'auto'
 nav:
   - 'Home': 'index.md'
   - 'ddev Basics':

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ GitPython==3.1.14
 htmlmin==0.1.12
 Jinja2==2.11.3
 joblib==1.0.1
-git+https://github.com/serenecloud/jsmin@6467320#egg=jsmin
+jsmin==3.0.0
 livereload==2.6.3
 lunr==0.5.8
 Markdown==3.3.4


### PR DESCRIPTION
## The Problem/Issue/Bug:

Previously jsmin stopped working when python2 was removed. See https://github.com/drud/ddev/pull/3235 and https://github.com/drud/ddev/issues/3232

Thanks so much @mootari !



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3267"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

