### PR TITLE
The absolute available space value was wrong for checking docker disk space

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1118,7 +1118,7 @@ func CheckAvailableSpace() {
 		return
 	}
 	spacePercent, _ := strconv.Atoi(parts[1])
-	spaceAbsolute, _ := strconv.Atoi(parts[0])
+	spaceAbsolute, _ := strconv.Atoi(parts[0]) // Note that this is in KB
 
 	if spaceAbsolute < nodeps.MinimumDockerSpaceWarning {
 		util.Error("Your docker installation has only %d available disk space, less than %d warning level (%d%% used). Please increase disk image size.", spaceAbsolute, nodeps.MinimumDockerSpaceWarning, spacePercent)

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -107,7 +107,7 @@ const (
 	// DdevDefaultTLD is the top-level-domain used by default, can be overridden
 	DdevDefaultTLD                  = "ddev.site"
 	InternetDetectionTimeoutDefault = 750
-	MinimumDockerSpaceWarning       = 5000 * 1024 // 5GB
+	MinimumDockerSpaceWarning       = 5000000 // 5GB in KB (to compare against df reporting in KB)
 )
 
 // IsValidPHPVersion is a helper function to determine if a PHP version is valid, returning


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noticed in a casual test on Colima that the value provided for absolute disk space was calculated wrong.

## How this PR Solves The Problem:

Try to get it right

## Manual Testing Instructions:

Try testing with various values and make sure it works



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3646"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

