### PR TITLE
Bump upstream web container to get php8.1.0

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.18.1-alpha8 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.18.2-alpha1 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20211117_explicit_db_hostname" // Note that this can be overridden by make
+var WebTag = "20211130_bump_upstream_php8.1.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Upstream deb.sury.org/ddev-images has updated many things
* php8.1.0 is now there

## How this PR Solves The Problem:

Update to these.

## Manual Testing Instructions:

- [x] `ddev start` and `ddev exec php8.1 --version` - you should have php 8.1.0



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3408"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

