### PR TITLE
Change docker-compose yaml to insert networks stanza, fixes #3587

### DIFF
--- a/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/docker-compose.example.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/docker-compose.example.yaml
@@ -14,7 +14,6 @@ services:
   memcached:
     container_name: ddev-${DDEV_SITENAME}-memcached
     image: memcached:1.6
-    networks: [default, ddev_default]
     restart: "no"
     # memcached is available at this port inside the container.
     expose:

--- a/docs/users/extend/custom-compose-files.md
+++ b/docs/users/extend/custom-compose-files.md
@@ -37,7 +37,6 @@ version: '3.6'
 services:
   someservice:
   container_name: "ddev-${DDEV_SITENAME}-someservice"
-  networks: [default, ddev_default]
   labels:
     com.ddev.site-name: ${DDEV_SITENAME}
     com.ddev.approot: ${DDEV_APPROOT}
@@ -70,7 +69,6 @@ When defining additional services for your project, we recommended you follow th
 * Exposing ports for service: you can expose the port for a service to be accessible as `projectname.ddev.site:portNum` while your project is running. This is achieved by the following configurations for the container(s) being added:
 
     * Define only the internal port in the `expose` section for docker-compose; use `ports:` only if the port will be bound directly to localhost, as may be required for non-http services.
-    * Add a `networks:` stanza: `networks: [default, ddev_default]`
 
     * To expose a web interface to be accessible over HTTP, define the following environment variables in the `environment` section for docker-compose:
 

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -38,7 +38,7 @@ Can I use additional databases with DDEV?
 
 <a name="projects-communicate-with-each-other"></a>
 Can different projects communicate with each other?
-: Yes, this is commonly required for situations like Drupal migrations. For the web container to access the db container of another project, use `ddev-<projectname>-db` as the hostname of the other project. For example, in project1, use `mysql -h ddev-project2-db` to access the db server of project2. For HTTP/S communication you can 1) access the web container of project2 directly with the hostname `ddev-<project2>-web` and port 80 or 443: `curl https://ddev-project2-web` or 2) Add a .ddev/docker-compose.communicate.yaml which will allow you to access the other project via the official FQDN. (In v1.19+ third-party services may need `networks: [default, ddev_default]`.)
+: Yes, this is commonly required for situations like Drupal migrations. For the web container to access the db container of another project, use `ddev-<projectname>-db` as the hostname of the other project. For example, in project1, use `mysql -h ddev-project2-db` to access the db server of project2. For HTTP/S communication you can 1) access the web container of project2 directly with the hostname `ddev-<project2>-web` and port 80 or 443: `curl https://ddev-project2-web` or 2) Add a .ddev/docker-compose.communicate.yaml which will allow you to access the other project via the official FQDN.
 
     ```yaml
       version: '3.6'

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -88,6 +88,7 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
+    networks: ["default", "ddev_default"]
     cap_add:
       - SYS_PTRACE
     working_dir: "{{ .WebWorkingDir }}"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -13,7 +13,6 @@ services:
         uid: '{{ .UID }}'
         gid: {{ if ne .DBType "postgres" }} {{ .GID }} {{ else }} "999" {{ end }}
     image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
-    networks: ["default", "ddev_default"]
     stop_grace_period: 60s
     working_dir: "{{ .DBWorkingDir }}"
     volumes:
@@ -89,7 +88,6 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
-    networks: ["default", "ddev_default"]
     cap_add:
       - SYS_PTRACE
     working_dir: "{{ .WebWorkingDir }}"
@@ -217,7 +215,6 @@ services:
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
-    networks: ["default", "ddev_default"]
     working_dir: "{{ .DBAWorkingDir }}"
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     labels:

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -54,12 +54,12 @@ func (app *DdevApp) WriteDockerComposeYAML() error {
 			util.Warning("Error closing %s: %v", fullHandle.Name(), err)
 		}
 	}()
-	fullContentsByles, err := yaml.Marshal(app.ComposeYaml)
+	fullContentsBytes, err := yaml.Marshal(app.ComposeYaml)
 	if err != nil {
 		return err
 	}
 
-	_, err = fullHandle.Write(fullContentsByles)
+	_, err = fullHandle.Write(fullContentsBytes)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
@@ -2,7 +2,6 @@ version: '3.6'
 services:
   busybox:
     image: busybox:stable
-    networks: [default, ddev_default]
     command: tail -f /dev/null
     container_name: ddev-${DDEV_SITENAME}-busybox
     labels:

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
@@ -7,7 +7,6 @@ services:
 
   dummy2:
     image: busybox:stable
-    networks: [default, ddev_default]
     container_name: dummy2
     environment:
     - HTTP_EXPOSE=9201

--- a/pkg/ddevapp/testdata/TestNetworkAmbiguity/docker-compose.test.yaml
+++ b/pkg/ddevapp/testdata/TestNetworkAmbiguity/docker-compose.test.yaml
@@ -3,7 +3,6 @@ services:
   test:
     container_name: ddev-${DDEV_SITENAME}-test
     image: "busybox:stable"
-    networks: [default, ddev_default]
     command: "tail -f /dev/null"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
+++ b/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
@@ -4,7 +4,6 @@ services:
   test-ssh-server:
     container_name: test-ssh-server
     image: drud/test-ssh-server:v1.16.0
-    networks: [default, ddev_default]
     restart: "no"
     ports:
     # Port is published for debugging reasons only. ssh -p 3333 root@localhost

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -22,7 +22,6 @@ services:
       LINES: '25'
       VIRTUAL_HOST: junk.ddev.site
     image: TEST-COMPOSE-WITH-STREAMS-IMAGE
-    networks: [default, ddev_default]
     user: "33:33"
     labels:
       com.ddev.app-type: php

--- a/pkg/dockerutil/testdata/docker-compose.yml
+++ b/pkg/dockerutil/testdata/docker-compose.yml
@@ -4,9 +4,6 @@ services:
   db:
     container_name: ddev-test-db
     image: DDEV_DBIMAGE
-    networks:
-      - default
-      - ddev
     user: "$DDEV_UID:$DDEV_GID"
     restart: always
     environment:
@@ -20,9 +17,6 @@ services:
   web:
     container_name: ddev-test-web
     image: DDEV_WEBIMAGE
-    networks:
-      - default
-      - ddev
     user: "$DDEV_UID:$DDEV_GID"
     volumes:
       - "../htdocs/:/var/www/html/docroot:cached"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3587

Because the requirement of the `networks` stanza in ddev v1.19 is pretty intrusive, requiring existing `docker-compose.*.yaml` all to be edited, this PR unmarshalls in the fully normalized yaml text into a golang map, replaces the `networks` array, and then marshalls the yaml back out to .ddev/.ddev-docker-compose-full.yaml.

## Manual Testing Instructions:

- [x] Try it out with recipes from ddev-contrib that haven't had the `networks` stanza added
- [x] Try it out with recipes that *do* have the `networks` stanza.

## TODO
- [x] Remove the docs that ask for the `networks` stanza

## Automated Testing Overview:

I'm just hoping that all existing pass. 
- [x] Add a test with a 3rd-party service that does not have `networks`

## Release/Deployment notes:

- [ ] Release notes can remove the worry about the networks stanza.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3620"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

