### PR TITLE
Update the docs on the use of DDEV with Compose V2 support in PHPStorm

### DIFF
--- a/docs/users/topics/phpstorm.md
+++ b/docs/users/topics/phpstorm.md
@@ -10,7 +10,7 @@ This is based on the wonderful [article](https://susi.dev/fully-integrate-ddev-a
 
 - PhpStorm 2021.2 or higher
 - You may need to add the `PHP Docker` plugin.
-- docker-compose v1. Due to a [bug or two in PhpStorm](https://youtrack.jetbrains.com/issue/WI-61205), it can't properly interpret docker-compose v2 output as of Sept 2021.  If this is still a problem, you can `ddev config global --required-docker-compose-version=v1.29.2` to globally require docker-compose v1.
+- As of version v1.18.2, DDEV is bundled with its own docker-compose binary, using Compose V2 by default. Enable _Use Compose V2_ in PHPStorm _Settings/Preferences | Build, Execution, Deployment | Docker | Tools_, in case you have an up to date docker-compose binary installed (Check with `docker-compose version` > 2.0). Otherwise, you can also set the bundled docker-compose binary as _Docker Compose executable_ which you can be found in `~/.ddev/bin`. In this case, you do not need to select the _Use Compose V2_ Checkbox.
 - Any OS platform, but if you're using Windows PhpStorm with WSL2 the path mappings are slightly more complex. WSL2 instructions are provided where necessary.
 
 #### Setup Technique

--- a/docs/users/topics/phpstorm.md
+++ b/docs/users/topics/phpstorm.md
@@ -10,7 +10,9 @@ This is based on the wonderful [article](https://susi.dev/fully-integrate-ddev-a
 
 - PhpStorm 2021.3 or higher
 - You may need to add the `PHP Docker` plugin.
-DDEV uses docker-compose v2 by default, so enable the **Use Compose V2** checkbox  in `PHPStorm _Settings/Preferences | Build, Execution, Deployment | Docker | Tools` and set the "Docker Compose executable" to ddev's private docker-compose binary at `~/.ddev/bin/docker-compose` (Home directory, `.ddev/bin/docker-compose.). However, if using PhpStorm on Windows side with WSL2 you'll need to use a docker-compose v2 binary as provided by Docker Desktop, normally `C:\Program Files\Docker\Docker\resources\bin\docker-compose`.
+- You need to enable Compose V2 Support in PHPStorm. This can be done in `Settings/Preferences | Build, Execution, Deployment | Docker | Tools` by either
+   1. set the bundled docker-compose binary as **Docker Compose executable** which can be found in `~/.ddev/bin`.
+   2. (Suggested for WSL) enabling **Use Compose V2** in PHPStorm and your Docker installation.
 - Any OS platform, but if you're using Windows PhpStorm with WSL2 the path mappings are slightly more complex. WSL2 instructions are provided where necessary.
 
 #### Setup Technique

--- a/docs/users/topics/phpstorm.md
+++ b/docs/users/topics/phpstorm.md
@@ -8,7 +8,7 @@ This is based on the wonderful [article](https://susi.dev/fully-integrate-ddev-a
 
 #### Requirements
 
-- PhpStorm 2021.2 or higher
+- PhpStorm 2021.3 or higher
 - You may need to add the `PHP Docker` plugin.
 - As of version v1.18.2, DDEV is bundled with its own docker-compose binary, using Compose V2 by default. Enable _Use Compose V2_ in PHPStorm _Settings/Preferences | Build, Execution, Deployment | Docker | Tools_, in case you have an up to date docker-compose binary installed (Check with `docker-compose version` > 2.0). Otherwise, you can also set the bundled docker-compose binary as _Docker Compose executable_ which you can be found in `~/.ddev/bin`. In this case, you do not need to select the _Use Compose V2_ Checkbox.
 - Any OS platform, but if you're using Windows PhpStorm with WSL2 the path mappings are slightly more complex. WSL2 instructions are provided where necessary.

--- a/docs/users/topics/phpstorm.md
+++ b/docs/users/topics/phpstorm.md
@@ -10,7 +10,7 @@ This is based on the wonderful [article](https://susi.dev/fully-integrate-ddev-a
 
 - PhpStorm 2021.3 or higher
 - You may need to add the `PHP Docker` plugin.
-- As of version v1.18.2, DDEV is bundled with its own docker-compose binary, using Compose V2 by default. Enable _Use Compose V2_ in PHPStorm _Settings/Preferences | Build, Execution, Deployment | Docker | Tools_, in case you have an up to date docker-compose binary installed (Check with `docker-compose version` > 2.0). Otherwise, you can also set the bundled docker-compose binary as _Docker Compose executable_ which you can be found in `~/.ddev/bin`. In this case, you do not need to select the _Use Compose V2_ Checkbox.
+DDEV uses docker-compose v2 by default, so enable the **Use Compose V2** checkbox  in `PHPStorm _Settings/Preferences | Build, Execution, Deployment | Docker | Tools` and set the "Docker Compose executable" to ddev's private docker-compose binary at `~/.ddev/bin/docker-compose` (Home directory, `.ddev/bin/docker-compose.). However, if using PhpStorm on Windows side with WSL2 you'll need to use a docker-compose v2 binary as provided by Docker Desktop, normally `C:\Program Files\Docker\Docker\resources\bin\docker-compose`.
 - Any OS platform, but if you're using Windows PhpStorm with WSL2 the path mappings are slightly more complex. WSL2 instructions are provided where necessary.
 
 #### Setup Technique


### PR DESCRIPTION
## The Problem/Issue/Bug:
The documentation currently contains information about a bug in PHPStorm that does not allow the use of Docker Compose V2 and provides a workaround by downgrading DDEV to use V1. This is no longer necessary as PHPStorm can use Compose V2 if it is available on the system, alternatively the bundled Docker Compose binary can be used.

## How this PR Solves The Problem:
The documentation section has been updated to recommend using your system's Docker Compose binary in V2 mode or using the bundled binary.

## Manual Testing Instructions:
None

## Automated Testing Overview:
None

## Related Issue Link(s):
https://youtrack.jetbrains.com/issue/WI-61205

## Release/Deployment notes:
None


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3631"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

