### PR TITLE
[docs] Typo in Pantheon config snippet

### DIFF
--- a/docs/users/providers/pantheon.md
+++ b/docs/users/providers/pantheon.md
@@ -14,7 +14,7 @@ If you have ddev installed, and have an active Pantheon account with an active s
 
    ```
    web_environment:
-   - TERMINUS_MACHINE_TOKEN=abcdeyourtoken`
+   - TERMINUS_MACHINE_TOKEN=abcdeyourtoken
    ```
 
 2. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>, the site ID is 009a2cda-2c22-4eee-8f9d-96f017321555.


### PR DESCRIPTION
## The Problem/Issue/Bug:
An extra apostrophe is present after the machine token dummy value