### PR TITLE
We shouldn't use util.Failed in api method, it exits everything

### DIFF
--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -251,7 +251,7 @@ func (p *Provider) UploadDB() error {
 	}
 	err = p.app.ExecOnHostOrService(s, p.injectedEnvironment()+"; "+p.DBPushCommand.Command)
 	if err != nil {
-		util.Failed("Failed to exec %s on %s: %v", p.DBPushCommand.Command, s, err)
+		return fmt.Errorf("Failed to exec %s on %s: %v", p.DBPushCommand.Command, s, err)
 	}
 	return nil
 }
@@ -272,7 +272,7 @@ func (p *Provider) UploadFiles() error {
 	}
 	err := p.app.ExecOnHostOrService(s, p.injectedEnvironment()+"; "+p.FilesPushCommand.Command)
 	if err != nil {
-		util.Failed("Failed to exec %s on %s: %v", p.FilesPushCommand.Command, s, err)
+		return fmt.Errorf("Failed to exec %s on %s: %v", p.FilesPushCommand.Command, s, err)
 	}
 	return nil
 }
@@ -308,7 +308,7 @@ func (p *Provider) getFilesBackup() (filename string, error error) {
 
 	err := p.app.ExecOnHostOrService(s, p.injectedEnvironment()+"; "+p.FilesPullCommand.Command)
 	if err != nil {
-		util.Failed("Failed to exec %s on %s: %v", p.FilesPullCommand.Command, s, err)
+		return "", fmt.Errorf("Failed to exec %s on %s: %v", p.FilesPullCommand.Command, s, err)
 	}
 
 	return filepath.Join(p.getDownloadDir(), "files"), nil


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noted looking through CirclCI logs that a failed TestPantheonPush actually exited the whole test. It's not supposed to do that. 

## How this PR Solves The Problem:

Don't use util.Failed() (which immediately exits) in api methods.

## Manual Testing Instructions:

Make sure `ddev push` works fine in example.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3635"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

