### PR TITLE
Drupal6 should use mysqli for driver, fixes #3522

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -43,7 +43,7 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 	dockerIP, _ := dockerutil.GetDockerIP()
 	dbPublishedPort, _ := app.GetPublishedPort("db")
 
-	return &DrupalSettings{
+	settings := &DrupalSettings{
 		DatabaseName:     "db",
 		DatabaseUsername: "db",
 		DatabasePassword: "db",
@@ -60,6 +60,10 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 		DockerIP:         dockerIP,
 		DBPublishedPort:  dbPublishedPort,
 	}
+	if app.Type == "drupal6" {
+		settings.DatabaseDriver = "mysqli"
+	}
+	return settings
 }
 
 // settingsIncludeStanza defines the template that will be appended to


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3522 

## How this PR Solves The Problem:

Use mysqli on drupal6

## Manual Testing Instructions:

Start project with drupal6 and look at settings.ddev.php, should have `mysql` for driver

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3542"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

