### PR TITLE
Make '2' the default composer_version so people get latest composer

### DIFF
--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -15,31 +15,36 @@ import (
 func TestComposerCmd(t *testing.T) {
 	assert := asrt.New(t)
 
-	oldDir, err := os.Getwd()
+	origDir, err := os.Getwd()
 	assert.NoError(err)
-	// nolint: errcheck
-	defer os.Chdir(oldDir)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
 	err = os.Chdir(tmpDir)
 	assert.NoError(err)
 
 	// Basic config
-	args := []string{"config", "--project-type", "php"}
-	_, err = exec.RunCommand(DdevBin, args)
+	_, err = exec.RunHostCommand(DdevBin, "config", "--project-type", "php")
 	assert.NoError(err)
 
 	// Test trivial command
-	args = []string{"composer"}
-	out, err := exec.RunCommand(DdevBin, args)
+	out, err := exec.RunHostCommand(DdevBin, "composer")
 	assert.NoError(err)
 	assert.Contains(out, "Available commands:")
 
 	// Get an app just so we can do waits
 	app, err := ddevapp.NewApp(tmpDir, true)
 	assert.NoError(err)
-	//nolint: errcheck
-	defer app.Stop(true, false)
+
+	t.Cleanup(func() {
+		//nolint: errcheck
+		err = app.Stop(true, false)
+		assert.NoError(err)
+
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = os.RemoveAll(tmpDir)
+		assert.NoError(err)
+	})
 
 	// Test create-project
 	// These two often fail on Windows with NFS
@@ -47,8 +52,8 @@ func TestComposerCmd(t *testing.T) {
 
 	if !(runtime.GOOS == "windows" && (app.NFSMountEnabled || app.NFSMountEnabledGlobal)) {
 		// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
-		args = []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0"}
-		out, err = exec.RunCommand(DdevBin, args)
+		args := []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0"}
+		out, err = exec.RunHostCommand(DdevBin, args...)
 		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 		assert.Contains(out, "Created project in ")
 		assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
@@ -57,21 +62,21 @@ func TestComposerCmd(t *testing.T) {
 		assert.NoError(err)
 		// ddev composer create --prefer-dist--no-dev --no-install psr/log:1.1.0
 		args = []string{"composer", "create", "--prefer-dist", "--no-dev", "--no-install", "psr/log:1.1.0"}
-		out, err = exec.RunCommand(DdevBin, args)
+		out, err = exec.RunHostCommand(DdevBin, args...)
 		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 		assert.Contains(out, "Created project in ")
 		assert.FileExists(filepath.Join(tmpDir, "Psr/Log/LogLevel.php"))
 	}
 
 	// Test a composer require, with passthrough args
-	args = []string{"composer", "require", "sebastian/version", "--no-plugins", "--ansi"}
-	out, err = exec.RunCommand(DdevBin, args)
+	args := []string{"composer", "require", "sebastian/version", "--no-plugins", "--ansi"}
+	out, err = exec.RunHostCommand(DdevBin, args...)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 	assert.Contains(out, "Generating autoload files")
 	assert.FileExists(filepath.Join(tmpDir, "vendor/sebastian/version/composer.json"))
 	// Test a composer remove
 	args = []string{"composer", "remove", "sebastian/version"}
-	out, err = exec.RunCommand(DdevBin, args)
+	out, err = exec.RunHostCommand(DdevBin, args...)
 	assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 	assert.Contains(out, "Generating autoload files")
 	assert.False(fileutil.FileExists(filepath.Join(tmpDir, "vendor/sebastian")))

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -18,6 +18,7 @@ import (
 func TestComposer(t *testing.T) {
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
+	origDir, _ := os.Getwd()
 
 	// Use drupal9 only for this test, just need a little composer action
 	site := FullTestSites[8]
@@ -32,14 +33,13 @@ func TestComposer(t *testing.T) {
 		t.Cleanup(func() {
 			err = app.Stop(true, false)
 			assert.NoError(err)
+			err := os.Chdir(origDir)
+			assert.NoError(err)
 			err = os.RemoveAll(app.AppRoot)
 			assert.NoError(err)
 		})
 	}
 
-	testDir, _ := os.Getwd()
-	// nolint: errcheck
-	defer os.Chdir(testDir)
 	_ = os.Chdir(site.Dir)
 
 	testcommon.ClearDockerEnv()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -847,12 +847,15 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 		contents = contents + `
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
-	// If composerVersion is set, and composer is in the container,
+	// If composerVersion is set,
 	// run composer self-update to the version (or --1 or --2)
+	// defaults to "2" even if ""
 	var composerSelfUpdateArg string
 	switch composerVersion {
 	case "1":
 		composerSelfUpdateArg = "--1"
+	case "":
+		fallthrough
 	case "2":
 		composerSelfUpdateArg = "--2"
 	default:

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -860,12 +860,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg:
 	}
 
 	// If composerVersion is not set, we don't need to self-update.
-	// Currently by default it will be composer v1 because of upstream setting
+	// Currently by default it will be composer v2 because of upstream setting
 	// Try composer self-update twice because of troubles with composer downloads
 	// breaking testing.
 	if composerVersion != "" {
 		contents = contents + fmt.Sprintf(`
-RUN if command -v composer >/dev/null 2>&1 ; then export XDEBUG_MODE=off && (composer self-update %s || composer self-update %s ) && chmod 777 /usr/local/bin/composer;  fi
+RUN export XDEBUG_MODE=off && (composer self-update %s || composer self-update %s )
 `, composerSelfUpdateArg, composerSelfUpdateArg)
 	}
 	return WriteImageDockerfile(fullpath, []byte(contents))

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -847,28 +847,32 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 		contents = contents + `
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
-	// If composerVersion is set,
-	// run composer self-update to the version (or --1 or --2)
-	// defaults to "2" even if ""
-	var composerSelfUpdateArg string
-	switch composerVersion {
-	case "1":
-		composerSelfUpdateArg = "--1"
-	case "":
-		fallthrough
-	case "2":
-		composerSelfUpdateArg = "--2"
-	default:
-		composerSelfUpdateArg = composerVersion
-	}
 
-	// If composerVersion is not set, we don't need to self-update.
-	// Composer v2 is default
-	// Try composer self-update twice because of troubles with composer downloads
-	// breaking testing.
-	contents = contents + fmt.Sprintf(`
-RUN export XDEBUG_MODE=off && (composer self-update %s || composer self-update %s )
+	// For webimage, update to latest composer.
+	if strings.Contains(fullpath, "webimageBuild") {
+		// If composerVersion is set,
+		// run composer self-update to the version (or --1 or --2)
+		// defaults to "2" even if ""
+		var composerSelfUpdateArg string
+		switch composerVersion {
+		case "1":
+			composerSelfUpdateArg = "--1"
+		case "":
+			fallthrough
+		case "2":
+			composerSelfUpdateArg = "--2"
+		default:
+			composerSelfUpdateArg = composerVersion
+		}
+
+		// If composerVersion is not set, we don't need to self-update.
+		// Composer v2 is default
+		// Try composer self-update twice because of troubles with composer downloads
+		// breaking testing.
+		contents = contents + fmt.Sprintf(`
+RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update %s )
 `, composerSelfUpdateArg, composerSelfUpdateArg)
+	}
 	return WriteImageDockerfile(fullpath, []byte(contents))
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -70,6 +70,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	app.ConfigPath = app.GetConfigPath("config.yaml")
 	app.Type = nodeps.AppTypePHP
 	app.PHPVersion = nodeps.PHPDefault
+	app.ComposerVersion = nodeps.ComposerDefault
 	app.MariaDBVersion = nodeps.MariaDBDefaultVersion
 	app.WebserverType = nodeps.WebserverDefault
 	app.NFSMountEnabled = nodeps.NFSMountEnabledDefault

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -863,14 +863,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg:
 	}
 
 	// If composerVersion is not set, we don't need to self-update.
-	// Currently by default it will be composer v2 because of upstream setting
+	// Composer v2 is default
 	// Try composer self-update twice because of troubles with composer downloads
 	// breaking testing.
-	if composerVersion != "" {
-		contents = contents + fmt.Sprintf(`
+	contents = contents + fmt.Sprintf(`
 RUN export XDEBUG_MODE=off && (composer self-update %s || composer self-update %s )
 `, composerSelfUpdateArg, composerSelfUpdateArg)
-	}
 	return WriteImageDockerfile(fullpath, []byte(contents))
 }
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -292,10 +292,10 @@ const ConfigInstructions = `
 # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # For example Europe/Dublin or MST7MDT
 
-# composer_version: ""
-# if composer_version:"" it will use the current ddev default composer release.
+# composer_version: "2"
+# if composer_version:"2" it will use the most recent composer v2
 # It can also be set to "1", to get most recent composer v1
-# or "2" for most recent composer v2.
+# or "" for the default v2 created at release time.
 # It can be set to any existing specific composer version.
 # After first project 'ddev start' this will not be updated until it changes
 

--- a/pkg/nodeps/php_values.go
+++ b/pkg/nodeps/php_values.go
@@ -27,3 +27,6 @@ var ValidPHPVersions = map[string]bool{
 	PHP80: true,
 	PHP81: true,
 }
+
+// Composer version default - will get latest composer v2
+var ComposerDefault = "2"


### PR DESCRIPTION
## The Problem/Issue/Bug:

`composer_version` defaulted to "" during the transition from composer v1 to v2. But now people are on composer v2, and ddev has long since made `composer_version: ""` mean `composer_version: 2`. But there's a subtle difference - `composer_version: ""` does not update to latest composer during image build, and `composer_version: 2` does. 

## How this PR Solves The Problem:

This changes the default for `composer_version` to "2" so that people starting a new project get latest composer version

## Manual Testing Instructions:

- [x] Create a new project. `composer_version` should be "2" and `ddev exec composer --version` should show latest composer version
- [x] Change `composer_version` to "" and `ddev restart`. You may have to delete the project. `ddev start` and verify that `ddev exec composer --version` shows the release-time composer version (currently 2.1.8)
- [x] Change composer_version to an explicit version (like `2.1.7` and verify that it gets `ddev exec composer --version` with 2.1.7

## Automated Testing Overview:
I think the existing tests will cover this.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3351"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

