### PR TITLE
Change keys of ddev version json object for more consistency, fixes #3572

### DIFF
--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -25,14 +25,14 @@ func TestCmdVersion(t *testing.T) {
 	raw, ok := versionData["raw"].(map[string]interface{})
 	require.True(t, ok, "raw section wasn't found in versioninfo %v", out)
 
-	assert.Equal(version.DdevVersion, raw["DDEV version"])
+	assert.Equal(version.DdevVersion, raw["ddev_version"])
 	assert.Equal(version.WebImg+":"+version.WebTag, raw["web"])
 	assert.Equal(version.GetDBImage(nodeps.MariaDB), raw["db"])
 	assert.Equal(version.GetDBAImage(), raw["dba"])
 	dockerVersion, _ := version.GetDockerVersion()
 	assert.Equal(dockerVersion, raw["docker"])
 	composeVersion, _ := version.GetDockerComposeVersion()
-	assert.Equal(composeVersion, raw["docker-compose"])
+	assert.Equal(composeVersion, raw["docker_compose"])
 
 	assert.Contains(versionData["msg"], version.DdevVersion)
 	assert.Contains(versionData["msg"], version.WebImg)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -93,28 +93,28 @@ func GetVersionInfo() map[string]string {
 	var err error
 	versionInfo := make(map[string]string)
 
-	versionInfo["DDEV version"] = DdevVersion
+	versionInfo["ddev_version"] = DdevVersion
 	versionInfo["web"] = GetWebImage()
 	versionInfo["db"] = GetDBImage(nodeps.MariaDB)
 	versionInfo["dba"] = GetDBAImage()
 	versionInfo["router"] = RouterImage + ":" + RouterTag
-	versionInfo["ddev-ssh-agent"] = SSHAuthImage + ":" + SSHAuthTag
-	versionInfo["build info"] = BUILDINFO
+	versionInfo["ddev_ssh_agent"] = SSHAuthImage + ":" + SSHAuthTag
+	versionInfo["build_info"] = BUILDINFO
 	versionInfo["os"] = runtime.GOOS
 	versionInfo["architecture"] = runtime.GOARCH
 	if versionInfo["docker"], err = GetDockerVersion(); err != nil {
 		versionInfo["docker"] = fmt.Sprintf("failed to GetDockerVersion(): %v", err)
 	}
-	if versionInfo["docker-platform"], err = GetDockerPlatform(); err != nil {
-		versionInfo["docker-platform"] = fmt.Sprintf("failed to GetDockerPlatform(): %v", err)
+	if versionInfo["docker_platform"], err = GetDockerPlatform(); err != nil {
+		versionInfo["docker_platform"] = fmt.Sprintf("failed to GetDockerPlatform(): %v", err)
 	}
-	if versionInfo["docker-compose"], err = GetDockerComposeVersion(); err != nil {
-		versionInfo["docker-compose"] = fmt.Sprintf("failed to GetDockerComposeVersion(): %v", err)
+	if versionInfo["docker_compose"], err = GetDockerComposeVersion(); err != nil {
+		versionInfo["docker_compose"] = fmt.Sprintf("failed to GetDockerComposeVersion(): %v", err)
 	}
 	versionInfo["mutagen"] = RequiredMutagenVersion
 
 	if runtime.GOOS == "windows" {
-		versionInfo["docker type"] = "Docker Desktop For Windows"
+		versionInfo["docker_type"] = "Docker Desktop For Windows"
 	}
 
 	return versionInfo

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -26,7 +26,7 @@ func TestGetVersionInfo(t *testing.T) {
 
 	v := GetVersionInfo()
 
-	assert.Equal(DdevVersion, v["DDEV version"])
+	assert.Equal(DdevVersion, v["ddev_version"])
 	assert.Contains(v["web"], WebImg)
 	assert.Contains(v["web"], WebTag)
 	assert.Contains(v["db"], DBImg)
@@ -34,9 +34,9 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Contains(v["dba"], DBAImg)
 	assert.Contains(v["dba"], DBATag)
 	assert.Equal(runtime.GOOS, v["os"])
-	assert.Equal(BUILDINFO, v["build info"])
-	assert.NotEmpty(v["docker-compose"])
-	assert.NotEmpty(v["docker-platform"])
+	assert.Equal(BUILDINFO, v["build_info"])
+	assert.NotEmpty(v["docker_compose"])
+	assert.NotEmpty(v["docker_platform"])
 
 	assert.NotEmpty(v["docker"])
 }


### PR DESCRIPTION
The Problem/Issue/Bug:
Inconsistent keys with spaces and alternating capitalisation
make the output hard to parse.

How this PR Solves The Problem:
To be consistent with the output of ddev status -j the keys get changed to snake_case.

Manual Testing Instructions:
N/A

Automated Testing Overview:
The test case has been adapted accordingly.

Related Issue Link(s):
* https://github.com/drud/ddev/issues/3572


Release/Deployment notes:
<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3573"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
