### PR TITLE
Suppress feedback from command failure, fixes #3518

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -146,6 +146,7 @@ func Execute() {
 
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&output.JSONOutput, "json-output", "j", false, "If true, user-oriented output will be in JSON format.")
+	RootCmd.PersistentFlags().BoolVarP(&output.NoOutput, "no-output", "n", false, "If true, error messages output will be suppressed.")
 
 	output.LogSetUp()
 

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -3,6 +3,7 @@ package output
 import (
 	log "github.com/sirupsen/logrus"
 	"os"
+	"io"
 )
 
 var (
@@ -14,6 +15,8 @@ var (
 	UserOutFormatter = new(TextFormatter)
 	// JSONOutput is a bool telling whether we're outputting in json. Set by command-line args.
 	JSONOutput = false
+	// NoOutput is a bool telling whether we want to supress any output. Set by command-line args.
+	NoOutput = false
 )
 
 // LogSetUp sets up UserOut and log loggers as needed by ddev
@@ -41,6 +44,10 @@ func LogSetUp() {
 		logLevel = log.DebugLevel
 	}
 	log.SetLevel(logLevel)
+
+	if NoOutput {
+		UserErr.Out = io.Discard
+	}
 }
 
 // ErrorWriter allows writing stderr


### PR DESCRIPTION
## The Problem/Issue/Bug:
* #3518 

## How this PR Solves The Problem:
It does not print a message when a command fails, thus only display the original command response and not the one from ddev/docker

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/520237/155616662-33a8d8ab-2165-4164-a887-ffd6d57d16d4.png) | ![image](https://user-images.githubusercontent.com/520237/155616081-38509a31-1a97-4eb4-9097-f095b20a64b7.png) |

## Manual Testing Instructions:
Do `ddev exec "ls whatever"` with and without the changes

## Related Issue Link(s):
#3518 

## Release/Deployment notes:
Unaware if it affects things elsewhere.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3627"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

