### PR TITLE
Added missing sudo to wsl2 docker install instructions

### DIFF
--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -46,7 +46,7 @@ sudo apt-get remove docker docker-engine docker.io containerd runc
 sudo apt-get update && sudo apt-get install ca-certificates curl gnupg lsb-release
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update && apt-get install docker-ce docker-ce-cli containerd.io
+sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io
 sudo groupadd docker && sudo usermod -aG docker $USER
 ```
 


### PR DESCRIPTION
There appears to be a missing `sudo` in the install commands for docker in WSL2 — I got "Could not open lock file /var/lib/dpkg/lock-frontend" before adding the `sudo` shown here.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3503"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

