### PR TITLE
Fix broken homedir tests on Windows

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	osexec "os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -31,17 +32,20 @@ func TestCustomCommands(t *testing.T) {
 
 	tmpHome := testcommon.CreateTmpDir(t.Name() + "-tempHome")
 	origHome := os.Getenv("HOME")
+	if runtime.GOOS == "windows" {
+		origHome = os.Getenv("USERPROFILE")
+	}
 	origDebug := os.Getenv("DDEV_DEBUG")
 	// Change the homedir temporarily
-	err := os.Setenv("HOME", tmpHome)
-	require.NoError(t, err)
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Setenv("USERPROFILE", tmpHome)
 	_ = os.Setenv("DDEV_DEBUG", "")
 
 	origDir, _ := os.Getwd()
 	testCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
 	site := TestSites[0]
-	err = os.Chdir(site.Dir)
+	err := os.Chdir(site.Dir)
 	require.NoError(t, err)
 
 	app, _ := ddevapp.NewApp("", false)
@@ -56,6 +60,7 @@ func TestCustomCommands(t *testing.T) {
 		err = os.RemoveAll(tmpHome)
 		assert.NoError(err)
 		_ = os.Setenv("HOME", origHome)
+		_ = os.Setenv("USERPROFILE", origHome)
 		_ = os.Setenv("DDEV_DEBUG", origDebug)
 		err = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
 		assert.NoError(err)

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -28,16 +29,19 @@ func TestHomeadditions(t *testing.T) {
 
 	tmpHome := testcommon.CreateTmpDir(t.Name() + "tempHome")
 	origHome := os.Getenv("HOME")
+	if runtime.GOOS == "windows" {
+		origHome = os.Getenv("USERPROFILE")
+	}
 	// Change the homedir temporarily
-	err := os.Setenv("HOME", tmpHome)
-	require.NoError(t, err)
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Setenv("USERPROFILE", tmpHome)
 
 	site := TestSites[0]
 	projectHomeadditionsDir := filepath.Join(site.Dir, ".ddev", "homeadditions")
 
 	// We can't use the standard getGlobalDDevDir here because *our* global hasn't changed.
 	// It's changed via $HOME for the ddev subprocess
-	err = os.MkdirAll(filepath.Join(tmpHome, ".ddev"), 0755)
+	err := os.MkdirAll(filepath.Join(tmpHome, ".ddev"), 0755)
 	assert.NoError(err)
 	tmpHomeGlobalHomeadditionsDir := filepath.Join(tmpHome, ".ddev", "homeadditions")
 	err = os.RemoveAll(tmpHomeGlobalHomeadditionsDir)
@@ -58,6 +62,7 @@ func TestHomeadditions(t *testing.T) {
 		err = os.RemoveAll(tmpHome)
 		assert.NoError(err)
 		_ = os.Setenv("HOME", origHome)
+		_ = os.Setenv("USERPROFILE", origHome)
 	})
 
 	// Simply run "ddev" to make sure homeadditions example files get populated


### PR DESCRIPTION
## The Problem/Issue/Bug:

Tests that manipulated `$HOME` were broken on Windows since #3313 

It turned out it was because os.HomeDir() respects only $USERPROFILE on Windows, so the tests needed to manipulate that, not $HOME.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

