### PR TITLE
Remove extra ` from machine token name

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -11,7 +11,7 @@
 #
 #    ```
 #    web_environment:
-#    - TERMINUS_MACHINE_TOKEN=abcdeyourtoken`
+#    - TERMINUS_MACHINE_TOKEN=abcdeyourtoken
 #    ```
 #
 # 2. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site uuid, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>, the site ID is 009a2cda-2c22-4eee-8f9d-96f017321555.


### PR DESCRIPTION
## The Problem/Issue/Bug:
Machine Token Name is failing due to a bad example given in the pantheon.example.yaml file

## How this PR Solves The Problem:
Removes an extra ` from the example - TERMINUS_MACHINE_TOKEN name

## Manual Testing Instructions:
Update Terminus_machine_token, replacing "abcdeyourtoken" with your actual token. ddev pull pantheon -y will fail.

## Automated Testing Overview:
If tests include a valid TERMINUS_MACHINE_TOKEN value,  then this could be tested automatically.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3323"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

