### PR TITLE
Artisan command sometimes isn't executable. Use php to run it.

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/artisan
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/artisan
@@ -6,5 +6,5 @@
 ## Example: "ddev artisan list" or "ddev artisan cache:clear"
 ## ProjectTypes: laravel
 
-./artisan "$@"
+php ./artisan "$@"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

People sometimes have artisan checked out without it being executable,  so they get this when they run `ddev artisan`:

```
/mnt/ddev_config/.global_commands/web/artisan: line 9: ./artisan: Permission denied
Failed to run artisan : exit status 126
```

## How this PR Solves The Problem:

Use `php` to run the artisan command.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3532"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

