### PR TITLE
Add notice about dots in project names for PHPStorm integration docs

### DIFF
--- a/docs/users/topics/phpstorm.md
+++ b/docs/users/topics/phpstorm.md
@@ -22,7 +22,7 @@ Steps:
     4. In the "Path mappings" of the "Server" you may have to map the local paths (which on WSL2 means /home/...) to the in-container paths, especially if you have mutagen enabled. So "Virtual Machine Path" would be "/var/www/html" and "Local path" would be something like /Users/rfay/workspace/d9 (on macOS) or \\wsl$\Ubuntu\home\rfay\workspace\d9 on Windows using WSL2.
     5. Now back in the "Configure Remote PHP Interpreter" for "Configuration files" use `.ddev/.ddev-docker-compose-full.yaml`
     6. Service: web
-    7. Add an environment variable `COMPOSE_PROJECT_NAME=ddev-<projectname>`. In this case, it's `ddev-d9`
+    7. Add an environment variable `COMPOSE_PROJECT_NAME=ddev-<projectname>`. In this case, it's `ddev-d9`. If your project name contains any dots, those have to be removed in order to work correctly (e.g. project name `my.project` has to be `ddev-myproject` then).
     8. In the CLI interpreter "Lifecycle" select "Connect to existing container"
     9. In the PHP Interpreter path, you can just put `php` if you're using the default PHP version (currently 7.4). Due to a [PhpStorm bug](https://youtrack.jetbrains.com/issue/WI-62463) you'll want to put the full name of the binary, like `php8.0` if you're not using the default version.
     10. Here's an example filled out ![example configuration](images/cli_interpreter.png)

--- a/docs/users/topics/phpstorm.md
+++ b/docs/users/topics/phpstorm.md
@@ -22,7 +22,7 @@ Steps:
     4. In the "Path mappings" of the "Server" you may have to map the local paths (which on WSL2 means /home/...) to the in-container paths, especially if you have mutagen enabled. So "Virtual Machine Path" would be "/var/www/html" and "Local path" would be something like /Users/rfay/workspace/d9 (on macOS) or \\wsl$\Ubuntu\home\rfay\workspace\d9 on Windows using WSL2.
     5. Now back in the "Configure Remote PHP Interpreter" for "Configuration files" use `.ddev/.ddev-docker-compose-full.yaml`
     6. Service: web
-    7. Add an environment variable `COMPOSE_PROJECT_NAME=ddev-<projectname>`. In this case, it's `ddev-d9`. If your project name contains any dots, those have to be removed in order to work correctly (e.g. project name `my.project` has to be `ddev-myproject` then).
+    7. Add an environment variable `COMPOSE_PROJECT_NAME=ddev-<projectname>`. In this case, it's `ddev-d9`. (Note that DDEV project names that contain dots do not currently work due to a [PhpStorm bug](https://youtrack.jetbrains.com/issue/WI-63293). You'll need to rename your project to get these instructions to work.)
     8. In the CLI interpreter "Lifecycle" select "Connect to existing container"
     9. In the PHP Interpreter path, you can just put `php` if you're using the default PHP version (currently 7.4). Due to a [PhpStorm bug](https://youtrack.jetbrains.com/issue/WI-62463) you'll want to put the full name of the binary, like `php8.0` if you're not using the default version.
     10. Here's an example filled out ![example configuration](images/cli_interpreter.png)


### PR DESCRIPTION
## The Problem/Issue/Bug:

If you have a `.` in your ddev project name, it can lead to problems when following the [PHPStorm integration guide](https://ddev.readthedocs.io/en/latest/users/topics/phpstorm/) - Example:

* **ddev project name:** `my.project`
* **Does not work:** `COMPOSE_PROJECT_NAME=ddev-my.project`
* **Works:** `COMPOSE_PROJECT_NAME=ddev-myproject`  (while still using `my.project` as actual ddev project name)

I also posted my findings to these PHPStorm issues:
* https://youtrack.jetbrains.com/issue/WI-63293
* https://youtrack.jetbrains.com/issue/WI-62914

## How this PR Solves The Problem:

Adds some information about this issue to the PHPStorm integration documentation where `COMPOSE_PROJECT_NAME` is set (see Steps 3.7)

## Manual Testing Instructions:

Create a ddev project with a dot in its name and try to follow the PHPStorm integration guide. Preserving the dot while settings `COMPOSE_PROJECT_NAME` environment variable should make e.g. composer executions fail (when executed via PHPStorm's "Tools -> Composer -> Update" menu). Removing the dot when setting the environment variable should make e.g. composer commands from within PHPStorm functional

