### PR TITLE
Clean up ports in `.gitpod.yml`

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -64,34 +64,12 @@ ports:
   # Ignore host https port
   - port: 8443
     onOpen: ignore
-  - port: 3306
-    onOpen: ignore
-  # Used by projector
-  - port: 6942
-    onOpen: ignore
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
     onOpen: ignore
-  # Currently un-notified and unsupported mailhog http port
-  - port: 8025
-    onOpen: ignore
   # Currently un-notified and unsupported mailhog https port
-  - port: 8026
-    onOpen: ignore
-  # Currently un-notified and unsupported phpmyadmin http port
-  - port: 8036
-    onOpen: ignore
-  # Currently un-notified and unsupported phpmyadmin https port
-  - port: 8037
-    onOpen: ignore
-  # router http port that we're ignoring.
-  - port: 8888
-    onOpen: ignore
-  # router https port that we're ignoring.
-  - port: 8889
+  - port: 8027
     onOpen: ignore
   # xdebug port
   - port: 9000
     onOpen: ignore
-  # projector port
-  - port: 9999

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,58 +2,30 @@ image: drud/ddev-gitpod-base:20211101_gitpod_experiments
 
 experimentalNetwork: true
 tasks:
-  - name: ddev
-  - name: demand-setup
-    command: |
-      if [ ! -z ${DDEV_REPO} ]; then
-        repo=${DDEV_REPO##*/}
-        mkdir /workspace/${repo}
-        cd /workspace/${repo}
-        git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} /workspace/${repo}
-        ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
-        if [ ! -f .ddev/config.yaml ]; then
-          ddev config --auto
-        fi
-        printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
-        ddev stop -a
-        ddev start -y
-        gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
-      fi
-  - name: simpleproj
-    init: |
+  - init: |
       # Compile ddev
       make
-
-      # Configure ddev to run on Gitpod
-      export DDEV_NONINTERACTIVE=true
-      ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
-
-      # Configure ddev Drupal project
-      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj
-      ddev config --project-type=drupal9 --docroot=web --create-docroot
-
-      gitpod-setup-ddev.sh /workspace/simpleproj
-
-      mkcert -install
-
-      # Download ddev's docker images
       ddev debug download-images
-
-      # Create 'simpleproj' - Umami demo on latest stable Drupal version
-      ddev start -y
-      ddev composer create drupal/recommended-project -y && ddev composer require drush/drush
-      ddev drush si demo_umami -y --account-pass=admin
-
     command: |
-      # Configure ddev to run on Gitpod
       export DDEV_NONINTERACTIVE=true
       ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
-      gitpod-setup-ddev.sh /workspace/simpleproj
-
-      # Start ddev
-      cd /workspace/simpleproj
-      # ddev start -y
-      # gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+      DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
+      DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
+      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##/*}"
+      reponame=${DDEV_REPO##*/}
+      mkdir /workspace/${reponame} && cd /workspace/${reponame}
+      git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} /workspace/${reponame}
+      ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
+      if [ ! -f .ddev/config.yaml ]; then
+        ddev config --auto
+      fi
+      printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
+      ddev stop -a
+      ddev start -y
+      ddev import-db --src=/tmp/${DDEV_ARTIFACTS##/*}/db.sql.gz
+      ddev import-files --src=/tmp/${DDEV_ARTIFACTS##/*}/files.tgz
+      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+  - name: ddev-build
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,7 +17,7 @@ tasks:
         printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
         ddev stop -a
         ddev start -y
-        gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+        #gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
       fi
   # - name: simpleproj
   #   init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,9 @@ tasks:
   - init: |
       # Compile ddev
       make
+      cd /tmp && ddev config --auto
       ddev debug download-images
+      ddev delete -Oy tmp
     command: |
       set -eu -o pipefail
       export DDEV_NONINTERACTIVE=true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,9 +10,11 @@ tasks:
       ddev debug download-images
       ddev delete -Oy tmp
     command: |
+      echo "This is a test"
       set -eu -o pipefail
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
+      DDEV_BRANCH=${DDEV_BRANCH:-main}
       DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
       git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}"
       reponame=${DDEV_REPO##*/}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,14 +7,15 @@ tasks:
       make
       ddev debug download-images
     command: |
+      set -eu -o pipefail
       export DDEV_NONINTERACTIVE=true
       ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
       DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
-      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##/*}"
+      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}"
       reponame=${DDEV_REPO##*/}
       mkdir /workspace/${reponame} && cd /workspace/${reponame}
-      git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} /workspace/${reponame}
+      git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} .
       ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
       if [ ! -f .ddev/config.yaml ]; then
         ddev config --auto
@@ -22,8 +23,8 @@ tasks:
       printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
       ddev stop -a
       ddev start -y
-      ddev import-db --src=/tmp/${DDEV_ARTIFACTS##/*}/db.sql.gz
-      ddev import-files --src=/tmp/${DDEV_ARTIFACTS##/*}/files.tgz
+      ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
+      ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
   - name: ddev-build
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,43 +17,43 @@ tasks:
         printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
         ddev stop -a
         ddev start -y
-        #gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+        gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
       fi
-  # - name: simpleproj
-  #   init: |
-  #     # Compile ddev
-  #     make
+  - name: simpleproj
+    init: |
+      # Compile ddev
+      make
 
-  #     # Configure ddev to run on Gitpod
-  #     export DDEV_NONINTERACTIVE=true
-  #     ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
+      # Configure ddev to run on Gitpod
+      export DDEV_NONINTERACTIVE=true
+      ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
 
-  #     # Configure ddev Drupal project
-  #     mkdir -p /workspace/simpleproj && cd /workspace/simpleproj
-  #     ddev config --project-type=drupal9 --docroot=web --create-docroot
+      # Configure ddev Drupal project
+      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj
+      ddev config --project-type=drupal9 --docroot=web --create-docroot
 
-  #     gitpod-setup-ddev.sh /workspace/simpleproj
+      gitpod-setup-ddev.sh /workspace/simpleproj
 
-  #     mkcert -install
+      mkcert -install
 
-  #     # Download ddev's docker images
-  #     ddev debug download-images
+      # Download ddev's docker images
+      ddev debug download-images
 
-  #     # Create 'simpleproj' - Umami demo on latest stable Drupal version
-  #     ddev start -y
-  #     ddev composer create drupal/recommended-project -y && ddev composer require drush/drush
-  #     ddev drush si demo_umami -y --account-pass=admin
+      # Create 'simpleproj' - Umami demo on latest stable Drupal version
+      ddev start -y
+      ddev composer create drupal/recommended-project -y && ddev composer require drush/drush
+      ddev drush si demo_umami -y --account-pass=admin
 
-  #   command: |
-  #     # Configure ddev to run on Gitpod
-  #     export DDEV_NONINTERACTIVE=true
-  #     ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
-  #     gitpod-setup-ddev.sh /workspace/simpleproj
+    command: |
+      # Configure ddev to run on Gitpod
+      export DDEV_NONINTERACTIVE=true
+      ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
+      gitpod-setup-ddev.sh /workspace/simpleproj
 
-  #     # Start ddev
-  #     cd /workspace/simpleproj
-  #     # ddev start -y
-  #     gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+      # Start ddev
+      cd /workspace/simpleproj
+      # ddev start -y
+      # gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ tasks:
       ddev delete -Oy tmp
     command: |
       echo "This is a test"
-      set -eu -o pipefail
+      # set -eu -o pipefail
       set -x
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,7 +13,7 @@ tasks:
         if [ ! -f .ddev/config.yaml ]; then
           ddev config --auto
         fi
-        cat <<END  >.ddev/config.gitpod.yaml
+        cat <<-END  >.ddev/config.gitpod.yaml
           host_http_port: 8080
           bind-all-interfaces: true
         END 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,9 +10,6 @@ tasks:
       ddev debug download-images
       ddev delete -Oy tmp
     command: |
-      echo "This is a test"
-      # set -eu -o pipefail
-      set -x
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
       DDEV_BRANCH=${DDEV_BRANCH:-main}
@@ -24,12 +21,12 @@ tasks:
       if [ ! -f .ddev/config.yaml ]; then
         ddev config --auto
       fi
-      # printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
-      # ddev stop -a
-      # ddev start -y
-      # ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
-      # ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
-      # gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+      printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
+      ddev stop -a
+      ddev start -y
+      ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
+      ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
+      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,9 +5,9 @@ tasks:
   - name: ddev
   - name: demand-setup
     command: |
-      if [ ! -z ${REPO} ]; then
+      if [ ! -z ${DDEV_REPO} ]; then
         mkdir /workspace/repo
-        git clone ${REPO} /workspace/repo --branch=${BRANCH}
+        git clone ${DDEV_REPO} /workspace/repo --branch=${DDEV_BRANCH}
         ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
         if [ ! -f .ddev/config.yaml ]; then
           ddev config --auto

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,9 +12,9 @@ tasks:
     command: |
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
+      DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
       DDEV_BRANCH=${DDEV_BRANCH:-main}
-      DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
-      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}"
+      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
       reponame=${DDEV_REPO##*/}
       mkdir /workspace/${reponame} && cd /workspace/${reponame}
       git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} .
@@ -24,8 +24,10 @@ tasks:
       printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
       ddev stop -a
       ddev start -y
-      ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
-      ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
+      if [ -d "/tmp/${DDEV_ARTIFACTS##*/}" ]; then
+        ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
+        ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
+      fi
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,7 @@ tasks:
       cd /tmp && ddev config --auto
       ddev debug download-images
       ddev delete -Oy tmp
+      mkcert -install
     command: |
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,11 @@ tasks:
       ddev debug download-images
       ddev delete -Oy tmp
       mkcert -install
-      sudo ln -s $(which gcd) /usr/local/bin/gcc-5
+      sudo ln -sf $(which gcc) /usr/local/bin/gcc-5
+      for item in golang.org/x/tools/gopls@latest github.com/go-delve/delve/cmd/dlv@latest; do
+        go install $item
+      done
+      mv ~/go/bin/dlv ~/go/bin/dlv-dap
     command: |
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,9 +6,10 @@ tasks:
   - name: demand-setup
     command: |
       if [ ! -z ${DDEV_REPO} ]; then
-        mkdir /workspace/repo
-        cd /workspace/repo
-        git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} /workspace/repo 
+        repo=${DDEV_REPO##*/}
+        mkdir /workspace/${repo}
+        cd /workspace/${repo}
+        git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} /workspace/${repo}
         ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
         if [ ! -f .ddev/config.yaml ]; then
           ddev config --auto
@@ -16,42 +17,43 @@ tasks:
         printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
         ddev stop -a
         ddev start -y
+        gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
       fi
-  - name: simpleproj
-    init: |
-      # Compile ddev
-      make
+  # - name: simpleproj
+  #   init: |
+  #     # Compile ddev
+  #     make
 
-      # Configure ddev to run on Gitpod
-      export DDEV_NONINTERACTIVE=true
-      ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
+  #     # Configure ddev to run on Gitpod
+  #     export DDEV_NONINTERACTIVE=true
+  #     ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
 
-      # Configure ddev Drupal project
-      mkdir -p /workspace/simpleproj && cd /workspace/simpleproj
-      ddev config --project-type=drupal9 --docroot=web --create-docroot
+  #     # Configure ddev Drupal project
+  #     mkdir -p /workspace/simpleproj && cd /workspace/simpleproj
+  #     ddev config --project-type=drupal9 --docroot=web --create-docroot
 
-      gitpod-setup-ddev.sh /workspace/simpleproj
+  #     gitpod-setup-ddev.sh /workspace/simpleproj
 
-      mkcert -install
+  #     mkcert -install
 
-      # Download ddev's docker images
-      ddev debug download-images
+  #     # Download ddev's docker images
+  #     ddev debug download-images
 
-      # Create 'simpleproj' - Umami demo on latest stable Drupal version
-      ddev start -y
-      ddev composer create drupal/recommended-project -y && ddev composer require drush/drush
-      ddev drush si demo_umami -y --account-pass=admin
+  #     # Create 'simpleproj' - Umami demo on latest stable Drupal version
+  #     ddev start -y
+  #     ddev composer create drupal/recommended-project -y && ddev composer require drush/drush
+  #     ddev drush si demo_umami -y --account-pass=admin
 
-    command: |
-      # Configure ddev to run on Gitpod
-      export DDEV_NONINTERACTIVE=true
-      ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
-      gitpod-setup-ddev.sh /workspace/simpleproj
+  #   command: |
+  #     # Configure ddev to run on Gitpod
+  #     export DDEV_NONINTERACTIVE=true
+  #     ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
+  #     gitpod-setup-ddev.sh /workspace/simpleproj
 
-      # Start ddev
-      cd /workspace/simpleproj
-      # ddev start -y
-      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+  #     # Start ddev
+  #     cd /workspace/simpleproj
+  #     # ddev start -y
+  #     gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,6 +12,7 @@ tasks:
     command: |
       echo "This is a test"
       set -eu -o pipefail
+      set -x
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
       DDEV_BRANCH=${DDEV_BRANCH:-main}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,10 +13,7 @@ tasks:
         if [ ! -f .ddev/config.yaml ]; then
           ddev config --auto
         fi
-        cat <<-END  >.ddev/config.gitpod.yaml
-          host_http_port: 8080
-          bind-all-interfaces: true
-        END 
+        printf "host_http_port: 8080\nbind-all-interfaces: true\n" >.ddev/config.gitpod.yaml
         ddev stop -a
         ddev start -y
       fi

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,9 @@ image: drud/ddev-gitpod-base:20211028_new_host_docker_internal_detection
 experimentalNetwork: true
 tasks:
   - name: ddev
+  - name: check-prebuild-env
+    init: |
+      echo ${SOMETHING}
   - name: simpleproj
     init: |
       # Compile ddev

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,6 @@ tasks:
       if [ ! -f .ddev/config.yaml ]; then
         ddev config --auto
       fi
-      printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
       ddev stop -a
       ddev start -y
       if [ -d "/tmp/${DDEV_ARTIFACTS##*/}" ]; then

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,7 +20,6 @@ tasks:
       reponame=${DDEV_REPO##*/}
       mkdir /workspace/${reponame} && cd /workspace/${reponame}
       git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} .
-      ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
       if [ ! -f .ddev/config.yaml ]; then
         ddev config --auto
       fi

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drud/ddev-gitpod-base:20211028_new_host_docker_internal_detection
+image: drud/ddev-gitpod-base:20211101_gitpod_experiments
 
 experimentalNetwork: true
 tasks:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,15 +10,17 @@ tasks:
       ddev debug download-images
       ddev delete -Oy tmp
       mkcert -install
+      sudo ln -s $(which gcd) /usr/local/bin/gcc-5
     command: |
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
       DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
-      DDEV_BRANCH=${DDEV_BRANCH:-main}
       git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
       reponame=${DDEV_REPO##*/}
-      mkdir /workspace/${reponame} && cd /workspace/${reponame}
-      git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} .
+      mkdir -p /workspace/${reponame} && cd /workspace/${reponame}
+      if [ ! -d /workspace/${reponame}/.git ]; then
+        git clone ${DDEV_REPO} /workspace/${reponame}
+      fi
       if [ ! -f .ddev/config.yaml ]; then
         ddev config --auto
       fi

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,19 +11,19 @@ tasks:
       ddev delete -Oy tmp
     command: |
       echo "This is a test"
-      # set -eu -o pipefail
-      # set -x
-      # export DDEV_NONINTERACTIVE=true
-      # DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
-      # DDEV_BRANCH=${DDEV_BRANCH:-main}
-      # DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
-      # git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}"
-      # reponame=${DDEV_REPO##*/}
-      # mkdir /workspace/${reponame} && cd /workspace/${reponame}
-      # git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} .
-      # if [ ! -f .ddev/config.yaml ]; then
-      #   ddev config --auto
-      # fi
+      set -eu -o pipefail
+      set -x
+      export DDEV_NONINTERACTIVE=true
+      DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
+      DDEV_BRANCH=${DDEV_BRANCH:-main}
+      DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
+      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}"
+      reponame=${DDEV_REPO##*/}
+      mkdir /workspace/${reponame} && cd /workspace/${reponame}
+      git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} .
+      if [ ! -f .ddev/config.yaml ]; then
+        ddev config --auto
+      fi
       # printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
       # ddev stop -a
       # ddev start -y

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image: drud/ddev-gitpod-base:20211101_gitpod_experiments
 
 experimentalNetwork: true
 tasks:
-  - name: prebuild
+  - name: build-run
     init: |
       # Compile ddev
       make
@@ -11,25 +11,25 @@ tasks:
       ddev delete -Oy tmp
     command: |
       echo "This is a test"
-      set -eu -o pipefail
-      set -x
-      export DDEV_NONINTERACTIVE=true
-      DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
-      DDEV_BRANCH=${DDEV_BRANCH:-main}
-      DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
-      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}"
-      reponame=${DDEV_REPO##*/}
-      mkdir /workspace/${reponame} && cd /workspace/${reponame}
-      git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} .
-      if [ ! -f .ddev/config.yaml ]; then
-        ddev config --auto
-      fi
-      printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
-      ddev stop -a
-      ddev start -y
-      ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
-      ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
-      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+      # set -eu -o pipefail
+      # set -x
+      # export DDEV_NONINTERACTIVE=true
+      # DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
+      # DDEV_BRANCH=${DDEV_BRANCH:-main}
+      # DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
+      # git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}"
+      # reponame=${DDEV_REPO##*/}
+      # mkdir /workspace/${reponame} && cd /workspace/${reponame}
+      # git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} .
+      # if [ ! -f .ddev/config.yaml ]; then
+      #   ddev config --auto
+      # fi
+      # printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
+      # ddev stop -a
+      # ddev start -y
+      # ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
+      # ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
+      # gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,8 @@ image: drud/ddev-gitpod-base:20211101_gitpod_experiments
 
 experimentalNetwork: true
 tasks:
-  - init: |
+  - name: prebuild
+    init: |
       # Compile ddev
       make
       cd /tmp && ddev config --auto

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,7 +13,7 @@ tasks:
         if [ ! -f .ddev/config.yaml ]; then
           ddev config --auto
         fi
-        printf "host_http_port: 8080\nbind-all-interfaces: true\n" >.ddev/config.gitpod.yaml
+        printf "host_webserver_port: 8080\nhost_https_port: 2222\nhost_db_port: 3306\nhost_mailhog_port: 8025\nhost_phpmyadmin_port: 8036\nbind_all_interfaces: true\n" >.ddev/config.gitpod.yaml
         ddev stop -a
         ddev start -y
       fi
@@ -50,7 +50,7 @@ tasks:
 
       # Start ddev
       cd /workspace/simpleproj
-      ddev start -y
+      # ddev start -y
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,8 @@ tasks:
     command: |
       if [ ! -z ${DDEV_REPO} ]; then
         mkdir /workspace/repo
-        git clone ${DDEV_REPO} /workspace/repo --branch=${DDEV_BRANCH}
+        cd /workspace/repo
+        git clone ${DDEV_REPO} --branch=${DDEV_BRANCH} /workspace/repo 
         ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
         if [ ! -f .ddev/config.yaml ]; then
           ddev config --auto

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -63,8 +63,8 @@ github:
     addLabel: true
 
 ports:
-  # Ignore direct-build https port
-  - port: 2222
+  # Ignore host https port
+  - port: 8443
     onOpen: ignore
   - port: 3306
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,11 +13,12 @@ tasks:
         if [ ! -f .ddev/config.yaml ]; then
           ddev config --auto
         fi
-        echo <<<END >.ddev/config.gitpod.yaml 
+        cat <<END  >.ddev/config.gitpod.yaml
           host_http_port: 8080
           bind-all-interfaces: true
-        END
-          
+        END 
+        ddev stop -a
+        ddev start -y
       fi
   - name: simpleproj
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,4 @@
 image: drud/ddev-gitpod-base:20211101_gitpod_experiments
-
-experimentalNetwork: true
 tasks:
   - name: build-run
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,6 @@ tasks:
       ddev debug download-images
       ddev delete -Oy tmp
       mkcert -install
-      sudo ln -sf $(which gcc) /usr/local/bin/gcc-5
       export GOPATH=/workspace/go
       for item in golang.org/x/tools/gopls@latest github.com/go-delve/delve/cmd/dlv@latest; do
         go install $item

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,13 +10,7 @@ tasks:
       ddev debug download-images
       ddev delete -Oy tmp
       mkcert -install
-      export GOPATH=/workspace/go
-      for item in golang.org/x/tools/gopls@latest github.com/go-delve/delve/cmd/dlv@latest; do
-        go install $item
-      done
-      mv ~/go/bin/dlv ~/go/bin/dlv-dap
     command: |
-      export GOPATH=/workspace/go
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
       DDEV_ARTIFACTS=${DDEV_REPO}-artifacts

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,9 +3,21 @@ image: drud/ddev-gitpod-base:20211028_new_host_docker_internal_detection
 experimentalNetwork: true
 tasks:
   - name: ddev
-  - name: check-prebuild-env
-    init: |
-      echo ${SOMETHING}
+  - name: demand-setup
+    command: |
+      if [ ! -z ${REPO} ]; then
+        mkdir /workspace/repo
+        git clone ${REPO} /workspace/repo --branch=${BRANCH}
+        ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
+        if [ ! -f .ddev/config.yaml ]; then
+          ddev config --auto
+        fi
+        echo <<<END >.ddev/config.gitpod.yaml 
+          host_http_port: 8080
+          bind-all-interfaces: true
+        END
+          
+      fi
   - name: simpleproj
     init: |
       # Compile ddev

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,6 @@ tasks:
     command: |
       set -eu -o pipefail
       export DDEV_NONINTERACTIVE=true
-      ddev config global --omit-containers=ddev-router,ddev-ssh-agent,dba
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
       DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-https://github.com/drud/d9simple-artifacts}
       git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}"
@@ -26,7 +25,6 @@ tasks:
       ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
       ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
-  - name: ddev-build
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,11 +11,13 @@ tasks:
       ddev delete -Oy tmp
       mkcert -install
       sudo ln -sf $(which gcc) /usr/local/bin/gcc-5
+      export GOPATH=/workspace/go
       for item in golang.org/x/tools/gopls@latest github.com/go-delve/delve/cmd/dlv@latest; do
         go install $item
       done
       mv ~/go/bin/dlv ~/go/bin/dlv-dap
     command: |
+      export GOPATH=/workspace/go
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
       DDEV_ARTIFACTS=${DDEV_REPO}-artifacts

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 ENV HOMEBREW_INSTALL_FROM_API=true
 
-RUN sudo apt-get update >/dev/null && sudo apt-get install -y file mysql-client netcat telnet >/dev/null
+RUN sudo apt-get update >/dev/null && sudo apt-get install -y autojump file mysql-client netcat telnet >/dev/null
 RUN brew install bash-completion bats-core drud/ddev/ddev golangci-lint
 RUN npm install -g markdownlint-cli
 
@@ -10,5 +10,8 @@ RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" 
 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
+RUN echo ". /usr/share/autojump/autojump.sh" >> ~/.bash_profile
+RUN ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
+
 
 COPY gitpod-setup-ddev.sh /usr/local/bin

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -37,6 +37,8 @@ RUN brew cleanup
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 COPY gitpod-setup-ddev.sh /usr/local/bin
+# a gcc instance named gcc-5 is required for some vscode installations
+RUN sudo ln -sf $(which gcc) /usr/local/bin/gcc-5
 # End workspace-base
 
 FROM scratch as ddev-gitpod-base

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-full as workspace-base
 SHELL ["/bin/bash", "-c"]
 ENV HOMEBREW_INSTALL_FROM_API=true
 
@@ -12,6 +12,14 @@ RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
 RUN echo ". /usr/share/autojump/autojump.sh" >> ~/.bashrc
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
 RUN ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
-
+RUN brew cleanup
+RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 COPY gitpod-setup-ddev.sh /usr/local/bin
+# End workspace-base
+
+FROM scratch as ddev-gitpod-base
+SHELL ["/bin/bash", "-c"]
+ENV HOMEBREW_INSTALL_FROM_API=true
+COPY --from=workspace-base / /
+

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -o /usr/bin/slirp4netns -fsSL https://github.com/rootless-containers/sl
 RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 \
     && chmod +x /usr/local/bin/docker-compose
 USER gitpod
-RUN sudo apt-get update >/dev/null && sudo apt-get install -y autojump file mysql-client netcat telnet >/dev/null
+RUN sudo apt-get update >/dev/null && sudo apt-get install -y autojump file mysql-client netcat telnet xdg-utils >/dev/null
 RUN brew install bash-completion bats-core drud/ddev/ddev golang golangci-lint nodejs
 RUN npm install -g markdownlint-cli
 

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -1,7 +1,27 @@
-FROM gitpod/workspace-full as workspace-base
+FROM gitpod/workspace-base as workspace-base
 SHELL ["/bin/bash", "-c"]
 ENV HOMEBREW_INSTALL_FROM_API=true
 
+### Homebrew ###
+USER gitpod
+RUN mkdir ~/.cache && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+ENV PATH=$PATH:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/
+ENV MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man"
+ENV INFOPATH="$INFOPATH:/home/linuxbrew/.linuxbrew/share/info"
+ENV HOMEBREW_NO_AUTO_UPDATE=1
+
+USER root
+RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    && apt-key add /var/lib/apt/dazzle-marks/docker.gpg \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    && install-packages docker-ce docker-ce-cli containerd.io
+
+RUN curl -o /usr/bin/slirp4netns -fsSL https://github.com/rootless-containers/slirp4netns/releases/download/v1.1.12/slirp4netns-$(uname -m) \
+    && chmod +x /usr/bin/slirp4netns
+
+RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 \
+    && chmod +x /usr/local/bin/docker-compose
+USER gitpod
 RUN sudo apt-get update >/dev/null && sudo apt-get install -y autojump file mysql-client netcat telnet >/dev/null
 RUN brew install bash-completion bats-core drud/ddev/ddev golang golangci-lint
 RUN npm install -g markdownlint-cli
@@ -21,5 +41,10 @@ COPY gitpod-setup-ddev.sh /usr/local/bin
 FROM scratch as ddev-gitpod-base
 SHELL ["/bin/bash", "-c"]
 ENV HOMEBREW_INSTALL_FROM_API=true
+ENV PATH=$PATH:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/
+ENV MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man"
+ENV INFOPATH="$INFOPATH:/home/linuxbrew/.linuxbrew/share/info"
+ENV HOMEBREW_NO_AUTO_UPDATE=1
+
 COPY --from=workspace-base / /
 

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -45,7 +45,6 @@ ENV HOMEBREW_INSTALL_FROM_API=true
 ENV PATH=$PATH:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/
 ENV MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man"
 ENV INFOPATH="$INFOPATH:/home/linuxbrew/.linuxbrew/share/info"
-ENV HOMEBREW_NO_AUTO_UPDATE=1
 
 COPY --from=workspace-base / /
 

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -8,7 +8,8 @@ RUN mkdir ~/.cache && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.c
 ENV PATH=$PATH:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/
 ENV MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man"
 ENV INFOPATH="$INFOPATH:/home/linuxbrew/.linuxbrew/share/info"
-ENV HOMEBREW_NO_AUTO_UPDATE=1
+RUN sudo apt remove -y cmake \
+    && brew update && brew install cmake
 
 USER root
 RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
@@ -23,7 +24,7 @@ RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compos
     && chmod +x /usr/local/bin/docker-compose
 USER gitpod
 RUN sudo apt-get update >/dev/null && sudo apt-get install -y autojump file mysql-client netcat telnet >/dev/null
-RUN brew install bash-completion bats-core drud/ddev/ddev golang golangci-lint
+RUN brew install bash-completion bats-core drud/ddev/ddev golang golangci-lint nodejs
 RUN npm install -g markdownlint-cli
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -39,6 +39,12 @@ RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 COPY gitpod-setup-ddev.sh /usr/local/bin
 # a gcc instance named gcc-5 is required for some vscode installations
 RUN sudo ln -sf $(which gcc) /usr/local/bin/gcc-5
+
+RUN for item in golang.org/x/tools/gopls@latest github.com/go-delve/delve/cmd/dlv@latest; do \
+        go install $item; \
+    done
+RUN cp ~/go/bin/dlv ~/go/bin/dlv-dap
+
 # End workspace-base
 
 FROM scratch as ddev-gitpod-base

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -3,14 +3,14 @@ SHELL ["/bin/bash", "-c"]
 ENV HOMEBREW_INSTALL_FROM_API=true
 
 RUN sudo apt-get update >/dev/null && sudo apt-get install -y autojump file mysql-client netcat telnet >/dev/null
-RUN brew install bash-completion bats-core drud/ddev/ddev golangci-lint
+RUN brew install bash-completion bats-core drud/ddev/ddev golang golangci-lint
 RUN npm install -g markdownlint-cli
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc
 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
+RUN echo ". /usr/share/autojump/autojump.sh" >> ~/.bashrc
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
-RUN echo ". /usr/share/autojump/autojump.sh" >> ~/.bash_profile
 RUN ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
 
 

--- a/.gitpod/images/push.sh
+++ b/.gitpod/images/push.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_REPO=drud/ddev-gitpod-base:20211028_new_host_docker_internal_detection
+DOCKER_REPO=drud/ddev-gitpod-base:20211101_gitpod_experiments
 
 echo "Pushing ${DOCKER_REPO}"
 set -x

--- a/.gitpod/images/push.sh
+++ b/.gitpod/images/push.sh
@@ -6,4 +6,4 @@ DOCKER_REPO=drud/ddev-gitpod-base:20211101_gitpod_experiments
 echo "Pushing ${DOCKER_REPO}"
 set -x
 # Build only current architecture and load into docker
-docker buildx build -t ${DOCKER_REPO} --push --platform=linux/amd64 .
+docker buildx build -t ${DOCKER_REPO} --push --target=ddev-gitpod-base --platform=linux/amd64 .

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "debug",
+            "name": "debug ddev start",
             "type": "go",
             "request": "launch",
             "mode": "debug",
@@ -14,6 +14,18 @@
             "showLog": true
         },
         {
+            "name": "debug ddev describe",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "remotePath": "",
+            "program": "${workspaceRoot}/cmd/ddev",
+            "cwd": "/workspace/d9simple",
+            "env": {"DDEV_DEBUG": true},
+            "args": ["describe"],
+            "showLog": true
+        },
+{
             "name": "pkg-level test",
             "type": "go",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,9 @@
             "mode": "debug",
             "remotePath": "",
             "program": "${workspaceRoot}/cmd/ddev",
-            "cwd": "/workspace/simpleproj",
+            "cwd": "/workspace/d9simple",
             "env": {"DDEV_DEBUG": true},
-            "args": [],
+            "args": ["start", "-y"],
             "showLog": true
         },
         {

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -57,7 +57,7 @@ var AuthSSHCommand = &cobra.Command{
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil || app == nil {
 			// We don't actually have to start ssh-agent in a project directory, so use a dummy app.
-			app = &ddevapp.DdevApp{OmitContainerGlobal: globalconfig.DdevGlobalConfig.OmitContainersGlobal}
+			app = &ddevapp.DdevApp{OmitContainersGlobal: globalconfig.DdevGlobalConfig.OmitContainersGlobal}
 		}
 		omitted := app.GetOmittedContainers()
 		if nodeps.ArrayContainsString(omitted, nodeps.DdevSSHAgentContainer) {

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -120,6 +120,8 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 				} else if httpURL, ok = v["http_url"]; ok {
 					urlPortParts = append(urlPortParts, httpURL)
 				}
+			} else if nodeps.IsGitpod() {
+				urlPortParts = append(urlPortParts, app.GetPrimaryURL())
 			} else {
 				httpURL = v["host_http_url"]
 				if httpURL != "" {

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -120,7 +120,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 				} else if httpURL, ok = v["http_url"]; ok {
 					urlPortParts = append(urlPortParts, httpURL)
 				}
-			} else if nodeps.IsGitpod() {
+			} else if nodeps.IsGitpod() && k == "web" {
 				urlPortParts = append(urlPortParts, app.GetPrimaryURL())
 			} else {
 				httpURL = v["host_http_url"]

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	"strings"
 
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -61,11 +62,11 @@ ddev start --all`,
 			}
 
 			util.Success("Successfully started %s", project.GetName())
-			httpURLs, urlList, _ := project.GetAllURLs()
-			if globalconfig.GetCAROOT() == "" || ddevapp.IsRouterDisabled(project) {
-				urlList = httpURLs
+			httpURLs, httpsURLs, _ := project.GetAllURLs()
+			if !nodeps.IsGitpod() && (globalconfig.GetCAROOT() == "" || ddevapp.IsRouterDisabled(project)) {
+				httpsURLs = httpURLs
 			}
-			util.Success("Project can be reached at %s", strings.Join(urlList, " "))
+			util.Success("Project can be reached at %s", strings.Join(httpsURLs, " "))
 		}
 	},
 }

--- a/docs/developers/building-contributing.md
+++ b/docs/developers/building-contributing.md
@@ -21,9 +21,9 @@ Gitpod.io provides a quick preconfigured ddev experience in the browser, so you 
 To just open and work on ddev you can use the button below.
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/drud/ddev)
 
-If you want to run a project in there, the easy way to set it up in `/workspace/<yourproject>` based on [ddev-gitpod](https://github.com/shaal/ddev-gitpod) is to `ddev config` and then `cd .ddev && cp ~/bin/gitpod-setup-ddev.sh . && ./gitpod-setup-ddev.sh`. This sets up ports for the project that are compatible with gitpod, etc.
+If you want to run a web project in there, you can just check it out into `/workspace/<yourproject>` and use it as usual. The things you're familiar with work as expected, except that `ddev-router` does not run, and 
 
-A dummy project for gitpod is also provided already set up in /workspace/simpleproj.
+A dummy project for gitpod is provided by default in /workspace/d9simple. You can just `ddev poweroff` and use your own.
 
 ## Making changes to ddev images
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -88,7 +88,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 
 	// Provide a default app name based on directory name
 	app.Name = filepath.Base(app.AppRoot)
-	app.OmitContainerGlobal = globalconfig.DdevGlobalConfig.OmitContainersGlobal
+	app.OmitContainersGlobal = globalconfig.DdevGlobalConfig.OmitContainersGlobal
 	app.ProjectTLD = nodeps.DdevDefaultTLD
 	app.UseDNSWhenPossible = true
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -88,7 +88,12 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 
 	// Provide a default app name based on directory name
 	app.Name = filepath.Base(app.AppRoot)
+
+	// Gather containers to omit, adding ddev-router for gitpod
 	app.OmitContainersGlobal = globalconfig.DdevGlobalConfig.OmitContainersGlobal
+	if nodeps.IsGitpod() {
+		app.OmitContainersGlobal = append(app.OmitContainersGlobal, "ddev-router")
+	}
 	app.ProjectTLD = nodeps.DdevDefaultTLD
 	app.UseDNSWhenPossible = true
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2007,9 +2007,9 @@ func (app *DdevApp) GetPrimaryURL() string {
 	}
 	if len(urlList) > 0 {
 		return urlList[0]
-	} else {
-		return ""
 	}
+	// Failure mode, just return empty string
+	return ""
 }
 
 // GetWebContainerDirectHTTPURL returns the URL that can be used without the router to get to web container.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1395,6 +1395,35 @@ func (app *DdevApp) DockerEnv() {
 	if app.HostDBPort != "" {
 		dbPortStr = app.HostDBPort
 	}
+	isGitpod := "false"
+
+	// For gitpod,
+	// * provide IS_GITPOD environment variable
+	// * provide default host-side port bindings, assuming only one project running,
+	//   as is usual on gitpod, but if more than one project, can override with normal
+	//   config.yaml settings.
+	if nodeps.IsGitpod() {
+		isGitpod = "true"
+		if app.HostWebserverPort == "" {
+			app.HostWebserverPort = "8080"
+		}
+		if app.HostHTTPSPort == "" {
+			app.HostHTTPSPort = "8443"
+		}
+		if app.HostDBPort == "" {
+			app.HostDBPort = "3306"
+		}
+		if app.HostMailhogPort == "" {
+			app.HostMailhogPort = "8025"
+		}
+		if app.HostPHPMyAdminPort == "" {
+			app.HostPHPMyAdminPort = "8036"
+		}
+	}
+	isWSL2 := "false"
+	if nodeps.IsWSL2() {
+		isWSL2 = "true"
+	}
 
 	envVars := map[string]string{
 		// Without COMPOSE_DOCKER_CLI_BUILD=0, docker-compose makes all kinds of mess
@@ -1431,6 +1460,8 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_PRIMARY_URL":           app.GetPrimaryURL(),
 		"DOCKER_SCAN_SUGGEST":        "false",
 		"IS_DDEV_PROJECT":            "true",
+		"IS_GITPOD":                  isGitpod,
+		"IS_WSL2":                    isWSL2,
 	}
 
 	// Set the mariadb_local command to empty to prevent docker-compose from complaining normally.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1967,7 +1967,8 @@ func (app *DdevApp) GetHTTPSURL() string {
 func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs []string) {
 	if nodeps.IsGitpod() {
 		url, err := exec.RunHostCommand("gp", "url", app.HostWebserverPort)
-		if err != nil {
+		if err == nil {
+			url = strings.Trim(url, "\n")
 			httpsURLs = append(httpsURLs, url)
 		}
 	}
@@ -2000,10 +2001,14 @@ func (app *DdevApp) GetPrimaryURL() string {
 	httpURLs, httpsURLs, _ := app.GetAllURLs()
 	urlList := httpsURLs
 	// If no mkcert trusted https, use the httpURLs instead
-	if globalconfig.GetCAROOT() == "" || IsRouterDisabled(app) {
+	if !nodeps.IsGitpod() && (globalconfig.GetCAROOT() == "" || IsRouterDisabled(app)) {
 		urlList = httpURLs
 	}
-	return urlList[0]
+	if len(urlList) > 0 {
+		return urlList[0]
+	} else {
+		return ""
+	}
 }
 
 // GetWebContainerDirectHTTPURL returns the URL that can be used without the router to get to web container.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -374,9 +374,6 @@ func (app *DdevApp) GetPublishedPort(serviceName string) (int, error) {
 func (app *DdevApp) GetOmittedContainers() []string {
 	omitted := app.OmitContainersGlobal
 	omitted = append(omitted, app.OmitContainers...)
-	if IsRouterDisabled(app) && !nodeps.ArrayContainsString(omitted, "ddev-router") {
-		omitted = append(omitted, "ddev-router")
-	}
 	return omitted
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -97,7 +97,7 @@ type DdevApp struct {
 	UploadDir             string                `yaml:"upload_dir,omitempty"`
 	WorkingDir            map[string]string     `yaml:"working_dir,omitempty"`
 	OmitContainers        []string              `yaml:"omit_containers,omitempty,flow"`
-	OmitContainerGlobal   []string              `yaml:"-"`
+	OmitContainersGlobal  []string              `yaml:"-"`
 	HostDBPort            string                `yaml:"host_db_port,omitempty"`
 	HostWebserverPort     string                `yaml:"host_webserver_port,omitempty"`
 	HostHTTPSPort         string                `yaml:"host_https_port,omitempty"`
@@ -372,8 +372,11 @@ func (app *DdevApp) GetPublishedPort(serviceName string) (int, error) {
 
 // GetOmittedContainers returns full list of global and local omitted containers
 func (app *DdevApp) GetOmittedContainers() []string {
-	omitted := app.OmitContainerGlobal
+	omitted := app.OmitContainersGlobal
 	omitted = append(omitted, app.OmitContainers...)
+	if IsRouterDisabled(app) && !nodeps.ArrayContainsString(omitted, "ddev-router") {
+		omitted = append(omitted, "ddev-router")
+	}
 	return omitted
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1414,7 +1414,7 @@ func (app *DdevApp) DockerEnv() {
 			app.HostDBPort = "3306"
 		}
 		if app.HostMailhogPort == "" {
-			app.HostMailhogPort = "8025"
+			app.HostMailhogPort = "8027"
 		}
 		if app.HostPHPMyAdminPort == "" {
 			app.HostPHPMyAdminPort = "8036"

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1422,6 +1422,7 @@ func (app *DdevApp) DockerEnv() {
 		if app.HostPHPMyAdminPort == "" {
 			app.HostPHPMyAdminPort = "8036"
 		}
+		app.BindAllInterfaces = true
 	}
 	isWSL2 := "false"
 	if nodeps.IsWSL2() {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1961,6 +1961,13 @@ func (app *DdevApp) GetHTTPSURL() string {
 
 // GetAllURLs returns an array of all the URLs for the project
 func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs []string) {
+	if nodeps.IsGitpod() {
+		url, err := exec.RunHostCommand("gp", "url", app.HostWebserverPort)
+		if err != nil {
+			httpsURLs = append(httpsURLs, url)
+		}
+	}
+
 	// Get configured URLs
 	for _, name := range app.GetHostnames() {
 		httpPort := ""

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1993,7 +1993,8 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 	}
 	httpURLs = append(httpURLs, app.GetWebContainerDirectHTTPURL())
 
-	return httpURLs, httpsURLs, append(httpsURLs, httpURLs...)
+	allURLs = append(httpsURLs, httpURLs...)
+	return httpURLs, httpsURLs, allURLs
 }
 
 // GetPrimaryURL returns the primary URL that can be used, https or http

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -178,6 +178,7 @@ func (app *DdevApp) FindContainerByType(containerType string) (*docker.APIContai
 
 // Describe returns a map which provides detailed information on services associated with the running site.
 func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
+	app.DockerEnv()
 	err := app.ProcessHooks("pre-describe")
 	if err != nil {
 		return nil, fmt.Errorf("failed to process pre-describe hooks: %v", err)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -39,7 +39,7 @@ func FullRenderedRouterComposeYAMLPath() string {
 // IsRouterDisabled returns true if the router is disabled
 func IsRouterDisabled(app *DdevApp) bool {
 	if nodeps.IsGitpod() {
-		return false
+		return true
 	}
 	return nodeps.ArrayContainsString(app.GetOmittedContainers(), globalconfig.DdevRouterContainer)
 }
@@ -279,7 +279,6 @@ func determineRouterPorts() []string {
 // if they're available for docker to bind to. Returns an error if either one results
 // in a successful connection.
 func CheckRouterPorts() error {
-
 	routerContainer, _ := FindDdevRouter()
 	var existingExposedPorts []string
 	var err error

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -38,6 +38,9 @@ func FullRenderedRouterComposeYAMLPath() string {
 
 // IsRouterDisabled returns true if the router is disabled
 func IsRouterDisabled(app *DdevApp) bool {
+	if nodeps.IsGitpod() {
+		return false
+	}
 	return nodeps.ArrayContainsString(app.GetOmittedContainers(), globalconfig.DdevRouterContainer)
 }
 

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -85,6 +85,9 @@ func IsMacM1() bool {
 
 // IsGitpod returns true if running on gitpod.io
 func IsGitpod() bool {
+	if os.Getenv("DDEV_PRETEND_GITPOD") == "true" {
+		return true
+	}
 	return runtime.GOOS == "linux" && os.Getenv("GITPOD_WORKSPACE_ID") != ""
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Many ports belong to previous setup that is no longer needed in current ddev workspace in Gitpod.
Each port that is defined in `.gitpod.yml`, is added to the list of ports, and can be confusing for users -
![image](https://user-images.githubusercontent.com/22901/144966035-2f2c8d1f-9e5a-418e-adbe-a3d4a73f16d3.png)


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3427"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

