### PR TITLE
Make more efficient chown of mutagen volume, speed up start

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -103,6 +103,14 @@ services:
         target: /var/www
         volume:
           nocopy: true
+      # This second mount is only to make just the volume available so it can be chowned
+      # without accidentally also hitting docker mounts
+      - type: volume
+        source: project_mutagen
+        target: /tmp/project_mutagen
+        volume:
+          nocopy: true
+
       {{ end }}
       {{ if .NoBindMounts }}
       - "ddev-config:/mnt/ddev_config"

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -25,6 +25,9 @@ import (
 )
 
 // SetMutagenVolumeOwnership chowns the volume in use to the current user.
+// The mutagen volume is mounted both in /var/www (where it gets used) and
+// also on /tmp/project_mutagen (where it can be chowned without accidentally hitting
+// lots of bind-mounted files).
 func SetMutagenVolumeOwnership(app *DdevApp) error {
 	// Make sure that if we have a volume mount it's got proper ownership
 	uidStr, gidStr, _ := util.GetContainerUIDGid()
@@ -32,9 +35,9 @@ func SetMutagenVolumeOwnership(app *DdevApp) error {
 	_, _, err := app.Exec(
 		&ExecOpts{
 			Dir: "/tmp",
-			Cmd: fmt.Sprintf("sudo chown -R %s:%s /var/www", uidStr, gidStr),
+			Cmd: fmt.Sprintf("sudo chown -R %s:%s /tmp/project_mutagen", uidStr, gidStr),
 		})
-	util.Debug("done chowning mutagen docker volume, result=%v", err)
+	util.Debug("done chowning mutagen docker volume")
 	return err
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

On mutagen, since 
* #3507 

the /var/www directory can be a mix of native filesystem and bind-mounted stuff. So the .git directory and upload_dir are typically bind-mounted. But then the chown of /var/www takes forever. Very painful.

## How this PR Solves The Problem:

This mounts the project_mutagen volume a separate place (/tmp/project_mutagen) so it can be chowned there and the chown command will only find native-filesystem files.

## Manual Testing Instructions:

`export DDEV_DEBUG=true` and `ddev start` and see the difference. 



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3515"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

