### PR TITLE
Terminate mutagen before chowning volume to avoid conflicts

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1035,6 +1035,8 @@ func (app *DdevApp) Start() error {
 		if err != nil {
 			return err
 		}
+		_ = TerminateMutagenSync(app)
+
 		err = SetMutagenVolumeOwnership(app)
 		if err != nil {
 			return err


### PR DESCRIPTION
## The Problem/Issue/Bug:

It's possible to have a race condition between mutagen doing things and the chown of the mutagen volume, see https://github.com/drud/ddev/runs/4843625816?check_suite_focus=true

## How this PR Solves The Problem:

Terminate an existing mutagen session before chowning the volume; it then gets created right away.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3528"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

