### PR TITLE
Add a git provider for ddev pull git

### DIFF
--- a/docs/users/providers/provider-introduction.md
+++ b/docs/users/providers/provider-introduction.md
@@ -15,7 +15,7 @@ Each provider recipe is a yaml file that can be named any way you want to name i
 Each provider recipe is a file named `<provider>.yaml` and consists of several mostly-optional stanzas:
 
 * `environment_variables`: Environment variables will be created in the web container for each of these during pull or push operations. They're used to provide context (project id, environment name, etc.) for each of the other stanzas.
-* `db_pull_command`: A script that determines how ddev should pull a database. It's job is to create a gzipped database dump in /var/www/html/.ddev/.downloads/db.sql.gz. This is optional; if nothing has to be done to obtain the database dump, this step can be omitted.
+* `db_pull_command`: A script that determines how ddev should obtain a database. It's job is to create a gzipped database dump in /var/www/html/.ddev/.downloads/db.sql.gz. This is optional; if nothing has to be done to obtain the database dump, this step can be omitted.
 * `db_import_command`: (optional) A script that imports the downloaded database. This is for advanced usages like multiple databases. The default behavior only imports a single database into the `db` database. The [localfile example](https://github.com/drud/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
 * `files_pull_command`: A script that determines how ddev can get user-generated files from upstream. Its job is to copy the files from upstream to  /var/www/html/.ddev/.downloads/files. This is optional; if nothing has to be done to obtain the files, this step can be omitted.
 * `files_import_command`: (optional) A script that imports the downloaded files. There are a number of situations where it's just messy to push a directory of files around, and one can just put it directly where it's needed. The [localfile example](https://github.com/drud/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
@@ -24,8 +24,13 @@ Each provider recipe is a file named `<provider>.yaml` and consists of several m
 
 The [environment variables provided to custom commands](../extend/custom-commands.md#environment-variables-provided) are also available for use in these recipes.
 
+### Example Integrations and Hints
+
+* All of the [supplied integrations](https://github.com/drud/ddev/tree/master/pkg/ddevapp/dotddev_assets/providers) are really just examples of what you can do.
+* You can name a provider anything you want. For example, an Acquia integration doesn't have to be named "acquia", it can be named "upstream", for example. This is a great technique for [downloading a particulr multisite](https://stackoverflow.com/a/68553116/215713)
+
 ### Provider Debugging
 
-You can uncomment the `set -x` in each stanza to see more of what's going on. It really helps.
+You can uncomment the `set -x` in each stanza to see more of what's going on. It really helps. Watch it as you do a `ddev pull <whatever>`.
 
 Although the various commands could be executed on the host or in other containers if configured that way, most commands are executed in the web container. So the best thing to do is to `ddev ssh` and manually execute each command you want to use. When you have it right, use it in the yaml file.

--- a/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
@@ -1,0 +1,55 @@
+#ddev-generated
+# Example git provider configuration.
+
+# To use this configuration,
+
+# 1. Create a git repository that contains a database dump and a files tarball. It can be private or public, but for most people they will be private.
+# 2. Configure access to the repository so that it can be accessed from where you need it. For example, on gitpod, you'll need to enable access to GitHub or Gitlab. On a regular local dev environment, you'll need to be able to access github via https or ssh.
+# 3. Update the environment_variables below to point to the git repository that contains your database dump and files.
+
+environment_variables:
+  project_url: https://github.com/rfay/ddev-d9-artifacts
+  branch: main
+  target: ~/tmp/ddev-d9-artifacts
+
+auth_command:
+  service: host
+  command: |
+    if [ ! -d ${target}/.git ] ; then
+        git clone ${project_url} --branch=${branch} ${target}
+    else
+        cd ${target} && git fetch && git checkout origin/${branch}
+    fi
+
+db_pull_command:
+  service: host
+  command: |
+    set -eu -o pipefail
+    set -x
+    cp ${target}/db.sql.gz .ddev/.downloads
+
+files_pull_command:
+  service: host
+  command: |
+    set -eu -o pipefail
+    set -x
+    tar -zxf ${target}/files.tgz -C .ddev/.downloads/files
+
+
+
+# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+db_push_command:
+  command: |
+    set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
+    ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
+    pushd /var/www/html/.ddev/.downloads >/dev/null;
+    gzip -dc db.sql.gz | platform db:sql --project="${project_id}" --environment="${environment}"
+
+# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+files_push_command:
+  command: |
+    set -x   # You can enable bash debugging output by uncommenting
+    set -eu -o pipefail
+    ls "${DDEV_FILES_DIR}" >/dev/null # This just refreshes stale NFS if possible
+    platform mount:upload --yes --quiet --project="${project_id}" --environment="${environment}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files

--- a/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
@@ -33,4 +33,4 @@ files_pull_command:
   command: |
     set -eu -o pipefail
     set -x
-    rmdir .ddev/.downloads/files && ln -s ${target}/files .ddev/.downloads/files
+    rm -rf .ddev/.downloads/files && ln -s ${target}/files .ddev/.downloads/files

--- a/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
@@ -3,34 +3,38 @@
 
 # To use this configuration,
 
-# 1. Create a git repository that contains a database dump and a files tarball. It can be private or public, but for most people they will be private.
+# 1. Create a git repository that contains a database dump (db.sql.gz) and a files tarball. It can be private or public, but for most people they will be private.
 # 2. Configure access to the repository so that it can be accessed from where you need it. For example, on gitpod, you'll need to enable access to GitHub or Gitlab. On a regular local dev environment, you'll need to be able to access github via https or ssh.
 # 3. Update the environment_variables below to point to the git repository that contains your database dump and files.
 
 environment_variables:
-  project_url: https://github.com/rfay/ddev-d9-artifacts
+  project_url: https://github.com/drud/ddev-pull-git-test-repo
   branch: main
-  target: ~/tmp/ddev-d9-artifacts
+  checkout_dir: ~/tmp/ddev-pull-git-test-repo
+
 
 auth_command:
   service: host
+  # This actually doesn't auth, but rather just checks out the repository
   command: |
-    if [ ! -d ${target}/.git ] ; then
-        git clone ${project_url} --branch=${branch} ${target}
+    set -eu -o pipefail
+    if [ ! -d ${checkout_dir}/.git ] ; then
+        git clone -q ${project_url} --branch=${branch} ${checkout_dir}
     else
-        cd ${target} && git fetch && git checkout origin/${branch}
+        cd ${checkout_dir}
+        git reset --hard -q && git fetch && git checkout -q origin/${branch}
     fi
 
-db_pull_command:
+db_import_command:
   service: host
   command: |
     set -eu -o pipefail
-    set -x
-    ln -s ${target}/db.sql.gz .ddev/.downloads/db.sql.gz
+    # set -x
+    ddev import-db --src="${checkout_dir}/db.sql.gz"
 
-files_pull_command:
+files_import_command:
   service: host
   command: |
     set -eu -o pipefail
-    set -x
-    rm -rf .ddev/.downloads/files && ln -s ${target}/files .ddev/.downloads/files
+    # set -x
+    ddev import-files --src="${checkout_dir}/files"

--- a/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
@@ -26,30 +26,11 @@ db_pull_command:
   command: |
     set -eu -o pipefail
     set -x
-    cp ${target}/db.sql.gz .ddev/.downloads
+    ln -s ${target}/db.sql.gz .ddev/.downloads/db.sql.gz
 
 files_pull_command:
   service: host
   command: |
     set -eu -o pipefail
     set -x
-    tar -zxf ${target}/files.tgz -C .ddev/.downloads/files
-
-
-
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
-db_push_command:
-  command: |
-    set -x   # You can enable bash debugging output by uncommenting
-    set -eu -o pipefail
-    ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    pushd /var/www/html/.ddev/.downloads >/dev/null;
-    gzip -dc db.sql.gz | platform db:sql --project="${project_id}" --environment="${environment}"
-
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
-files_push_command:
-  command: |
-    set -x   # You can enable bash debugging output by uncommenting
-    set -eu -o pipefail
-    ls "${DDEV_FILES_DIR}" >/dev/null # This just refreshes stale NFS if possible
-    platform mount:upload --yes --quiet --project="${project_id}" --environment="${environment}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files
+    rmdir .ddev/.downloads/files && ln -s ${target}/files .ddev/.downloads/files

--- a/pkg/ddevapp/providerGit_test.go
+++ b/pkg/ddevapp/providerGit_test.go
@@ -1,0 +1,73 @@
+package ddevapp_test
+
+import (
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+)
+
+// TestGitPull ensures we can pull backups from a git repository
+func TestGitPull(t *testing.T) {
+	assert := asrt.New(t)
+	var err error
+
+	testDir, _ := os.Getwd()
+
+	siteDir := testcommon.CreateTmpDir(t.Name())
+
+	err = os.Chdir(siteDir)
+	assert.NoError(err)
+	app, err := NewApp(siteDir, true)
+	assert.NoError(err)
+	app.Name = t.Name()
+	app.Type = nodeps.AppTypeDrupal9
+	app.Docroot = "web"
+	err = app.Stop(true, false)
+	require.NoError(t, err)
+	err = app.WriteConfig()
+	require.NoError(t, err)
+
+	testcommon.ClearDockerEnv()
+
+	t.Cleanup(func() {
+		err = app.Stop(true, false)
+		assert.NoError(err)
+
+		_ = os.Chdir(testDir)
+		_ = os.RemoveAll(siteDir)
+	})
+
+	err = PopulateExamplesCommandsHomeadditions(app.Name)
+	require.NoError(t, err)
+
+	// Build our git.yaml from the example file
+	s, err := os.ReadFile(app.GetConfigPath("providers/git.yaml.example"))
+	require.NoError(t, err)
+	err = os.WriteFile(app.GetConfigPath("providers/git.yaml"), []byte(s), 0666)
+	assert.NoError(err)
+	err = app.WriteConfig()
+	require.NoError(t, err)
+
+	provider, err := app.GetProvider("git")
+	require.NoError(t, err)
+
+	err = app.Start()
+	require.NoError(t, err)
+	err = app.Pull(provider, false, false, false)
+	assert.NoError(err)
+
+	assert.FileExists(filepath.Join(app.AppRoot, app.Docroot, app.GetUploadDir(), "tmp/veggie-pasta-bake-hero-umami.jpg"))
+	out, _, err := app.Exec(&ExecOpts{
+		Cmd:     "echo 'select COUNT(*) from users_field_data where mail=\"margaret.hopper@example.com\";' | mysql -N",
+		Service: "db",
+	})
+	assert.NoError(err)
+	assert.True(strings.HasPrefix(out, "1\n"))
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

A  (private) git repository is a perfectly fine place to store user-files and db dump for doing a pull, and most of us have access to great free storage on github/gitlab/etc.

## How this PR Solves The Problem:

Add git provider.
- [x] Needs docs

## Manual Testing Instructions:

- [x] Try it out with your own

## Automated Testing Overview:

- [x] Needs an end-to-end test

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3372"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

