### PR TITLE
Support tableplus for postgres projects

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -10,7 +10,12 @@
 ## HostBinaryExists: /Applications/TablePlus.app
 
 set -x
-query="mysql://root:root@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
+dbtype=${DDEV_DBIMAGE%:*}
+driver=mysql
+if [[ $dbtype == "postgres" ]]; then
+    driver=$dbtype
+fi
+query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
 
 open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

The classic database browsers like sequelace don't work with postgres, but tableplus does. make the `ddev tableplus` command support postgres.

## How this PR Solves The Problem:

Use a postgres dburl when using postgres. 

## Manual Testing Instructions:

Install Tableplus and
- [x] `ddev tableplus` on a postgres project
- [x] `ddev tableplus` on a maria/mysql project



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3623"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

