### PR TITLE
Make ddev-router build despite upstream changes, for #2980

### DIFF
--- a/containers/ddev-router/Dockerfile
+++ b/containers/ddev-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable
+FROM nginx:1.20.1
 
 ENV MKCERT_VERSION=v1.4.6
 
@@ -13,19 +13,12 @@ SHELL ["/bin/bash", "-c"]
 # Get forego, which may be either a binary download (jwilder) or
 # a tarball (from https://github.com/ddollar/forego download)
 RUN set -eu -o pipefail && \
-    FOREGO_URL="https://github.com/jwilder/forego/releases/download/v0.16.1/forego" && \
-    if [[ "${TARGETARCH}" = "arm"* ]]; then \
-        FOREGO_URL="https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-${TARGETARCH}.tgz"; \
-    fi && \
-    cd /tmp && curl -sSL -O "${FOREGO_URL}"  && \
-    if [ ${FOREGO_URL##*.} = "tgz" ]; then \
-        tar -zxf ${FOREGO_URL##*/} ; \
-    fi && \
-    mv forego /usr/local/bin && chmod +x /usr/local/bin/forego
+    FOREGO_URL="https://github.com/drud/forego/releases/download/v0.16.1/forego-${TARGETARCH}" && \
+    cd /tmp && curl -sSL -o /usr/local/bin/forego "${FOREGO_URL}"  && chmod +x /usr/local/bin/forego
 
 RUN apt-get -qq update && \
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
-        ca-certificates certbot curl iputils-ping less python-certbot-nginx procps telnet vim wget && \
+        ca-certificates certbot curl iputils-ping less python3-certbot-nginx procps telnet vim wget && \
     apt-get autoremove -y && \
     apt-get clean -y && \
 	rm -rf /var/lib/apt/lists/*

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -59,7 +59,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.18.0" // Note that this can be overridden by make
+var RouterTag = "20211117_update_ddev_router" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* the upstream source for arm64 forego builds went away
* nginx:stable moved to Debian bullseye, so the package name for certbot
  had to change - instead, stay with previous nginx 1.20.1

See https://github.com/drud/ddev/issues/2980#issuecomment-972227437

## How this PR Solves The Problem:

* Use explicit upstream nginx image, 1.20.1, instead of "stable", which moved to 1.20.2
* Put the forego binaries (amd64 and arm64) in the drud/forego release instead of getting it from other places
* Go ahead and start using python3-certbot-nginx instead of python-certbot-nginx (python-certbot-nginx is no longer available in debian bullseye.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3378"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

