### PR TITLE
Temporarily disable TestAcquiaPull because of hangs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,8 @@ jobs:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
       DDEV_NONINTERACTIVE: "true"
       GOTEST_SHORT: "true"
-      DDEV_TEST_USE_MUTAGEN: "true"
+      DDEV_TEST_USE_MUTAGEN: ""
+      DDEV_ACQUIA_API_KEY: ""
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## The Problem/Issue/Bug:

CircleCI tests have been hanging up on TestAcquiaPull (perhaps only when mutagen enabled?) 

## How this PR Solves The Problem:

Temporarily disable.

Will revisit in https://github.com/drud/ddev/issues/3263

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3320"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

