### PR TITLE
Adding VSCode Go debug setup [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,10 @@ tasks:
       cd /workspace/simpleproj && .ddev/gitpod-setup-ddev.sh
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
+vscode:
+  extensions:
+    - golang.go
+
 github:
   prebuilds:
     # enable for the master/default branch (defaults to true)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,10 +7,8 @@
             "request": "launch",
             "mode": "debug",
             "remotePath": "",
-            "port": 2345,
-            "host": "127.0.0.1",
             "program": "${workspaceRoot}/cmd/ddev",
-            "cwd": "$HOME/sites/drupal8",
+            "cwd": "/workspace/simpleproj",
             "env": {"DDEV_DEBUG": true},
             "args": [],
             "showLog": true


### PR DESCRIPTION
## The Problem/Issue/Bug:
It's difficult to debug DDEV when using Gitpod.

## How this PR Solves The Problem:
Completing the setup for Go debug in VSCode.

## Manual Testing Instructions:
1. Open this PR in Gitpod.
1. Hover above a function and confirm that VSCode now display hints for that function.
1. Open the file `main.go`
1. Place a breakpoint.
1. Open "Run and Debug" panel
1. Press the green play button next to the "debug" option in the dropdown.
1. VSCode will display a message that something is missing, select "Install All"
1. Once again, press the green play button next to the "debug" option in the dropdown.
1. Confirm VSCode stopped at the breakpoint

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3311"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

