### PR TITLE
Fix findAllImages() where project name has hyphen, fixes #3621

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1171,11 +1171,10 @@ func (app *DdevApp) FindAllImages() ([]string, error) {
 		for _, v := range y.(map[interface{}]interface{}) {
 			if i, ok := v.(map[interface{}]interface{})["image"]; ok {
 				if strings.HasSuffix(i.(string), "-built") {
-					// This technique is hacky and won't work completely correctly where project name has a hyphen in it.
-					// But the pull will still work out later in the docker-compose up
-					parts := strings.Split(i.(string), "-")
-					parts = parts[:len(parts)-2]
-					i = strings.Join(parts, "-")
+					i = strings.TrimSuffix(i.(string), "-built")
+					if strings.HasSuffix(i.(string), "-"+app.Name) {
+						i = strings.TrimSuffix(i.(string), "-"+app.Name)
+					}
 				}
 				images = append(images, i.(string))
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3621 

In projects with a hyphen in the project name, ddev didn't find the images to pull correctly, using a naive approach.

## How this PR Solves The Problem:

This PR uses a smarter approach to finding out the image to pull based on the full -built image name. 

## Manual Testing Instructions:

- [x] In a project with a hyphenated name, like `some-t3` do `ddev start` twice.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3622"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

