### PR TITLE
Remove special handling for gitpod getting host.docker.internal

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,7 +65,7 @@
             "hostname": "0.0.0.0",
             "port": 9003,
             "pathMappings": {
-                "/var/www/html": "${workspaceRoot}/d9simple"
+                "/var/www/html": "${workspaceRoot}/../d9simple"
             }
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,7 +65,7 @@
             "hostname": "0.0.0.0",
             "port": 9003,
             "pathMappings": {
-                "/var/www/html": "${workspaceRoot}"
+                "/var/www/html": "${workspaceRoot}/d9simple"
             }
         }
     ]

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -956,13 +956,6 @@ func GetHostDockerInternalIP() (string, error) {
 	hostDockerInternal := ""
 
 	switch {
-	// TODO: Remove this stanza when experimentalNetwork: true is no longer
-	// required on Gitpod - then it behaves as normal linux
-	case nodeps.IsGitpod():
-		addrs, err := net.LookupHost(os.Getenv("HOSTNAME"))
-		if err == nil && len(addrs) > 0 {
-			hostDockerInternal = addrs[0]
-		}
 	case IsColima():
 		// Lima just specifies this as a named explicit IP address at this time
 		// see https://github.com/lima-vm/lima/blob/master/docs/network.md#host-ip-19216852


### PR DESCRIPTION
## The Problem/Issue/Bug:

Xdebug wasn't working any more on gitpod because they changed the networking situation. Now the networking is normal Linux, so we don't need the previous technique (which now doesn't work).



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3597"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

