### PR TITLE
Fix blackfire-php being enabled by default on hardened/prod ddev-webserver

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -204,11 +204,8 @@ RUN mkdir /tmp/ddev && \
         echo 'MKCERT_ARCH="linux-amd64"' >/tmp/ddev/vars; \
     fi
 
-# blackfire-php is not available for arm64 (yet)
-RUN if [[ $TARGETPLATFORM != "linux/arm64" ]]; then \
-    DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" blackfire-php -y --allow-unauthenticated; \
-    fi
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
+    blackfire-php \
     fontconfig \
     gettext \
     git \
@@ -228,6 +225,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     zip
 
 ADD ddev-webserver-prod-files /
+RUN phpdismod blackfire xhprof
 
 RUN curl -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20211211_volumes_for_config" // Note that this can be overridden by make
+var WebTag = "20211230_blackfire_on_prod" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

blackfire extension is enabled by default on Casual Webhosting setup, and it shouldn't be

## How this PR Solves The Problem:

## Manual Testing Instructions:

`docker run --rm --name=blackfire drud/ddev-webserver-prod:20211230_blackfire_on_prod`
`ddev exec -it blackfire php --version` should not show blackfire

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3486"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

