### PR TITLE
Add `--file=` option to `ddev import-db` (same as `ddev import-db --src=`)

### DIFF
--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -25,9 +25,9 @@ can be provided if it is not located at the top level of the archive. An optiona
 can also be provided; the default is the default database named "db".
 Also note the related "ddev mysql" command`,
 	Example: `ddev import-db
-ddev import-db --src=.tarballs/junk.sql
-ddev import-db --src=.tarballs/junk.sql.gz
-ddev import-db --target-db=newdb --src=.tarballs/junk.sql.gz
+ddev import-db --file=.tarballs/junk.sql
+ddev import-db --file=.tarballs/junk.sql.gz
+ddev import-db --target-db=newdb --file=.tarballs/junk.sql.gz
 ddev import-db <db.sql
 ddev import-db someproject <db.sql
 gzip -dc db.sql.gz | ddev import-db`,
@@ -64,8 +64,9 @@ gzip -dc db.sql.gz | ddev import-db`,
 }
 
 func init() {
-	ImportDBCmd.Flags().StringVarP(&dbSource, "src", "f", "", "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format")
-	ImportDBCmd.Flags().StringVarP(&dbSource, "file", "", "", "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format")
+	ImportDBCmd.Flags().StringVarP(&dbSource, "src", "", "", "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format (same as --file)")
+	ImportDBCmd.Flags().StringVarP(&dbSource, "file", "f", "", "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format (same as --src)")
+	_ = ImportDBCmd.Flags().MarkHidden("src")
 	ImportDBCmd.Flags().StringVarP(&dbExtPath, "extract-path", "", "", "If provided asset is an archive, provide the path to extract within the archive.")
 	ImportDBCmd.Flags().StringVarP(&targetDB, "target-db", "d", "db", "If provided, target-db is alternate database to import into")
 	ImportDBCmd.Flags().BoolVarP(&noDrop, "no-drop", "", false, "Set if you do NOT want to drop the db before importing")


### PR DESCRIPTION
## The Problem/Issue/Bug:
While `export-db` uses `file` as the parameter to provide a name for the output file, `import-db` uses `src`, even though it is also a parameter that eventually references a file. 

## How this PR Solves The Problem:
For the sake of clarity and consistency a `file` flag is added to `import-db`, so users can simply think of a `file`, whether they use `import-db` or `export-db`.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

