### PR TITLE
Use docker interface to determine host.docker.internal, fixes #2904

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drud/ddev-gitpod-base:20211028_fix_gitpod_setup
+image: drud/ddev-gitpod-base:20211028_new_host_docker_internal_detection
 
 tasks:
   - name: ddev

--- a/.gitpod/images/gitpod-setup-ddev.sh
+++ b/.gitpod/images/gitpod-setup-ddev.sh
@@ -28,16 +28,3 @@ host_mailhog_port: "8025"
 # Assign phpMyAdmin port
 host_phpmyadmin_port: 8036
 CONFIGEND
-
-# We need host.docker.internal inside the container,
-# So add it via docker-compose.host-docker-internal.yaml
-hostip=$(awk "\$2 == \"$HOSTNAME\" { print \$1; }" /etc/hosts)
-
-cat <<COMPOSEEND >"${PROJDIR}"/docker-compose.host-docker-internal.yaml
-#ddev-gitpod-generated
-version: "3.6"
-services:
-  web:
-    extra_hosts:
-    - "host.docker.internal:${hostip}"
-COMPOSEEND

--- a/.gitpod/images/push.sh
+++ b/.gitpod/images/push.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_REPO=drud/ddev-gitpod-base:20211028_fix_gitpod_setup
+DOCKER_REPO=drud/ddev-gitpod-base:20211028_new_host_docker_internal_detection
 
 echo "Pushing ${DOCKER_REPO}"
 set -x

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -850,7 +850,7 @@ func GetHostDockerInternalIP() (string, error) {
 		return "", err
 	}
 
-	hostGatewayFirstVersion, _ := semver.NewVersion("20.10.0")
+	hostGatewayFirstVersion, _ := semver.NewVersion("20.10.6")
 	serverVersion, err := semver.NewVersion(info.ServerVersion)
 	if err == nil {
 		hostGatewayEnabled = serverVersion.GreaterThan(hostGatewayFirstVersion)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -846,7 +846,7 @@ func GetHostDockerInternalIP() (string, error) {
 
 	// Docker on linux doesn't define host.docker.internal
 	// so we need to go get the bridge IP address
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" && !nodeps.IsWSL2() {
 		// Gitpod does not use standard docker networking, so we need to use the official hostname
 		if nodeps.IsGitpod() {
 			addrs, err := net.LookupHost(os.Getenv("HOSTNAME"))

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -846,6 +846,8 @@ func GetHostDockerInternalIP() (string, error) {
 
 	// Docker on linux doesn't define host.docker.internal
 	// so we need to go get the bridge IP address
+	// WSL2 (with Docker Desktop) defines host.docker.internal itself.
+	// If people install docker *inside* WSL2, this logic won't be right.
 	if runtime.GOOS == "linux" && !nodeps.IsWSL2() {
 		// Gitpod does not use standard docker networking, so we need to use the official hostname
 		if nodeps.IsGitpod() {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/drud/ddev/pkg/archive"
-	exec2 "github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
@@ -844,21 +843,19 @@ func CreateVolume(volumeName string, driver string, driverOpts map[string]string
 func GetHostDockerInternalIP() (string, error) {
 	hostDockerInternal := ""
 
-	// Docker 18.09 on linux and docker-toolbox don't define host.docker.internal
-	// so we need to go get the ip address of docker0
+	// Docker on linux doesn't define host.docker.internal
+	// so we need to go get the ip address of docker0 (preferably)
+	// or fall back and try eth0
 	// We would hope to be able to remove this when
 	// https://github.com/docker/for-linux/issues/264 gets resolved.
 	if runtime.GOOS == "linux" {
-		out, err := exec2.RunCommandPipe("ip", []string{"address", "show", "dev", "docker0"})
-		// Do not process if ip command fails, we'll just ignore and not act.
-		if err == nil {
-			addr := regexp.MustCompile(`inet *[0-9\.]+`).FindString(out)
-			components := strings.Split(addr, " ")
-			if len(components) == 2 {
-				hostDockerInternal = components[1]
-			} else {
-				return "", fmt.Errorf("docker0 interface IP address cannot be determined. You may need to 'ip link set docker0 up' or restart docker or reboot to get xdebug or nfsmount_enabled to work")
-			}
+		client := GetDockerClient()
+		net, err := client.NetworkInfo("bridge")
+		if err != nil {
+			return "", err
+		}
+		if len(net.IPAM.Config) > 0 {
+			hostDockerInternal = net.IPAM.Config[0].Gateway
 		}
 	}
 	return hostDockerInternal, nil

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -67,6 +67,11 @@ func IsMacM1() bool {
 	return runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
 }
 
+// IsGitpod returns true if running on gitpod.io
+func IsGitpod() bool {
+	return runtime.GOOS == "linux" && os.Getenv("GITPOD_WORKSPACE_ID") != ""
+}
+
 // GetWSLDistro returns the WSL2 distro name if on Linux
 func GetWSLDistro() string {
 	wslDistro := ""


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Our technique for determining host.docker.internal didn't work on Gitpod, and may have occasionally failed elsewhere
* There is a "correct" way to get it on linux (`docker network inspect bridge`), see https://docs.docker.com/engine/tutorials/networkingcontainers/
* We can use the docker api to get it as well, as done here.
* Thanks to @shaal for the inspiration for the better detection technique!
* This would have fixed #2904 - On docker 20.10+ we use host-gateway. But it doesn't work out, because we need host.docker.internal for NFS usage as well, and we don't get that then. So giving up on #2904

## Manual Testing Instructions:

- [x] Test xdebug usage on normal Linux. (You can also `nc -l 0.0.0.0 9000` on the host and inside container `telnet host.docker.internal 9000` and type something - it should appear in the host window.)
- [x] Test on WSL2
- [x] Test on GitPod (without a docker-compose.host-docker-internal.yaml)

## Automated Testing Overview:

The existing xdebug tests should exercise this just fine.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3346"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

