### PR TITLE
Fixes DDev WordPress Config Files for Override & Coding Standards, fixes #2795

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_BASE_DIR ?= $(PWD)
 GOTMP=.gotmp
 SHELL = /bin/bash
 PWD = $(shell pwd)
-GOFILES = $(shell find $(SRC_DIRS) -name "*.go" -o -name "*.yaml")
+GOFILES = $(shell find $(SRC_DIRS) -name "*.go" -o -name "*.yaml" -o -name "*.php")
 .PHONY: darwin_amd64 darwin_arm64 darwin_amd64_notarized darwin_arm64_notarized darwin_arm64_signed darwin_amd64_signed linux_amd64 linux_arm64 linux_arm windows_amd64 windows_arm64
 
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"

--- a/pkg/ddevapp/assets.go
+++ b/pkg/ddevapp/assets.go
@@ -7,7 +7,7 @@ import (
 
 //The bundled assets for the project .ddev directory are in directory dotddev_assets
 // And the global .ddev assets are in directory global_dotddev_assets
-//go:embed dotddev_assets/* dotddev_assets/commands/.gitattributes global_dotddev_assets/* global_dotddev_assets/.gitignore global_dotddev_assets/commands/.gitattributes app_compose_template.yaml router_compose_template.yaml ssh_auth_compose_template.yaml
+//go:embed dotddev_assets/* dotddev_assets/commands/.gitattributes global_dotddev_assets/* global_dotddev_assets/.gitignore global_dotddev_assets/commands/.gitattributes app_compose_template.yaml router_compose_template.yaml ssh_auth_compose_template.yaml wordpress/*
 var bundledAssets embed.FS
 
 // PopulateExamplesCommandsHomeadditions grabs embedded assets and

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -84,73 +84,80 @@ func getWordpressUploadDir(app *DdevApp) string {
 }
 
 const wordpressSettingsTemplate = `<?php
-{{ $config := . }}
-/**
- {{ $config.Signature }}: Automatically generated WordPress settings file.
- ddev manages this file and may delete or overwrite the file unless this comment is removed.
- It is recommended that you leave this file alone.
+{{ $config := . }}/**
+ * {{ $config.Signature }}: Automatically generated WordPress settings file.
+ * ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ * It is recommended that you leave this file alone.
+ *
+ * @package ddevapp
  */
 
 /** Authentication Unique Keys and Salts. */
-define('AUTH_KEY',         '{{ $config.AuthKey }}');
-define('SECURE_AUTH_KEY',  '{{ $config.SecureAuthKey }}');
-define('LOGGED_IN_KEY',    '{{ $config.LoggedInKey }}');
-define('NONCE_KEY',        '{{ $config.NonceKey }}');
-define('AUTH_SALT',        '{{ $config.AuthSalt }}');
-define('SECURE_AUTH_SALT', '{{ $config.SecureAuthSalt }}');
-define('LOGGED_IN_SALT',   '{{ $config.LoggedInSalt }}');
-define('NONCE_SALT',       '{{ $config.NonceSalt }}');
+define( 'AUTH_KEY', '{{ $config.AuthKey }}' );
+define( 'SECURE_AUTH_KEY', '{{ $config.SecureAuthKey }}' );
+define( 'LOGGED_IN_KEY', '{{ $config.LoggedInKey }}' );
+define( 'NONCE_KEY', '{{ $config.NonceKey }}' );
+define( 'AUTH_SALT', '{{ $config.AuthSalt }}' );
+define( 'SECURE_AUTH_SALT', '{{ $config.SecureAuthSalt }}' );
+define( 'LOGGED_IN_SALT', '{{ $config.LoggedInSalt }}' );
+define( 'NONCE_SALT', '{{ $config.NonceSalt }}' );
 
 /** Absolute path to the WordPress directory. */
-if (!defined('ABSPATH')) {
-  define('ABSPATH', dirname(__FILE__) . '/{{ $config.AbsPath }}');
-}
+defined( 'ABSPATH' ) || define( 'ABSPATH', dirname( __FILE__ ) . '/{{ $config.AbsPath }}' );
 
 // Include for settings managed by ddev.
-$ddev_settings = dirname(__FILE__) . '/wp-config-ddev.php';
-if (is_readable($ddev_settings) && !defined('DB_USER') && getenv('IS_DDEV_PROJECT') == 'true') {
-  require_once($ddev_settings);
+$ddev_settings = dirname( __FILE__ ) . '/wp-config-ddev.php';
+if ( is_readable( $ddev_settings ) && ! defined( 'DB_USER' ) && getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
+	require_once( $ddev_settings );
 }
 
 /** Include wp-settings.php */
-if (file_exists(ABSPATH . '/wp-settings.php')) {
-  require_once ABSPATH . '/wp-settings.php';
+if ( file_exists( ABSPATH . '/wp-settings.php' ) ) {
+	require_once ABSPATH . '/wp-settings.php';
 }
 `
 
 const wordpressDdevSettingsTemplate = `<?php
-{{ $config := . }}
-/**
-{{ $config.Signature }}: Automatically generated WordPress settings file.
- ddev manages this file and may delete or overwrite the file unless this comment is removed.
+{{ $config := . }}/**
+ * {{ $config.Signature }}: Automatically generated WordPress settings file.
+ * ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ *
+ * @package ddevapp
  */
 
-if (getenv('IS_DDEV_PROJECT') == 'true') {
-  /** The name of the database for WordPress */
-  define('DB_NAME', '{{ $config.DatabaseName }}');
-  
-  /** MySQL database username */
-  define('DB_USER', '{{ $config.DatabaseUsername }}');
-  
-  /** MySQL database password */
-  define('DB_PASSWORD', '{{ $config.DatabasePassword }}');
-  
-  /** MySQL hostname */
-  define('DB_HOST', '{{ $config.DatabaseHost }}');
+if ( getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
+	/** The name of the database for WordPress */
+	defined( 'DB_NAME' ) || define( 'DB_NAME', '{{ $config.DatabaseName }}' );
 
-  /** WP_HOME URL */
-  define('WP_HOME', '{{ $config.DeployURL }}');
-  
-  /** WP_SITEURL location */
-  define('WP_SITEURL', WP_HOME . '/{{ $config.AbsPath  }}');
+	/** MySQL database username */
+	defined( 'DB_USER' ) || define( 'DB_USER', '{{ $config.DatabaseUsername }}' );
+
+	/** MySQL database password */
+	defined( 'DB_PASSWORD' ) || define( 'DB_PASSWORD', '{{ $config.DatabasePassword }}' );
+
+	/** MySQL hostname */
+	defined( 'DB_HOST' ) || define( 'DB_HOST', '{{ $config.DatabaseHost }}' );
+
+	/** WP_HOME URL */
+	defined( 'WP_HOME' ) || define( 'WP_HOME', '{{ $config.DeployURL }}' );
+
+	/** WP_SITEURL location */
+	defined( 'WP_SITEURL' ) || define( 'WP_SITEURL', WP_HOME . '/{{ $config.AbsPath  }}' );
+
+	/** Enable debug */
+	defined( 'WP_DEBUG' ) || define( 'WP_DEBUG', true );
+
+	/**
+	 * Set WordPress Database Table prefix if not already set.
+	 *
+	 * @global string $table_prefix
+	 */
+	if ( ! isset( $table_prefix ) || empty( $table_prefix ) ) {
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+		$table_prefix = 'wp_';
+		// phpcs:enable
+	}
 }
-
-/** Enable debug */
-define('WP_DEBUG', true);
-
-
-/** Define the database table prefix */
-$table_prefix  = 'wp_';
 `
 
 const wordpressConfigInstructions = `

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -2,7 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/Masterminds/sprig/v3"
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/util"
@@ -83,83 +82,6 @@ func getWordpressUploadDir(app *DdevApp) string {
 	return app.UploadDir
 }
 
-const wordpressSettingsTemplate = `<?php
-{{ $config := . }}/**
- * {{ $config.Signature }}: Automatically generated WordPress settings file.
- * ddev manages this file and may delete or overwrite the file unless this comment is removed.
- * It is recommended that you leave this file alone.
- *
- * @package ddevapp
- */
-
-/** Authentication Unique Keys and Salts. */
-define( 'AUTH_KEY', '{{ $config.AuthKey }}' );
-define( 'SECURE_AUTH_KEY', '{{ $config.SecureAuthKey }}' );
-define( 'LOGGED_IN_KEY', '{{ $config.LoggedInKey }}' );
-define( 'NONCE_KEY', '{{ $config.NonceKey }}' );
-define( 'AUTH_SALT', '{{ $config.AuthSalt }}' );
-define( 'SECURE_AUTH_SALT', '{{ $config.SecureAuthSalt }}' );
-define( 'LOGGED_IN_SALT', '{{ $config.LoggedInSalt }}' );
-define( 'NONCE_SALT', '{{ $config.NonceSalt }}' );
-
-/** Absolute path to the WordPress directory. */
-defined( 'ABSPATH' ) || define( 'ABSPATH', dirname( __FILE__ ) . '/{{ $config.AbsPath }}' );
-
-// Include for settings managed by ddev.
-$ddev_settings = dirname( __FILE__ ) . '/wp-config-ddev.php';
-if ( is_readable( $ddev_settings ) && ! defined( 'DB_USER' ) && getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
-	require_once( $ddev_settings );
-}
-
-/** Include wp-settings.php */
-if ( file_exists( ABSPATH . '/wp-settings.php' ) ) {
-	require_once ABSPATH . '/wp-settings.php';
-}
-`
-
-const wordpressDdevSettingsTemplate = `<?php
-{{ $config := . }}/**
- * {{ $config.Signature }}: Automatically generated WordPress settings file.
- * ddev manages this file and may delete or overwrite the file unless this comment is removed.
- *
- * @package ddevapp
- */
-
-if ( getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
-	/** The name of the database for WordPress */
-	defined( 'DB_NAME' ) || define( 'DB_NAME', '{{ $config.DatabaseName }}' );
-
-	/** MySQL database username */
-	defined( 'DB_USER' ) || define( 'DB_USER', '{{ $config.DatabaseUsername }}' );
-
-	/** MySQL database password */
-	defined( 'DB_PASSWORD' ) || define( 'DB_PASSWORD', '{{ $config.DatabasePassword }}' );
-
-	/** MySQL hostname */
-	defined( 'DB_HOST' ) || define( 'DB_HOST', '{{ $config.DatabaseHost }}' );
-
-	/** WP_HOME URL */
-	defined( 'WP_HOME' ) || define( 'WP_HOME', '{{ $config.DeployURL }}' );
-
-	/** WP_SITEURL location */
-	defined( 'WP_SITEURL' ) || define( 'WP_SITEURL', WP_HOME . '/{{ $config.AbsPath  }}' );
-
-	/** Enable debug */
-	defined( 'WP_DEBUG' ) || define( 'WP_DEBUG', true );
-
-	/**
-	 * Set WordPress Database Table prefix if not already set.
-	 *
-	 * @global string $table_prefix
-	 */
-	if ( ! isset( $table_prefix ) || empty( $table_prefix ) ) {
-		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
-		$table_prefix = 'wp_';
-		// phpcs:enable
-	}
-}
-`
-
 const wordpressConfigInstructions = `
 An existing user-managed wp-config.php file has been detected!
 Project ddev settings have been written to:
@@ -239,7 +161,7 @@ func createWordpressSettingsFile(app *DdevApp) (string, error) {
 // writeWordpressSettingsFile dynamically produces valid wp-config.php file by combining a configuration
 // object with a data-driven template.
 func writeWordpressSettingsFile(wordpressConfig *WordpressConfig, filePath string) error {
-	tmpl, err := template.New("wordpressConfig").Funcs(sprig.TxtFuncMap()).Parse(wordpressSettingsTemplate)
+	t, err := template.New("wp-config.php").ParseFS(bundledAssets, "wordpress/wp-config.php")
 	if err != nil {
 		return err
 	}
@@ -261,7 +183,7 @@ func writeWordpressSettingsFile(wordpressConfig *WordpressConfig, filePath strin
 	defer util.CheckClose(file)
 
 	//nolint: revive
-	if err = tmpl.Execute(file, wordpressConfig); err != nil {
+	if err = t.Execute(file, wordpressConfig); err != nil {
 		return err
 	}
 
@@ -284,7 +206,7 @@ func writeWordpressDdevSettingsFile(config *WordpressConfig, filePath string) er
 		}
 	}
 
-	tmpl, err := template.New("wordpressConfig").Funcs(sprig.TxtFuncMap()).Parse(wordpressDdevSettingsTemplate)
+	t, err := template.New("wp-config-ddev.php").ParseFS(bundledAssets, "wordpress/wp-config-ddev.php")
 	if err != nil {
 		return err
 	}
@@ -305,8 +227,7 @@ func writeWordpressDdevSettingsFile(config *WordpressConfig, filePath string) er
 	}
 	defer util.CheckClose(file)
 
-	//nolint: revive
-	if err = tmpl.Execute(file, config); err != nil {
+	if err = t.Execute(file, config); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/wordpress/.editorconfig
+++ b/pkg/ddevapp/wordpress/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.jshintrc,*.js,*.json,*.yml,.babelrc,.bowerrc,.browserslistrc,.postcssrc,*.scss}]
+indent_style = space
+indent_size = 2
+
+[*.txt,wp-config-sample.php]
+end_of_line = crlf

--- a/pkg/ddevapp/wordpress/phpcs.xml.dist
+++ b/pkg/ddevapp/wordpress/phpcs.xml.dist
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Plugin Coding Standards">
+	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki -->
+
+	<!-- Set a description for this ruleset. -->
+	<description>A custom set of code standard rules to check for WordPress plugins.</description>
+
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
+
+	<!-- Pass some flags to PHPCS:
+		 p flag: Show progress of the run.
+		 s flag: Show sniff codes in all reports.
+		 v flag: Print verbose output.
+		 n flag: Do not print warnings.
+	-->
+	<arg value="psvn"/>
+
+	<!-- Check up to 8 files simultanously. -->
+	<arg name="parallel" value="8"/>
+
+	<arg name="colors"/>
+
+	<!-- Only check the PHP files. CSS and SCSS files checked separately. JS files are checked separately with ESLint. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Check all files in this directory and the directories below it. -->
+	<file>.</file>
+
+	<exclude-pattern>*/dist/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+	<!--
+	#############################################################################
+	USE THE WordPress-Coding-Standards RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WordPress"/>
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress-Extra" />
+
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
+	<!-- Verify that the text_domain is set to the desired text-domain.
+		 Multiple valid text domains can be provided as a comma-delimited list. -->
+  <!-- <rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="text-domain"/>
+		</properties>
+  </rule> -->
+
+	<!-- Allow for plugin specific exceptions to the file name rules based
+		 on the plugin hierarchy and ensure PSR-4 autoloading compatibility. -->
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="strict_class_file_names" value="false" />
+			<property name="is_plugin" value="true"/>
+		</properties>
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+	</rule>
+
+	<!-- Set the minimum supported WP version. This is used by several sniffs.
+		 The minimum version set here should be in line with the minimum WP version
+		 as set in the "Requires at least" tag in the readme.txt file. -->
+	<config name="minimum_supported_wp_version" value="5.0"/>
+
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<!-- No need to adjust alignment of large arrays when the item with the largest key is removed. -->
+			<property name="exact" value="false"/>
+			<!-- Don't align multi-line items if ALL items in the array are multi-line. -->
+			<property name="alignMultilineItems" value="!=100"/>
+			<!-- Array assignment operator should always be on the same line as the array key. -->
+			<property name="ignoreNewlines" value="false"/>
+		</properties>
+	</rule>
+
+	<!--
+	#############################################################################
+	USE THE PHPCompatibility RULESET
+	#############################################################################
+	-->
+
+	<config name="testVersion" value="7.4-"/>
+	<rule ref="PHPCompatibilityWP" />
+
+</ruleset>

--- a/pkg/ddevapp/wordpress/wp-config-ddev.php
+++ b/pkg/ddevapp/wordpress/wp-config-ddev.php
@@ -1,0 +1,41 @@
+<?php
+{{ $config := . }}/**
+ * #ddev-generated: Automatically generated WordPress settings file.
+ * ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ *
+ * @package ddevapp
+ */
+
+if ( getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
+	/** The name of the database for WordPress */
+	defined( 'DB_NAME' ) || define( 'DB_NAME', '{{ $config.DatabaseName }}' );
+
+	/** MySQL database username */
+	defined( 'DB_USER' ) || define( 'DB_USER', '{{ $config.DatabaseUsername }}' );
+
+	/** MySQL database password */
+	defined( 'DB_PASSWORD' ) || define( 'DB_PASSWORD', '{{ $config.DatabasePassword }}' );
+
+	/** MySQL hostname */
+	defined( 'DB_HOST' ) || define( 'DB_HOST', '{{ $config.DatabaseHost }}' );
+
+	/** WP_HOME URL */
+	defined( 'WP_HOME' ) || define( 'WP_HOME', '{{ $config.DeployURL }}' );
+
+	/** WP_SITEURL location */
+	defined( 'WP_SITEURL' ) || define( 'WP_SITEURL', WP_HOME . '/{{ $config.AbsPath  }}' );
+
+	/** Enable debug */
+	defined( 'WP_DEBUG' ) || define( 'WP_DEBUG', true );
+
+	/**
+	 * Set WordPress Database Table prefix if not already set.
+	 *
+	 * @global string $table_prefix
+	 */
+	if ( ! isset( $table_prefix ) || empty( $table_prefix ) ) {
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+		$table_prefix = 'wp_';
+		// phpcs:enable
+	}
+}

--- a/pkg/ddevapp/wordpress/wp-config.php
+++ b/pkg/ddevapp/wordpress/wp-config.php
@@ -1,0 +1,32 @@
+<?php
+{{ $config := . }}/**
+ * #ddev-generated: Automatically generated WordPress settings file.
+ * ddev manages this file and may delete or overwrite the file unless this comment is removed.
+ * It is recommended that you leave this file alone.
+ *
+ * @package ddevapp
+ */
+
+/** Authentication Unique Keys and Salts. */
+define( 'AUTH_KEY', '{{ $config.AuthKey }}' );
+define( 'SECURE_AUTH_KEY', '{{ $config.SecureAuthKey }}' );
+define( 'LOGGED_IN_KEY', '{{ $config.LoggedInKey }}' );
+define( 'NONCE_KEY', '{{ $config.NonceKey }}' );
+define( 'AUTH_SALT', '{{ $config.AuthSalt }}' );
+define( 'SECURE_AUTH_SALT', '{{ $config.SecureAuthSalt }}' );
+define( 'LOGGED_IN_SALT', '{{ $config.LoggedInSalt }}' );
+define( 'NONCE_SALT', '{{ $config.NonceSalt }}' );
+
+/** Absolute path to the WordPress directory. */
+defined( 'ABSPATH' ) || define( 'ABSPATH', dirname( __FILE__ ) . '/{{ $config.AbsPath }}' );
+
+// Include for settings managed by ddev.
+$ddev_settings = dirname( __FILE__ ) . '/wp-config-ddev.php';
+if ( is_readable( $ddev_settings ) && ! defined( 'DB_USER' ) && getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
+	require_once( $ddev_settings );
+}
+
+/** Include wp-settings.php */
+if ( file_exists( ABSPATH . '/wp-settings.php' ) ) {
+	require_once ABSPATH . '/wp-settings.php';
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Currently, the generated `wp-config-ddev.php` defines the following WordPress configuration constants without checking if they are already defined:

* `DB_NAME`
* `DB_USER`
* `DB_PASSWORD`
* `DB_HOST`
* `WP_HOME`
* `WP_SITEURL`
* `WP_DEBUG`

Additionally, the `$table_prefix` global variable is set such that it will override any changes if the DDev configuration is included first which can prevent operability with configurations that have intentionally changed the WordPress table prefix. This setup become problematic with heavily customized WordPress setups and those that use, for example, the dotenv package to manage the WordPress configuration depending on the running environment.

## How this PR Solves The Problem:

* Changes `wp-config-ddev.php` output to allow overriding when included in an existing WordPress project configuration.
* Updates both the `wp-config.php` and `wp-config-ddev.php` output to follow WordPress coding standards.

## Manual Testing Instructions:

To test this PR, go to [checks](https://github.com/drud/ddev/pull/3468/checks) and choose "PR Build" and all the downloads will be there.  You can also test general functionality on [gitpod](https://gitpod.io/#https://github.com/drud/ddev/pull/3468)


1. Checkout or setup a new WordPress project.
2. Add the `// Include for ddev-managed settings in wp-config-ddev.php.` snippet along with the `wp-config-ddev.php` include code to a custom `wp-config.php` with any of the listed constants defined, or a custom `$table_prefix` defined.
3. Once started the site should be using the predefined constants in favor of the DDev generated values.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

N/A

## Related Issue Link(s):

Fixes #2795

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3468"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

