### PR TITLE
AUR: Add zsh and fish completions

### DIFF
--- a/.ci-scripts/bump_aur.sh
+++ b/.ci-scripts/bump_aur.sh
@@ -60,6 +60,8 @@ sha256sums=("${LINUX_HASH}")
 package() {
 	install -D -m 0755 ddev "\$pkgdir/usr/bin/ddev"
 	install -D -m 0644 ddev_bash_completion.sh "\$pkgdir/usr/share/bash-completion/completions/ddev"
+	install -D -m 0644 ddev_zsh_completion.sh "\$pkgdir/usr/share/zsh/site-functions/_ddev"
+	install -D -m 0644 ddev_fish_completion.sh "\$pkgdir/usr/share/fish/vendor_completions.d/ddev.fish"
 }
 END
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
I did not notice at first, but after reading the docs, I discovered that there are completions for all shells.
Tested in `zsh` and `fish`, everything works as expected.
It will be useful to have this functionality for all users of AUR out of the box.

## How this PR Solves The Problem:
Adds completions to standard `zsh` and `fish` folders.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3392"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

