### PR TITLE
Use an explicit hostname `ddev-<project>-db` in ddev-webserver .my.cnf, for #3369

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -17,9 +17,9 @@ env:
   DOCKER_CLI_EXPERIMENTAL: enabled
   NO_LOAD: true
   DDEV_IGNORE_EXPIRING_KEYS: ${{ secrets.DDEV_IGNORE_EXPIRING_KEYS }}
+  DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION: ${{ secrets.DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION }}
 
 jobs:
-
   container-build-and-test:
     name: ${{ matrix.os }} - Test container ${{ matrix.containers }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,11 +13,11 @@ on:
     - "containers/**"
 
 env:
-  BUILDKIT_PROGRESS: plain
-  DOCKER_CLI_EXPERIMENTAL: enabled
-  NO_LOAD: true
-  DDEV_IGNORE_EXPIRING_KEYS: ${{ secrets.DDEV_IGNORE_EXPIRING_KEYS }}
-  DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION: ${{ secrets.DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION }}
+  DDEV_IGNORE_EXPIRING_KEYS: "false"
+  # Unfortunately, we can't test forked PRs with the secret that's provided for this
+  # So it has to be hard-wired here. Needs to be switched back to "90" after mysql
+  # key is updated, see https://github.com/docker-library/mysql/issues/801
+  DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION: "45"
 
 jobs:
   container-build-and-test:

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -16,6 +16,7 @@ env:
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
   NO_LOAD: true
+  DDEV_IGNORE_EXPIRING_KEYS: ${{ secrets.DDEV_IGNORE_EXPIRING_KEYS }}
 
 jobs:
 

--- a/containers/ddev-dbserver/test/basic_database.bats
+++ b/containers/ddev-dbserver/test/basic_database.bats
@@ -8,7 +8,7 @@ load functions.sh
 function setup {
   basic_setup
 
-  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE"
+  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE" >&3
   docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
   containercheck
 }

--- a/containers/ddev-dbserver/test/custom_config.bats
+++ b/containers/ddev-dbserver/test/custom_config.bats
@@ -8,7 +8,7 @@ load functions.sh
 function setup {
   basic_setup
 
-  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE"
+  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE" >&3
   docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
   containercheck
 }

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -13,11 +13,11 @@ function setup {
 }
 
 @test "verify apt keys are not expiring" {
-  MAX_DAYS_BEFORE_EXPIRATION=90
+  DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  docker exec -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+  docker exec -e "max=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} bash -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -7,7 +7,7 @@ load functions.sh
 function setup {
   basic_setup
 
-  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE"
+  echo "# Starting container using: docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE" >&3
   docker run --rm -u "$MOUNTUID:$MOUNTGID" --rm -v $VOLUME:/var/lib/mysql --mount "type=bind,src=$PWD/test/testdata,target=/mnt/ddev_config" --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
   containercheck
 }
@@ -17,7 +17,8 @@ function setup {
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  docker exec -e "max=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} bash -c '
+  echo "# DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION='${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION}' DDEV_IGNORE_EXPIRING_KEYS='${DDEV_IGNORE_EXPIRING_KEYS}'" >&3
+  docker exec -e "max=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION}" ${CONTAINER_NAME} bash -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-router/test/containertest.sh
+++ b/containers/ddev-router/test/containertest.sh
@@ -73,11 +73,11 @@ fi
 docker exec -t $CONTAINER_NAME curl --fail https://127.0.0.1/healthcheck || (echo "Failed to run https healthcheck inside container" && exit 104)
 
 
-MAX_DAYS_BEFORE_EXPIRATION=90
+  DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}
 if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
   echo "Skipping test of expiring keys because DDEV_IGNORE_EXPIRING_KEYS is set"
 else
-  docker exec -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -x -c '
+  docker exec -e "max=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} bash -x -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-ssh-agent/test/image_general.bats
+++ b/containers/ddev-ssh-agent/test/image_general.bats
@@ -13,11 +13,11 @@ function setup {
 }
 
 @test "verify apt keys are not expiring" {
-  MAX_DAYS_BEFORE_EXPIRATION=90
+    DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  docker exec -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+  docker exec -e "max=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} bash -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -84,6 +84,8 @@ sudo mkdir -p ${CAROOT} && sudo chmod -R ugo+rw ${CAROOT}
 # This will install the certs from $CAROOT (/mnt/ddev-global-cache/mkcert)
 mkcert -install
 
+perl -pi -e "s/host=db/host=ddev-${DDEV_PROJECT}-db/" ~/.my.cnf
+
 # VIRTUAL_HOST is a comma-delimited set of fqdns, convert it to space-separated and mkcert
 CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev_default
 echo 'Server started'

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -84,7 +84,9 @@ sudo mkdir -p ${CAROOT} && sudo chmod -R ugo+rw ${CAROOT}
 # This will install the certs from $CAROOT (/mnt/ddev-global-cache/mkcert)
 mkcert -install
 
-perl -pi -e "s/host=db/host=ddev-${DDEV_PROJECT}-db/" ~/.my.cnf
+if [ -f ~/.my.cnf ]; then
+  perl -pi -e "s/host=db/host=ddev-${DDEV_PROJECT}-db/" ~/.my.cnf
+fi
 
 # VIRTUAL_HOST is a comma-delimited set of fqdns, convert it to space-separated and mkcert
 CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev_default

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -55,11 +55,11 @@
 
 
 @test "verify apt keys are not expiring" {
-  MAX_DAYS_BEFORE_EXPIRATION=90
+    DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  docker exec -e "max=$MAX_DAYS_BEFORE_EXPIRATION" ${CONTAINER_NAME} bash -c '
+  docker exec -e "max=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} bash -c '
     dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
     for item in ${dates}; do
       today=$(date -I)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.18.1" // Note that this can be overridden by make
+var WebTag = "20211117_explicit_db_hostname" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

This is for 
* https://github.com/drud/ddev/issues/3369

It only affected use of mysql client directly in ddev-webserver.

## How this PR Solves The Problem:

During start.sh, update ~/.my.cnf to use explicit hostname `ddev-<project>-db`

## Manual Testing Instructions:

- [x] `ddev ssh` and inspect `~/.my.cnf` - host should be `ddev-<project>-db`. 
- [x] `ddev ssh` and use `mysql` - should work
- [x] `docker run -it --rm drud/ddev-webserver:20211117_explicit_db_hostname` and make sure it doesn't fail startup due to my.cnf not being in there.

## Automated Testing Overview:

No changes required



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3376"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

