### PR TITLE
Use http for xtrabackup/percona for mariadb 5.5

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -22,15 +22,20 @@ RUN for item in "75DD C3C4 A499 F1A1 8CB5  F3C8 CBF8 D6FD 518E 17E1" "126C 0D24 
 # Older versions of mariadb have been removed from
 # the mariadb apt repository, so we don't want to
 # look there when doing apt-get update. And we don't use new packages from there.
-RUN rm -f /etc/apt/sources.list.d/mariadb.list
+# And we're going to install our own percona.list if needed, so get that if needed
+# and remove it here
+RUN rm -f /etc/apt/sources.list.d/mariadb.list /etc/apt/sources.list.d/percona.list
 
 RUN apt-get -qq update && apt-get -qq install -y tzdata gnupg2 pv less vim wget curl lsb-release >/dev/null
 
+# If on 14.04 Ubuntu the percona repositories won't allow TLS apparently, so
+# Use http when connecting. This currently only affects MariaDB 5.5
 RUN set -x; if ( ! command -v xtrabackup && ! command -v mariabackup ); then \
     curl -sSL https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb -o percona-release_latest.$(lsb_release -sc)_all.deb; \
     dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb >/dev/null; \
     rm percona-release*.deb ; \
     xtrabackup_version=percona-xtrabackup-24 ; \
+    if [ "$(lsb_release -i -s)" = "Ubuntu" && "$(lsb_release -r -s)" <= "16.04" ]; then sed -i s/https:/http:/g /etc/apt/sources.list.d/percona.list; fi; \
     if [ "$DB_VERSION" = "8.0" ]; then xtrabackup_version=percona-xtrabackup-80; fi ; \
     apt-get -qq update && apt-get -qq install -y ${xtrabackup_version} >/dev/null ; \
 fi

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -47,7 +47,7 @@ var WebTag = "v1.18.0" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.18.0"
+var BaseDBTag = "20211004_use_http_for_mariadb_5.5"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

This is about building the MariaDB 5.5 image only.

The upstream image (mariadb:5.5) is based on Ubuntu 14.04 Trusty, which seems not
to be allowed to connect to the Percona repos any more.
However, I did open https://jira.percona.com/browse/DISTMYSQL-125
about this issue, as we'd certainly rather use https.
http is only for mariadb 5.5 at this time.

## How this PR Solves The Problem:

Edit /etc/apt/sources.list.d/percona.list so it uses http instead of https when the upstream image is Ubuntu and older than 16.04

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3285"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

