### PR TITLE
Update cli-usage.md

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -318,6 +318,7 @@ Note that the git URL shown below is an example only, you'll need to use your ow
 git clone https://github.com/example/example-site
 cd example-site
 ddev config --project-type=laravel
+ddev start
 ddev composer install
 ddev exec "cat .env.example | sed  -E 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' > .env"
 ddev exec "php artisan key:generate"


### PR DESCRIPTION
line 306: ddev must be started in order to execute other commands

## The Problem/Issue/Bug: line 306: ddev must be started in order to execute other commands

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3467"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

