### PR TITLE
Add ddev get --list so people can discover add-ons, fixes #3552, fixes #3553

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -217,17 +217,19 @@ func renderRepositoryList(repos []github.Repository) string {
 		}
 		return false
 	})
+	t.AppendHeader(table.Row{"Add-on", "Description"})
+
 	for _, repo := range repos {
-		n := repo.GetFullName()
+		d := repo.GetDescription()
 		if repo.GetOwner().GetLogin() == globalconfig.DdevGithubOrg {
-			n = "*" + n
+			d = d + "*"
 		}
-		t.AppendRow([]interface{}{n, text.WrapSoft(repo.GetDescription(), 50)})
+		t.AppendRow([]interface{}{repo.GetFullName(), text.WrapSoft(d, 50)})
 	}
 
 	t.Render()
 
-	return out.String() + "Add-ons marked with '*' are official, maintained ddev add-ons."
+	return out.String() + "Add-ons marked with '*' are official, maintained DDEV add-ons."
 }
 
 func init() {

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -1,19 +1,27 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/output"
+	"github.com/drud/ddev/pkg/styles"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/google/go-github/github"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/otiai10/copy"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -29,12 +37,33 @@ type installDesc struct {
 var Get = &cobra.Command{
 	Use:   "get <addonOrURL> [project]",
 	Short: "Get/Download a 3rd party add-on (service, provider, etc.)",
-	Long:  `Get/Download a 3rd party add-on (service, provider, etc.). This can be a github repo, in which case the latest release will be used, or it can be a link to a .tar.gz in the correct format (like a particular release's .tar.gz) or it can be a local directory.`,
+	Long:  `Get/Download a 3rd party add-on (service, provider, etc.). This can be a github repo, in which case the latest release will be used, or it can be a link to a .tar.gz in the correct format (like a particular release's .tar.gz) or it can be a local directory. Use 'ddev get --list' or 'ddev get --list --all' to see a list of available add-ons. Without --all it shows only official ddev add-ons.`,
 	Example: `ddev get drud/ddev-drupal9-solr
 ddev get https://github.com/drud/ddev-drupal9-solr/archive/refs/tags/v0.0.5.tar.gz
 ddev get /path/to/package
-ddev get /path/to/tarball.tar.gz`,
+ddev get /path/to/tarball.tar.gz
+ddev get --list
+ddev get --list --all
+`,
 	Run: func(cmd *cobra.Command, args []string) {
+		officialOnly := true
+		if cmd.Flag("list").Changed {
+			if cmd.Flag("all").Changed {
+				officialOnly = false
+			}
+			repos, err := listAvailable(officialOnly)
+			if err != nil {
+				util.Failed("Failed to list available add-ons: %v", err)
+			}
+			if len(repos) == 0 {
+				util.Warning("No ddev add-ons found with topics 'ddev-get'.")
+				return
+			}
+			out := renderRepositoryList(repos)
+			output.UserOut.WithField("raw", repos).Print(out)
+			return
+		}
+
 		if len(args) < 1 {
 			util.Failed("You must specify an add-on to download")
 		}
@@ -73,22 +102,12 @@ ddev get /path/to/tarball.tar.gz`,
 		case len(parts) == 2: // github.com/owner/sourceRepoArg
 			owner := parts[0]
 			repo := parts[1]
-			client := github.NewClient(nil)
 			ctx := context.Background()
 
-			// Use authenticated client for higher rate limit, normally only needed for tests
-			githubToken := os.Getenv("DDEV_GITHUB_TOKEN")
-			if githubToken != "" {
-				ts := oauth2.StaticTokenSource(
-					&oauth2.Token{AccessToken: githubToken},
-				)
-				tc := oauth2.NewClient(ctx, ts)
-				client = github.NewClient(tc)
-			}
-
-			releases, _, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{})
+			client := getGithubClient(ctx)
+			releases, resp, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{})
 			if err != nil {
-				util.Failed("Unable to get releases for %v: %v", repo, err)
+				util.Failed("Unable to get releases for %v: %v\nresp.Rate=%v", repo, err, resp.Rate)
 			}
 			if len(releases) == 0 {
 				util.Failed("No releases found for %v", repo)
@@ -164,6 +183,83 @@ ddev get /path/to/tarball.tar.gz`,
 	},
 }
 
+func renderRepositoryList(repos []github.Repository) string {
+	var out bytes.Buffer
+
+	t := table.NewWriter()
+	t.SetOutputMirror(&out)
+	styles.SetGlobalTableStyle(t)
+	tWidth, _ := nodeps.GetTerminalWidthHeight()
+	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
+		t.SetAllowedRowLength(tWidth)
+	}
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{
+			Name: "Service",
+		},
+		{
+			Name: "Description",
+		},
+	})
+	sort.Slice(repos, func(i, j int) bool {
+		if repos[i].GetOwner().GetLogin() == "drud" {
+			return true
+		}
+		return false
+	})
+	for _, repo := range repos {
+		n := repo.GetFullName()
+		if repo.GetOwner().GetLogin() == globalconfig.DdevGithubOrg {
+			n = "*" + n
+		}
+		t.AppendRow([]interface{}{n, text.WrapSoft(repo.GetDescription(), 50)})
+	}
+
+	t.Render()
+
+	return out.String() + "Add-ons marked with '*' are official, maintained ddev add-ons."
+}
+
 func init() {
+	Get.Flags().Bool("list", true, fmt.Sprintf(`List available add-ons for 'ddev get'`))
+	Get.Flags().Bool("all", true, fmt.Sprintf(`List unofficial add-ons for 'ddev get' in addition to the official ones`))
 	RootCmd.AddCommand(Get)
+}
+
+// getGithubClient creates the required github client
+func getGithubClient(ctx context.Context) *github.Client {
+	client := github.NewClient(nil)
+
+	// Use authenticated client for higher rate limit, normally only needed for tests
+	githubToken := os.Getenv("DDEV_GITHUB_TOKEN")
+	if githubToken != "" {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: githubToken},
+		)
+		tc := oauth2.NewClient(ctx, ts)
+		client = github.NewClient(tc)
+	}
+	return client
+}
+
+// listAvailable lists the services that are listed on github
+func listAvailable(officialOnly bool) ([]github.Repository, error) {
+	client := getGithubClient(context.Background())
+	q := "topic:ddev-get fork:true"
+	if officialOnly {
+		q = q + " org:" + globalconfig.DdevGithubOrg
+	}
+
+	repos, resp, err := client.Search.Repositories(context.Background(), q, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get list of available services: %v\nresp.Rate=%v", err, resp.Rate)
+	}
+	out := ""
+	for _, r := range repos.Repositories {
+		out = out + fmt.Sprintf("%s: %s\n", r.GetFullName(), r.GetDescription())
+	}
+	if len(repos.Repositories) == 0 {
+		return nil, fmt.Errorf("No add-ons found")
+	}
+	return repos.Repositories, err
 }

--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -42,7 +42,7 @@ func TestCmdGet(t *testing.T) {
 	// Make sure get --list works first
 	out, err := exec.RunHostCommand(DdevBin, "get", "--list")
 	assert.NoError(err, "failed ddev get --list: %v (%s)", err, out)
-	assert.Contains(out, "*drud/ddev-memcached")
+	assert.Contains(out, "drud/ddev-memcached")
 
 	tarballFile := filepath.Join(origDir, "testdata", t.Name(), "ddev-memcached.tar.gz")
 

--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -39,7 +39,14 @@ func TestCmdGet(t *testing.T) {
 		assert.NoError(err)
 	})
 
+	// Make sure get --list works first
+	out, err := exec.RunHostCommand(DdevBin, "get", "--list")
+	assert.NoError(err, "failed ddev get --list: %v (%s)", err, out)
+	assert.Contains(out, "*drud/ddev-memcached")
+
 	tarballFile := filepath.Join(origDir, "testdata", t.Name(), "ddev-memcached.tar.gz")
+
+	// Test with many input styles
 	for _, arg := range []string{
 		"drud/ddev-memcached",
 		"https://github.com/drud/ddev-memcached/archive/refs/tags/v1.1.1.tar.gz",
@@ -50,6 +57,7 @@ func TestCmdGet(t *testing.T) {
 		assert.FileExists(app.GetConfigPath("docker-compose.memcached.yaml"))
 	}
 
+	// Test with a directory-path input
 	exampleDir := filepath.Join(origDir, "testdata", t.Name(), "example-repo")
 	_, err = exec.RunHostCommand(DdevBin, "get", exampleDir)
 	assert.NoError(err)

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -1,16 +1,34 @@
 ## Additional Service Configurations for ddev
 
-DDEV-Local projects can be extended to provide additional services. This is achieved by adding docker-compose files to a project's .ddev directory that defines the added service(s). This page provides configurations for services that are ready to be added to your project with minimal setup.
+DDEV-Local projects can be extended to provide additional add-ons, including services. This is achieved by adding docker-compose files to a project's .ddev directory that defines the added add-on(s).
 
 If you need a service not provided here, see [Defining an additional service with Docker Compose](custom-compose-files.md)
 
-Although anyone can create their own services with a `docker-compose.*.yaml` file, a growing number of services are supported and tested and can be installed with the `ddev get` command starting with DDEV v1.19.0-alpha3.
+Although anyone can create their own services with a `.ddev/docker-compose.*.yaml` file, a growing number of services are supported and tested and can be installed with the `ddev get` command starting with DDEV v1.19.0+.
+
+You can see available supported and tested add-ons with the command `ddev get --list`. To see all possible add-ons (not necessarily supported or tested), use `ddev get --list --all`.
+
+For example,
+
+```bash
+$ ddev get --list
+┌─────────────────────────┬───────────────────────────────────────────────┐
+│ *drud/ddev-beanstalkd   │ beanstalkd for ddev                           │
+├─────────────────────────┼───────────────────────────────────────────────┤
+│ *drud/ddev-memcached    │ Install memcached as an extra service in ddev │
+├─────────────────────────┼───────────────────────────────────────────────┤
+│ *drud/ddev-drupal9-solr │ Drupal 9 Apache Solr installation for DDEV    │
+└─────────────────────────┴───────────────────────────────────────────────┘
+Add-ons marked with '*' are official, maintained ddev add-ons.
+```
+
+Here are some of the add-ons that are currently supported:
 
 * [Apache Solr for Drupal 9](https://github.com/drud/ddev-drupal9-solr): `ddev get drud/ddev-drupal9-solr`.
 * [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
 * [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev get drud/ddev-beanstalkd`.
 
-## Additional services in ddev-contrib (MongoDB, PostgresSQL, etc)
+## Additional services in ddev-contrib (MongoDB, Elasticsearch, etc)
 
 Commonly used services will be migrated from the ddev-contrib repository to individual, tested, supported repositories, but
  [ddev-contrib](https://github.com/drud/ddev-contrib) repository has a wealth of additional examples and instructions:
@@ -20,9 +38,7 @@ Commonly used services will be migrated from the ddev-contrib repository to indi
 * **Headless Chrome**: See [Headless Chrome for Behat Testing](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/headless-chrome)
 * **MongoDB**: See [MongoDB](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/mongodb).
 * **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/old_php)
-* **PostgresSQL**: See [PostgresSQL](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/postgres).
 * **RabbitMQ**: See [RabbitMQ](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
-* **Redis**: See [redis](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/redis).
 * **Redis Commander**: See [redis commander](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/redis-commander)
 * **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/typo3-solr)
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -186,7 +186,7 @@ func (app *DdevApp) Push(provider *Provider, skipDbArg bool, skipFilesArg bool) 
 			return err
 		}
 
-		output.UserOut.Printf("ProjectFiles uploaded")
+		output.UserOut.Printf("Files uploaded")
 	}
 	err = app.ProcessHooks("post-push")
 	if err != nil {

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -9,6 +9,8 @@ const (
 	DdevRouterContainer   = "ddev-router"
 )
 
+const DdevGithubOrg = "drud"
+
 // ValidOmitContainers is the valid omit's that can be done in for a project
 var ValidOmitContainers = map[string]bool{
 	DdevRouterContainer:   true,


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3552
* #3553

`ddev get` is great, but it doesn't help people discover the add-ons that may be available.

## How this PR Solves The Problem:

With this PR you can `ddev get --list` or `ddev get --list --all` (--all picks up unofficial add-ons)

## Manual Testing Instructions:

- [ ] `ddev get --list`
- [ ] `ddev get --list --all`
- [ ] `ddev get drud/ddev-memcached` and pay attention to what it says and see if it's helpful.

## Automated Testing Overview:

* Added just a bit to TestCmdGet



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3641"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

