### PR TITLE
add Mailhog note for Laravel users

### DIFF
--- a/docs/users/developer-tools.md
+++ b/docs/users/developer-tools.md
@@ -80,6 +80,17 @@ After your project is started, access the MailHog web interface at its default p
 
 Please note this will not intercept emails if your application is configured to use SMTP or a 3rd-party ESP integration. If you are using SMTP for outgoing mail handling ([Swift Mailer](https://www.drupal.org/project/swiftmailer) or [SMTP](https://www.drupal.org/project/smtp) modules for example), update your application configuration to use `localhost` on port `1025` as the SMTP server locally in order to use MailHog.
 
+For Laravel projects, Mailhog will capture Swift messages via SMTP. Update your `.env` to use Mailhog with the following settings:
+
+```env
+MAIL_MAILER=smtp
+MAIL_HOST=localhost
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+```
+
 ### Database Management
 
 [phpMyAdmin](https://www.phpmyadmin.net/) is a free software tool to manage MySQL and MariaDB databases from a browser. phpMyAdmin comes installed with ddev. After your project is started, use `ddev launch -p` or just access the phpMyAdmin web interface at its default port, `http://mysite.ddev.site:8036`.


### PR DESCRIPTION
## The Problem/Issue/Bug:
The documents [Email Capture and Review](https://ddev.readthedocs.io/en/stable/users/developer-tools/#email-capture-and-review) documents seem misleading for Laravel projects.

They state that mailhog "will not intercept emails if your application is configured to use SMTP ...", although later it talks about configuration.


## How this PR Solves The Problem:
This PR adds specific Laravel `.env` settings to configure Mailhog email interception.

## Manual Testing Instructions:
- Create a Laravel project
- Config DDEV with default settings
- Update the `.env` file with the settings
- Attempt to send mail

A [demo project](https://github.com/tyler36/ddev-smpt-mailhog) was created for testing purposes.


## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
- I debated about updating the quickstart guide or adding the config here. 
- I'm not sure if other frameworks have a similar "simple steps" that could help simplify this section or be delegated to quick start guides.




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3352"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

