### PR TITLE
Use more robust technique to detect Docker Desktop (WSL2), fixes #3441

### DIFF
--- a/docs/developers/release-checklist.md
+++ b/docs/developers/release-checklist.md
@@ -56,7 +56,7 @@ Basic instructions:
 1. On a Windows machine, install the certificate as suggested. You need the cert file and password, and you install it into Chrome or IE (This is a one-time operation)
 2. Install the suggested [Windows SDK 10](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
 3. Install [Visual Studio Community 2015](https://msdn.microsoft.com/en-us/library/mt613162.aspx)
-4. Run the [Developer Command Prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs)
+4. Run the [Developer Command Prompt](https://docs.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2019)
 5. Sign the binary with something like `signtool sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a z:\Downloads\ddev_windows_installer.v0.18.0.exe` (I did this with the downloaded ddev_windows_installer physically on my mac (Z: drive))
 6. Generate a new sha256 file (I did this on mac): `shasum -a 256 ddev_windows_installer.v0.18.0.exe >ddev_windows_installer.v0.18.0.exe.sha256.txt`
 7. Upload the ddev_windows_installer and sha256.txt to the release

--- a/docs/users/step-debugging.md
+++ b/docs/users/step-debugging.md
@@ -133,7 +133,7 @@ NOTE: If you are using a PHP version below PHP7.2, you will be using Xdebug vers
 Debugging Xdebug in any setup can be a little trouble, but here are the steps to take. The steps here assume that you're using PhpStorm, but they can be adapted to any IDE.
 
 * Reboot your computer.
-* Temporarily disable any firewall or vpn if you're having trouble. Xdebug is a network protocol, and the php process inside the web container must be able to establish a TCP connection to the listening IDE (PhpStorm, for example).
+* Temporarily disable any firewall or VPN if you're having trouble. Xdebug is a network protocol, and the php process inside the web container must be able to establish a TCP connection to the listening IDE (PhpStorm, for example).
 * Use `ddev xdebug on` to enable xdebug when you want it, and `ddev xdebug off` when you're done with it.
 * Set a breakpoint at the first executable line of your index.php.
 * Tell your IDE to start listening. (PhpStorm: Click the telephone button, vscode: run the debugger.)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -874,8 +874,8 @@ func GetHostDockerInternalIP() (string, error) {
 
 	// Docker on linux doesn't define host.docker.internal
 	// so we need to go get the bridge IP address
-	// WSL2 (with Docker Desktop) defines host.docker.internal itself.
-	case runtime.GOOS == "linux" && !nodeps.IsDockerDesktopWSL2():
+	// Docker Desktop) defines host.docker.internal itself.
+	case runtime.GOOS == "linux" && !IsDockerDesktop():
 		// look up info from the bridge network
 		client := GetDockerClient()
 		n, err := client.NetworkInfo("bridge")
@@ -1129,4 +1129,18 @@ func dockerComposeDownloadLinkV2() (string, error) {
 		ComposeURL = ComposeURL + ".exe"
 	}
 	return ComposeURL, nil
+}
+
+// IsDockerDesktop detects if running on Docker Desktop
+func IsDockerDesktop() bool {
+	client := GetDockerClient()
+	info, err := client.Info()
+	if err != nil {
+		util.Warning("IsDockerDesktop(): Unable to get docker info, err=%v", err)
+		return false
+	}
+	if info.OperatingSystem == "Docker Desktop" {
+		return true
+	}
+	return false
 }

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -4,10 +4,8 @@ import (
 	"golang.org/x/term"
 	"math/rand"
 	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
-	"strings"
 	"time"
 	"unicode"
 )
@@ -62,20 +60,6 @@ func RandomString(length int) string {
 // IsWSL2 returns true if running WSL2
 func IsWSL2() bool {
 	return GetWSLDistro() != ""
-}
-
-// IsDockerDesktopWSL2 detects if running on WSL2 using Docker Desktop
-func IsDockerDesktopWSL2() bool {
-	if IsWSL2() {
-		p, err := exec.LookPath("docker")
-		if err == nil {
-			link, err := os.Readlink(p)
-			if err == nil && strings.HasPrefix(link, "/mnt/wsl/docker-desktop") {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // IsMacM1 returns true if running on mac M1


### PR DESCRIPTION
## The Problem/Issue/Bug:

In the v1.18.2 release, to make xdebug work for both docker-installed-in-wsl2 and docker-desktop-wsl2 environments, a technique for detecting Docker Desktop was introduced. It looked for the docker client symlink. But that was fragile, because
* People might have docker-ce installed but not be using it
* The /usr/bin/docker symlink might not be exactly the one we were looking for (if people have manipulated wsl.conf, etc)

## How this PR Solves The Problem:

Use the api equivalent of `docker info` to detect "Docker Desktop" as the "Operating System"

## Manual Testing Instructions:

Try xdebug on:
- [x] WSL2 with Docker Desktop
- [x] WSL2 with docker installed inside
- [x] WSL2 with Docker Desktop but with a different mountpoint
- [x] Ordinary linux

## Automated Testing Overview:
* There are no tests for the (so far unsupported) docker-install-inside-wsl2
* Other than that hopefully most things can catch this.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3443"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

