### PR TITLE
Don't fail if composer self-update fails in web image build (like with no internet)

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -872,12 +872,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg:
 			composerSelfUpdateArg = composerVersion
 		}
 
-		// If composerVersion is not set, we don't need to self-update.
 		// Composer v2 is default
 		// Try composer self-update twice because of troubles with composer downloads
 		// breaking testing.
 		contents = contents + fmt.Sprintf(`
-RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update %s )
+RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update %s || true )
 `, composerSelfUpdateArg, composerSelfUpdateArg)
 	}
 	return WriteImageDockerfile(fullpath, []byte(contents))


### PR DESCRIPTION
## The Problem/Issue/Bug:

In certain network situations, including when no internet is available, the `composer self-update` in generated .ddev/.web-image-build/Dockerfile can fail.

## How this PR Solves The Problem:

Try twice, but allow failure.

## Manual Testing Instructions:

Try starting a fresh project with no internet. (All images need to have been previously downloaded of course)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3508"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

