### PR TITLE
Compile binary with goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Compiled binaries by goreleaser
+/dist
 # Temporary build-tools artifacts to be ignored
 /.gotmp/
 /VERSION.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,35 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    main: ./cmd/ddev
+    goarch:
+      - amd64
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
## The Problem/Issue/Bug:
#1678 Consider packaging native linux packages.

## How this PR Solves The Problem:
- [x] Proof of concept that binaries can be achieved with goreleaser
- [x] Create linux (and windows/mac) binaries
- [ ] Add binaries into github release with `goreleaser release`
- [ ] Create linux packages (deb etc)

## Manual Testing Instructions:
- [Install goreleaser](https://goreleaser.com/install/) and go 1.16+
- Run `goreleaser release --snapshot --rm-dist`
- Check `dist` folder.

**See it in action: https://asciinema.org/a/1ys721qaRcSc3HhJbo474xt4a**
[![asciicast](https://asciinema.org/a/1ys721qaRcSc3HhJbo474xt4a.svg)](https://asciinema.org/a/1ys721qaRcSc3HhJbo474xt4a)

From here on, DEB files can *probably* be created, but that is not well documented (for me) in goreleaser docs.
It is also possible to automatically create binaries and add then in the release page of github, this is handled by goreleaser, but for the moment I was only looking for a proof of concept.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

