### PR TITLE
Push mariadb-10.1 to arm64 and amd64

### DIFF
--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,7 +10,7 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_amd64 mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.26
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.26
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
 	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3482

#3482 pointed out that mariadb 10.1 was not working on mac M1 (arm64). 

## How this PR Solves The Problem:

There was an error in the build list and mariadb 10.1 was only being pushed for arm64, even though the upstream mariadb 10.1 image is pushed for arm64 as well.

## Manual Testing Instructions:

Start a project with `mariadb_version: 10.1`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3483"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

