### PR TITLE
Avoid redeclaration of constant `ABSPATH`

### DIFF
--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -103,7 +103,9 @@ define('LOGGED_IN_SALT',   '{{ $config.LoggedInSalt }}');
 define('NONCE_SALT',       '{{ $config.NonceSalt }}');
 
 /** Absolute path to the WordPress directory. */
-define('ABSPATH', dirname(__FILE__) . '/{{ $config.AbsPath }}');
+if (!defined('ABSPATH')) {
+  define('ABSPATH', dirname(__FILE__) . '/{{ $config.AbsPath }}');
+}
 
 // Include for settings managed by ddev.
 $ddev_settings = dirname(__FILE__) . '/wp-config-ddev.php';


### PR DESCRIPTION
## The Problem/Issue/Bug:

If the constant `ABSPATH` is already declared there will be an PHP notice on `ddev start`.

## How this PR Solves The Problem:

This patch checks if the constant is already declared and only defines it if it's not already declared before.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

Fixes #3297

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3298"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

