### PR TITLE
Fix up golangci-lint for v3 after update

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,12 +21,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
     - uses: actions/checkout@v2
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3.1.0
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.42
+        version: v1.44
 
         # Optional: working directory, useful for monorepos
         # working-directory: somedir


### PR DESCRIPTION
## The Problem/Issue/Bug:

A dependabot auto-PR tried to do this in https://github.com/drud/ddev/pull/3638 but it completely failed



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3640"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

