### PR TITLE
Truncate existing file when `ddev export-db --file=`, fixes #3402

### DIFF
--- a/cmd/ddev/cmd/export-db_test.go
+++ b/cmd/ddev/cmd/export-db_test.go
@@ -60,6 +60,8 @@ func TestCmdExportDB(t *testing.T) {
 	err = os.Chdir(tmpDir)
 	assert.NoError(err)
 
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
 	err = os.RemoveAll(outputFileName)
 	assert.NoError(err)
 	command = exec.Command(DdevBin, "export-db", site.Name, "-f="+outputFileName, "--gzip=false")

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -576,7 +576,7 @@ func (app *DdevApp) ExportDB(outFile string, gzip bool, targetDB string) error {
 		opts.Cmd = fmt.Sprintf("mysqldump %s | gzip", targetDB)
 	}
 	if outFile != "" {
-		f, err := os.OpenFile(outFile, os.O_RDWR|os.O_CREATE, 0644)
+		f, err := os.OpenFile(outFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return fmt.Errorf("failed to open %s: %v", outFile, err)
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1424,6 +1424,7 @@ func TestDdevExportDB(t *testing.T) {
 	assert.NoError(err)
 	assert.Greater(f.Size(), int64(2000))
 	l, err := readLastLine("tmp/users1.sql")
+	assert.NoError(err)
 	assert.Contains(l, "-- Dump completed on")
 
 	// Now rename our (larger) users1.sql to users1.sql.gz
@@ -1505,6 +1506,9 @@ func readLastLine(fileName string) (string, error) {
 
 	buf := make([]byte, 80)
 	stat, err := os.Stat(fileName)
+	if err != nil {
+		return "", err
+	}
 	start := stat.Size() - 80
 	_, err = file.ReadAt(buf, start)
 	if err != nil {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1413,9 +1413,32 @@ func TestDdevExportDB(t *testing.T) {
 	err = fileutil.PurgeDirectory("tmp")
 	assert.NoError(err)
 
-	// Test that we can export-db to a gzipped file
+	// Test that we can export-db to a plain file. This should be larger than
+	// the gzipped file we'll do next.
+	err = app.ExportDB("tmp/users1.sql", false, "db")
+	assert.NoError(err)
+
+	// The users1.sql should be something over 2K
+	// and should finish with "Dump completed on"
+	f, err := os.Stat("tmp/users1.sql")
+	assert.NoError(err)
+	assert.Greater(f.Size(), int64(2000))
+	l, err := readLastLine("tmp/users1.sql")
+	assert.Contains(l, "-- Dump completed on")
+
+	// Now rename our (larger) users1.sql to users1.sql.gz
+	// so we can overwrite it and come out with a totally valid new file.
+	err = os.Rename("tmp/users1.sql", "tmp/users1.sql.gz")
+	assert.NoError(err)
+
+	// Test that we can export-db to an existing gzipped file
 	err = app.ExportDB("tmp/users1.sql.gz", true, "db")
 	assert.NoError(err)
+
+	// The new gzipped file should be less than 1K
+	f, err = os.Stat("tmp/users1.sql.gz")
+	assert.NoError(err)
+	assert.Less(f.Size(), int64(1000))
 
 	// Validate contents
 	err = archive.Ungzip("tmp/users1.sql.gz", "tmp")
@@ -1469,6 +1492,25 @@ func TestDdevExportDB(t *testing.T) {
 	assert.Equal("2\n", out)
 
 	runTime()
+}
+
+// readLastLine opens the fileName listed and returns the last
+// 80 bytes of the file
+func readLastLine(fileName string) (string, error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	buf := make([]byte, 80)
+	stat, err := os.Stat(fileName)
+	start := stat.Size() - 80
+	_, err = file.ReadAt(buf, start)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
 }
 
 // TestDdevFullSiteSetup tests a full import-db and import-files and then looks to see if

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -232,7 +232,7 @@ func CreateGitIgnore(targetDir string, ignores ...string) error {
 		return err
 	}
 
-	file, err := os.OpenFile(gitIgnoreFilePath, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := os.OpenFile(gitIgnoreFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

When using `ddev export-db` if the output file already exists and is larger than the new output file, the file will be the same size as before. This causes `ddev import-db` to fail again, `gunzip` to consider that the file has garbage at the end, etc.

Closes #3402

## How this PR Solves The Problem:

The file is truncated at opening.

## Manual Testing Instructions:

Copy a very large file to db.sql.gz.
Run `ddev export-db -f db.sql.gz` on a site with a small database.
The file should be smaller than before, and `gunzip` should not complain about it.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3407"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

