### PR TITLE
Fix error in home .bashrc.d in .profile 

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -116,4 +116,4 @@ for f in /etc/bashrc/*.bashrc; do
   source $f;
 done
 
-for i in $HOME/.bashrc.d/*; do source $i; done
+for i in $(\ls $HOME/.bashrc.d/* 2>/dev/null); do source $i; done

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20211124_bashrc.d" // Note that this can be overridden by make
+var WebTag = "20211203_fix_bashrc.d" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

In https://github.com/drud/ddev/pull/3397 I added the capability of adding files to homeadditions .bashrc.d - but there was a flaw in it that resulted in an error when `ddev ssh`

## Manual Testing Instructions:

- [x] `ddev ssh` and make sure no errors
- [x] Add something to homeadditions (global or project) .bashrc.d and make sure it gets executed on `ddev ssh`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3420"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

