### PR TITLE
Support both amd64 and  arm64 image tarballs for quicksprint usage

### DIFF
--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -7,7 +7,7 @@ set -o pipefail
 set -o nounset
 
 MKCERT_VERSION=v1.4.6
-BUILD_IMAGE_TARBALLS=false
+BUILD_IMAGE_TARBALLS=${BUILD_IMAGE_TARBALLS:-false}
 
 ARTIFACTS=${1:-/artifacts}
 BASE_DIR=$PWD
@@ -18,21 +18,29 @@ export VERSION=$(git describe --tags --always --dirty)
 # If the version does not have a dash in it, it's not prerelease,
 # so build image tarballs
 if [ "${VERSION}" = "${VERSION%%-*}" ]; then
-    BUILD_IMAGE_TARBALLS=true
+  BUILD_IMAGE_TARBALLS=true
 fi
 
 BUILTPATH=.gotmp/bin/$(go env GOOS)_$(go env GOARCH)
 
 if [ "${BUILD_IMAGE_TARBALLS}" = "true" ]; then
-    # Make sure we have all our docker images, and save them in a tarball
-    $BUILTPATH/ddev version | awk '/(drud|phpmyadmin)\// {print $2;}' >/tmp/images.txt
+  ${BUILTPATH}/ddev poweroff
+  # Make sure we have all our docker images, and save them in a tarball
+  $BUILTPATH/ddev version | awk '/(drud|phpmyadmin)\// {print $2;}' >/tmp/images.txt
+  for arch in amd64 arm64; do
     for item in $(cat /tmp/images.txt); do
-      docker pull $item
+      docker pull --platform=linux/$arch $item
     done
-    echo "Generating ddev_docker_images.$VERSION.tar"
-    docker save -o $ARTIFACTS/ddev_docker_images.$VERSION.tar $(cat /tmp/images.txt)
-    echo "Generating ddev_docker_images.$VERSION.tar.xz"
-    xz $ARTIFACTS/ddev_docker_images.$VERSION.tar
+    echo "Generating ddev_docker_images.${arch}.${VERSION}.tar"
+    docker save -o $ARTIFACTS/ddev_docker_images.${arch}.${VERSION}.tar $(cat /tmp/images.txt)
+    echo "Generating ddev_docker_images.${arch}.${VERSION}.tar.xz"
+    xz $ARTIFACTS/ddev_docker_images.${arch}.$VERSION.tar
+  done
+  # Untag the pulled images in case they're the wrong platform for
+  # where we're executing this.
+  for item in $(cat /tmp/images.txt); do
+    docker rmi $item
+  done
 fi
 
 # Generate and place extra items like autocomplete
@@ -83,29 +91,29 @@ pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
 curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe
 tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe *completion*.sh mkcert.exe
 if [ -d chocolatey ]; then
-    tar -czf $ARTIFACTS/ddev_chocolatey_amd64-.$VERSION.tar.gz chocolatey
+  tar -czf $ARTIFACTS/ddev_chocolatey_amd64-.$VERSION.tar.gz chocolatey
 fi
 popd >/dev/null
 
 # Create macOS and Linux homebrew bottles
-for os in high_sierra arm64_big_sur x86_64_linux ; do
-    NO_V_VERSION=${VERSION#v}
-    rm -rf /tmp/bottle
-    BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
-    mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh/site-functions,share/fish/vendor_completions.d}
-    cp $BASE_DIR/.gotmp/bin/ddev_bash_completion.sh $BOTTLE_BASE/etc/bash_completion.d/ddev
-    cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh/site-functions/_ddev
-    cp $BASE_DIR/.gotmp/bin/ddev_fish_completion.sh $BOTTLE_BASE/share/fish/vendor_completions.d/ddev.fish
+for os in high_sierra arm64_big_sur x86_64_linux; do
+  NO_V_VERSION=${VERSION#v}
+  rm -rf /tmp/bottle
+  BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
+  mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh/site-functions,share/fish/vendor_completions.d}
+  cp $BASE_DIR/.gotmp/bin/ddev_bash_completion.sh $BOTTLE_BASE/etc/bash_completion.d/ddev
+  cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh/site-functions/_ddev
+  cp $BASE_DIR/.gotmp/bin/ddev_fish_completion.sh $BOTTLE_BASE/share/fish/vendor_completions.d/ddev.fish
 
-    if [ "${os}" = "high_sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin ; fi
-    if [ "${os}" = "arm64_big_sur" ]; then cp $BASE_DIR/.gotmp/bin/darwin_arm64/ddev $BOTTLE_BASE/bin ; fi
-    if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/linux_amd64/ddev $BOTTLE_BASE/bin ; fi
-    cp $BASE_DIR/{README.md,LICENSE} $BOTTLE_BASE
-    tar -czf $ARTIFACTS/ddev-$NO_V_VERSION.$os.bottle.tar.gz -C /tmp/bottle .
+  if [ "${os}" = "high_sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin; fi
+  if [ "${os}" = "arm64_big_sur" ]; then cp $BASE_DIR/.gotmp/bin/darwin_arm64/ddev $BOTTLE_BASE/bin; fi
+  if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/linux_amd64/ddev $BOTTLE_BASE/bin; fi
+  cp $BASE_DIR/{README.md,LICENSE} $BOTTLE_BASE
+  tar -czf $ARTIFACTS/ddev-$NO_V_VERSION.$os.bottle.tar.gz -C /tmp/bottle .
 done
 
 # Create the sha256 files
 cd $ARTIFACTS
 for item in *.*; do
-  sha256sum $item > $item.sha256.txt
+  sha256sum $item >$item.sha256.txt
 done


### PR DESCRIPTION
## The Problem/Issue/Bug:

Quicksprint needs to support mac M1, see https://github.com/drud/quicksprint/pull/203

## How this PR Solves The Problem:

* Separately package up amd64 and arm64 images

Note that using the script here I manually created the ddev_docker_images*.tar.xz that are needed and added them to the v1.18.0 release. That allows Quicksprint to move forward

## Manual Testing Instructions:

- [ ] This will have to be tested using a release creation on the fork (rfay).

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3274"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

