### PR TITLE
Prepare ddev directory earlier, fixes #3239

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -848,6 +848,11 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
+	err = PrepDdevDirectory(filepath.Dir(app.ConfigPath))
+	if err != nil {
+		util.Warning("Unable to PrepDdevDirectory: %v", err)
+	}
+
 	err = app.GenerateWebserverConfig()
 	if err != nil {
 		return err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -826,6 +826,13 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
+	// This is done early here so users won't see gitignored contents of .ddev for too long
+	// It also gets done by `ddev config`
+	err = PrepDdevDirectory(filepath.Dir(app.ConfigPath))
+	if err != nil {
+		util.Warning("Unable to PrepDdevDirectory: %v", err)
+	}
+
 	// The .ddev directory may still need to be populated, especially in tests
 	err = PopulateExamplesCommandsHomeadditions(app.Name)
 	if err != nil {
@@ -846,11 +853,6 @@ func (app *DdevApp) Start() error {
 	err = app.ProcessHooks("pre-start")
 	if err != nil {
 		return err
-	}
-
-	err = PrepDdevDirectory(filepath.Dir(app.ConfigPath))
-	if err != nil {
-		util.Warning("Unable to PrepDdevDirectory: %v", err)
 	}
 
 	err = app.GenerateWebserverConfig()


### PR DESCRIPTION
## The Problem/Issue/Bug:

The `.ddev/.gitingore` is created very late in the start process and until the creation git status shows many untracked files.

## How this PR Solves The Problem:

The `.ddev` folder preparation and `.ddev/.gitingore` creation is now done before any other files are created.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

#3239

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3551"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

