### PR TITLE
Use new signed and notarized mutagen downloads, bump to v0.12.0-beta8, first test on macOS Monterrey

### DIFF
--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -311,13 +311,6 @@ func DownloadMutagen() error {
 	globalMutagenDir := filepath.Dir(globalconfig.GetMutagenPath())
 	destFile := filepath.Join(globalMutagenDir, "mutagen.tgz")
 	mutagenURL := fmt.Sprintf("https://github.com/mutagen-io/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", version.RequiredMutagenVersion, flavor, version.RequiredMutagenVersion)
-	// Temporary workaround to get signed/notarized binaries for macOS.
-	// See https://github.com/drud/mutagen/releases/tag/v0.12.0-beta5 and
-	// https://github.com/mutagen-io/mutagen/issues/290
-	// TODO: Remove this when mutagen has signed releases
-	if runtime.GOOS == "darwin" {
-		mutagenURL = fmt.Sprintf("https://github.com/drud/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", version.RequiredMutagenVersion, flavor, version.RequiredMutagenVersion)
-	}
 	output.UserOut.Printf("Downloading %s ...", mutagenURL)
 
 	// Remove the existing file. This may help on macOS to prevent the Gatekeeper's

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -82,7 +82,7 @@ var DockerComposeVersion = ""
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.12.0-beta7"
+const RequiredMutagenVersion = "0.12.0-beta8"
 
 // GetVersionInfo returns a map containing the version info defined above.
 func GetVersionInfo() map[string]string {


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Mutagen v1.12.0-beta8 is out, bump it up
* Mutagen now signs and notarizes its own binaries, so it's no longer necessary to manually sign copied binaries
* It would be good to start checking the SHASUMs, this may be the place to do it.
* This is also the first PR to be tested on macOS Monterrey

## Manual Testing Instructions:

- [x] `ddev start` a mutagen-enabled project. You should see the new beta8 downloaded
- [x] Verify project working
- [x] Verify that the downloaded binary in ~/.ddev/bin/mutagen is signed and notarized. `codesign --test-requirement="=notarized" --verify --verbose ~/.ddev/bin/mutagen` will tell about signing and maybe notarization. Use Archichect (https://eclecticlight.co/32-bitcheck-archichect/) to check notarization. 

## Automated Testing Overview:

This gets hit by the regular enabled mutagen builds on macOS and Windows and Linux




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3341"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

