### PR TITLE
Adds delete all images command flag, fixes #2968

### DIFF
--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -54,10 +54,11 @@ ddev delete images --all`,
 			for _, image := range images {
 				for _, tag := range image.RepoTags {
 					if strings.HasPrefix(tag, "drud/ddev-") {
-						dockerRemoveImage(tag)
+						if err = dockerutil.RemoveImage(tag); err != nil {
+							util.Warning("Failed to remove %s: %v", tag, err)
+						}
 					}
 				}
-			}
 			util.Success("All ddev images discovered were deleted.")
 			os.Exit(0)
 		}
@@ -88,35 +89,37 @@ ddev delete images --all`,
 			for _, tag := range image.RepoTags {
 				// If a webimage, but doesn't match our webimage, delete it
 				if strings.HasPrefix(tag, version.WebImg) && !strings.HasPrefix(tag, webimg) && !strings.HasPrefix(tag, webimg+"-built") {
-					dockerRemoveImage(tag)
+					if err = dockerutil.RemoveImage(tag); err != nil {
+						util.Warning("Failed to remove %s: %v", tag, err)
+					}
 				}
 				if strings.HasPrefix(tag, "drud/ddev-dbserver") && !strings.HasSuffix(tag, keepDBImageTag) && !strings.HasSuffix(tag, keepDBImageTag+"-built") {
-					dockerRemoveImage(tag)
+					if err = dockerutil.RemoveImage(tag); err != nil {
+						util.Warning("Failed to remove %s: %v", tag, err)
+					}
 				}
 				// If a dbaimage, but doesn't match our dbaimage, delete it
 				if strings.HasPrefix(tag, version.DBAImg) && !strings.HasPrefix(tag, dbaimage) {
-					dockerRemoveImage(tag)
+					if err = dockerutil.RemoveImage(tag); err != nil {
+						util.Warning("Failed to remove %s: %v", tag, err)
+					}
 				}
 				// If a routerImage, but doesn't match our routerimage, delete it
 				if strings.HasPrefix(tag, version.RouterImage) && !strings.HasPrefix(tag, routerimage) {
-					dockerRemoveImage(tag)
+					if err = dockerutil.RemoveImage(tag); err != nil {
+						util.Warning("Failed to remove %s: %v", tag, err)
+					}
 				}
 				// If a sshAgentImage, but doesn't match our sshAgentImage, delete it
 				if strings.HasPrefix(tag, version.SSHAuthImage) && !strings.HasPrefix(tag, sshimage) && !strings.HasPrefix(tag, sshimage+"-built") {
-					dockerRemoveImage(tag)
+					if err = dockerutil.RemoveImage(tag); err != nil {
+						util.Warning("Failed to remove %s: %v", tag, err)
+					}
 				}
 			}
 		}
 		util.Success("Any non-current images discovered were deleted.")
 	},
-}
-
-// dockerRemoveImage Deletes an images by its tag
-func dockerRemoveImage(tag string) {
-	err := dockerutil.RemoveImage(tag)
-	if err != nil {
-		util.Warning("Unable to remove %s: %v", tag, err)
-	}
 }
 
 func init() {

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -22,7 +22,8 @@ var deleteAllImages bool
 // DeleteImagesCmd implements the ddev delete images command
 var DeleteImagesCmd = &cobra.Command{
 	Use:   "images",
-	Short: "Deletes ddev docker images",
+	Short: "Deletes ddev docker images not in use by current ddev version",
+	Long: "with --all it deletes all ddev docker images"
 	Example: `ddev delete images
 ddev delete images -y
 ddev delete images --all`,

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -1,26 +1,32 @@
 package cmd
 
 import (
+	"os"
+	"sort"
+	"strings"
+
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/spf13/cobra"
-	"os"
-	"sort"
-	"strings"
 )
 
 // noConfirm: If true, --yes, we won't stop and prompt before each deletion
 var deleteImagesNocConfirm bool
 
+// deleteAllImages: If set, deletes all images created by ddev
+var deleteAllImages bool
+
 // DeleteImagesCmd implements the ddev delete images command
 var DeleteImagesCmd = &cobra.Command{
 	Use:   "images",
-	Short: "Delete docker images not currently in use",
+	Short: "Deletes ddev docker images",
 	Example: `ddev delete images
-ddev delete images -y`,
+ddev delete images -y
+ddev delete images --all`,
+
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !deleteImagesNocConfirm {
@@ -39,6 +45,23 @@ ddev delete images -y`,
 		if err != nil {
 			util.Failed("Failed to list images: %v", err)
 		}
+
+		// The user can select to delete all ddev images.
+		if deleteAllImages {
+			// Attempt to find ddev images by tag, searching for "drud/ddev-".
+			// Some ddev images will not be found by this tag, future work will
+			// be done to improve finding database images.
+			for _, image := range images {
+				for _, tag := range image.RepoTags {
+					if strings.HasPrefix(tag, "drud/ddev-") {
+						dockerRemoveImage(tag)
+					}
+				}
+			}
+			util.Success("All ddev images discovered were deleted.")
+			os.Exit(0)
+		}
+
 		// Sort so that images that have -built on the end
 		// come up before their parent images that don't
 		sort.Slice(images, func(i, j int) bool {
@@ -65,32 +88,22 @@ ddev delete images -y`,
 			for _, tag := range image.RepoTags {
 				// If a webimage, but doesn't match our webimage, delete it
 				if strings.HasPrefix(tag, version.WebImg) && !strings.HasPrefix(tag, webimg) && !strings.HasPrefix(tag, webimg+"-built") {
-					if err = dockerutil.RemoveImage(tag); err != nil {
-						util.Warning("Failed to remove %s: %v", tag, err)
-					}
+					dockerRemoveImage(tag)
 				}
 				if strings.HasPrefix(tag, "drud/ddev-dbserver") && !strings.HasSuffix(tag, keepDBImageTag) && !strings.HasSuffix(tag, keepDBImageTag+"-built") {
-					if err = dockerutil.RemoveImage(tag); err != nil {
-						util.Warning("Unable to remove %s: %v", tag, err)
-					}
+					dockerRemoveImage(tag)
 				}
 				// If a dbaimage, but doesn't match our dbaimage, delete it
 				if strings.HasPrefix(tag, version.DBAImg) && !strings.HasPrefix(tag, dbaimage) {
-					if err = dockerutil.RemoveImage(tag); err != nil {
-						util.Warning("Failed to remove %s: %v", tag, err)
-					}
+					dockerRemoveImage(tag)
 				}
 				// If a routerImage, but doesn't match our routerimage, delete it
 				if strings.HasPrefix(tag, version.RouterImage) && !strings.HasPrefix(tag, routerimage) {
-					if err = dockerutil.RemoveImage(tag); err != nil {
-						util.Warning("Failed to remove %s: %v", tag, err)
-					}
+					dockerRemoveImage(tag)
 				}
 				// If a sshAgentImage, but doesn't match our sshAgentImage, delete it
 				if strings.HasPrefix(tag, version.SSHAuthImage) && !strings.HasPrefix(tag, sshimage) && !strings.HasPrefix(tag, sshimage+"-built") {
-					if err = dockerutil.RemoveImage(tag); err != nil {
-						util.Warning("Failed to remove %s: %v", tag, err)
-					}
+					dockerRemoveImage(tag)
 				}
 			}
 		}
@@ -98,7 +111,16 @@ ddev delete images -y`,
 	},
 }
 
+// dockerRemoveImage Deletes an images by its tag
+func dockerRemoveImage(tag string) {
+	err := dockerutil.RemoveImage(tag)
+	if err != nil {
+		util.Warning("Unable to remove %s: %v", tag, err)
+	}
+}
+
 func init() {
 	DeleteImagesCmd.Flags().BoolVarP(&deleteImagesNocConfirm, "yes", "y", false, "Yes - skip confirmation prompt")
+	DeleteImagesCmd.Flags().BoolVarP(&deleteAllImages, "all", "a", false, "If set, deletes all Docker images created by ddev.")
 	DeleteCmd.AddCommand(DeleteImagesCmd)
 }

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -23,7 +23,7 @@ var deleteAllImages bool
 var DeleteImagesCmd = &cobra.Command{
 	Use:   "images",
 	Short: "Deletes ddev docker images not in use by current ddev version",
-	Long: "with --all it deletes all ddev docker images"
+	Long:  "with --all it deletes all ddev docker images",
 	Example: `ddev delete images
 ddev delete images -y
 ddev delete images --all`,
@@ -60,6 +60,7 @@ ddev delete images --all`,
 						}
 					}
 				}
+			}
 			util.Success("All ddev images discovered were deleted.")
 			os.Exit(0)
 		}


### PR DESCRIPTION
This adds a flag --all to delete all ddev Docker images.
More work will be needed for database images (postgres etc).

I also wrapped the remove image code into a function because it
was repeated many times.

## The Problem/Issue/Bug:

* #2968 

The existing delete images command leaves the default ddev images and people want to be able to delete *all* ddev-pulled images when cleaning up.

## How this PR Solves The Problem:
This additional flag will allow the delete images command to delete all ddev images.

## Manual Testing Instructions:
Start a ddev project and then run this command
`ddev delete images --all`
Verify all your project images and the default ddev images are removed.

## Automated Testing Overview:
There is no test file for the delete command.

## Related Issue Link(s):
#2968 

## Release/Deployment notes:
None
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3615"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

