### PR TITLE
Ignore a couple of misbehaving spellcheck items

### DIFF
--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -19,7 +19,7 @@ on:
       - ".readthedocs.yml"
       - "requirements.txt"
       - ".github/workflows/**"
-
+      - "markdown-link-check.json"
 jobs:
   build:
     name: Docs check (spellcheck, markdownlint)

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -14,6 +14,12 @@
     },
     {
       "pattern": "^https://www.drupal.org/(u|project)"
+    },
+    {
+      "pattern": "^https://nssm.cc/"
+    },
+    {
+      "pattern": "^https://www.cyberciti.biz/"
     }
   ],
   "timeout": "20s",


### PR DESCRIPTION
## The Problem/Issue/Bug:

A couple of sites are now blocked by captchas that curl can't deal with.
And `nssm.cc` regularly fails. Ignore them



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3525"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

