### PR TITLE
Command `docker context show` not available on all docker client versions

### DIFF
--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -19,7 +19,7 @@ Reasons to use Colima include:
 * `colima status` will show colima's status.
 * After a computer restart you'll need to `colima start` again.
 * If you don't have Docker Desktop installed, you'll need the docker client, `brew install docker`.
-* Colima activates its own docker context in order to not conflict with Docker Desktop, so if you `docker context show` you'll see the current context (which will be "colima" after you've started colima). You can change to the default with `docker context use default` and see all the contexts with `docker context ls`.
+* Colima activates its own docker context in order to not conflict with Docker Desktop, so if you `docker context ls` you'll see a list of available contexts with currently active context indicated with an "\*" (which will be "colima" after you've started colima). You can change to the default with `docker context use default`.
 * For webserver performance and predictability mutagen is recommended, `ddev config global --mutagen-enabled`. See [Performance docs](performance.md#using-mutagen). Since the file mounting technique on lima/colima is immature (sshfs) you may want to just use no-bind-mounts, `ddev config global --no-bind-mounts` (which also implies mutagen).
 
 DDEV has extensive automated test coverage for colima on macOS, but of course colima is new and this integration is new, so please share your results and open issues or [contact us](../index.md#support-and-user-contributed-documentation) for help.


### PR DESCRIPTION
## The Problem/Issue/Bug:
According to [official Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/context/), `docker context show` command does not exist. 

## How this PR Solves The Problem:
Replacing it with `docker context ls`.

## Manual Testing Instructions:
To replicate run `docker context show` on latest docker CLI. 
Note: apparently the command works on "some" docker CLI installation. Still the command is not documented in the official docs.

## Release/Deployment notes:
This doesn't affect anything. It's just a documentation update, and not related to any setting changes but just how to check the docker active context.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3589"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

