### PR TITLE
Mount .git and upload_dir with bind-mount when using mutagen, fixes #3505, fixes #3400, fixes #3384, fixes #3357

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -492,6 +492,7 @@ webenv
 webhosting
 webimage
 webserver
+webserving
 will
 winnfsd
 with

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -110,8 +110,12 @@ services:
       - ".:/mnt/ddev_config:ro"
       - "./xhprof:/usr/local/bin/xhprof:ro"
         {{ if .MutagenEnabled }}
-      - "../{{ .UploadDir }}:/var/www/html/{{ .UploadDir }}:rw"
-      - "../.git:/var/www/html/.git:rw"
+          {{ if .UploadDir }}
+      - ../{{ .UploadDir }}:/var/www/html/{{ .UploadDir }}:rw
+          {{ end }} {{/* end if .UploadDir */}}
+          {{ if .GitDirMount }}
+      - ../.git:/var/www/html/.git:rw
+          {{ end }} {{/* end if .GitDirMount */}}
         {{ end }} {{/* end if .MutagenEnabled */}}
       {{ end }} {{/* end else of if .NoBindMounts */}}
       - "ddev-global-cache:/mnt/ddev-global-cache"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -93,7 +93,7 @@ services:
           nocopy: true
         {{ else }} {{/* if eq .MountType "volume"*/}}
         consistency: cached
-        {{ end }} {{/* end if eq .MountType "volume"*/}}
+        {{ end }} {{/* end if eq .MountType "volume" */}}
       {{ end }} {{/* end if and (not .MutagenEnabled) (not .NoProjectMount)*/}}
       {{ if and .MutagenEnabled (not .NoProjectMount) }}
       # For mutagen, mount a directory higher in /var/www so that we can use
@@ -109,7 +109,11 @@ services:
       {{ else }}
       - ".:/mnt/ddev_config:ro"
       - "./xhprof:/usr/local/bin/xhprof:ro"
-      {{ end }}
+        {{ if .MutagenEnabled }}
+      - "../{{ .UploadDir }}:/var/www/html/{{ .UploadDir }}"
+      - "../.git:/var/www/html/.git"
+        {{ end }} {{/* end if .MutagenEnabled */}}
+      {{ end }} {{/* end else of if .NoBindMounts */}}
       - "ddev-global-cache:/mnt/ddev-global-cache"
       {{ if not .OmitSSHAgent }}
       - "ddev-ssh-agent_socket_dir:/home/.ssh-agent"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -110,8 +110,8 @@ services:
       - ".:/mnt/ddev_config:ro"
       - "./xhprof:/usr/local/bin/xhprof:ro"
         {{ if .MutagenEnabled }}
-      - "../{{ .UploadDir }}:/var/www/html/{{ .UploadDir }}"
-      - "../.git:/var/www/html/.git"
+      - "../{{ .UploadDir }}:/var/www/html/{{ .UploadDir }}:rw"
+      - "../.git:/var/www/html/.git:rw"
         {{ end }} {{/* end if .MutagenEnabled */}}
       {{ end }} {{/* end else of if .NoBindMounts */}}
       - "ddev-global-cache:/mnt/ddev-global-cache"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -698,6 +698,7 @@ type composeYAMLVars struct {
 	NoBindMounts              bool
 	Docroot                   string
 	UploadDir                 string
+	GitDirMount               bool
 }
 
 // RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.
@@ -774,7 +775,17 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		NoBindMounts:          globalconfig.DdevGlobalConfig.NoBindMounts,
 		Docroot:               app.GetDocroot(),
 		UploadDir:             path.Join(app.GetDocroot(), app.GetUploadDir()),
+		GitDirMount:           false,
 	}
+	// We don't want to bind-mount git dir if it doesn't exist
+	if fileutil.IsDirectory(filepath.Join(app.AppRoot, ".git")) {
+		templateVars.GitDirMount = true
+	}
+	// And we don't want to bind-mount upload dir if it doesn't exist
+	if app.GetUploadDir() == "" || !fileutil.FileExists(templateVars.UploadDir) {
+		templateVars.UploadDir = ""
+	}
+
 	if app.NFSMountEnabled || app.NFSMountEnabledGlobal {
 		templateVars.MountType = "volume"
 		templateVars.WebMount = "nfsmount"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -695,6 +696,8 @@ type composeYAMLVars struct {
 	DBAWorkingDir             string
 	WebEnvironment            []string
 	NoBindMounts              bool
+	Docroot                   string
+	UploadDir                 string
 }
 
 // RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.
@@ -769,6 +772,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		MariaDBVolumeName:     app.GetMariaDBVolumeName(),
 		NFSMountVolumeName:    app.GetNFSMountVolumeName(),
 		NoBindMounts:          globalconfig.DdevGlobalConfig.NoBindMounts,
+		Docroot:               app.GetDocroot(),
+		UploadDir:             path.Join(app.GetDocroot(), app.GetUploadDir()),
 	}
 	if app.NFSMountEnabled || app.NFSMountEnabledGlobal {
 		templateVars.MountType = "volume"

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -439,7 +439,13 @@ func (app *DdevApp) GenerateMutagenYml() error {
 	if err != nil {
 		return err
 	}
-	err = fileutil.TemplateStringToFile(content, map[string]interface{}{"SymlinkMode": symlinkMode}, mutagenYmlPath)
+
+	templateMap := map[string]interface{}{
+		"SymlinkMode": symlinkMode,
+		"UploadDir":   path.Join(app.GetDocroot(), app.GetUploadDir()),
+	}
+
+	err = fileutil.TemplateStringToFile(content, templateMap, mutagenYmlPath)
 	return err
 }
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -444,6 +444,10 @@ func (app *DdevApp) GenerateMutagenYml() error {
 		"SymlinkMode": symlinkMode,
 		"UploadDir":   path.Join(app.GetDocroot(), app.GetUploadDir()),
 	}
+	// If no bind mounts, then we can't ignore UploadDir, must sync it
+	if globalconfig.DdevGlobalConfig.NoBindMounts {
+		templateMap["UploadDir"] = ""
+	}
 
 	err = fileutil.TemplateStringToFile(content, templateMap, mutagenYmlPath)
 	return err

--- a/pkg/ddevapp/mutagen_config_assets/mutagen.yml
+++ b/pkg/ddevapp/mutagen_config_assets/mutagen.yml
@@ -20,6 +20,9 @@ sync:
       - "/.ddev/.importdb*"
       - ".DS_Store"
       - ".idea"
+      {{ if .UploadDir }}
+      - "/{{ .UploadDir }}"
+      {{ end }}
       # For example /var/www/html/var does not need to sync in TYPO3
       # - "/var"
       # vcs like .git can be ignored for safety, but then some

--- a/pkg/ddevapp/mutagen_config_assets/mutagen.yml
+++ b/pkg/ddevapp/mutagen_config_assets/mutagen.yml
@@ -12,9 +12,10 @@ sync:
     stageMode: "neighboring"
     ignore:
       paths:
-      # The top-level .git directory is ignored to encourage git actions on the host
-      # side, but if you need it inside the container you can remove this
+      # The top-level .git directory is ignored because where possible it's mounted
+      # into the container with a traditional docker bind-mount
       - "/.git"
+
       - "/.tarballs"
       - "/.ddev/db_snapshots"
       - "/.ddev/.importdb*"
@@ -23,7 +24,10 @@ sync:
       {{ if .UploadDir }}
       - "/{{ .UploadDir }}"
       {{ end }}
+
+      # You can also exclude other directories from mutagen-syncing
       # For example /var/www/html/var does not need to sync in TYPO3
+      # so you can add:
       # - "/var"
       # vcs like .git can be ignored for safety, but then some
       # composer operations may fail if they use dev versions/git.


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3505
* #3400 
* #3384 
* #3357 

## How this PR Solves The Problem:

* When mutagen is enabled (and --no-bind-mounts=false so bind-mounts are possible) then mount .git and upload_dir into the container via traditional bind-mount and exclude them from mutagen. That way they're available inside the container, but have no mutagen-setup time.
* Rework the docs a bit

## Manual Testing Instructions:

- [x] Do a `ddev composer install` on TYPO3 git checkout
- [x] `ddev exec df -T web/sites/default/files` on a mutagen-enabled Drupal project should show that it's NFS or docker-mounted
- [x] `ddev exec df -T .git` on a mutagen-enabled project with a .git directory should show it's NFS or docker-mounted.
- [x] Read the updated mutagen instructions.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3507"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

