### PR TITLE
Introspect to determine service volumes to delete, fixes #3537

### DIFF
--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -79,15 +79,6 @@ When defining additional services for your project, we recommended you follow th
         * `HTTP_EXPOSE=portNum` The `hostPort:containerPort` convention may be used here to expose a container's port to a different external port. To expose multiple ports for a single container, define the ports as comma-separated values.
         * `HTTPS_EXPOSE=<exposedPortNumber>:portNum` This will expose an https interface on `<exposedPortNumber>` to the host (and to the web container) as `https://<project>.ddev.site:exposedPortNumber`. To expose multiple ports for a single container, use comma-separated definitions, as in `HTTPS_EXPOSE=9998:80,9999:81`, which would expose http port 80 from the container as `https://<project>.ddev.site:9998` and http port 81 from the container as `https://<project>.ddev.site:9999`.
 
-* **Naming volumes for persistent data**: A volume with persistent data should have the same name as the service and should not have a custom name. For example, the persistent volume for the [Postgres](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/postgres) service has:
-
-    ```yaml
-    volumes:
-      postgres:
-    ```
-
-  and as a result will end up with a volume named `ddev-<projectname>_postgres`; this default volume name will be automatically deleted by ddev if you do a `ddev delete` or `ddev stop --remove-data`.
-
 ### Interacting with additional services
 
  `ddev exec`, `ddev ssh`, and `ddev logs` interact with containers on an individual basis. By default, these commands interact with the web container for a project. All of these commands, however, provide a `--service` or `-s` flag allowing you to specify the service name of the container you want to interact with. For example, if you added a service to provide Apache Solr, and the service was named `solr`, you would be able to run `ddev logs --service solr` to retrieve the logs of the Solr container.


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3537

The method for deleting docker volumes owned by 3rd party services on `ddev delete` was pretty rigid and just name-based. As a result, it was hard to have multiple volumes, and a mistake in naming could have consequences.

## How this PR Solves The Problem:

Look up what we actually have for volumes and use that information to delete.

## Manual Testing Instructions:

- [x] Create a service with multiple oddly named volumes. Verify they get created. Verify they get deleted on `ddev delete`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3543"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

