### PR TITLE
Look for tableplus in setapp directory as well, fixes #3606

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -7,7 +7,7 @@
 ## Usage: tableplus
 ## Example: "ddev tableplus"
 ## OSTypes: darwin
-## HostBinaryExists: /Applications/TablePlus.app
+## HostBinaryExists: /Applications/TablePlus.app,/Applications/Setapp/TablePlus.app
 
 set -x
 query="mysql://root:root@127.0.0.1:${DDEV_HOST_DB_PORT}/db"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Some people have tableplus installed in /Applications/Setapp

* #3606

## How this PR Solves The Problem:

Look for it there as well

## Manual Testing Instructions:

Use Tableplus on a machine that has it intalled in /Applications/Setapp

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3607"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

