### PR TITLE
[tests only] Clean up several test directories that grow over time, for #2619

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -53,21 +53,6 @@ if command -v killall >/dev/null ; then
   killall mutagen || true
 fi
 
-# Try to get important names cached; try twice
-docker run --rm alpine sh -c '
-  for hostname in github.com raw.githubusercontent.com github-releases.githubusercontent.com registry-1.docker.io auth.docker.io production.cloudflare.docker.com; do
-    nslookup $hostname >/dev/null 2>&1 || nslookup $hostname >/dev/null 2>&1 || true
-  done
-'
-
-rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml ~/.ddev/homeadditions ~/.ddev/commands ~/.ddev/bin/docker-comnpose*
-
-# There are discrepancies in golang hash checking in 1.11+, so kill off modcache to solve.
-# See https://github.com/golang/go/issues/27925
-# This can probably be removed when current work is merged 2018-12-27
-# go clean -modcache  (Doesn't work due to current bug in golang)
-chmod -R u+w ~/go/pkg && rm -rf ~/go/pkg/*
-
 # Run any testbot maintenance that may need to be done
 echo "--- running testbot_maintenance.sh"
 bash "$(dirname $0)/testbot_maintenance.sh" || true

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -4,6 +4,8 @@ set -eu -o pipefail
 
 os=$(go env GOOS)
 
+rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml ~/.ddev/homeadditions ~/.ddev/commands ~/.ddev/bin/docker-comnpose* ~/tmp/ddevtest
+
 # Install ngrok if it's not there.
 if ! command -v ngrok >/dev/null; then
     case $os in

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -264,7 +264,8 @@ func TestLaunchCommand(t *testing.T) {
 		assert.NoError(err)
 		err = os.Chdir(pwd)
 		assert.NoError(err)
-		_ = os.RemoveAll(tmpdir)
+		err = os.RemoveAll(tmpdir)
+		assert.NoError(err)
 	})
 
 	// This only tests the https port changes, but that might be enough

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -19,6 +19,9 @@ import (
 
 // TestMutagenSimple tests basic mutagen functionality
 func TestMutagenSimple(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TestMutagenSimple one takes way too long on Windows, skipping")
+	}
 	assert := asrt.New(t)
 
 	mutagenPath := globalconfig.GetMutagenPath()

--- a/pkg/ddevapp/providerGit_test.go
+++ b/pkg/ddevapp/providerGit_test.go
@@ -2,6 +2,7 @@ package ddevapp_test
 
 import (
 	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
@@ -42,6 +43,8 @@ func TestGitPull(t *testing.T) {
 
 		_ = os.Chdir(testDir)
 		_ = os.RemoveAll(siteDir)
+		home, _ := homedir.Dir()
+		_ = os.RemoveAll(filepath.Join(home, "tmp", "ddev-pull-git-test-repo"))
 	})
 
 	err = PopulateExamplesCommandsHomeadditions(app.Name)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #2619
There are flaws in a number of tests and test setup where storage on the buildkite runners builds up over time.

## How this PR Solves The Problem:

* Fix a couple of tests
* `rm -r ~/tmp/ddevtest` at beginning of test

## More detail

Details on usage and where it comes from are at https://gist.github.com/rfay/baa24ff932d6f9ae6d4b59b2b4ac0731



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3474"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

