### PR TITLE
Remove duplicate networks key in docs

### DIFF
--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -47,7 +47,6 @@ services:
   - VIRTUAL_HOST=$DDEV_HOSTNAME
   - HTTP_EXPOSE=9998:9999
   - HTTPS_EXPOSE=9999:9999
-  networks: [default, ddev_default]
 ```
 
 ### Confirming docker-compose configurations


### PR DESCRIPTION
## The Problem/Issue/Bug:

Small typo in docs. The network key is already defined a few lines above.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

