### PR TITLE
Fix pantheon.yaml.example auth section so it checks for successful login

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -47,7 +47,7 @@ auth_command:
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     if [ -z "${TERMINUS_MACHINE_TOKEN:-}" ]; then echo "Please make sure you have set TERMINUS_MACHINE_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
-    terminus auth:login --machine-token="${TERMINUS_MACHINE_TOKEN}" >/dev/null 2>&1
+    terminus auth:login --machine-token="${TERMINUS_MACHINE_TOKEN}" || ( echo "terminus auth login failed, check your TERMINUS_MACHINE_TOKEN" && exit 1 )
     terminus aliases 2>/dev/null
 
 db_pull_command:


### PR DESCRIPTION
## The Problem/Issue/Bug:
Adding debugging/verbose code that Randy walked me through when experiencing trying to do a ddev pull pantheon -y with a bad machine token. It wasn't clear that the token was bad, and it was returning a "Pull failed: exit status 1 " status that wasn't at all verbose/clear what was going on. The issue was a bad character in the machine token.

## How this PR Solves The Problem:
The PR displays the error message of where the pull is failing if it's caused by a bad machine token

## Manual Testing Instructions:
Insert a bad machine token into the global_config.yaml file, and you'll see the error messages. (Although, it's not exiting the pull as Randy had expected)





<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3324"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

