### PR TITLE
Bump images for v1.18.0

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -224,6 +224,7 @@ exec
 existing
 export
 extradb
+facebook
 fi
 file
 files
@@ -341,6 +342,7 @@ or
 oriented
 output
 pause
+pecl
 performant
 php
 phpMyAdmin
@@ -387,6 +389,7 @@ s
 sTCP
 sbin
 scalable
+screencast
 sequelace
 sequelpro
 serverName

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.18.0-rc3.1 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.18.0 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/docs/users/xhprof-profiling.md
+++ b/docs/users/xhprof-profiling.md
@@ -20,7 +20,7 @@ You can change the contents of the xhprof_prepend function - it's in `.ddev/xhpr
 
 For example, you may want to add a link to the profile run to the bottom of the profiled web page; the provided xhprof_prepend.php has comments and a sample function to do that, which works with Drupal 7. If you change it, remove the `#ddev-generated` line from the top, and check it in (`git add -f .ddev/xhprof/xhprof_prepend.php`)
 
-For another example, if you want to exclude the memory profiling so there are less columns to study, change `xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);` to just `xhprof_enable(XHPROF_FLAGS_CPU);` in `.ddev/xhprof/xhprof_prepend.php` and remote the `#ddev-generated` at the top of the file. See the docs on [xhprof_enable()](https://www.php.net/manual/en/function.xhprof-enable.php). 
+For another example, if you want to exclude the memory profiling so there are less columns to study, change `xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);` to just `xhprof_enable(XHPROF_FLAGS_CPU);` in `.ddev/xhprof/xhprof_prepend.php` and remote the `#ddev-generated` at the top of the file. See the docs on [xhprof_enable()](https://www.php.net/manual/en/function.xhprof-enable.php).
 
 ### Information Links
 
@@ -28,4 +28,4 @@ For another example, if you want to exclude the memory profiling so there are le
 * [Old facebook xhprof docs](http://web.archive.org/web/20110514095512/http://mirror.facebook.net/facebook/xhprof/doc.html)
 * [rfay screencast on xhprof and blackfire.io](https://www.youtube.com/watch?v=6h2QMAtRjTA)
 * [pecl.php.net docs](https://pecl.php.net/package/xhprof)
-* [Upstream github repo lonngxhinH/xhprof](https://github.com/longxinH/xhprof)
+* [Upstream github repo `lonngxhinH/xhprof`](https://github.com/longxinH/xhprof)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,13 +41,13 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "20210923_xdebug_max_nesting" // Note that this can be overridden by make
+var WebTag = "v1.18.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20210917_update_images"
+var BaseDBTag = "v1.18.0"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"
@@ -59,13 +59,13 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "20210917_update_images" // Note that this can be overridden by make
+var RouterTag = "v1.18.0" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "20210917_update_images"
+var SSHAuthTag = "v1.18.0"
 
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"


### PR DESCRIPTION
## The Problem/Issue/Bug:

v1.18.0 images are ready in preparation for v1.18.0 release. Also use latest upstream ddev-images



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3270"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

