### PR TITLE
install_ddev.sh script should handle `HEAD` option for latest

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,10 +53,8 @@
         {
             "type": "bashdb",
             "request": "launch",
-            "name": "Bash-Debug (select script from list of sh files)",
-            "cwd": "${workspaceFolder}",
-            "program": "${command:SelectScriptName}",
-            "args": []
+            "name": "Bash-Debug (current script)",
+            "program": "${file}"
         },
         {
             "name": "Listen for XDebug",

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,10 @@ The installation script can also take a version argument in order to install a s
 ```
 curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v1.17.0-alpha2
 ```
+or 
+```
+curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh HEAD
+```
 
 Later, to upgrade DDEV to the latest version, just run `ddev poweroff` and run the script again.
 

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -103,7 +103,7 @@ How can I install a specific version of DDEV?
 
     1. Download the version you want from the [releases page](https://github.com/drud/ddev/releases) and place it somewhere in your `$PATH`.
     2. Use the [install_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, use `curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v1.18.3-alpha1`
-    3. If you want the very latest, unreleased version of ddev, use `brew unlink ddev && brew install drud/ddev/ddev --HEAD`.
+    3. If you want the very latest, unreleased version of ddev, use `brew unlink ddev && brew install drud/ddev/ddev --HEAD`, or `curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh HEAD`
 
 How can I back up or restore all databases of all projects?
 : You can back up all projects that show in `ddev list` with `ddev start -a && ddev snapshot -a` but most people don't have enough memory to run all their projects at once. If you have `jq` on your system (`brew install jq`) then you can snapshot them one at a time with `for proj in $(ddev list -j  | jq -r '.raw[].name'); do ddev start $proj; ddev snapshot $proj; ddev stop $proj; done`. You can restore the latest snapshot in all projects listed by `ddev list` with `for dir in $(ddev list -j  | jq -r '.raw[].approot'); do pushd "$dir" && ddev snapshot restore --latest && ddev stop && popd; done`

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -153,7 +153,9 @@ fi
 curl -fsSL "https://raw.githubusercontent.com/${GITHUB_USERNAME}/ddev/master/scripts/macos_ddev_nfs_setup.sh" -o "${TMPDIR}/macos_ddev_nfs_setup.sh" || (printf "${RED}Failed downloading "https://raw.githubusercontent.com/${GITHUB_USERNAME}/ddev/master/scripts/macos_ddev_nfs_setup.sh"${RESET}\n" && exit 110)
 
 cd $TMPDIR
-$SHACMD -c "$SHAFILE"
+if [ ${VERSION} != "HEAD" ]; then
+  $SHACMD -c "$SHAFILE"
+fi
 tar -xzf $TARBALL
 
 printf "${GREEN}Download verified. Ready to place ddev and mkcert in your /usr/local/bin.${RESET}\n"

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -156,7 +156,11 @@ cd $TMPDIR
 if [ ${VERSION} != "HEAD" ]; then
   $SHACMD -c "$SHAFILE"
 fi
-tar -xzf $TARBALL
+if [ ${VERSION} != "HEAD" ]; then
+  tar -xzf ${TARBALL}
+else 
+  unzip ${TARBALL}
+ fi
 
 printf "${GREEN}Download verified. Ready to place ddev and mkcert in your /usr/local/bin.${RESET}\n"
 

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -139,7 +139,7 @@ if ! docker --version >/dev/null 2>&1; then
     printf "${YELLOW}Docker is required for ddev. Please see https://ddev.readthedocs.io/en/stable/#docker-installation.${RESET}\n"
 fi
 
-if [ "$VERSION" == 'HEAD' ]; then 
+if [ "$VERSION" = 'HEAD' ]; then 
   TARBALL="$FILEBASE.zip"
 else
   TARBALL="$FILEBASE.$VERSION.tar.gz"

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -99,7 +99,7 @@ if [ $# -ge 1 ]; then
   VERSION=$1
 fi
 
-if [ "$VERSION" == 'HEAD' ]; then
+if [ "$VERSION" = 'HEAD' ]; then
   RELEASE_BASE_URL="https://nightly.link/drud/ddev/workflows/master-build/master"
 else
   RELEASE_BASE_URL="https://github.com/${GITHUB_USERNAME}/ddev/releases/download/$VERSION"

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -125,7 +125,7 @@ else
 fi
 
 if [ "$VERSION" == 'HEAD' ]; then
-  FILEBASE="${FILEBASE//-/_}"
+  FILEBASE="${FILEBASE//_/-}"
   USE_ARCH=1
 else
   USE_ARCH=$(semver_compare "${VERSION}" "v1.16.0-alpha4")

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -124,7 +124,7 @@ else
     exit 1
 fi
 
-if [ "$VERSION" == 'HEAD' ]; then
+if [ "$VERSION" = 'HEAD' ]; then
   FILEBASE="${FILEBASE//_/-}"
   USE_ARCH=1
 else


### PR DESCRIPTION
## The Problem/Issue/Bug:
The `install_ddev.ssh` support only released versions, but doesn't support getting the latest unreleased version - `HEAD` 

## How this PR Solves The Problem:
Adding `HEAD` as a version option, ie. `install_ddev.sh HEAD`

## Manual Testing Instructions:
Run `scripts/install_ddev.sh HEAD`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3604"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

