### PR TITLE
Remove homebrew existing cache to solve download problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,6 @@ jobs:
     - checkout
     - attach_workspace:
         at: ~/
-    # Temporary cache-clear, remove this after run
-    - run: rm -rf /home/linuxbrew ~/.cache/Homebrew
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
@@ -485,9 +483,9 @@ workflows:
   version: 2
   normal_build_and_test:
     jobs:
-    - build
+#    - build
 #    - mac_container_test
-    - lx_amd64_container_test
+#    - lx_amd64_container_test
 #    - staticrequired
     - lx_amd64_fpm_test
     - lx_arm64_fpm_test


### PR DESCRIPTION
## The Problem/Issue/Bug:

Homebrew nightly build is still not working due to cached version. Try to fix

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3334"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

