### PR TITLE
Make sure .gitattributes gets into commands directory, fixes #3449

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -228,11 +228,11 @@ func TestCustomCommands(t *testing.T) {
 	}
 
 	// Make sure that the non-command stuff we installed is in globalCommandsDir
-	for _, f := range []string{"db/mysqldump.example", "db/README.txt", "host/heidisql", "host/mysqlworkbench.example", "host/phpstorm.example", "host/README.txt", "host/sequelace", "host/sequelpro", "host/tableplus", "web/README.txt"} {
+	for _, f := range []string{".gitattributes", "db/mysqldump.example", "db/README.txt", "host/heidisql", "host/mysqlworkbench.example", "host/phpstorm.example", "host/README.txt", "host/sequelace", "host/sequelpro", "host/tableplus", "web/README.txt"} {
 		assert.FileExists(filepath.Join(globalCommandsDir, f))
 	}
 	// Make sure that the non-command stuff we installed is in project commands dir
-	for _, f := range []string{"db/mysql", "db/README.txt", "host/launch", "host/README.txt", "host/solrtail.example", "solr/README.txt", "solr/solrtail.example", "web/README.txt", "web/xdebug"} {
+	for _, f := range []string{".gitattributes", "db/mysql", "db/README.txt", "host/launch", "host/README.txt", "host/solrtail.example", "solr/README.txt", "solr/solrtail.example", "web/README.txt", "web/xdebug"} {
 		assert.FileExists(filepath.Join(projectCommandsDir, f))
 	}
 

--- a/pkg/ddevapp/assets.go
+++ b/pkg/ddevapp/assets.go
@@ -7,7 +7,7 @@ import (
 
 //The bundled assets for the project .ddev directory are in directory dotddev_assets
 // And the global .ddev assets are in directory global_dotddev_assets
-//go:embed dotddev_assets global_dotddev_assets
+//go:embed dotddev_assets/* dotddev_assets/commands/.gitattributes global_dotddev_assets/* global_dotddev_assets/.gitignore global_dotddev_assets/commands/.gitattributes
 var bundledAssets embed.FS
 
 // PopulateExamplesCommandsHomeadditions grabs embedded assets and


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3449 

It turns out .gitattributes (that helps Windows people not to check out files with CRLF in them) got lost in embedding when embed changed.

## How this PR Solves The Problem:

Bring the file back.

## Manual Testing Instructions:

- [x] Remove the .gitattributes file from the commands directory and `ddev start`. It should reappear.

## Automated Testing Overview:

* TestCustomCommands got coverage added for this.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3450"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

