### PR TITLE
Don't allow snapshots for postgres:9, fixes #3583

### DIFF
--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 	"strings"
@@ -38,7 +39,9 @@ ddev snapshot --all`,
 		}
 
 		for _, app := range apps {
-
+			if app.Database.Type == nodeps.Postgres && app.Database.Version == nodeps.Postgres9 {
+				util.Failed("Snapshots are not supported for postgres:9")
+			}
 			switch {
 			case snapshotList:
 				listAppSnapshots(app)

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -21,6 +21,9 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 		if err != nil {
 			util.Failed("Failed to find active project: %v", err)
 		}
+		if app.Database.Type == nodeps.Postgres && app.Database.Version == nodeps.Postgres9 {
+			util.Failed("Snapshots are not supported for postgres:9")
+		}
 
 		if snapshotRestoreLatest {
 			if snapshotName, err = app.GetLatestSnapshot(); err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Snapshots don't work with postgres:9. Nobody has really stepped up to study it, and postgres:9 is probably a very limited case anyway, so just don't let people use snapshots there.

## Manual Testing Instructions:

- [x] `ddev snapshot` and `ddev snapshot restore` on a project with database=`postgres:9`



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3630"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

