### PR TITLE
Make sure that rootca is writeable in ddev-global-cache

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -90,8 +90,12 @@ if [ -d /mnt/ddev_config/.homeadditions ]; then
 fi
 
 # It's possible CAROOT does not exist or is not writeable (if host-side mkcert -install not run yet)
-sudo mkdir -p ${CAROOT} && sudo chmod -R ugo+rw ${CAROOT}
+sudo mkdir -p ${CAROOT} && sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/
 # This will install the certs from $CAROOT (/mnt/ddev-global-cache/mkcert)
+# It also creates them if they don't already exist
+if [ ! -f  "${CAROOT}/rootCA.pem" ]; then
+  echo "rootCA.pem not found in ${CAROOT}"
+fi
 mkcert -install
 
 # VIRTUAL_HOST is a comma-delimited set of fqdns, convert it to space-separated and mkcert

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220108_xdebug_9003" // Note that this can be overridden by make
+var WebTag = "20220117_no_volume_copy" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

An obscure bug was discovered in https://github.com/docker/compose/pull/9033 - 

* If ddev-global-cache volume does not exist
* And if mkcert does not exist

Then ddev-webserver crashes on startup, and `ddev logs` shows a permission error accessing /mnt/ddev-global-cache/mkcert/rootCA-key.pem:
```
Failed to start d9: container failed to become healthy: err=container 'web' exited, please use 'ddev logs -s web' to find out why it failed 
```

`ddev logs` shows:
```
+ mkcert -install
ERROR: failed to save CA key: open /mnt/ddev-global-cache/mkcert/rootCA-key.pem: permission denied
```

## How this PR Solves The Problem:

Make sure the ddev-global-cache/mkcert directory is readable/writeable by current user even if it just got created. 

## Manual Testing Instructions:

```
mkcert -uninstall
rm -rf "$(mkcert -CAROOT)"
brew unlink mkcert
ddev poweroff
docker volume rm ddev-global-cache
ddev start
```

Should not croak.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3527"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

