### PR TITLE
Fix bug where upload_dir is docroot if no upload_dir

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -114,9 +114,9 @@ services:
       - ".:/mnt/ddev_config:ro"
       - "./xhprof:/usr/local/bin/xhprof:ro"
         {{ if .MutagenEnabled }}
-          {{ if .UploadDir }}
-      - ../{{ .UploadDir }}:/var/www/html/{{ .UploadDir }}:rw
-          {{ end }} {{/* end if .UploadDir */}}
+          {{ if .ContainerUploadDir }}
+      - {{ .HostUploadDir }}:{{ .ContainerUploadDir }}:rw
+          {{ end }} {{/* end if .ContainerUploadDir */}}
           {{ if .GitDirMount }}
       - ../.git:/var/www/html/.git:rw
           {{ end }} {{/* end if .GitDirMount */}}

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -126,8 +126,8 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	}
 
 	// Create the upload dir so that mounts will happen with mutagen.
-	if app.GetUploadDirFullPath() != "" {
-		err = os.MkdirAll(app.GetUploadDirFullPath(), 0755)
+	if app.GetHostUploadDirFullPath() != "" {
+		err = os.MkdirAll(app.GetHostUploadDirFullPath(), 0755)
 		if err != nil {
 			return "", fmt.Errorf("Unable to create upload directory: %v", err)
 		}

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -126,8 +126,8 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	}
 
 	// Create the upload dir so that mounts will happen with mutagen.
-	if app.GetUploadDir() != "" {
-		err = os.MkdirAll(filepath.Join(app.AppRoot, app.Docroot, app.GetUploadDir()), 0755)
+	if app.GetUploadDirFullPath() != "" {
+		err = os.MkdirAll(app.GetUploadDirFullPath(), 0755)
 		if err != nil {
 			return "", fmt.Errorf("Unable to create upload directory: %v", err)
 		}

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -175,7 +175,7 @@ func backdropPostImportDBAction(app *DdevApp) error {
 // backdropImportFilesAction defines the Backdrop workflow for importing project files.
 // The Backdrop workflow is currently identical to the Drupal import-files workflow.
 func backdropImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetUploadDirFullPath()
+	destPath := app.GetHostUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -175,7 +175,7 @@ func backdropPostImportDBAction(app *DdevApp) error {
 // backdropImportFilesAction defines the Backdrop workflow for importing project files.
 // The Backdrop workflow is currently identical to the Drupal import-files workflow.
 func backdropImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := filepath.Join(app.GetAppRoot(), app.GetDocroot(), app.GetUploadDir())
+	destPath := app.GetUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -700,7 +700,8 @@ type composeYAMLVars struct {
 	WebEnvironment            []string
 	NoBindMounts              bool
 	Docroot                   string
-	UploadDir                 string
+	ContainerUploadDir        string
+	HostUploadDir             string
 	GitDirMount               bool
 }
 
@@ -777,7 +778,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		NFSMountVolumeName:    app.GetNFSMountVolumeName(),
 		NoBindMounts:          globalconfig.DdevGlobalConfig.NoBindMounts,
 		Docroot:               app.GetDocroot(),
-		UploadDir:             app.GetUploadDirFullPath(),
+		HostUploadDir:         app.GetHostUploadDirFullPath(),
+		ContainerUploadDir:    app.GetContainerUploadDirFullPath(),
 		GitDirMount:           false,
 	}
 	// We don't want to bind-mount git dir if it doesn't exist
@@ -786,8 +788,9 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	}
 	// And we don't want to bind-mount upload dir if it doesn't exist.
 	// templateVars.UploadDir is relative path rooted in approot.
-	if app.GetUploadDirFullPath() == "" || !fileutil.FileExists(app.GetUploadDirFullPath()) {
-		templateVars.UploadDir = ""
+	if app.GetHostUploadDirFullPath() == "" || !fileutil.FileExists(app.GetHostUploadDirFullPath()) {
+		templateVars.HostUploadDir = ""
+		templateVars.ContainerUploadDir = ""
 	}
 
 	if app.NFSMountEnabled || app.NFSMountEnabledGlobal {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -778,7 +777,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		NFSMountVolumeName:    app.GetNFSMountVolumeName(),
 		NoBindMounts:          globalconfig.DdevGlobalConfig.NoBindMounts,
 		Docroot:               app.GetDocroot(),
-		UploadDir:             path.Join(app.GetDocroot(), app.GetUploadDir()),
+		UploadDir:             app.GetUploadDirFullPath(),
 		GitDirMount:           false,
 	}
 	// We don't want to bind-mount git dir if it doesn't exist
@@ -787,7 +786,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	}
 	// And we don't want to bind-mount upload dir if it doesn't exist.
 	// templateVars.UploadDir is relative path rooted in approot.
-	if app.GetUploadDir() == "" || !fileutil.FileExists(filepath.Join(app.AppRoot, templateVars.UploadDir)) {
+	if app.GetUploadDirFullPath() == "" || !fileutil.FileExists(app.GetUploadDirFullPath()) {
 		templateVars.UploadDir = ""
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2602,10 +2602,18 @@ func FormatSiteStatus(status string) string {
 	return formattedStatus
 }
 
-// GetUploadDirFullPath returns the full path to the upload directory or "" if there is none
-func (app *DdevApp) GetUploadDirFullPath() string {
+// GetHostUploadDirFullPath returns the full path to the upload directory on the host or "" if there is none
+func (app *DdevApp) GetHostUploadDirFullPath() string {
 	if app.GetUploadDir() != "" {
 		return path.Join(app.AppRoot, app.Docroot, app.GetUploadDir())
+	}
+	return ""
+}
+
+// GetContainerUploadDirFullPath returns the full path to the upload directory in container or "" if there is none
+func (app *DdevApp) GetContainerUploadDirFullPath() string {
+	if app.GetUploadDir() != "" {
+		return path.Join("/var/www/html", app.Docroot, app.GetUploadDir())
 	}
 	return ""
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2601,3 +2601,11 @@ func FormatSiteStatus(status string) string {
 	}
 	return formattedStatus
 }
+
+// GetUploadDirFullPath returns the full path to the upload directory or "" if there is none
+func (app *DdevApp) GetUploadDirFullPath() string {
+	if app.GetUploadDir() != "" {
+		return path.Join(app.AppRoot, app.Docroot, app.GetUploadDir())
+	}
+	return ""
+}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1529,7 +1529,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_PROJECT":                  app.Name,
 		"DDEV_WEBIMAGE":                 app.WebImage,
 		"DDEV_APPROOT":                  app.AppRoot,
-		"DDEV_FILES_DIR":                path.Join("/var/www/html", app.GetDocroot(), app.GetUploadDir()),
+		"DDEV_FILES_DIR":                app.GetContainerUploadDirFullPath(),
 
 		"DDEV_HOST_DB_PORT":          dbPortStr,
 		"DDEV_HOST_WEBSERVER_PORT":   app.HostWebserverPort,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2038,12 +2038,12 @@ func TestWriteableFilesDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	// Not all the example projects have an upload dir, so create it just in case
-	err = os.MkdirAll(filepath.Join(app.AppRoot, app.GetDocroot(), app.GetUploadDir()), 0777)
+	err = os.MkdirAll(app.GetUploadDirFullPath(), 0777)
 	assert.NoError(err)
 	err = app.Start()
 	require.NoError(t, err)
 
-	uploadDir := app.GetUploadDir()
+	uploadDir := app.GetUploadDirFullPath()
 	assert.NotEmpty(uploadDir)
 
 	// Use exec to touch a file in the container and see what the result is. Make sure it comes out with ownership
@@ -2173,7 +2173,7 @@ func TestDdevImportFilesDir(t *testing.T) {
 		assert.NoError(err, "Importing a directory returned an error:", err)
 
 		// Confirm contents of destination dir after import
-		absUploadDir := filepath.Join(app.AppRoot, app.Docroot, app.GetUploadDir())
+		absUploadDir := app.GetUploadDirFullPath()
 		uploadedFilesDirEntrySlice, err := os.ReadDir(absUploadDir)
 		assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2038,7 +2038,7 @@ func TestWriteableFilesDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	// Not all the example projects have an upload dir, so create it just in case
-	err = os.MkdirAll(app.GetUploadDirFullPath(), 0777)
+	err = os.MkdirAll(app.GetHostUploadDirFullPath(), 0777)
 	assert.NoError(err)
 	err = app.Start()
 	require.NoError(t, err)
@@ -2173,7 +2173,7 @@ func TestDdevImportFilesDir(t *testing.T) {
 		assert.NoError(err, "Importing a directory returned an error:", err)
 
 		// Confirm contents of destination dir after import
-		absUploadDir := app.GetUploadDirFullPath()
+		absUploadDir := app.GetHostUploadDirFullPath()
 		uploadedFilesDirEntrySlice, err := os.ReadDir(absUploadDir)
 		assert.NoError(err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2043,7 +2043,7 @@ func TestWriteableFilesDirectory(t *testing.T) {
 	err = app.Start()
 	require.NoError(t, err)
 
-	uploadDir := app.GetUploadDirFullPath()
+	uploadDir := app.GetUploadDir()
 	assert.NotEmpty(uploadDir)
 
 	// Use exec to touch a file in the container and see what the result is. Make sure it comes out with ownership

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -493,7 +493,7 @@ func appendIncludeToDrupalSettingsFile(siteSettingsPath string, appType string) 
 
 // drupalImportFilesAction defines the Drupal workflow for importing project files.
 func drupalImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetUploadDirFullPath()
+	destPath := app.GetHostUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -493,7 +493,7 @@ func appendIncludeToDrupalSettingsFile(siteSettingsPath string, appType string) 
 
 // drupalImportFilesAction defines the Drupal workflow for importing project files.
 func drupalImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := filepath.Join(app.GetAppRoot(), app.GetDocroot(), app.GetUploadDir())
+	destPath := app.GetUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -67,7 +67,7 @@ func setMagentoSiteSettingsPaths(app *DdevApp) {
 
 // magentoImportFilesAction defines the magento workflow for importing project files.
 func magentoImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := filepath.Join(app.GetAppRoot(), app.GetDocroot(), app.GetUploadDir())
+	destPath := app.GetUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -67,7 +67,7 @@ func setMagentoSiteSettingsPaths(app *DdevApp) {
 
 // magentoImportFilesAction defines the magento workflow for importing project files.
 func magentoImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetUploadDirFullPath()
+	destPath := app.GetHostUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -443,9 +443,14 @@ func (app *DdevApp) GenerateMutagenYml() error {
 		return err
 	}
 
+	uploadDir := ""
+	if app.GetUploadDir() != "" {
+		uploadDir = path.Join(app.Docroot, app.GetUploadDir())
+	}
+
 	templateMap := map[string]interface{}{
 		"SymlinkMode": symlinkMode,
-		"UploadDir":   app.GetUploadDirFullPath(),
+		"UploadDir":   uploadDir,
 	}
 	// If no bind mounts, then we can't ignore UploadDir, must sync it
 	if globalconfig.DdevGlobalConfig.NoBindMounts {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -445,7 +445,7 @@ func (app *DdevApp) GenerateMutagenYml() error {
 
 	templateMap := map[string]interface{}{
 		"SymlinkMode": symlinkMode,
-		"UploadDir":   path.Join(app.GetDocroot(), app.GetUploadDir()),
+		"UploadDir":   app.GetUploadDirFullPath(),
 	}
 	// If no bind mounts, then we can't ignore UploadDir, must sync it
 	if globalconfig.DdevGlobalConfig.NoBindMounts {

--- a/pkg/ddevapp/php.go
+++ b/pkg/ddevapp/php.go
@@ -28,7 +28,7 @@ func phpImportFilesAction(app *DdevApp, importPath, extPath string) error {
 	if app.UploadDir == "" {
 		return errors.Errorf("No upload_dir is set for this project")
 	}
-	destPath := app.GetUploadDirFullPath()
+	destPath := app.GetHostUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/php.go
+++ b/pkg/ddevapp/php.go
@@ -28,7 +28,7 @@ func phpImportFilesAction(app *DdevApp, importPath, extPath string) error {
 	if app.UploadDir == "" {
 		return errors.Errorf("No upload_dir is set for this project")
 	}
-	destPath := filepath.Join(app.GetAppRoot(), app.GetDocroot(), app.GetUploadDir())
+	destPath := app.GetUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -117,7 +117,7 @@ func TestAcquiaPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	require.NoError(t, err)
 
-	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "chocolate-brownie-umami.jpg"))
+	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "chocolate-brownie-umami.jpg"))
 	out, err := exec.RunCommand("bash", []string{"-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="randy@example.com";' | %s mysql -N`, DdevBin)})
 	assert.NoError(err)
 	assert.True(strings.HasPrefix(out, "1\n"))

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -117,7 +117,7 @@ func TestAcquiaPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	require.NoError(t, err)
 
-	assert.FileExists(filepath.Join(app.GetUploadDir(), "chocolate-brownie-umami.jpg"))
+	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "chocolate-brownie-umami.jpg"))
 	out, err := exec.RunCommand("bash", []string{"-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="randy@example.com";' | %s mysql -N`, DdevBin)})
 	assert.NoError(err)
 	assert.True(strings.HasPrefix(out, "1\n"))

--- a/pkg/ddevapp/providerGit_test.go
+++ b/pkg/ddevapp/providerGit_test.go
@@ -66,7 +66,7 @@ func TestGitPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	assert.NoError(err)
 
-	assert.FileExists(filepath.Join(app.AppRoot, app.Docroot, app.GetUploadDir(), "tmp/veggie-pasta-bake-hero-umami.jpg"))
+	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "tmp/veggie-pasta-bake-hero-umami.jpg"))
 	out, _, err := app.Exec(&ExecOpts{
 		Cmd:     "echo 'select COUNT(*) from users_field_data where mail=\"margaret.hopper@example.com\";' | mysql -N",
 		Service: "db",

--- a/pkg/ddevapp/providerGit_test.go
+++ b/pkg/ddevapp/providerGit_test.go
@@ -66,7 +66,7 @@ func TestGitPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	assert.NoError(err)
 
-	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "tmp/veggie-pasta-bake-hero-umami.jpg"))
+	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "tmp/veggie-pasta-bake-hero-umami.jpg"))
 	out, _, err := app.Exec(&ExecOpts{
 		Cmd:     "echo 'select COUNT(*) from users_field_data where mail=\"margaret.hopper@example.com\";' | mysql -N",
 		Service: "db",

--- a/pkg/ddevapp/providerLocalfile_test.go
+++ b/pkg/ddevapp/providerLocalfile_test.go
@@ -77,7 +77,7 @@ func TestLocalfilePull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	require.NoError(t, err)
 
-	assert.FileExists(filepath.Join(app.AppRoot, app.Docroot, app.GetUploadDir(), "docs/developers/building-contributing.md"))
+	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "docs/developers/building-contributing.md"))
 	out, _, err = app.Exec(&ExecOpts{
 		Cmd:     "echo 'select COUNT(*) from users_field_data where mail=\"margaret.hopper@example.com\";' | mysql -N",
 		Service: "db",

--- a/pkg/ddevapp/providerLocalfile_test.go
+++ b/pkg/ddevapp/providerLocalfile_test.go
@@ -77,7 +77,7 @@ func TestLocalfilePull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	require.NoError(t, err)
 
-	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "docs/developers/building-contributing.md"))
+	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "docs/developers/building-contributing.md"))
 	out, _, err = app.Exec(&ExecOpts{
 		Cmd:     "echo 'select COUNT(*) from users_field_data where mail=\"margaret.hopper@example.com\";' | mysql -N",
 		Service: "db",

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -113,7 +113,7 @@ func TestPantheonPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	require.NoError(t, err)
 
-	assert.FileExists(filepath.Join(app.GetUploadDir(), "2017-07/22-24_tn.jpg"))
+	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "2017-07/22-24_tn.jpg"))
 	out, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="admin@example.com";' | %s mysql -N`, DdevBin))
 	assert.NoError(err)
 	assert.True(strings.HasPrefix(out, "1\n"))

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -113,7 +113,7 @@ func TestPantheonPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	require.NoError(t, err)
 
-	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "2017-07/22-24_tn.jpg"))
+	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "2017-07/22-24_tn.jpg"))
 	out, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="admin@example.com";' | %s mysql -N`, DdevBin))
 	assert.NoError(err)
 	assert.True(strings.HasPrefix(out, "1\n"))

--- a/pkg/ddevapp/providerPlatform_test.go
+++ b/pkg/ddevapp/providerPlatform_test.go
@@ -103,7 +103,7 @@ func TestPlatformPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	assert.NoError(err)
 
-	assert.FileExists(filepath.Join(app.GetUploadDir(), "victoria-sponge-umami.jpg"))
+	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "victoria-sponge-umami.jpg"))
 	out, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="margaret.hopper@example.com";' | %s mysql -N`, DdevBin))
 	assert.NoError(err)
 	assert.True(strings.HasPrefix(out, "1\n"))

--- a/pkg/ddevapp/providerPlatform_test.go
+++ b/pkg/ddevapp/providerPlatform_test.go
@@ -103,7 +103,7 @@ func TestPlatformPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	assert.NoError(err)
 
-	assert.FileExists(filepath.Join(app.GetUploadDirFullPath(), "victoria-sponge-umami.jpg"))
+	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "victoria-sponge-umami.jpg"))
 	out, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="margaret.hopper@example.com";' | %s mysql -N`, DdevBin))
 	assert.NoError(err)
 	assert.True(strings.HasPrefix(out, "1\n"))

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -25,7 +25,7 @@ func setShopware6SiteSettingsPaths(app *DdevApp) {
 
 // shopware6ImportFilesAction defines the shopware6 workflow for importing user-generated files.
 func shopware6ImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetUploadDirFullPath()
+	destPath := app.GetHostUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -25,7 +25,7 @@ func setShopware6SiteSettingsPaths(app *DdevApp) {
 
 // shopware6ImportFilesAction defines the shopware6 workflow for importing user-generated files.
 func shopware6ImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := filepath.Join(app.GetAppRoot(), app.GetDocroot(), app.GetUploadDir())
+	destPath := app.GetUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -159,7 +159,7 @@ func isTypo3App(app *DdevApp) bool {
 // typo3ImportFilesAction defines the TYPO3 workflow for importing project files.
 // The TYPO3 import-files workflow is currently identical to the Drupal workflow.
 func typo3ImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := filepath.Join(app.GetAppRoot(), app.GetDocroot(), app.GetUploadDir())
+	destPath := app.GetUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -159,7 +159,7 @@ func isTypo3App(app *DdevApp) bool {
 // typo3ImportFilesAction defines the TYPO3 workflow for importing project files.
 // The TYPO3 import-files workflow is currently identical to the Drupal workflow.
 func typo3ImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetUploadDirFullPath()
+	destPath := app.GetHostUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -263,7 +263,7 @@ func isWordpressApp(app *DdevApp) bool {
 // wordpressImportFilesAction defines the Wordpress workflow for importing project files.
 // The Wordpress workflow is currently identical to the Drupal import-files workflow.
 func wordpressImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := filepath.Join(app.GetAppRoot(), app.GetDocroot(), app.GetUploadDir())
+	destPath := app.GetUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -263,7 +263,7 @@ func isWordpressApp(app *DdevApp) bool {
 // wordpressImportFilesAction defines the Wordpress workflow for importing project files.
 // The Wordpress workflow is currently identical to the Drupal import-files workflow.
 func wordpressImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetUploadDirFullPath()
+	destPath := app.GetHostUploadDirFullPath()
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {


### PR DESCRIPTION
## The Problem/Issue/Bug:

I stumbled on a bug where app.GetUploadDir() was returning the docroot when the UploadDir was "". 

This happened always with php projects that didn't have an UploadDir. 

The way I hit it was I had mutagen enabled globally and started a php project and found that the docroot wasn't mounted!

## How this PR Solves The Problem:

Use a new function to return the full upload dir instead of repeating it everywhere.

## Manual Testing Instructions:

Start a mutagen-enabled PHP project that has a docroot and no upload_dir.
`ddev ssh` and make sure the docroot exists!

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3540"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

