### PR TITLE
[tests only] Tests should use updated wordpress 5.6 code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v27
+        - linux-homebrew-v28
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v27
+        key: linux-homebrew-v28
         paths:
           - /home/linuxbrew
     - run:
@@ -64,16 +64,16 @@ jobs:
     - run: 'mkdir -p ~/.ngrok2 && echo "authtoken: ${NGROK_TOKEN}" >~/.ngrok2/ngrok.yml'
     - restore_cache:
         keys:
-        - linux-homebrew-v27
+        - linux-homebrew-v28
     - restore_cache:
         keys:
-          - linux-testcache-v24
+          - linux-testcache-v25
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v27
+        key: linux-homebrew-v28
         paths:
           - /home/linuxbrew
     - run: echo "$(docker --version) $(docker-compose --version)"
@@ -84,7 +84,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-testcache-v24
+        key: linux-testcache-v25
         paths:
         - /home/circleci/.ddev/testcache
 
@@ -135,7 +135,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - macos-v24
+        - macos-v25
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -146,7 +146,7 @@ jobs:
         name: ddev tests
         no_output_timeout: "40m"
     - save_cache:
-        key: macos-v24
+        key: macos-v25
         paths:
         - /home/circleci/.ddev/testcache
     - store_test_results:
@@ -165,7 +165,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - macos-v24
+        - macos-v25
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -178,7 +178,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: macos-v24
+        key: macos-v25
         paths:
         - /home/circleci/.ddev/testcache
 
@@ -195,7 +195,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - macos-v24
+        - macos-v25
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -207,7 +207,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: macos-v24
+        key: macos-v25
         paths:
         - /home/circleci/.ddev/testcache
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -29,15 +29,17 @@ var (
 	DdevBin   = "ddev"
 	TestSites = []testcommon.TestSite{
 		{
-			Name:                          "TestCmdWordpress",
-			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
-			FilesTarballURL:               "https://github.com/drud/wordpress/releases/download/v0.4.0/files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/wordpress/releases/download/v0.4.0/db.tar.gz",
-			HTTPProbeURI:                  "wp-admin/setup-config.php",
-			Docroot:                       "htdocs",
+			SourceURL:                     "https://wordpress.org/wordpress-5.8.2.tar.gz",
+			ArchiveInternalExtractionPath: "wordpress/",
+			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/wordpress5.8.2_files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/wordpress5.8.2_db.sql.tar.gz",
+			Docroot:                       "",
 			Type:                          nodeps.AppTypeWordPress,
 			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "this post has a photo"},
+			FilesImageURI:                 "/wp-content/uploads/2021/12/DSCF0436-randy-and-nancy-with-traditional-wedding-out-fit-2048x1536.jpg",
+			Name:                          "TestCmdWordpress",
+			HTTPProbeURI:                  "wp-admin/setup-config.php",
 		},
 		// Drupal6 is used here just because it's smaller and we don't actually
 		// care much about CMS functionality.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -41,15 +41,15 @@ var (
 		// 0: wordpress
 		{
 			Name:                          "TestPkgWordpress",
-			SourceURL:                     "https://github.com/drud/wordpress/archive/v0.4.0.tar.gz",
-			ArchiveInternalExtractionPath: "wordpress-0.4.0/",
-			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_files.tar.gz",
-			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.0/wordpress_db.tar.gz",
-			Docroot:                       "htdocs",
+			SourceURL:                     "https://wordpress.org/wordpress-5.8.2.tar.gz",
+			ArchiveInternalExtractionPath: "wordpress/",
+			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/wordpress5.8.2_files.tar.gz",
+			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/wordpress5.8.2_db.sql.tar.gz",
+			Docroot:                       "",
 			Type:                          nodeps.AppTypeWordPress,
 			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/readme.html", Expect: "Welcome. WordPress is a very special project to me."},
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "this post has a photo"},
-			FilesImageURI:                 "/wp-content/uploads/2017/04/pexels-photo-265186-1024x683.jpeg",
+			FilesImageURI:                 "/wp-content/uploads/2021/12/DSCF0436-randy-and-nancy-with-traditional-wedding-out-fit-2048x1536.jpg",
 		},
 		// 1: drupal8
 		{


### PR DESCRIPTION
## The Problem/Issue/Bug:

Testing was using an ancient version of WordPress

## How this PR Solves The Problem:

Use a current version.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3488"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

