### PR TITLE
Fix bug where ddev-router gets pulled even though omitted

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1015,7 +1015,7 @@ func (app *DdevApp) PullContainerImages() error {
 		"dba":            app.DBAImage,
 		"ddev-ssh-agent": version.GetSSHAuthImage(),
 		"web":            app.WebImage,
-		"router":         version.GetRouterImage(),
+		"ddev-router":    version.GetRouterImage(),
 		"busybox":        version.BusyboxImage,
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

ddev tries to download needed images on `ddev start` (or on `ddev debug download-images`) but it shouldn't download images that are omitted

## How this PR Solves The Problem:

Use the correct key for `ddev-router` instead of using `router` for the key.

/cc @shaal 

## Manual testing

* `ddev config global --omit-containers=ddev-router`
* export DDEV_DEBUG=true
* `ddev start`

You should not see the `ddev-router` image get pulled because it's omitted.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3337"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

