### PR TITLE
First implementation of global project-tld config option

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -136,6 +136,11 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = val
 		dirty = true
 	}
+	if cmd.Flag("project-tdl").Changed {
+		val, _ := cmd.Flags().GetString("project-tld")
+		globalconfig.DdevGlobalConfig.ProjectTldGlobal = val
+		dirty = true
+	}
 
 	if cmd.Flag("use-docker-compose-from-path").Changed {
 		val, _ := cmd.Flags().GetBool("use-docker-compose-from-path")
@@ -179,6 +184,7 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 	output.UserOut.Printf("required-docker-compose-version=%v", globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion)
 	output.UserOut.Printf("use-docker-compose-from-path=%v", globalconfig.DdevGlobalConfig.UseDockerComposeFromPath)
 	output.UserOut.Printf("no-bind-mounts=%v", globalconfig.DdevGlobalConfig.NoBindMounts)
+	output.UserOut.Printf("project-tdl=%v", globalconfig.DdevGlobalConfig.ProjectTldGlobal)
 }
 
 func init() {
@@ -198,6 +204,7 @@ func init() {
 	configGlobalCommand.Flags().Bool("mutagen-enabled", false, "If true, web container will use mutagen caching/asynchronous updates.")
 	configGlobalCommand.Flags().String("table-style", "", "Table style for list and describe, see ~/.ddev/global_config.yaml for values")
 	configGlobalCommand.Flags().String("required-docker-compose-version", "", "Override default docker-compose version")
+	configGlobalCommand.Flags().String("project-tld", "", "Override default project tld")
 	configGlobalCommand.Flags().Bool("use-docker-compose-from-path", true, "If true, use docker-compose from path instead of private ~/.ddev/bin/docker-compose")
 	configGlobalCommand.Flags().Bool("no-bind-mounts", true, "If true, don't use bind-mounts - useful for environments like remote docker where bind-mounts are impossible")
 

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -55,7 +55,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	// Update a config
 	// Don't include no-bind-mounts because global testing
 	// will turn it on and break this
-	args = []string{"config", "global", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent", "--mutagen-enabled=true", "--nfs-mount-enabled=true", "--router-bind-all-interfaces=true", "--internet-detection-timeout-ms=850", "--use-letsencrypt", "--letsencrypt-email=nobody@example.com", "--table-style=bright", "--simple-formatting=true", "--auto-restart-containers=true", "--use-hardened-images=true", "--fail-on-hook-fail=true", `--disable-http2`, `--web-environment="SOMEENV=some+val"`}
+	args = []string{"config", "global", "--project-tld=ddev.test", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent", "--mutagen-enabled=true", "--nfs-mount-enabled=true", "--router-bind-all-interfaces=true", "--internet-detection-timeout-ms=850", "--use-letsencrypt", "--letsencrypt-email=nobody@example.com", "--table-style=bright", "--simple-formatting=true", "--auto-restart-containers=true", "--use-hardened-images=true", "--fail-on-hook-fail=true", `--disable-http2`, `--web-environment="SOMEENV=some+val"`}
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]\nweb-environment=[\"SOMEENV=some+val\"]\nmutagen-enabled=true\nnfs-mount-enabled=true\nrouter-bind-all-interfaces=true\ninternet-detection-timeout-ms=850\ndisable-http2=true\nuse-letsencrypt=true\nletsencrypt-email=nobody@example.com\ntable-style=bright\nsimple-formatting=true\nauto-restart-containers=true\nuse-hardened-images=true\nfail-on-hook-fail=true\nrequired-docker-compose-version=\nuse-docker-compose-from-path=false")
@@ -69,6 +69,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.True(globalconfig.DdevGlobalConfig.NFSMountEnabledGlobal)
 	assert.Len(globalconfig.DdevGlobalConfig.OmitContainersGlobal, 2)
 	assert.Equal("nobody@example.com", globalconfig.DdevGlobalConfig.LetsEncryptEmail)
+	assert.Equal("ddev.test", globalconfig.DdevGlobalConfig.ProjectTldGlobal)
 	assert.True(globalconfig.DdevGlobalConfig.UseLetsEncrypt)
 	assert.True(globalconfig.DdevGlobalConfig.UseHardenedImages)
 	assert.True(globalconfig.DdevGlobalConfig.FailOnHookFailGlobal)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -96,7 +96,11 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	if nodeps.IsGitpod() {
 		app.OmitContainersGlobal = append(app.OmitContainersGlobal, "ddev-router")
 	}
-	app.ProjectTLD = nodeps.DdevDefaultTLD
+
+	app.ProjectTLD = globalconfig.DdevGlobalConfig.ProjectTldGlobal
+	if globalconfig.DdevGlobalConfig.ProjectTldGlobal == "" {
+		app.ProjectTLD = nodeps.DdevDefaultTLD
+	}
 	app.UseDNSWhenPossible = true
 
 	app.WebImage = version.GetWebImage()
@@ -165,7 +169,7 @@ func (app *DdevApp) WriteConfig() error {
 	if appcopy.PHPMyAdminHTTPSPort == nodeps.DdevDefaultPHPMyAdminHTTPSPort {
 		appcopy.PHPMyAdminHTTPSPort = ""
 	}
-	if appcopy.ProjectTLD == nodeps.DdevDefaultTLD {
+	if appcopy.ProjectTLD == nodeps.DdevDefaultTLD || appcopy.ProjectTLD == globalconfig.DdevGlobalConfig.ProjectTldGlobal {
 		appcopy.ProjectTLD = ""
 	}
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -59,6 +59,7 @@ type GlobalConfig struct {
 	NoBindMounts                 bool                    `yaml:"no_bind_mounts"`
 	MkcertCARoot                 string                  `yaml:"mkcert_caroot"`
 	ProjectList                  map[string]*ProjectInfo `yaml:"project_info"`
+	ProjectTldGlobal             string                  `yaml:"project_tld"`
 }
 
 // GetGlobalConfigPath gets the path to global config file
@@ -175,6 +176,7 @@ func ReadGlobalConfig() error {
 	if nodeps.NoBindMountsDefault == true {
 		DdevGlobalConfig.NoBindMounts = true
 	}
+
 	err = ValidateGlobalConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
Unfortunately i cannot test this at work. Ill try and build at home. 

There is still a few things missing, like the docs for this and the description in the CLI.

## The Problem/Issue/Bug:
I want to set a global project tld

## How this PR Solves The Problem:
Adds a config global config option for project-tld that overwrites the default.

## Manual Testing Instructions:
Build, use --project-tld globally and see it work.

## Automated Testing Overview:
Added the option in the tests.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/2746

## Release/Deployment notes:


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3611"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

