### PR TITLE
Set writable perms on /var/lib/php in ddev-webserver start.sh

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -79,7 +79,7 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory}/${HOSTNAME}
-sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/
+sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 
 # /mnt/ddev_config/.homeadditions may be either
 # a bind-mount, or a volume mount, but we don't care,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220124_postgres" // Note that this can be overridden by make
+var WebTag = "20211122_php_sessions" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Problems cleaning up php gc() were reported in https://gitter.im/drud/ddev?at=619b5d2fcd3f06175dcbff24

`Uncaught PHP Exception ErrorException: "Notice: SessionHandler::gc(): ps_files_cleanup_dir: opendir(/var/lib/php/sessions) failed: Permission denied (13)` when PHP tries to clear / delete old sessions

## TODO

- [x] This doesn't solve the problem for hardened images (casual webhosting), because there we don't have sudo inside the container. But also, a 777 on /var/lib/php/sessions would be inappropriate and a security problem. So probably we have to run an elevated container during app.Start() to set this properly, as in https://github.com/drud/ddev/blob/d80a4d5c7f74d3aa43fbab366bcce7ff6b9d71aa/pkg/ddevapp/ddevapp.go#L851
- [x] This fix will allow rogue PHP code to explore php sessions, which doesn't matter much in a development environment, but definitely does in real webhosting.

## How this PR Solves The Problem:

Make sure that /var/lib/php is owned by the php-fpm user.

## Manual Testing Instructions:

Not sure how to recreate this.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3391"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

