### PR TITLE
Remove HTTPS_EXPOSE from solr recipe

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -6,6 +6,8 @@ If you need a service not provided here, see [Defining an additional service wit
 
 ### Apache Solr
 
+**Note:** The [ddev-contrib Apache Solr recipe](https://github.com/drud/ddev-contrib/tree/master/docker-compose-services/solr) will soon replace this one. It's a more sophisticated and easier-to-manage approach.
+
 This recipe adds an Apache Solr container to a project. It will set up a solr core named "dev" with the solr configuration you define.
 
 #### Installation

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -105,7 +105,6 @@ func TestServices(t *testing.T) {
 func checkSolrService(t *testing.T, app *ddevapp.DdevApp) {
 	service := "solr"
 	httpPort := 8983
-	httpsPort := 8984
 	path := fmt.Sprintf("http://%s:%d/solr/", service, httpPort)
 
 	var err error
@@ -138,10 +137,6 @@ func checkSolrService(t *testing.T, app *ddevapp.DdevApp) {
 
 	// Ensure solr service is available via HTTP at exposed port location
 	resp, err := testcommon.EnsureLocalHTTPContent(t, fmt.Sprintf("http://%s.ddev.site:%d/solr/", app.GetName(), httpPort), "", 5)
-	assert.NoError(err, "resp=%v", resp)
-
-	// Ensure solr service is available via HTTPS at exposed port location 8984
-	resp, err = testcommon.EnsureLocalHTTPContent(t, fmt.Sprintf("https://%s.ddev.site:%d/solr/", app.GetName(), httpsPort), "", 5)
 	assert.NoError(err, "resp=%v", resp)
 }
 

--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -47,9 +47,6 @@ services:
       # HTTP_EXPOSE exposes http traffic from the container port 8983
       # to the host port 8983 vid ddev-router reverse proxy.
       - HTTP_EXPOSE=8983:8983
-      # HTTPS_EXPOSE exposes https traffic from the container port 8983
-      # to the host port 8984 vid ddev-router reverse proxy.
-      - HTTPS_EXPOSE=8984:8983
     volumes:
       # solr core *data* is stored on the 'solr' docker volume
       # This mount is optional; without it your search index disappears


### PR DESCRIPTION
## The Problem/Issue/Bug:

https to access the solr UI has never worked right; somehow the solr interface always redirects to the wrong thing.

## How this PR Solves The Problem:

Stop using HTTPS_EXPOSE. `ddev describe` will then show the http URL.

## Manual Testing Instructions:

- [x] Set up solr and `ddev describe` and verify that http url and that it works.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3394"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

