### PR TITLE
Don't let ddev continue processing if docker context inspect doesn't work, fixes #3548

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -94,7 +94,7 @@ func GetDockerClient() *docker.Client {
 	if dockerHost == "" {
 		contextInfo, err := exec2.RunHostCommand("docker", "context", "inspect", "-f", `{{ .Name }} {{ .Endpoints.docker.Host }}`)
 		if err != nil {
-			util.Warning("unable to run docker context inspect: %v", err)
+			util.Failed("unable to run 'docker context inspect' - please make sure docker client is in path and up-to-date: %v", err)
 		} else {
 			contextInfo = strings.Trim(contextInfo, " \r\n")
 			parts := strings.SplitN(contextInfo, " ", 2)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3548 

This has only been seen on WSL2 when the docker client disappears, due to Docker Desktop problems with integrating with WSL2 distro.

## How this PR Solves The Problem:

If we can't use `docker context inspect` for whatever reason, just bail.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3605"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

