### PR TITLE
LDAP missing TLS_CACERT path from libldap-common

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -83,6 +83,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     iproute2 \
     iputils-ping \
     jq \
+    libldap-common \
     libpcre3 \
     locales-all \
     nano \

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag for drud dev
-var WebTag = "v1.18.0" // Note that this can be overridden by make
+var WebTag = "20211004_joelpittet_ldap" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:
LDAP+SSL aka `ldaps://` doesn't work without the OS CA cert being set. In version 1.17.0, libldap-common was a dependency of libldap-2.4-2, and in 1.18.0 it moved it to "recommends" and doesn't install it.

```
DDEV 1.17 
Package: libldap-2.4-2
Version: 2.4.47+dfsg-3+deb10u6
Depends: libc6 (>= 2.28), libgnutls30 (>= 3.6.6), libsasl2-2 (>= 2.1.27+dfsg), libldap-common

DDEV 1.18
Package: libldap-2.4-2
Version: 2.4.57+dfsg-3
Depends: libc6 (>= 2.28), libgnutls30 (>= 3.7.0), libsasl2-2 (>= 2.1.27+dfsg)
Recommends: libldap-common
```

The file needed is:
`/etc/ldap/ldap.conf` which has `TLS_CACERT /etc/ssl/certs/ca-certificates.crt` pointing to the OS CA's path which is needed for client SSL connections.

## How this PR Solves The Problem:
Explicitly adds the package back.

## Manual Testing Instructions:
`apt install ldap-utils` and use ldapsearch with ldaps:// like `ldapsearch -x -v -H ldaps://ldap.example.org`
before it will say `ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)`
and after 
```
filter: (objectclass=*)
requesting: All userApplication attributes
# extended LDIF
#
# LDAPv3
# base <> (default) with scope subtree
# filter: (objectclass=*)
# requesting: ALL
#

# search result
search: 2
result: 32 No such object
```

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3284"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

