### PR TITLE
Update golang-build-container to 1.17.2 (Use golang 1.17)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ BUILD_OS = $(shell go env GOHOSTOS)
 BUILD_ARCH = $(shell go env GOHOSTARCH)
 VERSION_LDFLAGS=$(foreach v,$(VERSION_VARIABLES),-X '$(PKG)/pkg/version.$(v)=$($(v))')
 LDFLAGS=-extldflags -static $(VERSION_LDFLAGS)
-BUILD_IMAGE ?= drud/golang-build-container:v1.16.6
+BUILD_IMAGE ?= drud/golang-build-container:v1.17.2
 DOCKERBUILDCMD=docker run -t --rm -u $(shell id -u):$(shell id -g) \
 	-v "/$(PWD)://workdir$(DOCKERMOUNTFLAG)" \
 	-e GOPATH="//workdir/$(GOTMP)" \


### PR DESCRIPTION
## The Problem/Issue/Bug:

Time to upgrade golang.

Tests latest golang-build-container, with far less in it.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3309"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

