### PR TITLE
[tests only] composer drush is failing, fix up

### DIFF
--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -97,7 +97,7 @@ func TestAcquiaPull(t *testing.T) {
 
 	// Make sure we have drush
 	_, _, err = app.Exec(&ExecOpts{
-		Cmd: "composer require drush/drush >/dev/null 2>/dev/null",
+		Cmd: "composer require --no-interaction drush/drush:* >/dev/null 2>/dev/null",
 	})
 	require.NoError(t, err)
 
@@ -198,7 +198,7 @@ func TestAcquiaPush(t *testing.T) {
 
 	// Make sure we have drush
 	_, _, err = app.Exec(&ExecOpts{
-		Cmd: "composer require drush/drush >/dev/null 2>/dev/null",
+		Cmd: "composer require --no-interaction drush/drush:* >/dev/null 2>/dev/null",
 	})
 	require.NoError(t, err)
 

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -106,7 +106,7 @@ func TestPantheonPull(t *testing.T) {
 
 	// Make sure we have drush
 	_, _, err = app.Exec(&ExecOpts{
-		Cmd: "composer require drush/drush >/dev/null 2>/dev/null",
+		Cmd: "composer require --no-interaction drush/drush:* >/dev/null 2>/dev/null",
 	})
 	require.NoError(t, err)
 
@@ -206,9 +206,11 @@ func TestPantheonPush(t *testing.T) {
 
 	// Make sure we have drush
 	_, _, err = app.Exec(&ExecOpts{
-		Cmd: "composer require drush/drush >/dev/null 2>/dev/null",
+		Cmd: "composer require --no-interaction drush/drush:* >/dev/null 2>/dev/null",
 	})
 	require.NoError(t, err)
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
 
 	// Do minimal install so it can find %file dir
 	_, _, err = app.Exec(&ExecOpts{


### PR DESCRIPTION
## The Problem/Issue/Bug:

The pantheon and acquia push tests were failing, apparently due to drush 11 coming out and causing extra composer hell. 

## How this PR Solves The Problem:

Use `composer require drush/drush:*` instead of just `composer require drush/drush`

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3512"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

