### PR TITLE
Set correct permission for bash completion in AUR

### DIFF
--- a/.ci-scripts/bump_aur.sh
+++ b/.ci-scripts/bump_aur.sh
@@ -59,7 +59,7 @@ sha256sums=("${LINUX_HASH}")
 
 package() {
 	install -D -m 0755 ddev "\$pkgdir/usr/bin/ddev"
-	install -D -m 0755 ddev_bash_completion.sh "\$pkgdir/usr/share/bash-completion/completions/ddev"
+	install -D -m 0644 ddev_bash_completion.sh "\$pkgdir/usr/share/bash-completion/completions/ddev"
 }
 END
 


### PR DESCRIPTION
It works fine with 644, no executable permissions required.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3389"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

