### PR TITLE
Remove warning about missing SegmentKey in json mode

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -167,7 +167,7 @@ func init() {
 }
 
 func instrumentationNotSetUpWarning() {
-	if version.SegmentKey == "" && globalconfig.DdevGlobalConfig.InstrumentationOptIn {
+	if !output.JSONOutput && version.SegmentKey == "" && globalconfig.DdevGlobalConfig.InstrumentationOptIn {
 		output.UserOut.Warning("Instrumentation is opted in, but SegmentKey is not available.")
 	}
 }

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -168,7 +168,7 @@ func init() {
 
 func instrumentationNotSetUpWarning() {
 	if !output.JSONOutput && version.SegmentKey == "" && globalconfig.DdevGlobalConfig.InstrumentationOptIn {
-		output.UserOut.Warning("Instrumentation is opted in, but SegmentKey is not available.")
+		output.UserOut.Warning("Instrumentation is opted in, but SegmentKey is not available. This usually means you have a locally-built ddev binary or one from a PR build. It's not an error. Please report it if you're using an official release build.")
 	}
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
The warning about the missing SegmentKey generates a second obejct on output which causes it to be invalid for parsers.

## How this PR Solves The Problem:
In json output mode the warning is no longer triggert.

## Manual Testing Instructions:
Execute ddev describe -j on a self build ddev binary. The following warning must not appear:
```json
{
  "level": "warning",
  "msg": "Instrumentation is opted in, but SegmentKey is not available.",
  "time": "2022-02-05T16:52:26+01:00"
}
```

## Automated Testing Overview:
N/A

## Related Issue Link(s):
N/A

## Release/Deployment notes:
N/A


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3574"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

