### PR TITLE
[docs] Explain relationship between composer project and docroot

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -172,6 +172,8 @@ Quickstart instructions regarding database imports can be found under [Database 
 
 #### Drupal 9 Composer Setup Example
 
+NB: `ddev composer create "drupal/recommended-project"` will, by default, set the webroot to `web`. If you set a different value in the `ddev config` command, Drush won't be able to find the database, and the install commands will fail.
+
 ```bash
 mkdir my-drupal9-site
 cd my-drupal9-site


### PR DESCRIPTION
## The Problem/Issue/Bug:

I tried to spin up a brand new Drupal site using the instructions at https://ddev.readthedocs.io/en/stable/users/cli-usage/#drupal-9-quickstart 

Years of using Acquia meant I set the DDEV config to use `docroot`: 

```
ddev config --project-type=drupal9 --docroot=docroot --create-docroot
```

Because the Composer create command automatically sets the Composer `[web-root]` to `web`, this caused conflicts in my install. DDEV looked for `docroot` while Drupal was in `web`. **This is expected behaviour** but it wasn't immediately apparent from the docs that this would be an issue.

## How this PR Solves The Problem:

Just adds a little bit of context to the docs page, telling people not to be dumb like I was :) 

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3626"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

