### PR TITLE
ddev shouldn't output so much stuff when pulling 3rd party images, fixes #3556

### DIFF
--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -31,6 +31,11 @@ var DebugDownloadImagesCmd = &cobra.Command{
 			util.Warning("Unable to download mutagen: %v", err)
 		}
 
+		app.DockerEnv()
+		err = app.WriteDockerComposeYAML()
+		if err != nil {
+			util.Failed("Unable to WriteDockerComposeYAML(): %v", err)
+		}
 		err = app.PullContainerImages()
 		if err != nil {
 			util.Failed("Failed to debug download-images: %v", err)

--- a/cmd/ddev/cmd/debug-download-images_test.go
+++ b/cmd/ddev/cmd/debug-download-images_test.go
@@ -31,12 +31,12 @@ func TestDebugDownloadImages(t *testing.T) {
 		assert.NoError(err)
 	})
 
-	_, err = exec.RunHostCommand(DdevBin, "config", "--project-name", t.Name())
-	assert.NoError(err)
+	out, err := exec.RunHostCommand(DdevBin, "config", "--project-name", t.Name())
+	require.NoError(t, err, "Failed to run ddev config: %s", out)
 
 	_ = os.Setenv("DDEV_DEBUG", "true")
-	out, err := exec.RunHostCommand(DdevBin, "debug", "download-images")
-	assert.NoError(err)
+	out, err = exec.RunHostCommand(DdevBin, "debug", "download-images")
+	require.NoError(t, err, "Failed to run ddev debug download-images: %s", out)
 	assert.Contains(out, "ddev-webserver")
 	assert.Contains(out, "ddev-router")
 	assert.Contains(out, "Successfully downloaded ddev images")

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1138,13 +1138,14 @@ func (app *DdevApp) Restart() error {
 	return err
 }
 
-// PullContainerImages pulls the main images with full output, since docker-compose up won't show enough output
+// PullContainerImages configured docker images with full output, since docker-compose up doesn't have nice output
 func (app *DdevApp) PullContainerImages() error {
 	images, err := app.FindAllImages()
 	if err != nil {
 		return err
 	}
 
+	images = append(images, version.GetRouterImage(), version.GetSSHAuthImage())
 	for _, i := range images {
 		err := dockerutil.Pull(i)
 		if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1140,29 +1140,39 @@ func (app *DdevApp) Restart() error {
 
 // PullContainerImages pulls the main images with full output, since docker-compose up won't show enough output
 func (app *DdevApp) PullContainerImages() error {
-	containerImages := map[string]string{
-		"db":             app.GetDBImage(),
-		"dba":            version.GetDBAImage(),
-		"ddev-ssh-agent": version.GetSSHAuthImage(),
-		"web":            app.WebImage,
-		"ddev-router":    version.GetRouterImage(),
-		"busybox":        version.BusyboxImage,
+	images, err := app.FindAllImages()
+	if err != nil {
+		return err
 	}
 
-	omitted := app.GetOmittedContainers()
-	for containerName, imageName := range containerImages {
-		if !nodeps.ArrayContainsString(omitted, containerName) {
-			err := dockerutil.Pull(imageName)
-			if err != nil {
-				return err
-			}
-			if globalconfig.DdevDebug {
-				output.UserOut.Printf("Pulling image for %s: %s", containerName, imageName)
-			}
+	for _, i := range images {
+		err := dockerutil.Pull(i)
+		if err != nil {
+			return err
+		}
+		if globalconfig.DdevDebug {
+			output.UserOut.Printf("Pulling image for %s", i)
 		}
 	}
 
 	return nil
+}
+
+// FindAllImages returns an array of image tags for all containers in the compose file
+func (app *DdevApp) FindAllImages() ([]string, error) {
+	var images []string
+	y := app.ComposeYaml["services"]
+	for _, v := range y.(map[interface{}]interface{}) {
+		if i, ok := v.(map[interface{}]interface{})["image"]; ok {
+			if strings.HasSuffix(i.(string), "-built") {
+				parts := strings.Split(i.(string), "-")
+				parts = parts[:len(parts)-2]
+				i = strings.Join(parts, "-")
+			}
+			images = append(images, i.(string))
+		}
+	}
+	return images, nil
 }
 
 // CheckExistingAppInApproot looks to see if we already have a project in this approot with different name

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1165,6 +1165,8 @@ func (app *DdevApp) FindAllImages() ([]string, error) {
 	for _, v := range y.(map[interface{}]interface{}) {
 		if i, ok := v.(map[interface{}]interface{})["image"]; ok {
 			if strings.HasSuffix(i.(string), "-built") {
+				// This technique is hacky and won't work completely correctly where project name has a hyphen in it.
+				// But the pull will still work out later in the docker-compose up
 				parts := strings.Split(i.(string), "-")
 				parts = parts[:len(parts)-2]
 				i = strings.Join(parts, "-")

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1161,19 +1161,25 @@ func (app *DdevApp) PullContainerImages() error {
 // FindAllImages returns an array of image tags for all containers in the compose file
 func (app *DdevApp) FindAllImages() ([]string, error) {
 	var images []string
-	y := app.ComposeYaml["services"]
-	for _, v := range y.(map[interface{}]interface{}) {
-		if i, ok := v.(map[interface{}]interface{})["image"]; ok {
-			if strings.HasSuffix(i.(string), "-built") {
-				// This technique is hacky and won't work completely correctly where project name has a hyphen in it.
-				// But the pull will still work out later in the docker-compose up
-				parts := strings.Split(i.(string), "-")
-				parts = parts[:len(parts)-2]
-				i = strings.Join(parts, "-")
+	if app.ComposeYaml == nil {
+		return images, nil
+	}
+	if y, ok := app.ComposeYaml["services"]; ok {
+		for _, v := range y.(map[interface{}]interface{}) {
+			if i, ok := v.(map[interface{}]interface{})["image"]; ok {
+				if strings.HasSuffix(i.(string), "-built") {
+					// This technique is hacky and won't work completely correctly where project name has a hyphen in it.
+					// But the pull will still work out later in the docker-compose up
+					parts := strings.Split(i.(string), "-")
+					parts = parts[:len(parts)-2]
+					i = strings.Join(parts, "-")
+				}
+				images = append(images, i.(string))
+
 			}
-			images = append(images, i.(string))
 		}
 	}
+
 	return images, nil
 }
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -503,7 +503,7 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 	// Container (or Volume) ... Creating or Created or Stopping or Starting or Removing
 	// Container Stopped or Created
 	// No resource found to remove (when doing a stop and no project exists)
-	ignoreRegex := "(^(Network|Container|Volume) .* (Creat|Start|Stopp|Remov)ing$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove$)"
+	ignoreRegex := "(^(Network|Container|Volume) .* (Creat|Start|Stopp|Remov)ing$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove$|Pulling fs layer|Waiting|Downloading|Extracting|Verifying Checksum|Download complete|Pull complete)"
 	downRE, err := regexp.Compile(ignoreRegex)
 	if err != nil {
 		util.Warning("failed to compile regex %v: %v", ignoreRegex, err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3556 

ddev (really docker-compose) makes way too much noise when downloading images. 

## How this PR Solves The Problem:

Limit what it says. 

Now pulling solr, for example, it says

```
rfay@rfay-tag1-m1:~/workspace/d9$ ddev start
Starting d9...
Pushed mkcert rootca certs to ddev-global-cache/mkcert
solr Pulling
solr Pulled
Network ddev-d9_default  Created
```

## Manual Testing Instructions:

`ddev get drud/ddev-drupal9-solr && ddev start`

## Automated Testing Overview:

No tests added.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3614"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

