### PR TITLE
Add apt-get dist-upgrade -y to webimage_extra_packages

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -845,7 +845,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 `
 	if extraPackages != nil {
 		contents = contents + `
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
+RUN apt-get update && apt-get dist-upgrade -y && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 
 	// For webimage, update to latest composer.


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/oerdnj/deb.sury.org/issues/1682

An update to the upstream deb.sury.org repositories doesn't work with ddev's Dockerfile generation because of a needed `apt-get dist-upgrade`. This adds it.

TestExtraPackages was breaking, and it would break lots of ddev installations already in the wild.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3385"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

