### PR TITLE
Remove parens from usernames, fixes #3421

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -152,6 +152,8 @@ func GetContainerUIDGid() (uidStr string, gidStr string, username string) {
 
 	username = strings.ReplaceAll(username, " ", "")
 	username = strings.ToLower(username)
+	username = strings.ReplaceAll(username, "(", "")
+	username = strings.ReplaceAll(username, ")", "")
 
 	// If we have a numeric username it's going to create havoc, so
 	// change it into "a" + number


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3421 

A username can't have parens in it.

## How this PR Solves The Problem:

Remove them.

## Manual Testing Instructions:

- [x] On Windows (the only place it can possibly happen) create a username like 'Xyz Abcd (XMM)' and try to use ddev there. The result should be a username like 'xyzabcdxmm'.

* Created account "Some Body (SSG)"
* Started a project with that user
* `ddev ssh` and `id` showed the username as "somebodyssg"

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3423"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

