### PR TITLE
[Just experimenting] Remove db volume

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -20,11 +20,6 @@ services:
     stop_grace_period: 60s
     working_dir: "{{ .DBWorkingDir }}"
     volumes:
-      - type: "volume"
-        source: mariadb-database
-        target: "/var/lib/mysql"
-        volume:
-          nocopy: true
       - type: "bind"
         source: "."
         target: "/mnt/ddev_config"


### PR DESCRIPTION
Just exploring if our custom Db image works right if DDEV skips its usual volume. No reviews needed.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3424"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

