### PR TITLE
ddev drush should be available for drupal10

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -7,8 +7,8 @@
 ## OSTypes: darwin
 ## HostBinaryExists: /Applications/Sequel ace.app
 
-set -x
 query="mysql://root:root@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
 
+set -x
 open "$query" -a "/Applications/Sequel Ace.app/Contents/MacOS/Sequel Ace"
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -9,7 +9,6 @@
 ## OSTypes: darwin
 ## HostBinaryExists: /Applications/TablePlus.app
 
-set -x
 dbtype=${DDEV_DBIMAGE%:*}
 driver=mysql
 if [[ $dbtype == "postgres" ]]; then
@@ -17,5 +16,6 @@ if [[ $dbtype == "postgres" ]]; then
 fi
 query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
 
+set -x
 open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/drush
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/drush
@@ -4,7 +4,7 @@
 ## Description: Run drush CLI inside the web container
 ## Usage: drush [flags] [args]
 ## Example: "ddev drush uli" or "ddev drush sql-cli" or "ddev drush --version"
-## ProjectTypes: drupal7,drupal8,drupal9,backdrop
+## ProjectTypes: drupal7,drupal8,drupal9,drupal10,backdrop
 ## ExecRaw: true
 
 if ! command -v drush >/dev/null; then


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noted in testing v1.19.0-rc3 that `ddev drush` didn't work on drush10. It should.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3655"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

