### PR TITLE
Add support for docker context, changes required docker constraint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ $(TARGETS): pullbuildimage $(GOFILES)
 	export DEFCTX=$(shell docker context inspect -f '{{ .Name }}') && docker context use default >/dev/null 2>&1 &&\
 	mkdir -p $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	chmod 777 $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
-	docker context use default >/dev/null && \
 	$(DOCKERBUILDCMD) \
 	bash -c "GOOS=$$GOOS GOARCH=$$GOARCH $$GOBUILDER build -o $(GOTMP)/bin/$$TARGET -installsuffix static -ldflags \" $(LDFLAGS) \" $(SRC_AND_UNDER)" && \
 	docker context use $$DEFCTX >/dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -111,14 +111,17 @@ $(TARGETS): pullbuildimage $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)";
 	@#echo "LDFLAGS=$(LDFLAGS)";
 	@rm -f $@
-	@export TARGET=$(word 3, $(subst /, ,$@)) && \
+	export TARGET=$(word 3, $(subst /, ,$@)) && \
 	export GOOS="$${TARGET%_*}" && \
 	export GOARCH="$${TARGET#*_}" && \
 	export GOBUILDER=go && \
+	export DEFCTX=$(shell docker context show) && docker context use default >/dev/null &&\
 	mkdir -p $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	chmod 777 $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
+	docker context use default >/dev/null && \
 	$(DOCKERBUILDCMD) \
-	bash -c "GOOS=$$GOOS GOARCH=$$GOARCH $$GOBUILDER build -o $(GOTMP)/bin/$$TARGET -installsuffix static -ldflags \" $(LDFLAGS) \" $(SRC_AND_UNDER)"
+	bash -c "GOOS=$$GOOS GOARCH=$$GOARCH $$GOBUILDER build -o $(GOTMP)/bin/$$TARGET -installsuffix static -ldflags \" $(LDFLAGS) \" $(SRC_AND_UNDER)" && \
+	docker context use $$DEFCTX >/dev/null
 	$( shell if [ -d $(GOTMP) ]; then chmod -R u+w $(GOTMP); fi )
 	@echo $(VERSION) >VERSION.txt
 

--- a/Makefile
+++ b/Makefile
@@ -111,17 +111,17 @@ $(TARGETS): pullbuildimage $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)";
 	@#echo "LDFLAGS=$(LDFLAGS)";
 	@rm -f $@
-	export TARGET=$(word 3, $(subst /, ,$@)) && \
+	@export TARGET=$(word 3, $(subst /, ,$@)) && \
 	export GOOS="$${TARGET%_*}" && \
 	export GOARCH="$${TARGET#*_}" && \
 	export GOBUILDER=go && \
-	export DEFCTX=$(shell docker context show) && docker context use default >/dev/null &&\
+	export DEFCTX=$(shell docker context inspect -f '{{ .Name }}') && docker context use default >/dev/null 2>&1 &&\
 	mkdir -p $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	chmod 777 $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	docker context use default >/dev/null && \
 	$(DOCKERBUILDCMD) \
 	bash -c "GOOS=$$GOOS GOARCH=$$GOARCH $$GOBUILDER build -o $(GOTMP)/bin/$$TARGET -installsuffix static -ldflags \" $(LDFLAGS) \" $(SRC_AND_UNDER)" && \
-	docker context use $$DEFCTX >/dev/null
+	docker context use $$DEFCTX >/dev/null 2>&1
 	$( shell if [ -d $(GOTMP) ]; then chmod -R u+w $(GOTMP); fi )
 	@echo $(VERSION) >VERSION.txt
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -622,7 +622,7 @@ func GetDockerIP() (string, error) {
 	if dockerHostRawURL != "" {
 		dockerHostURL, err := url.Parse(dockerHostRawURL)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse $DOCKER_HOST=%s: %v, err: %v", dockerHostRawURL, err)
+			return "", fmt.Errorf("failed to parse $DOCKER_HOST=%s: %v", dockerHostRawURL, err)
 		}
 		hostPart := dockerHostURL.Hostname()
 		// Check to see if the hostname we found is an IP address
@@ -633,7 +633,7 @@ func GetDockerIP() (string, error) {
 			if err == nil && len(ip) > 0 {
 				hostPart = ip[0]
 			} else {
-				return "", fmt.Errorf("failed to look up IP address for $DOCKER_HOST=%s, hostname=%s: %v, err: %v", dockerHostRawURL, hostPart, err)
+				return "", fmt.Errorf("failed to look up IP address for $DOCKER_HOST=%s, hostname=%s: %v", dockerHostRawURL, hostPart, err)
 			}
 		}
 		dockerIP = hostPart

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -625,18 +625,20 @@ func GetDockerIP() (string, error) {
 			return "", fmt.Errorf("failed to parse $DOCKER_HOST=%s: %v", dockerHostRawURL, err)
 		}
 		hostPart := dockerHostURL.Hostname()
-		// Check to see if the hostname we found is an IP address
-		addr := net.ParseIP(hostPart)
-		if addr == nil {
-			// If it wasn't an IP address, look it up to get IP address
-			ip, err := net.LookupHost(hostPart)
-			if err == nil && len(ip) > 0 {
-				hostPart = ip[0]
-			} else {
-				return "", fmt.Errorf("failed to look up IP address for $DOCKER_HOST=%s, hostname=%s: %v", dockerHostRawURL, hostPart, err)
+		if hostPart != "" {
+			// Check to see if the hostname we found is an IP address
+			addr := net.ParseIP(hostPart)
+			if addr == nil {
+				// If it wasn't an IP address, look it up to get IP address
+				ip, err := net.LookupHost(hostPart)
+				if err == nil && len(ip) > 0 {
+					hostPart = ip[0]
+				} else {
+					return "", fmt.Errorf("failed to look up IP address for $DOCKER_HOST=%s, hostname=%s: %v", dockerHostRawURL, hostPart, err)
+				}
 			}
+			dockerIP = hostPart
 		}
-		dockerIP = hostPart
 	}
 	return dockerIP, nil
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -619,7 +619,7 @@ var dockerHostRawURL string
 var DockerIP string
 
 // GetDockerIP returns either the default Docker IP address (127.0.0.1)
-// or the value as configured by $DOCKER_HOST (if DOCKER_HOST is an http/s URL)
+// or the value as configured by $DOCKER_HOST (if DOCKER_HOST is an tcp:// URL)
 func GetDockerIP() (string, error) {
 	if DockerIP == "" {
 		DockerIP = "127.0.0.1"

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -61,7 +61,7 @@ func EnsureDdevNetwork() {
 	}
 }
 
-// GetDockerClient returns a docker client for a docker-machine.
+// GetDockerClient returns a docker client respecting DOCKER_HOST, etc
 func GetDockerClient() *docker.Client {
 	client, err := docker.NewClientFromEnv()
 	if err != nil {

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -587,8 +587,10 @@ func TestGetDockerIP(t *testing.T) {
 
 	for k, v := range expectations {
 		_ = os.Setenv("DOCKER_HOST", k)
+		// DockerIP is cached, so we have to reset it to check
+		DockerIP = ""
 		result, err := GetDockerIP()
 		assert.NoError(err)
-		assert.Equal(v, result)
+		assert.Equal(v, result, "for %s expected %s, got %s", k, v, result)
 	}
 }

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -571,3 +571,24 @@ subdir1.txt
 	})
 
 }
+
+// TestDockerIP tries out a number of DOCKER_HOST permutations
+// to verify that GetDockerIP does them right
+func TestGetDockerIP(t *testing.T) {
+	assert := asrt.New(t)
+
+	expectations := map[string]string{
+		"":                            "127.0.0.1",
+		"unix:///var/run/docker.sock": "127.0.0.1",
+		"unix:///Users/rfay/.docker/run/docker.sock": "127.0.0.1",
+		"unix:///Users/rfay/.colima/docker.sock":     "127.0.0.1",
+		"tcp://ddev.com:2375":                        "35.202.87.134",
+	}
+
+	for k, v := range expectations {
+		_ = os.Setenv("DOCKER_HOST", k)
+		result, err := GetDockerIP()
+		assert.NoError(err)
+		assert.Equal(v, result)
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var SegmentKey = ""
 // REMEMBER TO CHANGE docs/index.md if you touch this!
 // The constraint MUST HAVE a -pre of some kind on it for successful comparison.
 // See https://github.com/drud/ddev/pull/738.. and regression https://github.com/drud/ddev/issues/1431
-var DockerVersionConstraint = ">= 18.06.1-alpha1"
+var DockerVersionConstraint = ">= 19.03.9-alpha1"
 
 // DockerComposeVersionConstraint is the versions allowed for ddev
 // REMEMBER TO CHANGE docs/index.md if you touch this!


### PR DESCRIPTION
## The Problem/Issue/Bug:

The nice new way to specify a docker endpoint instead of complicated `$DOCKER_HOST` is `docker context`.

Unfortunately neither the fsouza/go-dockerclient (that we currently use) nor the docker https://github.com/moby/moby has direct support for this, it's all written into the docker cli AFAICT.

## How this PR Solves The Problem:

Use `docker context inspect` to find out the current context's endpoint, then use that for DOCKER_HOST (if DOCKER_HOST is not set).

## TODO:
- [x] Cache the value so we don't have to look it up often
- [x] Should we support the DOCKER_CONTEXT environment variable?

## Manual Testing Instructions:

Try it out with colima or another remote context

## Automated Testing Overview:



## Related Issue Link(s):

## Release/Deployment notes:

This changes the docker constraint to 19.03.9 (oldest version I could find that supported contexts).

As a result, it needs to wait for ddev v1.19.0


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3452"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

