### PR TITLE
Add brew install --head capability to homebrew on release

### DIFF
--- a/.ci-scripts/bump_homebrew.sh
+++ b/.ci-scripts/bump_homebrew.sh
@@ -33,13 +33,17 @@ cd ${TMPDIR} && git clone https://github.com/${HOMEBREW_REPO} && cd "$(basename 
 
 cat >Formula/${PROJECT_NAME}.rb <<END
 class Ddev < Formula
-  desc "Local development environment management system"
-  homepage "https://ddev.readthedocs.io/en/stable/"
+  desc "Local web development system"
+  homepage "https://ddev.readthedocs.io/"
   url "${SOURCE_URL}"
   sha256 "${SOURCE_SHA}"
+  license "apache-2.0"
+  head "https://github.com/drud/ddev.git", branch: "master"
 
   depends_on "mkcert" => :run
   depends_on "nss" => :run
+  depends_on "go" => :build
+  depends_on "make" => :build
 
   bottle do
     root_url "https://github.com/${GITHUB_USERNAME}/${PROJECT_NAME}/releases/download/${VERSION_NUMBER}/"
@@ -51,11 +55,17 @@ class Ddev < Formula
     system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
     system "mkdir", "-p", "#{bin}"
     if OS.mac?
-      system "cp", ".gotmp/bin/darwin_amd64/ddev", "#{bin}/ddev"
-      system ".gotmp/bin/darwin_amd64/ddev_gen_autocomplete"
-    else
-      system "cp", ".gotmp/bin/ddev", "#{bin}/ddev"
-      system ".gotmp/bin/ddev_gen_autocomplete"
+        if Hardware::CPU.arm?
+            system "cp", ".gotmp/bin/darwin_arm64/ddev", "#{bin}/ddev"
+            system ".gotmp/bin/darwin_arm64/ddev_gen_autocomplete"
+        else
+            system "cp", ".gotmp/bin/darwin_amd64/ddev", "#{bin}/ddev"
+            system ".gotmp/bin/darwin_amd64/ddev_gen_autocomplete"
+        end
+    end
+    if OS.linux?
+      system "cp", ".gotmp/bin/linux_amd64/ddev", "#{bin}/ddev"
+      system ".gotmp/bin/linux_amd64/ddev_gen_autocomplete"
     end
     bash_completion.install ".gotmp/bin/ddev_bash_completion.sh" => "ddev"
     zsh_completion.install ".gotmp/bin/ddev_zsh_completion.sh" => "ddev"
@@ -66,8 +76,8 @@ class Ddev < Formula
     <<~EOS
             Make sure to do a 'mkcert -install' if you haven't done it before, it may require your sudo password.
       #{"      "}
-            ddev requires docker and docker-compose.
-            Docker installation instructions at https://ddev.readthedocs.io/en/stable/users/docker_installation/
+            ddev requires docker or colima.
+            See https://ddev.readthedocs.io/en/latest/users/docker_installation/
     EOS
   end
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

It's always been complicated for people to get the latest version of ddev for testing, but with this, `head` is added to the homebrew formula, so `brew unlink ddev && brew install --head ddev` will do the job.

It's already live, this PR makes it so it will be in future updates.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3476"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

