### PR TITLE
Add Drupal 10 Project Type

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -78,6 +78,9 @@ func init() {
 		nodeps.AppTypeDrupal9: {
 			settingsCreator: createDrupal9SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
+		nodeps.AppTypeDrupal10: {
+			settingsCreator: createDrupal10SettingsFile, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal10App, postImportDBAction: nil, configOverrideAction: drupal10ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
+		},
 
 		nodeps.AppTypeWordPress: {
 			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: wordpressImportFilesAction,

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -57,6 +57,7 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeDrupal7:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal8:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal9:   nodeps.PHPDefault,
+		nodeps.AppTypeDrupal10:  nodeps.PHP80,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:  nodeps.PHPDefault,
 		nodeps.AppTypeMagento:   nodeps.PHP56,

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -299,6 +299,11 @@ func createDrupal9SettingsFile(app *DdevApp) (string, error) {
 	return createDrupal8SettingsFile(app)
 }
 
+// createDrupal9SettingsFile is just a wrapper on d9
+func createDrupal10SettingsFile(app *DdevApp) (string, error) {
+	return createDrupal9SettingsFile(app)
+}
+
 // createDrupal6SettingsFile manages creation and modification of settings.php and settings.ddev.php.
 // If a settings.php file already exists, it will be modified to ensure that it includes
 // settings.ddev.php, which contains ddev-specific configuration.
@@ -575,6 +580,15 @@ func isDrupal9App(app *DdevApp) bool {
 	return false
 }
 
+// isDrupal10App returns true if the app is of type drupal10
+func isDrupal10App(app *DdevApp) bool {
+	isD10, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.Docroot, "core/lib/Drupal.php"), `const VERSION = '10`)
+	if err == nil && isD10 {
+		return true
+	}
+	return false
+}
+
 // isDrupal6App returns true if the app is of type Drupal6
 func isDrupal6App(app *DdevApp) bool {
 	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "misc/ahah.js")); err == nil {
@@ -587,6 +601,12 @@ func isDrupal6App(app *DdevApp) bool {
 // with php7+
 func drupal6ConfigOverrideAction(app *DdevApp) error {
 	app.PHPVersion = nodeps.PHP56
+	return nil
+}
+
+// drupal10ConfigOverrideAction overrides php_version for D10, requires PHP8.0
+func drupal10ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP80
 	return nil
 }
 

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -67,6 +67,7 @@ const (
 	AppTypeDrupal7   = "drupal7"
 	AppTypeDrupal8   = "drupal8"
 	AppTypeDrupal9   = "drupal9"
+	AppTypeDrupal10  = "drupal10"
 	AppTypePHP       = "php"
 	AppTypeTYPO3     = "typo3"
 	AppTypeWordPress = "wordpress"


### PR DESCRIPTION
## The Problem/Issue/Bug:
Fixes #3417
## How this PR Solves The Problem:
Adds the Drupal 10 app type
## Manual Testing Instructions:
Make sure D10 shows as an option, and is detected if a 10.0.x Drupal code base exists.
## Automated Testing Overview:

- [ ] Needs a full stanza in TestSites so that TestDdevFullSiteSetup can test, https://github.com/drud/ddev/blob/67d99ed417e6d410a3cf181c9a4ccc28d0743246/pkg/ddevapp/ddevapp_test.go#L40-L207

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3418"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

