### PR TITLE
Bump homebrew version to get current versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v23
+        - linux-v24
     - attach_workspace:
         at: ~/
     - run:
@@ -215,7 +215,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v23
+        key: linux-v24
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -233,7 +233,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v23
+        - linux-v24
     - attach_workspace:
         at: ~/
     - run:
@@ -252,7 +252,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-v23
+        key: linux-v24
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -267,7 +267,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v23
+        - linux-v24
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
@@ -289,7 +289,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v23
+        - linux-v24
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
@@ -313,7 +313,7 @@ jobs:
         name: linux container test
 
     - save_cache:
-        key: linux-v23
+        key: linux-v24
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -380,7 +380,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-v23
+        - linux-v24
     - attach_workspace:
         at: ~/
     - run:
@@ -388,7 +388,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-v23
+        key: linux-v24
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache


### PR DESCRIPTION
## The Problem/Issue/Bug:

brew install mkcert was failing in nightly build.
Must be homebrew being out of date due to cache



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3329"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

