### PR TITLE
Drupal 10 will require php8.1, use it by default

### DIFF
--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -66,7 +66,7 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeDrupal7:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal8:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal9:   nodeps.PHPDefault,
-		nodeps.AppTypeDrupal10:  nodeps.PHP80,
+		nodeps.AppTypeDrupal10:  nodeps.PHP81,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:  nodeps.PHPDefault,
 		nodeps.AppTypeMagento:   nodeps.PHPDefault,

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -348,7 +348,7 @@ func drupal6ConfigOverrideAction(app *DdevApp) error {
 
 // drupal10ConfigOverrideAction overrides php_version for D10, requires PHP8.0
 func drupal10ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP80
+	app.PHPVersion = nodeps.PHP81
 	return nil
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

It was announced that Drupal 10 will require php8.1, so we'll use it by default

## Manual Testing Instructions:

Create a drupal10 project. It should automatically have php8.1 as the PHP version.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3633"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

