### PR TITLE
[Tests only] Limit how many places TestShareCmd can run

### DIFF
--- a/.buildkite/macos-m1.yml
+++ b/.buildkite/macos-m1.yml
@@ -11,6 +11,7 @@
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
       BUILDKIT_PROGRESS: plain
+      DDEV_TEST_SHARE_CMD: "true"
       # M1 has some NFS failures (TestComposer, TestProcessHooks, TestNFSMount) and  as of 2021-02-18; test without NFS by default
 #      DDEV_TEST_USE_NFSMOUNT: true
     parallelism: 1

--- a/.buildkite/macosdockerformac.yml
+++ b/.buildkite/macosdockerformac.yml
@@ -12,4 +12,5 @@
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
       BUILDKIT_PROGRESS: plain
       DDEV_TEST_USE_NFSMOUNT: true
+      DDEV_TEST_SHARE_CMD: "true"
     parallelism: 1

--- a/.buildkite/wsl2.yml
+++ b/.buildkite/wsl2.yml
@@ -10,4 +10,5 @@
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
       BUILDKIT_PROGRESS: plain
+      DDEV_TEST_SHARE_CMD: "true"
     parallelism: 1

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -17,6 +17,9 @@ import (
 
 // TestShareCmd tests `ddev share`
 func TestShareCmd(t *testing.T) {
+	if os.Getenv("DDEV_TEST_SHARE_CMD") != "true" {
+		t.Skip("Skipping because DDEV_TEST_SHARE_CMD != true")
+	}
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping because unreliable on Windows due to DNS lookup failure")
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Avoid the complaint
Your account is limited to 1 simultaneous ngrok client session.\nActive ngrok client sessions in region 'us'

Cut down on how many test runners can use it. Now just macOS (both kinds) and WSL2

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3457"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

