### PR TITLE
Add .bashrc.d option when starting shell

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -115,3 +115,5 @@ fi
 for f in /etc/bashrc/*.bashrc; do
   source $f;
 done
+
+for i in $HOME/.bashrc.d/*; do source $i; done

--- a/docs/users/extend/in-container-configuration.md
+++ b/docs/users/extend/in-container-configuration.md
@@ -18,6 +18,7 @@ Usage examples:
     StrictHostKeyChecking=no
     ```
 
+* You can add small scripts to the `.bashrc.d` directory and they will be executed on `ddev ssh`. For example, add a `~/.ddev/homeadditions/.bashrc.d/whereami` containing `echo "I am in the $(hostname) container"` and (after `ddev restart`) when you `ddev ssh` that will be executed.
 * If you have a favorite .bashrc, copy it in to either the global or project homeadditions.
 
 * If you like the traditional `ll` bash alias for `ls -l`, add a .ddev/homeadditions/.bash_aliases with these contents:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20211130_bump_upstream_php8.1.0" // Note that this can be overridden by make
+var WebTag = "20211124_bashrc.d" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Allows users to easily add to the .bashrc by adding files (via homeadditions) to ~/.bashrc.d, and the files will then be executed on bash start. (This does not work with `ddev exec`.)

- [x] Needs docs

## Manual Testing Instructions:

- [x] In global homeadditions, add a `.bashrc.d/<somefile>` and verify that it gets executed on `ddev ssh`. Experiment with it on `ddev exec` as well
- [x] Do the same using project homeadditions.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3397"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

