### PR TITLE
Fix WSL2 docker-native host.docker.internal, use experimentalNetwork in .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,6 @@
 image: drud/ddev-gitpod-base:20211028_new_host_docker_internal_detection
 
+experimentalNetwork: true
 tasks:
   - name: ddev
   - name: simpleproj

--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -16,8 +16,7 @@ Docker Desktop for Windows can be downloaded via [Chocolatey](https://chocolatey
 
 Docker installation on Linux depends on what flavor you're using. Where possible the Ubuntu/Deb/yum repository is the preferred technique.
 
-* Ubuntu 20.04+ has recent enough versions that you can `sudo apt-get update && sudo apt-get install docker.io docker-compose`
-* [Ubuntu before 20.04](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+* [Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
 * [CentOS](https://docs.docker.com/install/linux/docker-ce/centos/)
 * [Debian](https://docs.docker.com/install/linux/docker-ce/debian/)
 * [Fedora](https://docs.docker.com/install/linux/docker-ce/fedora/). Recent versions of Fedora (32, 33+) require a [different approach, installing the original CGroups](https://fedoramagazine.org/docker-and-fedora-32/). In addition, you must [disable SELinux](https://www.cyberciti.biz/faq/disable-selinux-on-centos-7-rhel-7-fedora-linux/).
@@ -28,6 +27,8 @@ After installing Docker you *must* install docker-compose separately except on U
 ### Linux Post-installation steps (required)
 
 See [Docker's post-installation steps](https://docs.docker.com/install/linux/linux-postinstall/). You need to add your linux user to the "docker" group and configure the docker daemon to start on boot.
+
+On systems that do not include systemd or equivalent (mostly if installing inside WSL2) you'll need to manually start docker with `service docker start` or the equivalent in your distro. You can add this into your .profile or equivalent.
 
 <a name="troubleshooting"></a>
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -838,15 +839,24 @@ func CreateVolume(volumeName string, driver string, driverOpts map[string]string
 	return volume, err
 }
 
-// GetHostDockerInternalIP returns either "host.docker.internal"
+// GetHostDockerInternalIP returns either "" (will use the hostname as is)
 // (for docker-for-mac and Win10 Docker-for-windows) or a usable IP address
 func GetHostDockerInternalIP() (string, error) {
 	hostDockerInternal := ""
 
+	switch {
+	// TODO: Remove this stanza when experimentalNetwork: true is no longer
+	// required on Gitpod - then it behaves as normal linux
+	case nodeps.IsGitpod():
+		addrs, err := net.LookupHost(os.Getenv("HOSTNAME"))
+		if err == nil && len(addrs) > 0 {
+			hostDockerInternal = addrs[0]
+		}
+
 	// Docker on linux doesn't define host.docker.internal
 	// so we need to go get the bridge IP address
 	// WSL2 (with Docker Desktop) defines host.docker.internal itself.
-	if runtime.GOOS == "linux" && !nodeps.IsDockerDesktopWSL2() {
+	case runtime.GOOS == "linux" && !nodeps.IsDockerDesktopWSL2():
 		// look up info from the bridge network
 		client := GetDockerClient()
 		n, err := client.NetworkInfo("bridge")
@@ -854,9 +864,14 @@ func GetHostDockerInternalIP() (string, error) {
 			return "", err
 		}
 		if len(n.IPAM.Config) > 0 {
-			hostDockerInternal = n.IPAM.Config[0].Gateway
+			if n.IPAM.Config[0].Gateway != "" {
+				hostDockerInternal = n.IPAM.Config[0].Gateway
+			} else {
+				util.Warning("Unable to determine host.docker.internal - no gateway")
+			}
 		}
 	}
+
 	return hostDockerInternal, nil
 }
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -846,7 +846,7 @@ func GetHostDockerInternalIP() (string, error) {
 	// Docker on linux doesn't define host.docker.internal
 	// so we need to go get the bridge IP address
 	// WSL2 (with Docker Desktop) defines host.docker.internal itself.
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" && !nodeps.IsDockerDesktopWSL2() {
 		// look up info from the bridge network
 		client := GetDockerClient()
 		n, err := client.NetworkInfo("bridge")

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -4,6 +4,7 @@ import (
 	"golang.org/x/term"
 	"math/rand"
 	"os"
+	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -66,9 +67,12 @@ func IsWSL2() bool {
 // IsDockerDesktopWSL2 detects if running on WSL2 using Docker Desktop
 func IsDockerDesktopWSL2() bool {
 	if IsWSL2() {
-		link, err := os.Readlink("docker")
-		if err == nil && strings.HasPrefix(link, "/mnt/wsl/docker-desktop") {
-			return true
+		p, err := exec.LookPath("docker")
+		if err == nil {
+			link, err := os.Readlink(p)
+			if err == nil && strings.HasPrefix(link, "/mnt/wsl/docker-desktop") {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 	"unicode"
 )
@@ -60,6 +61,17 @@ func RandomString(length int) string {
 // IsWSL2 returns true if running WSL2
 func IsWSL2() bool {
 	return GetWSLDistro() != ""
+}
+
+// IsDockerDesktopWSL2 detects if running on WSL2 using Docker Desktop
+func IsDockerDesktopWSL2() bool {
+	if IsWSL2() {
+		link, err := os.Readlink("docker")
+		if err == nil && strings.HasPrefix(link, "/mnt/wsl/docker-desktop") {
+			return true
+		}
+	}
+	return false
 }
 
 // IsMacM1 returns true if running on mac M1


### PR DESCRIPTION
## The Problem/Issue/Bug:

`host.docker.internal` does not currently work on WSL2 with native docker install (as opposed to Docker Desktop).  This is because of name resolution changes for Gitpod, which should probably be reverted. These went into ddev v1.18.1 in https://github.com/drud/ddev/pull/3346

* https://github.com/gitpod-io/gitpod/issues/6446 claims that `experimentalNetwork: true` in .gipod.yml can make it behave as expected with regard to the bridge network.

## Blocker
- [x] Determine if there is a way to tell inside WSL2 whether we're running Docker Desktop

## How this PR Solves The Problem:

## Manual Testing Instructions:

- [x] Manual test xdebug usage on ordinary Linux
- [x] Manually test xdebug usage on WSL2 Docker Desktop
- [x] Manually test xdebug on WSL2 with docker installed inside
- [x] Manually test xdebug using PhpStorm on Windows and WSL2 with Docker Desktop
- [x] Manually test on Gitpod with experimentalNetwork: true
- [x] Manually test on Gitpod with experimentalNetwork omitted

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3415"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

