### PR TITLE
Debug download images with mutagen and docker compose

### DIFF
--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -18,8 +19,18 @@ var DebugDownloadImagesCmd = &cobra.Command{
 
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil {
-			util.Failed("Failed to debug download-images: %v", err)
+			util.Failed("No active project was found: %v", err)
 		}
+
+		_, err = dockerutil.DownloadDockerComposeIfNeeded()
+		if err != nil {
+			util.Warning("Unable to download docker-compose: %v", err)
+		}
+		err = ddevapp.DownloadMutagenIfNeeded(app)
+		if err != nil {
+			util.Warning("Unable to download mutagen: %v", err)
+		}
+
 		err = app.PullContainerImages()
 		if err != nil {
 			util.Failed("Failed to debug download-images: %v", err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1070,6 +1070,8 @@ func (app *DdevApp) PullContainerImages() error {
 		"web":            app.WebImage,
 		"ddev-router":    version.GetRouterImage(),
 		"busybox":        version.BusyboxImage,
+		"docker-compose": version.RequiredDockerComposeVersion,
+		"mutagen":        version.RequiredMutagenVersion,
 	}
 
 	omitted := app.GetOmittedContainers()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1070,8 +1070,6 @@ func (app *DdevApp) PullContainerImages() error {
 		"web":            app.WebImage,
 		"ddev-router":    version.GetRouterImage(),
 		"busybox":        version.BusyboxImage,
-		"docker-compose": version.RequiredDockerComposeVersion,
-		"mutagen":        version.RequiredMutagenVersion,
 	}
 
 	omitted := app.GetOmittedContainers()


### PR DESCRIPTION
## The Problem/Issue/Bug:
docker-compose and mutagen are images that are currently loaded upon request.

## How this PR Solves The Problem:
Updating `ddev debug download-images` command, to include the missing images.

## Manual Testing Instructions:
1. Run `ddev debug download-images` and confirm it includes `mutagen` and `docker-compose`.
1. Run `ddev start`, and confirm that no extra images are downloaded.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3472"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

