### PR TITLE
[docs] Exclude URLs from spellchecking

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -15,6 +15,7 @@ matrix:
       ignores:
       - code
       - pre
+  - pyspelling.filters.url:
   sources:
   - 'docs/users/*.md'
   - 'index.md'


### PR DESCRIPTION
## The Problem/Issue/Bug:
`pyspelling` should not check words inside URLs

## How this PR Solves The Problem:
 applies the proper filter

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3319"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

