### PR TITLE
Add example for arguments forwarding / passing in ddev custom commands

### DIFF
--- a/docs/users/extend/custom-commands.md
+++ b/docs/users/extend/custom-commands.md
@@ -57,7 +57,21 @@ For example, to add a "solrtail" command that runs in a solr service, add `.ddev
 tail -f /opt/solr/server/logs/solr.log
 
 ```
+#### Arguments forwarding
+    
+You can also pass arguments from the ddev custom command to the command(s) run. Append `$@` behind the custom command where to place the arguments.
+    
+```bash
+#!/bin/bash
 
+## Description: Run phpcs with progress and optional forwarded parameters
+## Usage: phpcs
+## Example: ddev phpcs --standard=Drupal -v
+
+phpcs -p $@
+
+```
+    
 ### Global commands
 
 Global commands work exactly the same as project-level commands, you just have to put them in your global .ddev directory. Your home directory has a .ddev/commands in it; there you can add host or web or db commands.


### PR DESCRIPTION
## The Problem/Issue/Bug:
Passing arguments into custom commands is quite typical, but there's no documentation about that yet.
See https://github.com/drud/ddev/issues/3272

## How this PR Solves The Problem:
Adds documentation and an example

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
https://github.com/drud/ddev/issues/3272

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

