### PR TITLE
v1.19.x vs v1.18.x compatibility with 3rd party services, especially solr

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
     paths:
       - "go.*"
-      - "pkg"
-      - "cmd"
+      - "pkg/**"
+      - "cmd/**"
       - "Makefile"
-      - "vendor"
+      - "vendor/**"
 
 env:
   BUILDKIT_PROGRESS: plain

--- a/cmd/ddev/cmd/poweroff.go
+++ b/cmd/ddev/cmd/poweroff.go
@@ -50,7 +50,7 @@ func powerOff() {
 		util.Error("Failed to remove ddev-ssh-agent: %v", err)
 	}
 	// Remove current global network ("ddev") plus the former "ddev_default"
-	removals := []string{"ddev", "ddev_default"}
+	removals := []string{"ddev_default"}
 	for _, networkName := range removals {
 		err = dockerutil.RemoveNetwork(networkName)
 		_, isNoSuchNetwork := err.(*docker.NoSuchNetwork)

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -12,7 +12,7 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
 
 #### Installation
 
-1. Copy [docker-compose.solr.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml) to the .ddev folder for your project.
+1. Copy [docker-compose.solr.yaml](https://github.com/drud/ddev/tree/master/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml) to the .ddev folder for your project. **In versions of ddev before v1.19, you must remove the `networks:` line in this file.**
 2. Solr version can be changed by updating this line `image: solr:8` in `docker-compose.solr.yaml` file, but the recipe here assumes solr:8 and it may not work with other versions. Acquia and Pantheon.io hosting seem to require versions from 3 to 7, and you'll want to see the [contributed recipes](https://github.com/drud/ddev-contrib) for older versions of solr.
 3. Create the folder path .ddev/solr/conf.
     * If needed, you may copy/extract the Solr configuration files for your project into `.ddev/solr/conf`. Ensure that the configuration files are present before running `ddev start`.

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -37,7 +37,7 @@ version: '3.6'
 services:
   someservice:
   container_name: "ddev-${DDEV_SITENAME}-someservice"
-  networks: [default, ddev]
+  networks: [default, ddev_default]
   labels:
     com.ddev.site-name: ${DDEV_SITENAME}
     com.ddev.approot: ${DDEV_APPROOT}
@@ -47,7 +47,7 @@ services:
   - VIRTUAL_HOST=$DDEV_HOSTNAME
   - HTTP_EXPOSE=9998:9999
   - HTTPS_EXPOSE=9999:9999
-  networks: [default, ddev]
+  networks: [default, ddev_default]
 ```
 
 ### Confirming docker-compose configurations
@@ -71,7 +71,7 @@ When defining additional services for your project, we recommended you follow th
 * Exposing ports for service: you can expose the port for a service to be accessible as `projectname.ddev.site:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
 
     * Define only the internal port in the `expose` section for docker-compose; use `ports:` only if the port will be bound directly to localhost, as may be required for non-http services.
-    * Add a `networks:` stanza: `networks: [default, ddev]`
+    * Add a `networks:` stanza: `networks: [default, ddev_default]`
 
     * To expose a web interface to be accessible over HTTP, define the following environment variables in the `environment` section for docker-compose:
 

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -36,15 +36,18 @@ version: '3.6'
 
 services:
   someservice:
-    expose: 
-    - 9999
-    environment:
-    - VIRTUAL_HOST=$DDEV_HOSTNAME
-    - HTTP_EXPOSE=9998:9999
-    - HTTPS_EXPOSE=9999:9999
-    networks:
-    - default
-    - ddev
+  container_name: "ddev-${DDEV_SITENAME}-someservice"
+  networks: [default, ddev]
+  labels:
+    com.ddev.site-name: ${DDEV_SITENAME}
+    com.ddev.approot: ${DDEV_APPROOT}
+  expose: 
+  - "9999"
+  environment:
+  - VIRTUAL_HOST=$DDEV_HOSTNAME
+  - HTTP_EXPOSE=9998:9999
+  - HTTPS_EXPOSE=9999:9999
+  networks: [default, ddev]
 ```
 
 ### Confirming docker-compose configurations
@@ -55,17 +58,20 @@ To better understand how ddev is parsing your custom docker-compose files, you c
 
 When defining additional services for your project, we recommended you follow these conventions to ensure ddev handles your service the same way ddev handles default services.
 
-* To name containers follow this naming convention `ddev-[projectname]-[servicename]`
+* The container name should be `ddev-${DDEV_SITENAME}-<servicename>`
 
-* Provide containers with the following labels
+* Provide containers with required labels:
 
-    * `com.ddev.site-name: ${DDEV_SITENAME}`
-
-    * `com.ddev.approot: $DDEV_APPROOT`
+  ```yaml
+      labels:
+        com.ddev.site-name: ${DDEV_SITENAME}
+        com.ddev.approot: ${DDEV_APPROOT}
+  ```
 
 * Exposing ports for service: you can expose the port for a service to be accessible as `projectname.ddev.site:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
 
-    * Define only the internal port in the `ports` section for docker-compose. The `hostPort:containerPort` convention normally used to expose ports in docker should not be used here, since we are leveraging the ddev router to expose the ports.
+    * Define only the internal port in the `expose` section for docker-compose; use `ports:` only if the port will be bound directly to localhost, as may be required for non-http services.
+    * Add a `networks:` stanza: `networks: [default, ddev]`
 
     * To expose a web interface to be accessible over HTTP, define the following environment variables in the `environment` section for docker-compose:
 

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -38,7 +38,7 @@ Can I use additional databases with DDEV?
 
 <a name="projects-communicate-with-each-other"></a>
 Can different projects communicate with each other?
-: Yes, this is commonly required for situations like Drupal migrations. For the web container to access the db container of another project, use `ddev-<projectname>-db` as the hostname of the other project. For example, in project1, use `mysql -h ddev-project2-db` to access the db server of project2. For HTTP/S communication you can 1) access the web container of project2 directly with the hostname `ddev-<project2>-web` and port 80 or 443: `curl https://ddev-project2-web` or 2) Add a .ddev/docker-compose.communicate.yaml which will allow you to access the other project via the official FQDN.
+: Yes, this is commonly required for situations like Drupal migrations. For the web container to access the db container of another project, use `ddev-<projectname>-db` as the hostname of the other project. For example, in project1, use `mysql -h ddev-project2-db` to access the db server of project2. For HTTP/S communication you can 1) access the web container of project2 directly with the hostname `ddev-<project2>-web` and port 80 or 443: `curl https://ddev-project2-web` or 2) Add a .ddev/docker-compose.communicate.yaml which will allow you to access the other project via the official FQDN. (In v1.19+ third-party services may need `networks: [default, ddev]`.)
 
     ```yaml
       version: '3.6'
@@ -104,3 +104,6 @@ How can I install a specific version of DDEV?
     1. Download the version you want from the [releases page](https://github.com/drud/ddev/releases) and place it somewhere in your `$PATH`.
     2. Use the [install_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, use `curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v1.18.3-alpha1`
     3. If you want the very latest, unreleased version of ddev, use `brew unlink ddev && brew install drud/ddev/ddev --HEAD`.
+
+How can I back up or restore all databases of all projects?
+: You can back up all projects that show in `ddev list` with `ddev start -a && ddev snapshot -a` but most people don't have enough memory to run all their projects at once. If you have `jq` on your system (`brew install jq`) then you can snapshot them one at a time with `for proj in $(ddev list -j  | jq -r '.raw[].name'); do ddev start $proj; ddev snapshot $proj; ddev stop $proj; done`. You can restore the latest snapshot in all projects listed by `ddev list` with `for dir in $(ddev list -j  | jq -r '.raw[].approot'); do pushd "$dir" && ddev snapshot restore --latest && ddev stop && popd; done`

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -38,7 +38,7 @@ Can I use additional databases with DDEV?
 
 <a name="projects-communicate-with-each-other"></a>
 Can different projects communicate with each other?
-: Yes, this is commonly required for situations like Drupal migrations. For the web container to access the db container of another project, use `ddev-<projectname>-db` as the hostname of the other project. For example, in project1, use `mysql -h ddev-project2-db` to access the db server of project2. For HTTP/S communication you can 1) access the web container of project2 directly with the hostname `ddev-<project2>-web` and port 80 or 443: `curl https://ddev-project2-web` or 2) Add a .ddev/docker-compose.communicate.yaml which will allow you to access the other project via the official FQDN. (In v1.19+ third-party services may need `networks: [default, ddev]`.)
+: Yes, this is commonly required for situations like Drupal migrations. For the web container to access the db container of another project, use `ddev-<projectname>-db` as the hostname of the other project. For example, in project1, use `mysql -h ddev-project2-db` to access the db server of project2. For HTTP/S communication you can 1) access the web container of project2 directly with the hostname `ddev-<project2>-web` and port 80 or 443: `curl https://ddev-project2-web` or 2) Add a .ddev/docker-compose.communicate.yaml which will allow you to access the other project via the official FQDN. (In v1.19+ third-party services may need `networks: [default, ddev_default]`.)
 
     ```yaml
       version: '3.6'

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -13,7 +13,7 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
-    networks: ["default", "ddev"]
+    networks: ["default", "ddev_default"]
     stop_grace_period: 60s
     working_dir: "{{ .DBWorkingDir }}"
     volumes:
@@ -75,7 +75,7 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
-    networks: ["default", "ddev"]
+    networks: ["default", "ddev_default"]
     cap_add:
       - SYS_PTRACE
     working_dir: "{{ .WebWorkingDir }}"
@@ -190,7 +190,7 @@ services:
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
-    networks: ["default", "ddev"]
+    networks: ["default", "ddev_default"]
     working_dir: "{{ .DBAWorkingDir }}"
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     labels:
@@ -220,8 +220,8 @@ services:
       retries: 1
     {{ end }}{{/* end if not .OmitDBA */}}
 networks:
-  ddev:
-    name: ddev
+  ddev_default:
+    name: ddev_default
     external: true
 volumes:
   {{if not .OmitDB }}

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -13,9 +13,7 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
-    networks:
-      - default
-      - ddev
+    networks: ["default", "ddev"]
     stop_grace_period: 60s
     working_dir: "{{ .DBWorkingDir }}"
     volumes:
@@ -77,9 +75,7 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
-    networks:
-      - default
-      - ddev
+    networks: ["default", "ddev"]
     cap_add:
       - SYS_PTRACE
     working_dir: "{{ .WebWorkingDir }}"
@@ -194,9 +190,7 @@ services:
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
-    networks:
-      - default
-      - ddev
+    networks: ["default", "ddev"]
     working_dir: "{{ .DBAWorkingDir }}"
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     labels:

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -126,7 +126,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 		if err != nil {
 			return app, err
 		}
-		err = yaml.Unmarshal([]byte(content), &app.ComposeYaml)
+		err = app.UpdateComposeYaml(content)
 		if err != nil {
 			return app, err
 		}
@@ -565,6 +565,10 @@ func (app *DdevApp) WriteDockerComposeYAML() error {
 		return err
 	}
 
+	err = app.UpdateComposeYaml(fullContents)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2533,6 +2533,10 @@ func (app *DdevApp) StartAppIfNotRunning() error {
 
 // CheckAddonIncompatibilities() looks for problems with docker-compose.*.yaml 3rd-party services
 func (app *DdevApp) CheckAddonIncompatibilities() error {
+	if _, ok := app.ComposeYaml["services"]; !ok {
+		util.Warning("Unable to check 3rd-party services for missing networks stanza")
+		return nil
+	}
 	// Look for missing "networks" stanza and request it.
 	for s, v := range app.ComposeYaml["services"].(map[interface{}]interface{}) {
 		x := v.(map[interface{}]interface{})

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -990,7 +990,7 @@ func (app *DdevApp) Start() error {
 
 	err = app.CheckAddonIncompatibilities()
 	if err != nil {
-		util.Failed("third-party service incompatibilities: %v", err)
+		return err
 	}
 
 	err = app.AddHostsEntriesIfNeeded()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/fs"
 	"net"
 	"os"
@@ -2552,6 +2553,15 @@ func (app *DdevApp) CheckAddonIncompatibilities() error {
 				return errMsg
 			}
 		}
+	}
+	return nil
+}
+
+// UpdateComposeYaml updates app.ComposeYaml from available content
+func (app *DdevApp) UpdateComposeYaml(content string) error {
+	err := yaml.Unmarshal([]byte(content), &app.ComposeYaml)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2541,14 +2541,14 @@ func (app *DdevApp) CheckAddonIncompatibilities() error {
 	// Look for missing "networks" stanza and request it.
 	for s, v := range app.ComposeYaml["services"].(map[interface{}]interface{}) {
 		x := v.(map[interface{}]interface{})
-		errMsg := fmt.Errorf("service '%s' does not have the 'networks: [default, ddev]' stanza, required since v1.19, please add it, see %s", s, "https://ddev.readthedocs.io/en/latest/users/extend/custom-compose-files/#docker-composeyaml-examples")
+		errMsg := fmt.Errorf("service '%s' does not have the 'networks: [default, ddev_default]' stanza, required since v1.19, please add it, see %s", s, "https://ddev.readthedocs.io/en/latest/users/extend/custom-compose-files/#docker-composeyaml-examples")
 		var nets map[interface{}]interface{}
 		ok := false
 		if nets, ok = x["networks"].(map[interface{}]interface{}); !ok {
 			return errMsg
 		}
 		// Make sure both "default" and "ddev" networks are in there.
-		for _, requiredNetwork := range []string{"default", "ddev"} {
+		for _, requiredNetwork := range []string{"default", "ddev_default"} {
 			if _, ok := nets[requiredNetwork]; !ok {
 				return errMsg
 			}

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -3,7 +3,7 @@ services:
   ddev-router:
     image: {{ .router_image }}:{{ .router_tag }}
     networks:
-        - ddev
+        - ddev_default
     container_name: ddev-router
     ports:{{ $dockerIP := .dockerIP }}{{ if not .router_bind_all_interfaces }}{{ range $port := .ports }}
     - "{{ $dockerIP }}:{{ $port }}:{{ $port }}"{{ end }}{{ else }}{{ range $port := .ports }}
@@ -28,8 +28,8 @@ services:
       timeout: 120s
 
 networks:
-  ddev:
-    name: ddev
+  ddev_default:
+    name: ddev_default
     external: true
 volumes:
   ddev-global-cache:

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -18,7 +18,7 @@ services:
         gid: '{{ .GID }}'
     image: '{{ .ssh_auth_image }}:{{ .ssh_auth_tag }}-built'
     networks:
-      - ddev
+      - ddev_default
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     user: '$DDEV_UID:$DDEV_GID'
     volumes:
@@ -32,6 +32,6 @@ services:
       start_period: 10s
       timeout: 62s
 networks:
-  ddev:
-    name: ddev
+  ddev_default:
+    name: ddev_default
     external: true

--- a/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
@@ -2,7 +2,7 @@ version: '3.6'
 services:
   busybox:
     image: busybox:stable
-    networks: [default, ddev]
+    networks: [default, ddev_default]
     command: tail -f /dev/null
     container_name: ddev-${DDEV_SITENAME}-busybox
     labels:

--- a/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
@@ -2,6 +2,7 @@ version: '3.6'
 services:
   busybox:
     image: busybox:stable
+    networks: [default, ddev]
     command: tail -f /dev/null
     container_name: ddev-${DDEV_SITENAME}-busybox
     labels:

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
@@ -7,6 +7,7 @@ services:
 
   dummy2:
     image: busybox:stable
+    networks: [default, ddev]
     container_name: dummy2
     environment:
     - HTTP_EXPOSE=9201

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
@@ -7,7 +7,7 @@ services:
 
   dummy2:
     image: busybox:stable
-    networks: [default, ddev]
+    networks: [default, ddev_default]
     container_name: dummy2
     environment:
     - HTTP_EXPOSE=9201

--- a/pkg/ddevapp/testdata/TestNetworkAmbiguity/docker-compose.test.yaml
+++ b/pkg/ddevapp/testdata/TestNetworkAmbiguity/docker-compose.test.yaml
@@ -3,6 +3,7 @@ services:
   test:
     container_name: ddev-${DDEV_SITENAME}-test
     image: "busybox:stable"
+    networks: [default, ddev_default]
     command: "tail -f /dev/null"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
+++ b/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
@@ -4,6 +4,7 @@ services:
   test-ssh-server:
     container_name: test-ssh-server
     image: drud/test-ssh-server:v1.16.0
+    networks: [default, ddev]
     restart: "no"
     ports:
     # Port is published for debugging reasons only. ssh -p 3333 root@localhost

--- a/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
+++ b/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
@@ -4,7 +4,7 @@ services:
   test-ssh-server:
     container_name: test-ssh-server
     image: drud/test-ssh-server:v1.16.0
-    networks: [default, ddev]
+    networks: [default, ddev_default]
     restart: "no"
     ports:
     # Port is published for debugging reasons only. ssh -p 3333 root@localhost

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -33,7 +33,7 @@ import (
 )
 
 // NetName provides the default network name for ddev.
-const NetName = "ddev"
+const NetName = "ddev_default"
 
 // EnsureNetwork will ensure the docker network for ddev is created.
 func EnsureNetwork(client *docker.Client, name string) error {
@@ -56,7 +56,7 @@ func EnsureNetwork(client *docker.Client, name string) error {
 // EnsureDdevNetwork just creates or ensures the ddev network exists or
 // exits with fatal.
 func EnsureDdevNetwork() {
-	// ensure we have docker network
+	// ensure we have the fallback global ddev network
 	client := GetDockerClient()
 	err := EnsureNetwork(client, NetName)
 	if err != nil {

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -1,6 +1,6 @@
 networks:
-  ddev:
-    name: ddev
+  ddev_default:
+    name: ddev_default
     external: true
 
 services:
@@ -22,9 +22,7 @@ services:
       LINES: '25'
       VIRTUAL_HOST: junk.ddev.site
     image: TEST-COMPOSE-WITH-STREAMS-IMAGE
-    networks:
-      - default
-      - ddev
+    networks: [default, ddev_default]
     user: "33:33"
     labels:
       com.ddev.app-type: php

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -25,6 +25,7 @@ import (
 // runs each service's check function to ensure it's accessible from
 // the web container.
 func TestServices(t *testing.T) {
+	// Colima can't do solr at this point because it requires single-file mount.
 	if runtime.GOOS == "windows" || dockerutil.IsColima() {
 		t.Skip("skipping because unreliable, windows and colima seem to have port conflicts")
 	}

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -25,9 +25,9 @@ import (
 // runs each service's check function to ensure it's accessible from
 // the web container.
 func TestServices(t *testing.T) {
-	//if runtime.GOOS == "windows" || dockerutil.IsColima() {
-	//	t.Skip("skipping because unreliable, windows and colima seem to have port conflicts")
-	//}
+	if runtime.GOOS == "windows" || dockerutil.IsColima() {
+		t.Skip("skipping because unreliable, windows and colima seem to have port conflicts")
+	}
 
 	assert := asrt.New(t)
 	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")

--- a/pkg/servicetest/servicetest_test.go
+++ b/pkg/servicetest/servicetest_test.go
@@ -25,9 +25,9 @@ import (
 // runs each service's check function to ensure it's accessible from
 // the web container.
 func TestServices(t *testing.T) {
-	if runtime.GOOS == "windows" || dockerutil.IsColima() {
-		t.Skip("skipping because unreliable, windows and colima seem to have port conflicts")
-	}
+	//if runtime.GOOS == "windows" || dockerutil.IsColima() {
+	//	t.Skip("skipping because unreliable, windows and colima seem to have port conflicts")
+	//}
 
 	assert := asrt.New(t)
 	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")
@@ -40,13 +40,6 @@ func TestServices(t *testing.T) {
 
 	origDir, _ := os.Getwd()
 	testDir := testcommon.CreateTmpDir(t.Name())
-
-	t.Cleanup(func() {
-		err = os.Chdir(origDir)
-		assert.NoError(err)
-		err = os.RemoveAll(testDir)
-		assert.NoError(err)
-	})
 
 	workingServices := map[string]bool{
 		"beanstalkd": true,
@@ -79,13 +72,6 @@ func TestServices(t *testing.T) {
 		}
 	}
 
-	t.Cleanup(func() {
-		err = app.Stop(true, false)
-		assert.NoError(err)
-		err = os.RemoveAll(testDir)
-		assert.NoError(err)
-	})
-
 	app.Name = t.Name()
 	err = app.WriteConfig()
 	assert.NoError(err)
@@ -98,6 +84,16 @@ func TestServices(t *testing.T) {
 	// Unfortunately to get service description to work, we have to create a new app
 	// now that files are in place
 	app, err = ddevapp.NewApp(app.AppRoot, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = os.RemoveAll(testDir)
+		assert.NoError(err)
+	})
 
 	if workingServices["solr"] {
 		checkSolrService(t, app)

--- a/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
@@ -7,10 +7,7 @@ version: '3.6'
 services:
   beanstalk: # This is the service name used when running ddev commands accepting the --service flag
     container_name: ddev-${DDEV_SITENAME}-beanstalk # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
-    image: schickling/beanstalkd:latest
-    networks:
-      - default
-      - ddev
+    image: schickling/beanstalkd
     restart: "no"
     expose:
     - 11300 # beanstalk is available at this port inside the container (default port for beanstalkd)

--- a/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
@@ -8,6 +8,7 @@ services:
   beanstalk: # This is the service name used when running ddev commands accepting the --service flag
     container_name: ddev-${DDEV_SITENAME}-beanstalk # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
     image: schickling/beanstalkd
+    networks: [default, ddev]
     restart: "no"
     expose:
     - 11300 # beanstalk is available at this port inside the container (default port for beanstalkd)

--- a/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.beanstalkd.yaml
@@ -8,7 +8,7 @@ services:
   beanstalk: # This is the service name used when running ddev commands accepting the --service flag
     container_name: ddev-${DDEV_SITENAME}-beanstalk # This is the name of the container. It is recommended to follow the same name convention used in the main docker-compose.yml file.
     image: schickling/beanstalkd
-    networks: [default, ddev]
+    networks: [default, ddev_default]
     restart: "no"
     expose:
     - 11300 # beanstalk is available at this port inside the container (default port for beanstalkd)

--- a/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
@@ -18,6 +18,7 @@ services:
     # name convention used in the main docker-compose.yml file.
     container_name: ddev-${DDEV_SITENAME}-memcached
     image: memcached:1.5
+    networks: [default, ddev]
     restart: "no"
     # memcached is available at this port inside the container.
     expose:

--- a/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.memcached.yaml
@@ -18,7 +18,7 @@ services:
     # name convention used in the main docker-compose.yml file.
     container_name: ddev-${DDEV_SITENAME}-memcached
     image: memcached:1.5
-    networks: [default, ddev]
+    networks: [default, ddev_default]
     restart: "no"
     # memcached is available at this port inside the container.
     expose:

--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -1,5 +1,8 @@
 # DDev Apache Solr recipe file.
 #
+# SEE IMPORTANT COMPATIBILITY DIFFERENCES BETWEEEN DDEV v1.18.* and v1.19+ below!
+# Before v1.19.* you must comment out the `networks:` line below.
+#
 # To use this in your own project:
 # 1. Copy this file to your project's ".ddev" directory.
 # 2. Create the folder path ".ddev/solr/conf".
@@ -32,9 +35,9 @@ services:
     # README: https://github.com/docker-solr/docker-solr/blob/master/README.md
     # It's almost impossible to work with it if you don't read the docs there
     image: solr:8
-    networks:
-      - default
-      - ddev
+    # CRITICAL COMPATIBILITY ISSUE WITH DDEV V1.18.x and below.
+    # REMOVE THIS `networks:` line for ddev v1.18.x and below
+    networks: [default, ddev]
     restart: "no"
     # Solr is served from this port inside the container.
     expose:

--- a/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
+++ b/pkg/servicetest/testdata/TestServices/docker-compose.solr.yaml
@@ -37,7 +37,7 @@ services:
     image: solr:8
     # CRITICAL COMPATIBILITY ISSUE WITH DDEV V1.18.x and below.
     # REMOVE THIS `networks:` line for ddev v1.18.x and below
-    networks: [default, ddev]
+    networks: [default, ddev_default]
     restart: "no"
     # Solr is served from this port inside the container.
     expose:


### PR DESCRIPTION
## The Problem/Issue/Bug:

* People on versions below v1.19 are referred to the HEAD version of docker-compose.solr.yaml, which does not work until v1.19.x
* People upgrading to v1.19 with solr and other 3rd party services have to *add* the `networks:` line to make their project work.
* The failure mode if people are missing the networks line is awful - ddev-router has a fatal that's hard to understand and says nothing about solr.

## How this PR Solves The Problem:

- [x] Add comment in `docker-compose.solr.yaml` explaining to remove the networks line below v1.19
- [x] Figure out how to reduce the problems with people hitting the ddev-router issue with solr

## Manual Testing Instructions:

- [x] Read docs
- [x] Try adding a service without the required `networks` line, `ddev start` and get the error
- [x] Try adding a service *with* the required `networks` line and `ddev start` and see no error

## Automated Testing Overview:

* Nothing added at this point. It's possible we should add a test for the network-checking behavior

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3510"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

