### PR TITLE
Remove incorrect usages of `ddev service get`, fixes #3545

### DIFF
--- a/cmd/ddev/cmd/service-enable.go
+++ b/cmd/ddev/cmd/service-enable.go
@@ -13,7 +13,7 @@ const disabledServicesDir = ".disabled-services"
 var ServiceEnable = &cobra.Command{
 	Use:     "enable service [project]",
 	Short:   "Enable a 3rd party service",
-	Long:    fmt.Sprintf(`Enable a 3rd party service. The service must exist as .ddev/%s/docker-compose.<service>.yaml. Note that you can use "ddev service get" to obtain a service not already on your system.`, disabledServicesDir),
+	Long:    fmt.Sprintf(`Enable a 3rd party service. The service must exist as .ddev/%s/docker-compose.<service>.yaml. Note that you can use "ddev get" to obtain a service not already on your system.`, disabledServicesDir),
 	Example: `ddev service enable solr`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {

--- a/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/README.md
+++ b/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/README.md
@@ -2,11 +2,11 @@
 
 ## What is this?
 
-This repository allows you to quickly install memcached into a [Ddev](https://ddev.readthedocs.io) project using just `ddev service get drud/ddev-memcached`.
+This repository allows you to quickly install memcached into a [Ddev](https://ddev.readthedocs.io) project using just `ddev  get drud/ddev-memcached`.
 
 ## Installation
 
-1.`ddev service get drud/ddev-memcached && ddev restart`
+1.`ddev get drud/ddev-memcached && ddev restart`
 5. `ddev restart`
 
 ## Explanation

--- a/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/tests/test.bats
+++ b/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/tests/test.bats
@@ -17,7 +17,7 @@ teardown() {
 
 @test "basic installation" {
   cd ${TESTDIR}
-  ddev service get ${DIR}
+  ddev get ${DIR}
   ddev restart
   v=$(ddev exec 'printf "version\nquit\nquit\n" | nc memcached 11211')
   [[ "${v}" = VERSION* ]]

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -4,11 +4,11 @@ DDEV-Local projects can be extended to provide additional services. This is achi
 
 If you need a service not provided here, see [Defining an additional service with Docker Compose](custom-compose-files.md)
 
-Although anyone can create their own services with a `docker-compose.*.yaml` file, a growing number of services are supported and tested and can be installed with the `ddev service get` command starting with DDEV v1.19.0-alpha3.
+Although anyone can create their own services with a `docker-compose.*.yaml` file, a growing number of services are supported and tested and can be installed with the `ddev get` command starting with DDEV v1.19.0-alpha3.
 
-* [Apache Solr for Drupal 9](https://github.com/drud/ddev-drupal9-solr): `ddev service get drud/ddev-drupal9-solr`.
-* [Memcached](https://github.com/drud/ddev-memcached): `ddev service get drud/ddev-memcached`.
-* [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev service get drud/ddev-beanstalkd`.
+* [Apache Solr for Drupal 9](https://github.com/drud/ddev-drupal9-solr): `ddev get drud/ddev-drupal9-solr`.
+* [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
+* [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev get drud/ddev-beanstalkd`.
 
 ## Additional services in ddev-contrib (MongoDB, PostgresSQL, etc)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3545

Some instances of `ddev service get` appeared in docs etc after it was changed to `ddev get`

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3546"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

