### PR TITLE
Use simple container name as hostname inside docker network (use "db" instead of "ddev-<project>-db")

### DIFF
--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -35,7 +35,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	assert.NoError(err)
 
 	// Run a simple ssh server to act on and get its internal IP address
-	_, err = exec.RunCommand("docker", []string{"run", "-d", "--name=test-cmd-ssh-server", "--network=ddev_default", "drud/test-ssh-server:v1.16.0"})
+	_, err = exec.RunCommand("docker", []string{"run", "-d", "--name=test-cmd-ssh-server", "--network=ddev", "drud/test-ssh-server:v1.16.0"})
 	assert.NoError(err)
 	//nolint: errcheck
 	defer dockerutil.RemoveContainer("test-cmd-ssh-server", 10)

--- a/containers/ddev-router/docker-entrypoint.sh
+++ b/containers/ddev-router/docker-entrypoint.sh
@@ -40,9 +40,9 @@ mkcert -install
 
 # It's unknown what docker event causes an attempt to use these certs/.crt files, but they might as well exist
 # to prevent it.
-mkcert -cert-file /etc/nginx/certs/.crt -key-file /etc/nginx/certs/.key "*.ddev.local" "*.ddev.site" 127.0.0.1 localhost ddev-router ddev-router.ddev_default
+mkcert -cert-file /etc/nginx/certs/.crt -key-file /etc/nginx/certs/.key "*.ddev.local" "*.ddev.site" 127.0.0.1 localhost ddev-router ddev-router.ddev
 
 if [ ! -f /etc/nginx/certs/master.crt ]; then
-  mkcert -cert-file /etc/nginx/certs/master.crt -key-file /etc/nginx/certs/master.key "*.ddev.local" "*.ddev.site" "ddev-router" "ddev-router.ddev_default" 127.0.0.1 localhost
+  mkcert -cert-file /etc/nginx/certs/master.crt -key-file /etc/nginx/certs/master.key "*.ddev.local" "*.ddev.site" "ddev-router" "ddev-router.ddev" 127.0.0.1 localhost
 fi
 exec "$@"

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -94,10 +94,6 @@ sudo mkdir -p ${CAROOT} && sudo chmod -R ugo+rw ${CAROOT}
 # This will install the certs from $CAROOT (/mnt/ddev-global-cache/mkcert)
 mkcert -install
 
-if [ -f ~/.my.cnf ]; then
-  perl -pi -e "s/host=db/host=ddev-${DDEV_PROJECT}-db/" ~/.my.cnf
-fi
-
 # VIRTUAL_HOST is a comma-delimited set of fqdns, convert it to space-separated and mkcert
 CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev_default
 echo 'Server started'

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -95,7 +95,7 @@ sudo mkdir -p ${CAROOT} && sudo chmod -R ugo+rw ${CAROOT}
 mkcert -install
 
 # VIRTUAL_HOST is a comma-delimited set of fqdns, convert it to space-separated and mkcert
-CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev_default
+CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev
 echo 'Server started'
 
 # We don't want the various daemons to know about PHP_IDE_CONFIG

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -89,10 +89,6 @@ mkdir -p ${CAROOT}
 # This will install the certs from $CAROOT (/mnt/ddev-global-cache/mkcert)
 mkcert -install
 
-if [ -f ~/.my.cnf ]; then
-  perl -pi -e "s/host=db/host=ddev-${DDEV_PROJECT}-db/" ~/.my.cnf
-fi
-
 # VIRTUAL_HOST is a comma-delimited set of fqdns, convert it to space-separated and mkcert
 CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev_default
 echo 'Server started'

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -90,7 +90,7 @@ mkdir -p ${CAROOT}
 mkcert -install
 
 # VIRTUAL_HOST is a comma-delimited set of fqdns, convert it to space-separated and mkcert
-CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev_default
+CAROOT=$CAROOT mkcert -cert-file /etc/ssl/certs/master.crt -key-file /etc/ssl/certs/master.key ${VIRTUAL_HOST//,/ } localhost 127.0.0.1 ${DOCKER_IP} web ddev-${DDEV_PROJECT:-}-web ddev-${DDEV_PROJECT:-}-web.ddev
 echo 'Server started'
 
 # We don't want the various daemons to know about PHP_IDE_CONFIG

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -25,7 +25,7 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
 * Add a solr server at `https://<projectname>>.ddev.site/en/admin/config/search/search-api/add-server`.
     * Use the "standard" Solr connector
     * Use the "http" protocol
-    * The "solr host" should be `ddev-<projectname>-solr` **NOT the default "localhost"**, because it does not run in the same container as the webserver. (Note that just using "solr" will often work, and used to be recommended, but it can be ambiguous if there are more than one projects running with a solr service.)
+    * The "solr host" should be `solr` **NOT the default "localhost"**, because it does not run in the same container as the webserver. (Note that just using "solr" will often work, and used to be recommended, but it can be ambiguous if there are more than one projects running with a solr service.)
     * The "solr core" should be named "dev" unless you customize the docker-compose.solr.yaml
     * Systems that use the Solr API v1 should use the "solr path" value of "/solr", while systems that use the Solr API v2 should use "/", otherwise they won't be able to connect to the Solr server.
     * Under "Advanced server configuration" set the "solr.install.dir" to `/opt/solr`
@@ -59,8 +59,8 @@ This recipe adds a Memcached 1.5 container to a project. The default configurati
 #### Interacting with Memcached
 
 * The Memcached instance will listen on TCP port 11211 (the Memcached default).
-* Configure your application to access Memcached on the host:port `ddev-<projectname>-memcached:11211`.
-* To reach the Memcached admin interface, run `ddev ssh` to connect to the web container, then use `nc` or `telnet` to connect to the Memcached container on port 11211, i.e. `nc ddev-<projectname>-memcached 11211`. You can then run commands such as `stats` to see usage information.
+* Configure your application to access Memcached on the host:port `memcached:11211`.
+* To reach the Memcached admin interface, run `ddev ssh` to connect to the web container, then use `nc` or `telnet` to connect to the Memcached container on port 11211, i.e. `nc memcached 11211`. You can then run commands such as `stats` to see usage information.
 
 ### Beanstalk (Work Queue)
 
@@ -74,7 +74,7 @@ This recipe adds a [Beanstalk](https://beanstalkd.github.io/) container to a pro
 #### Interacting with the Beanstalk Queue
 
 * The Beanstalk instance will listen on TCP port 11300 (the beanstalkd default).
-* Configure your application to access Beanstalk on the host:port `ddev-<projectname>-beanstalk:11300`.
+* Configure your application to access Beanstalk on the host:port `beanstalk:11300`.
 
 ## Additional services in ddev-contrib (MongoDB, PostgresSQL, etc)
 

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -26,7 +26,7 @@ version: '3.6'
 services:
   someservice:
     ports:
-      - "9999:9999"
+    - "9999:9999"
 ```
 
 That approach usually isn't sustainable because two projects might want to use the same port, so we *expose* the additional port (to the docker network) and then use the ddev-router to bind it to the host. This works only for services with an http API, but results in having both http and https ports (9998 and 9999).
@@ -37,11 +37,14 @@ version: '3.6'
 services:
   someservice:
     expose: 
-      - 9999
+    - 9999
     environment:
-      - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - HTTP_EXPOSE=9998:9999
-      - HTTPS_EXPOSE=9999:9999
+    - VIRTUAL_HOST=$DDEV_HOSTNAME
+    - HTTP_EXPOSE=9998:9999
+    - HTTPS_EXPOSE=9999:9999
+    networks:
+    - default
+    - ddev_default
 ```
 
 ### Confirming docker-compose configurations

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -44,7 +44,7 @@ services:
     - HTTPS_EXPOSE=9999:9999
     networks:
     - default
-    - ddev_default
+    - ddev
 ```
 
 ### Confirming docker-compose configurations

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -7,7 +7,7 @@ Do I lose my data when I do a `ddev poweroff` or `ddev stop` or `ddev restart`?
 : No, you don't lose data in your database or code with any of these commands. Your database is safely stored on a docker volume.
 
 How does my project connect to the database?
-: `ddev describe` gives full details of how to connect to the database. *Inside* the container the hostname is 'ddev-<projectname>-db' (**NOT** 127.0.0.1). User/password/database are all 'db'. For connection from the *host*, see `ddev describe`.
+: `ddev describe` gives full details of how to connect to the database. *Inside* the container the hostname is 'db' (**NOT** 127.0.0.1). User/password/database are all 'db'. For connection from the *host*, see `ddev describe`.
 
 How can I troubleshoot what's going wrong?
 : See the [troubleshooting](troubleshooting.md), [Docker troubleshooting](docker_installation.md#troubleshooting) and [Xdebug troubleshooting](step-debugging.md#troubleshooting-xdebug) sections of the docs.

--- a/docs/users/topics/database_management.md
+++ b/docs/users/topics/database_management.md
@@ -6,7 +6,7 @@ Remember, you can run `ddev [command] --help` for more info on many of the topic
 
 **Many database backends**: You can use a vast array of different database types, including MariaDB from 5.5 through 10.6 and MySQL from 5.5 through 8.0 ([docs](../extend/database_types.md#database-server-types)). Note that if you want to _change_ database type, especially to downgrade, you need to export your database and then `ddev delete` the project (to kill off the existing database), make the change to a new db type, start again, and import.
 
-**Default database**: DDEV creates a default database named `db` and default permissions for the `db` user with password `db`, and it's on the (inside Docker) hostname `ddev-<projectname>-db`.
+**Default database**: DDEV creates a default database named `db` and default permissions for the `db` user with password `db`, and it's on the (inside Docker) hostname `db`.
 
 **Extra databases**: In DDEV you can easily create and populate other databases as well. For example, `ddev import-db --target-db=backend --src=backend.sql.gz` will create the database named `backend` with permissions for that same `db` user and import from the `backend.sql.gz dumpfile`.
 

--- a/docs/users/topics/how_ddev_works.md
+++ b/docs/users/topics/how_ddev_works.md
@@ -3,7 +3,7 @@
 The easiest way to think about how DDEV works is to think of it as a set of little networked computers (docker containers). You can think of them as being in a different network world than your workstation computer, but reachable from there.
 
 * The `ddev-webserver` container (one per project) runs `nginx` or `apache` and `php-fpm` for a single site, so it does all the basic work of a PHP-interpreting webserver.
-* The `ddev-dbserver` container (one per project) handles MariaDB or MySQL database management. It can be reached from the webserver by the hostname `db` but better with the more explicit name `ddev-<projectname>-db`.
+* The `ddev-dbserver` container (one per project) handles MariaDB or MySQL database management. It can be reached from the webserver by the hostname `db` or with the more explicit name `ddev-<projectname>-db`.
 * The optional `dba` container runs PhpMyAdmin.
 * Additional add-on services may be there for a given project, for example `solr` or `elasticsearch` or `memcached`.
 

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -165,7 +165,7 @@ If you see "no space left on device" on Linux, it most likely means your filesys
 
 If a container fails to become ready, it means it's failing the healthcheck.  This can happen to any of the containers, but you can usually find out quickly what the issue is with a `docker inspect` command.
 
-You may need to install `jq` for these, `brew install jq`, or just remove the "| jq" from the command and read the raw json output.
+You may need to install [jq](https://stedolan.github.io/jq/download/) for these, `brew install jq`, or just remove the "| jq" from the command and read the raw json output.
 
 For the web container, `docker inspect --format "{{json .State.Health }}" ddev-<projectname>-web | jq`
 For ddev-router, `docker inspect --format "{{json .State.Health }}" ddev-router`

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -13,6 +13,9 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
+    networks:
+      - default
+      - ddev_default
     stop_grace_period: 60s
     working_dir: "{{ .DBWorkingDir }}"
     volumes:
@@ -74,6 +77,9 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
+    networks:
+      - default
+      - ddev_default
     cap_add:
       - SYS_PTRACE
     working_dir: "{{ .WebWorkingDir }}"
@@ -184,6 +190,9 @@ services:
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
+    networks:
+      - default
+      - ddev_default
     working_dir: "{{ .DBAWorkingDir }}"
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     labels:
@@ -215,7 +224,7 @@ services:
       retries: 1
     {{ end }}{{/* end if not .OmitDBA */}}
 networks:
-  default:
+  ddev_default:
     name: ddev_default
     external: true
 volumes:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -118,10 +118,6 @@ services:
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     user: '$DDEV_UID:$DDEV_GID'
     hostname: {{ .Name }}-web
-    {{if not .OmitDB }}
-    links:
-      - db:db
-    {{end}}
 
     ports:
       - "{{ .DockerIP }}:$DDEV_HOST_WEBSERVER_PORT:80"
@@ -200,8 +196,6 @@ services:
       com.ddev.platform: {{ .Plugin }}
       com.ddev.app-type: {{ .AppType }}
       com.ddev.approot: $DDEV_APPROOT
-    links:
-      - db:db
     expose:
       - "80"
     {{ if .HostPHPMyAdminPort }}

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -15,7 +15,7 @@ services:
     image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
     networks:
       - default
-      - ddev_default
+      - ddev
     stop_grace_period: 60s
     working_dir: "{{ .DBWorkingDir }}"
     volumes:
@@ -79,7 +79,7 @@ services:
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
     networks:
       - default
-      - ddev_default
+      - ddev
     cap_add:
       - SYS_PTRACE
     working_dir: "{{ .WebWorkingDir }}"
@@ -188,7 +188,7 @@ services:
     image: $DDEV_DBAIMAGE
     networks:
       - default
-      - ddev_default
+      - ddev
     working_dir: "{{ .DBAWorkingDir }}"
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     labels:
@@ -218,8 +218,8 @@ services:
       retries: 1
     {{ end }}{{/* end if not .OmitDBA */}}
 networks:
-  ddev_default:
-    name: ddev_default
+  ddev:
+    name: ddev
     external: true
 volumes:
   {{if not .OmitDB }}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -183,6 +183,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	assert.NoError(err)
 
 	// After the config has been written and directories exist, the write should work.
+	app.DockerEnv()
 	err = app.WriteDockerComposeYAML()
 	assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -507,7 +507,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 	insideContainerImportPath := path.Join("/mnt/ddev_config/", filepath.Base(dbPath))
 	// But if we don't have bind mounts, we have to copy dump into the container
 	if globalconfig.DdevGlobalConfig.NoBindMounts {
-		dbContainerName := "db"
+		dbContainerName := GetContainerName(app, "db")
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -236,7 +236,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 			dbinfo["username"] = "db"
 			dbinfo["password"] = "db"
 			dbinfo["dbname"] = "db"
-			dbinfo["host"] = GetContainerName(app, "db")
+			dbinfo["host"] = "db"
 			dbPublicPort, err := app.GetPublishedPort("db")
 			util.CheckErr(err)
 			dbinfo["dbPort"] = GetPort("db")
@@ -507,7 +507,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 	insideContainerImportPath := path.Join("/mnt/ddev_config/", filepath.Base(dbPath))
 	// But if we don't have bind mounts, we have to copy dump into the container
 	if globalconfig.DdevGlobalConfig.NoBindMounts {
-		dbContainerName := GetContainerName(app, "db")
+		dbContainerName := "db"
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -245,7 +245,7 @@ func TestMain(m *testing.M) {
 	output.LogSetUp()
 
 	// Since this may be first time ddev has been used, we need the
-	// ddev_default network available.
+	// ddev network available.
 	dockerutil.EnsureDdevNetwork()
 
 	// Avoid having sudo try to add to /etc/hosts.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -385,9 +385,6 @@ func TestDdevStart(t *testing.T) {
 		assert.True(check, "Container check on %s failed", containerType)
 	}
 
-	x := dockerutil.NetworkExists("ddev-" + app.Name + "_default")
-	_ = x
-
 	if util.IsCommandAvailable("mysql") {
 		dbPort, err := app.GetPublishedPort("db")
 		assert.NoError(err)

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -47,7 +47,7 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 		DatabaseName:     "db",
 		DatabaseUsername: "db",
 		DatabasePassword: "db",
-		DatabaseHost:     GetContainerName(app, "db"),
+		DatabaseHost:     "db",
 		DatabaseDriver:   "mysql",
 		DatabasePort:     GetPort("db"),
 		DatabasePrefix:   "",

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -50,7 +50,7 @@ func createMagentoSettingsFile(app *DdevApp) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		templateVars := map[string]interface{}{"DBHostname": GetContainerName(app, "db")}
+		templateVars := map[string]interface{}{"DBHostname": "db"}
 		err = fileutil.TemplateStringToFile(string(content), templateVars, app.SiteSettingsPath)
 		if err != nil {
 			return "", err
@@ -151,7 +151,7 @@ func createMagento2SettingsFile(app *DdevApp) (string, error) {
 			return "", err
 		}
 
-		templateVars := map[string]interface{}{"DBHostname": GetContainerName(app, "db")}
+		templateVars := map[string]interface{}{"DBHostname": "db"}
 		err = fileutil.TemplateStringToFile(string(content), templateVars, app.SiteSettingsPath)
 		if err != nil {
 			return "", err

--- a/pkg/ddevapp/network_test.go
+++ b/pkg/ddevapp/network_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 // TestNetworkAmbiguity tests the behavior and setup of docker networking.
-// With `links:` statement, we should get unambiguous name resolution,
-// but without it, our two projects can have crosstalk.
+// There should be no crosstalk between different projects
 func TestNetworkAmbiguity(t *testing.T) {
 	assert := asrt.New(t)
 
@@ -61,9 +60,10 @@ func TestNetworkAmbiguity(t *testing.T) {
 		assert.NoError(err)
 	}
 
-	// With the standard setup, we'll get TWO matching "test" services on db
+	// With the improved two-network handling, the simple service names
+	// are no longer ambiguious. We'll see just one entry for web and one for db
 	// very ambiguous, but just one on web, because it has 'links'
-	expectations := map[string]int{"web": 1, "db": 2}
+	expectations := map[string]int{"web": 1, "db": 1}
 	for projName := range projects {
 		app, err := ddevapp.GetActiveApp(projName)
 		assert.NoError(err)

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -2,6 +2,8 @@ version: '{{ .compose_version }}'
 services:
   ddev-router:
     image: {{ .router_image }}:{{ .router_tag }}
+    networks:
+        - ddev_default
     container_name: ddev-router
     ports:{{ $dockerIP := .dockerIP }}{{ if not .router_bind_all_interfaces }}{{ range $port := .ports }}
     - "{{ $dockerIP }}:{{ $port }}:{{ $port }}"{{ end }}{{ else }}{{ range $port := .ports }}
@@ -26,7 +28,7 @@ services:
       timeout: 120s
 
 networks:
-  default:
+  ddev_default:
     name: ddev_default
     external: true
 volumes:

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -3,7 +3,7 @@ services:
   ddev-router:
     image: {{ .router_image }}:{{ .router_tag }}
     networks:
-        - ddev_default
+        - ddev
     container_name: ddev-router
     ports:{{ $dockerIP := .dockerIP }}{{ if not .router_bind_all_interfaces }}{{ range $port := .ports }}
     - "{{ $dockerIP }}:{{ $port }}:{{ $port }}"{{ end }}{{ else }}{{ range $port := .ports }}
@@ -28,8 +28,8 @@ services:
       timeout: 120s
 
 networks:
-  ddev_default:
-    name: ddev_default
+  ddev:
+    name: ddev
     external: true
 volumes:
   ddev-global-cache:

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -82,7 +82,7 @@ func getShopwareUploadDir(app *DdevApp) string {
 func shopware6PostStartAction(app *DdevApp) error {
 	envFile := filepath.Join(app.AppRoot, ".env")
 	var addOnConfig string
-	expectedDatabaseURL := fmt.Sprintf(`DATABASE_URL="mysql://db:db@%s:3306/db"`, GetContainerName(app, "db"))
+	expectedDatabaseURL := `DATABASE_URL="mysql://db:db@db:3306/db"`
 	expectedPrimaryURL := fmt.Sprintf(`APP_URL="%s"`, app.GetPrimaryURL())
 	expectedMailerURL := `MAILER_URL="smtp://localhost:1025?encryption=&auth_mode="`
 

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -17,6 +17,8 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: '{{ .ssh_auth_image }}:{{ .ssh_auth_tag }}-built'
+    networks:
+      - ddev_default
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     user: '$DDEV_UID:$DDEV_GID'
     volumes:
@@ -29,3 +31,7 @@ services:
       retries: 2
       start_period: 10s
       timeout: 62s
+networks:
+  ddev_default:
+    name: ddev_default
+    external: true

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -18,7 +18,7 @@ services:
         gid: '{{ .GID }}'
     image: '{{ .ssh_auth_image }}:{{ .ssh_auth_tag }}-built'
     networks:
-      - ddev_default
+      - ddev
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     user: '$DDEV_UID:$DDEV_GID'
     volumes:
@@ -32,6 +32,6 @@ services:
       start_period: 10s
       timeout: 62s
 networks:
-  ddev_default:
-    name: ddev_default
+  ddev:
+    name: ddev
     external: true

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -17,6 +17,8 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: '{{ .ssh_auth_image }}:{{ .ssh_auth_tag }}-built'
+    networks:
+      - ddev_default
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     user: '$DDEV_UID:$DDEV_GID'
     volumes:
@@ -30,6 +32,6 @@ services:
       start_period: 10s
       timeout: 62s
 networks:
-  default:
+  ddev_default:
     name: ddev_default
     external: true

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -17,8 +17,6 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: '{{ .ssh_auth_image }}:{{ .ssh_auth_tag }}-built'
-    networks:
-      - ddev_default
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     user: '$DDEV_UID:$DDEV_GID'
     volumes:
@@ -31,7 +29,3 @@ services:
       retries: 2
       start_period: 10s
       timeout: 62s
-networks:
-  ddev_default:
-    name: ddev_default
-    external: true

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -109,7 +109,7 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 		}
 	}
 
-	templateVars := map[string]interface{}{"DBHostname": GetContainerName(app, "db")}
+	templateVars := map[string]interface{}{"DBHostname": "db"}
 	err := fileutil.TemplateStringToFile(typo3AdditionalConfigTemplate, templateVars, filePath)
 	if err != nil {
 		return err

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -100,11 +100,19 @@ func Cleanup(app *DdevApp) error {
 	labels := map[string]string{
 		"com.ddev.site-name": app.GetName(),
 	}
-	containers, err := dockerutil.FindContainersByLabels(labels)
+
+	// remove project network
+	// "docker-compose down" - removes project network and any left-overs
+	_, _, err := dockerutil.ComposeCmd([]string{app.DockerComposeFullRenderedYAMLPath()}, "down")
 	if err != nil {
 		return err
 	}
 
+	// If any leftovers or lost souls, find them as well
+	containers, err := dockerutil.FindContainersByLabels(labels)
+	if err != nil {
+		return err
+	}
 	// First, try stopping the listed containers if they are running.
 	for i := range containers {
 		containerName := containers[i].Names[0][1:len(containers[i].Names[0])]

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/fsouza/go-dockerclient"
+	"github.com/drud/ddev/pkg/output"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"path"
 	"path/filepath"
@@ -17,7 +18,6 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 )
 
@@ -103,9 +103,11 @@ func Cleanup(app *DdevApp) error {
 
 	// remove project network
 	// "docker-compose down" - removes project network and any left-overs
-	_, _, err := dockerutil.ComposeCmd([]string{app.DockerComposeFullRenderedYAMLPath()}, "down")
-	if err != nil {
-		return err
+	// There can be awkward cases where we're doing an app.Stop() but the rendered
+	// yaml does not exist, all in testing situations.
+	if fileutil.FileExists(app.DockerComposeFullRenderedYAMLPath()) {
+		_, _, err := dockerutil.ComposeCmd([]string{app.DockerComposeFullRenderedYAMLPath()}, "down")
+		util.Warning("Failed to docker-compose down: %v", err)
 	}
 
 	// If any leftovers or lost souls, find them as well

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -107,7 +107,9 @@ func Cleanup(app *DdevApp) error {
 	// yaml does not exist, all in testing situations.
 	if fileutil.FileExists(app.DockerComposeFullRenderedYAMLPath()) {
 		_, _, err := dockerutil.ComposeCmd([]string{app.DockerComposeFullRenderedYAMLPath()}, "down")
-		util.Warning("Failed to docker-compose down: %v", err)
+		if err != nil {
+			util.Warning("Failed to docker-compose down: %v", err)
+		}
 	}
 
 	// If any leftovers or lost souls, find them as well

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/version"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
 	"runtime"
@@ -78,7 +79,7 @@ func TestDockerComposeDownload(t *testing.T) {
 		}
 		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = v
 		downloaded, err = dockerutil.DownloadDockerComposeIfNeeded()
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.True(downloaded)
 		// We have to reset version.DockerComposeVersion so it will actually check
 		// instead of using cached value.

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -52,7 +52,7 @@ func EnsureNetwork(client *docker.Client, name string) error {
 	return nil
 }
 
-// EnsureDdevNetwork just creates or ensures the ddev_default network exists or
+// EnsureDdevNetwork just creates or ensures the ddev network exists or
 // exits with fatal.
 func EnsureDdevNetwork() {
 	// ensure we have docker network

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -71,6 +71,13 @@ func NetworkExists(netName string) bool {
 	return NetExists(client, strings.ToLower(netName))
 }
 
+// RemoveNetwork removes the named docker network
+func RemoveNetwork(netName string) error {
+	client := GetDockerClient()
+	err := client.RemoveNetwork(netName)
+	return err
+}
+
 var dockerHost string
 
 // GetDockerClient returns a docker client respecting the current docker context

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -63,6 +63,14 @@ func EnsureDdevNetwork() {
 	}
 }
 
+// NetworkExists returns true if the named network exists
+// Mostly intended for tests
+func NetworkExists(netName string) bool {
+	// ensure we have docker network
+	client := GetDockerClient()
+	return NetExists(client, strings.ToLower(netName))
+}
+
 var dockerHost string
 
 // GetDockerClient returns a docker client respecting the current docker context

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -32,7 +32,7 @@ import (
 )
 
 // NetName provides the default network name for ddev.
-const NetName = "ddev_default"
+const NetName = "ddev"
 
 // EnsureNetwork will ensure the docker network for ddev is created.
 func EnsureNetwork(client *docker.Client, name string) error {
@@ -487,7 +487,7 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 	// Container (or Volume) ... Creating or Created or Stopping or Starting or Removing
 	// Container Stopped or Created
 	// No resource found to remove (when doing a stop and no project exists)
-	ignoreRegex := "(^(Container|Volume) .* (Creat|Start|Stopp|Remov)ing$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove$)"
+	ignoreRegex := "(^(Network|Container|Volume) .* (Creat|Start|Stopp|Remov)ing$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove$)"
 	downRE, err := regexp.Compile(ignoreRegex)
 	if err != nil {
 		util.Warning("failed to compile regex %v: %v", ignoreRegex, err)

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -1,5 +1,5 @@
 networks:
-  default:
+  ddev_default:
     name: ddev_default
     external: true
 
@@ -22,6 +22,9 @@ services:
       LINES: '25'
       VIRTUAL_HOST: junk.ddev.site
     image: TEST-COMPOSE-WITH-STREAMS-IMAGE
+    networks:
+      - default
+      - ddev_default
     user: "33:33"
     labels:
       com.ddev.app-type: php

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -1,6 +1,6 @@
 networks:
-  ddev_default:
-    name: ddev_default
+  ddev:
+    name: ddev
     external: true
 
 services:
@@ -24,7 +24,7 @@ services:
     image: TEST-COMPOSE-WITH-STREAMS-IMAGE
     networks:
       - default
-      - ddev_default
+      - ddev
     user: "33:33"
     labels:
       com.ddev.app-type: php

--- a/pkg/dockerutil/testdata/docker-compose.yml
+++ b/pkg/dockerutil/testdata/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   db:
     container_name: ddev-test-db
     image: DDEV_DBIMAGE
+    networks:
+      - default
+      - ddev_default
     user: "$DDEV_UID:$DDEV_GID"
     restart: always
     environment:
@@ -17,6 +20,9 @@ services:
   web:
     container_name: ddev-test-web
     image: DDEV_WEBIMAGE
+    networks:
+      - default
+      - ddev_default
     user: "$DDEV_UID:$DDEV_GID"
     volumes:
       - "../htdocs/:/var/www/html/docroot:cached"
@@ -43,7 +49,7 @@ services:
       start_period: 20s
       timeout: 120s
 networks:
-  default:
+  ddev_default:
     name: ddev_default
     external: true
 

--- a/pkg/dockerutil/testdata/docker-compose.yml
+++ b/pkg/dockerutil/testdata/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: DDEV_DBIMAGE
     networks:
       - default
-      - ddev_default
+      - ddev
     user: "$DDEV_UID:$DDEV_GID"
     restart: always
     environment:
@@ -22,7 +22,7 @@ services:
     image: DDEV_WEBIMAGE
     networks:
       - default
-      - ddev_default
+      - ddev
     user: "$DDEV_UID:$DDEV_GID"
     volumes:
       - "../htdocs/:/var/www/html/docroot:cached"
@@ -47,7 +47,7 @@ services:
       start_period: 20s
       timeout: 120s
 networks:
-  ddev_default:
-    name: ddev_default
+  ddev:
+    name: ddev
     external: true
 

--- a/pkg/dockerutil/testdata/docker-compose.yml
+++ b/pkg/dockerutil/testdata/docker-compose.yml
@@ -29,8 +29,6 @@ services:
     restart: always
     depends_on:
       - db
-    links:
-      - db:db
     ports:
       - "80"
       - 8025

--- a/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
@@ -8,6 +8,9 @@ services:
   beanstalk: # This is the service name used when running ddev commands accepting the --service flag
     container_name: ddev-${DDEV_SITENAME}-beanstalk # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
     image: schickling/beanstalkd:latest
+    networks:
+      - default
+      - ddev_default
     restart: "no"
     expose:
     - 11300 # beanstalk is available at this port inside the container (default port for beanstalkd)

--- a/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
@@ -10,7 +10,7 @@ services:
     image: schickling/beanstalkd:latest
     networks:
       - default
-      - ddev_default
+      - ddev
     restart: "no"
     expose:
     - 11300 # beanstalk is available at this port inside the container (default port for beanstalkd)

--- a/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
@@ -19,7 +19,4 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
     volumes:
     - ".:/mnt/ddev_config"
-  web:
-    links:
-    - beanstalk:beanstalk
 

--- a/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
@@ -31,6 +31,3 @@ services:
 
     volumes:
     - ".:/mnt/ddev_config"
-  web:
-    links:
-    - memcached:memcached

--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -76,12 +76,6 @@ services:
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
 
-  # This links the Solr service to the web service defined in the main
-  # docker-compose.yml, allowing applications running inside the web container to
-  # access the Solr service at http://solr:8983
-  web:
-    links:
-      - solr:solr
 volumes:
   # solr is a persistent Docker volume for solr data
   # The persistent volume should have the same name as the service so it can be deleted

--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -34,7 +34,7 @@ services:
     image: solr:8
     networks:
       - default
-      - ddev_default
+      - ddev
     restart: "no"
     # Solr is served from this port inside the container.
     expose:

--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -32,6 +32,9 @@ services:
     # README: https://github.com/docker-solr/docker-solr/blob/master/README.md
     # It's almost impossible to work with it if you don't read the docs there
     image: solr:8
+    networks:
+      - default
+      - ddev_default
     restart: "no"
     # Solr is served from this port inside the container.
     expose:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -59,7 +59,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.18.2" // Note that this can be overridden by make
+var RouterTag = "20211128__docker-compose-networking" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,13 +41,13 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20211230_blackfire_on_prod" // Note that this can be overridden by make
+var WebTag = "20211128__docker-compose-networking" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20211128__docker-compose-networking"
+var BaseDBTag = "20211211_volumes_for_config"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -47,7 +47,7 @@ var WebTag = "20211230_blackfire_on_prod" // Note that this can be overridden by
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20211211_volumes_for_config"
+var BaseDBTag = "20211128__docker-compose-networking"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* In recent versions of docker-compose there have been problems with the `links` stanza, where it does not properly bind "db" for example, to the project's "db" service. These have been solved in the docker-compose that is currently bundled by ddev.
* But for years (since the beginning of ddev) containers included without a "links" (like solr) have resulted in ambiguity and unpredictable behavior between projects. One ddev project might accidentally connect to another project's solr service, for example.

Unambiguity in name resolution was recently only possible in `ddev`when using `ddev-<projectname>-<service>` which requires a level of environment-awareness in apps that should usually not be necessary in a container environment.

## How this PR Solves The Problem:

This PR sets up networking where the service name of a project's container is perfectly adequate to address it. For example, `ping db` in the web container will always get the related project's db container. `ping solr` will always get the related solr container, not one from another service.

This makes ddev use  standard docker-compose networking as described in https://docs.docker.com/compose/networking/.

The "ddev" network is now only used to communicate across projects and with the proxy.

Contrib-service-recipes that only need per-project networking (via its service name or `ddev-<projectname>-<service>:<port>`) will not need any changes.
Those that use HTTP_EXPOSE and HTTPS_EXPOSE to be reachable externally via `http[s]://<project>:<port>` (via ddev-router) or cross-project need to add the "ddev" network:
```
networks: [default, ddev]
```
This can be given as general advise, too because it does not hurt.

All ddev-contrib service examples should be updated.

## Manual Testing Instructions:

To test this: 
* Use [gitpod](https://gitpod.io/#https://github.com/drud/ddev/pull/3403)
* Download the artifacts in the latest [build](https://github.com/drud/ddev/actions/workflows/pr-build.yml?query=branch%3A20211128__docker-compose-networking++) and [put ddev in your path](https://github.com/drud/ddev/blob/master/docs/developers/building-contributing.md#testing-a-pr)

Create multiple ddev projects (`ddev config` with all defaults).
Run `ddev exec ping db` from them.

You should see answers only from the project-local "db" container.
With docker-compose v2.1.1 you would see answers from other "db" containers.

In order to test cross-project connectivity, run 
* `ddev exec ping ddev-<other-projectname>-db`.

To test this properly, use docker-compose v2.1.1, which had the bug about not respecting `links`. `ddev config global --docker-compose-version=v2.1.1`


## Automated Testing Overview:

- [x] Added TestNetworkAmbiguity

## Related Issue Link(s):

* #3369
* docker/compose#8935

## Remarks/tbd:
* This change tries to minimize code changes. For improved self-documentation the network should rather be called "ddev_proxy" or "ddev_frontend".
- [x] Removed ddev-ssh-agent networks completely
- [x] Usage of docker-compose service "links" should not be necessary any more.
- [ ] ddev-contrib services (especially containing HTTP_EXPOSE) needs to be updated with the new networking on release
- [ ] Release notes need to explain the change and what it means to 3rd party projects

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3403"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

