### PR TITLE
Change renderAppDescribe to use different URLs for each service, fixes #3520

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/styles"
 	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/version"
 	"sort"
 	"strings"
 
@@ -89,7 +91,11 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			},
 		})
 	}
-	t.SetTitle(fmt.Sprintf("Project: %s %s %s", app.Name, desc["shortroot"].(string), app.GetPrimaryURL()))
+	dockerEnv := fmt.Sprintf("docker %s", version.DockerVersion)
+	if dockerutil.IsColima() {
+		dockerEnv = "Colima"
+	}
+	t.SetTitle(fmt.Sprintf("Project: %s %s %s\nDocker environment: %s", app.Name, desc["shortroot"].(string), app.GetPrimaryURL(), dockerEnv))
 	t.AppendHeader(table.Row{"Service", "Stat", "URL/Port", "Info"})
 
 	// Only show extended status for running sites.

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -57,15 +57,6 @@ Support: https://ddev.readthedocs.io/en/stable/#support`,
 			}
 		}
 
-		//err = dockerutil.CheckDockerCompose()
-		//if err != nil {
-		//	if err.Error() == "no docker-compose" {
-		//		util.Failed("docker-compose does not appear to be installed.")
-		//	} else {
-		//		util.Failed("The docker-compose version currently installed does not meet ddev's requirements: %v", version.DockerComposeVersionConstraint)
-		//	}
-		//}
-
 		updateFile := filepath.Join(globalconfig.GetGlobalDdevDir(), ".update")
 
 		// Do periodic detection of whether an update is available for ddev users.

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -44,7 +44,7 @@ func SetInstrumentationBaseTags() {
 
 	if globalconfig.DdevGlobalConfig.InstrumentationOptIn {
 		dockerVersion, _ := version.GetDockerVersion()
-
+		dockerPlaform, _ := version.GetDockerPlatform()
 		timezone, _ := time.Now().In(time.Local).Zone()
 		lang := os.Getenv("LANG")
 
@@ -57,6 +57,7 @@ func SetInstrumentationBaseTags() {
 			nodeps.InstrumentationTags["OS"] = "wsl2"
 		}
 		nodeps.InstrumentationTags["dockerVersion"] = dockerVersion
+		nodeps.InstrumentationTags["dockerPlatform"] = dockerPlaform
 		nodeps.InstrumentationTags["dockerToolbox"] = strconv.FormatBool(false)
 		nodeps.InstrumentationTags["version"] = version.DdevVersion
 		nodeps.InstrumentationTags["ServerHash"] = GetInstrumentationUser()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -176,6 +176,11 @@ func GetDockerVersion() (string, error) {
 	}
 	DockerVersion = v.Get("Version")
 
+	i, err := client.Info()
+	if i.Name == "colima" {
+		DockerVersion = DockerVersion + " (colima)"
+	}
+
 	return DockerVersion, nil
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -177,6 +177,9 @@ func GetDockerVersion() (string, error) {
 	DockerVersion = v.Get("Version")
 
 	i, err := client.Info()
+	if err != nil {
+		return "", err
+	}
 	if i.Name == "colima" {
 		DockerVersion = DockerVersion + " (colima)"
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -105,6 +105,9 @@ func GetVersionInfo() map[string]string {
 	if versionInfo["docker"], err = GetDockerVersion(); err != nil {
 		versionInfo["docker"] = fmt.Sprintf("failed to GetDockerVersion(): %v", err)
 	}
+	if versionInfo["docker-platform"], err = GetDockerPlatform(); err != nil {
+		versionInfo["docker-platform"] = fmt.Sprintf("failed to GetDockerPlatform(): %v", err)
+	}
 	if versionInfo["docker-compose"], err = GetDockerComposeVersion(); err != nil {
 		versionInfo["docker-compose"] = fmt.Sprintf("failed to GetDockerComposeVersion(): %v", err)
 	}
@@ -176,15 +179,24 @@ func GetDockerVersion() (string, error) {
 	}
 	DockerVersion = v.Get("Version")
 
-	i, err := client.Info()
+	return DockerVersion, nil
+}
+
+// GetDockerPlatform gets the platform used for docker engine
+func GetDockerPlatform() (string, error) {
+	var client *docker.Client
+	var err error
+	if client, err = docker.NewClientFromEnv(); err != nil {
+		return "", err
+	}
+
+	info, err := client.Info()
 	if err != nil {
 		return "", err
 	}
-	if i.Name == "colima" {
-		DockerVersion = DockerVersion + " (colima)"
-	}
+	platform := info.Name
 
-	return DockerVersion, nil
+	return platform, nil
 }
 
 // GetLiveMutagenVersion runs `mutagen version` and caches result

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -36,5 +36,7 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Equal(runtime.GOOS, v["os"])
 	assert.Equal(BUILDINFO, v["build info"])
 	assert.NotEmpty(v["docker-compose"])
+	assert.NotEmpty(v["docker-platform"])
+
 	assert.NotEmpty(v["docker"])
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3520

Some changes for gitpod broke the regular describe for normal users

## How this PR Solves The Problem:

Go back to looking up port for each service

## Manual Testing Instructions:

- [x] Create a regular project, look at ddev describe
- [x] Create a gitpod project, look at describe
- [x] Create a regular project but with router disabled, look at describe

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3544"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

