### PR TITLE
Improve healthcheck for db container including postgres, fixes #3617

### DIFF
--- a/containers/ddev-dbserver/files/home/.my.cnf
+++ b/containers/ddev-dbserver/files/home/.my.cnf
@@ -1,0 +1,6 @@
+[client]
+user=root
+password=root
+
+[mysql]
+database=db

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -69,7 +69,7 @@ services:
     command: ${DDEV_DB_CONTAINER_COMMAND}
     healthcheck:
       {{ if eq .DBType "postgres" }}
-      test: ["pg_isready"]
+      test: ["CMD-SHELL", "/postgres_healthcheck.sh"]
       {{ end }}
       interval: 1s
       retries: 120

--- a/pkg/ddevapp/assets.go
+++ b/pkg/ddevapp/assets.go
@@ -7,7 +7,7 @@ import (
 
 //The bundled assets for the project .ddev directory are in directory dotddev_assets
 // And the global .ddev assets are in directory global_dotddev_assets
-//go:embed dotddev_assets/* dotddev_assets/commands/.gitattributes global_dotddev_assets/* global_dotddev_assets/.gitignore global_dotddev_assets/commands/.gitattributes app_compose_template.yaml router_compose_template.yaml ssh_auth_compose_template.yaml drupal/* magento/* wordpress/* typo3/* postgres/*
+//go:embed dotddev_assets/* dotddev_assets/commands/.gitattributes global_dotddev_assets/* global_dotddev_assets/.gitignore global_dotddev_assets/commands/.gitattributes app_compose_template.yaml router_compose_template.yaml ssh_auth_compose_template.yaml drupal/* magento/* wordpress/* typo3/* postgres/* healthcheck/*
 var bundledAssets embed.FS
 
 // PopulateExamplesCommandsHomeadditions grabs embedded assets and

--- a/pkg/ddevapp/healthcheck/postgres_healthcheck.sh
+++ b/pkg/ddevapp/healthcheck/postgres_healthcheck.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-## mysql health check for docker
+## postgres healthcheck
+##dev-generated
 
 set -eo pipefail
 sleeptime=59
@@ -15,23 +16,9 @@ if [ -f /tmp/healthy ]; then
     sleep ${sleeptime}
 fi
 
-# If /tmp/initializing, it means we're loading the default starter database
-if [ -f /tmp/initializing ]; then
-  printf "initializing"
-  exit 1
-fi
-
-# If mariabackup or xtrabackup is running (and not initializing)
-# It means snapshot restore is in progress
-if killall -0 mariabackup 2>/dev/null || killall -0 xtrabackup 2>/dev/null ; then
-  printf "currently restoring snapshot"
-  touch /tmp/healthy
-  exit 0
-fi
-
 # If we can now access the server, we're healthy and ready
-if  mysql --host=127.0.0.1 -udb -pdb --database=db -e "SHOW DATABASES LIKE 'db';" >/dev/null;  then
-    printf "healthy"
+if  pg_isready >/dev/null;  then
+    printf "pg_isready: healthy"
     touch /tmp/healthy
     exit 0
 fi

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -20,7 +20,7 @@ import (
 
 // CopyFile copies the contents of the file named src to the file named
 // by dst. The file will be created if it does not already exist. If the
-// destination file exists, all it's contents will be replaced by the contents
+// destination file exists, all its contents will be replaced by the contents
 // of the source file. The file mode will be copied from the source and
 // the copied data is synced/flushed to stable storage. Credit @m4ng0squ4sh https://gist.github.com/m4ng0squ4sh/92462b38df26839a3ca324697c8cba04
 func CopyFile(src string, dst string) error {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -47,7 +47,7 @@ var WebTag = "20220219_nodejs_version" // Note that this can be overridden by ma
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20220102_gzip_snapshots"
+var BaseDBTag = "20220223_improve_db_healthcheck"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3617 

## How this PR Solves The Problem:

* Add healthcheck with backoff to postgres container
* Improve maria/mysql healthcheck so it doesn't show irrelevant output
* Improve PrepDdevDirectory() so it lists named files that can be grepped for #ddev-generated properly

## Manual Testing Instructions:

- [ ] Start postgres project and `docker inspect --format "{{json .State.Health }}" ddev-<project>-db | jq`



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3625"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

