### PR TITLE
Prevent unconditional overriding config sync directory

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -40,4 +40,7 @@ $settings['trusted_host_patterns'] = ['.*'];
 // better performance.
 $settings['class_loader_auto_detect'] = FALSE;
 
-$settings['config_sync_directory'] = 'sites/default/files/sync';
+// Set $settings['config_sync_directory'] if not set in settings.php.
+if (empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = 'sites/default/files/sync';
+}

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -40,4 +40,7 @@ $settings['trusted_host_patterns'] = ['.*'];
 // better performance.
 $settings['class_loader_auto_detect'] = FALSE;
 
-$settings['config_sync_directory'] = 'sites/default/files/sync';
+// Set $settings['config_sync_directory'] if not set in settings.php.
+if (empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = 'sites/default/files/sync';
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

#3549

## How this PR Solves The Problem:

Check if `$settings['config_sync_directory']` is empty before setting it.

## Manual Testing Instructions:

1. Have a Drupal 9 project. Define a config sync directory in the default `settings.php` file, e.g. `$settings['config_sync_directory'] = $app_root . '/../config/sync';`.
2. Export config.
3. Config should be exported to `config/sync` directory outside the webroot instead of `sites/default/files/sync`.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

Fixes #3549 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3550"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

