### PR TITLE
Add make mkdocs-serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,17 @@ mkdocs:
 		echo "Not running mkdocs because it's not installed"; \
 	fi
 
+# To see what the docs build will be, you can use `make mkdocs-serve`
+# It works best with mkdocs installed, `pip3 install mkdocs`,
+# see https://www.mkdocs.org/user-guide/installation/
+# But it will also work using docker.
+mkdocs-serve:
+	if command -v mkdocs >/dev/null ; then \
+  		mkdocs serve; \
+	else \
+		docker run -it -p 8000:8000 -v "$${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true"  -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs; \
+	fi
+
 # Install markdown-link-check locally with "npm install -g markdown-link-check"
 markdown-link-check:
 	@echo "markdown-link-check: "

--- a/docs/developers/testing-docs.md
+++ b/docs/developers/testing-docs.md
@@ -1,0 +1,5 @@
+# Working with docs
+
+You can see what the docs will look like after you've edited them by running `make mkdocs-serve`. It will launch a webserver on port 8000 so you can see what the docs will look like when they land on readthedocs.io.
+
+It's easiest to [install mkdocs locally](https://www.mkdocs.org/user-guide/installation/) with `pip3 install mkdocs` and `pip3 install -r requirements.txt`, but if mkdocs isn't installed, `make mkdocs-serve` will run a docker command to serve them on `http://localhost:8000`.

--- a/docs/developers/testing-docs.md
+++ b/docs/developers/testing-docs.md
@@ -3,3 +3,5 @@
 You can see what the docs will look like after you've edited them by running `make mkdocs-serve`. It will launch a webserver on port 8000 so you can see what the docs will look like when they land on readthedocs.io.
 
 It's easiest to [install mkdocs locally](https://www.mkdocs.org/user-guide/installation/) with `pip3 install mkdocs` and `pip3 install -r requirements.txt`, but if mkdocs isn't installed, `make mkdocs-serve` will run a docker command to serve them on `http://localhost:8000`.
+
+If you don't have `make` on your system, you can easily install it, but you can also just run the docker command that `make mkdocs-serve` runs. `docker run -it -p 8000:8000 -v "$${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true"  -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs;`


### PR DESCRIPTION
## The Problem/Issue/Bug:

@tyler36 pioneered all of this while trying to test docs as they would really look in https://github.com/drud/ddev/pull/3495 - so this is all credited to him. 

## How this PR Solves The Problem:

`make mkdocs-serve` will run either local mkdocs or run a docker command to serve it.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3541"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

