### PR TITLE
Revert "Add apt-get dist-upgrade -y to webimage_extra_packages (#3385)"

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -845,7 +845,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 `
 	if extraPackages != nil {
 		contents = contents + `
-RUN apt-get update && apt-get dist-upgrade -y && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 
 	// For webimage, update to latest composer.


### PR DESCRIPTION
This exact dist-upgrade is now breaking dbimage_extra_packages.
It's probably due to an error in mariadb packages,
but it seems that apt-get dist-upgrade is not a risk-free
action.

Also, this whole problem seems to have been solved upstream in
the deb.sury.org package.

See https://github.com/drud/ddev/pull/3385 and
https://github.com/oerdnj/deb.sury.org/issues/1682

This reverts commit d385ef98feb6ddb98013cd484c55ab49e9094b3f.




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3425"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

