### PR TITLE
Do nightly build on github instead of circleci, fixes #3013

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,20 +540,20 @@ workflows:
 #        requires:
 #        - build
 
-  nightly_build:
-    triggers:
-      - schedule:
-          cron: "0 3 * * *"
-          filters:
-            branches:
-              only:
-                - master
-                - "pull/[0-9]+"
-    jobs:
-    - lx_amd64_container_test
-#    - lx_arm64_container_test
-#    - lx_amd64_fpm_test
-    - lx_arm64_fpm_test
+#  nightly_build:
+#    triggers:
+#      - schedule:
+#          cron: "0 3 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - "pull/[0-9]+"
+#    jobs:
+#    - lx_amd64_container_test
+##    - lx_arm64_container_test
+##    - lx_amd64_fpm_test
+#    - lx_arm64_fpm_test
 
 #  release_build:
 #    jobs:

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -11,6 +11,8 @@ on:
     # Only run when something changes in the actual containers
     paths:
     - "containers/**"
+  schedule:
+    - cron: '01 24 * * *'
 
 env:
   DDEV_IGNORE_EXPIRING_KEYS: "false"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ on:
   push:
     branches: [ master, main ]
 
+  schedule:
+    - cron: '01 00 * * *'
+
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Moving nightly builds to github (free) instead of circleci.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3490"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

