### PR TITLE
Compatibility with docker-compose v1, fixes #3649

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,7 +37,7 @@
             "args": ["list"],
             "showLog": true
         },
-{
+        {
             "name": "pkg-level test",
             "type": "go",
             "request": "launch",
@@ -47,6 +47,17 @@
             "host": "127.0.0.1",
             "program": "${workspaceRoot}/pkg/plugins/platform",
             "env": {"DDEV_DEBUG": true},
+            "args": [],
+            "showLog": true
+        },
+        {
+            "name": "TestComposeV1",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "remotePath": "",
+            "program": "${workspaceRoot}/pkg/ddevapp",
+            "env": {"GOTEST_SHORT": "true"},
             "args": [],
             "showLog": true
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,7 +56,7 @@
             "request": "launch",
             "mode": "test",
             "remotePath": "",
-            "program": "${workspaceRoot}/pkg/ddevapp",
+            "program": "${workspaceRoot}/pkg/ddevapp/compose_test.go",
             "env": {"GOTEST_SHORT": "true"},
             "args": [],
             "showLog": true

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/ddevapp"
 	"os"
 	"sort"
 	"strings"
@@ -36,7 +37,7 @@ ddev delete images --all`,
 			}
 		}
 		util.Success("Powering off ddev to avoid conflicts")
-		powerOff()
+		ddevapp.PowerOff()
 
 		client := dockerutil.GetDockerClient()
 

--- a/cmd/ddev/cmd/poweroff.go
+++ b/cmd/ddev/cmd/poweroff.go
@@ -2,10 +2,6 @@ package cmd
 
 import (
 	"github.com/drud/ddev/pkg/ddevapp"
-	"github.com/drud/ddev/pkg/dockerutil"
-	"github.com/drud/ddev/pkg/util"
-	"github.com/drud/ddev/pkg/version"
-	docker "github.com/fsouza/go-dockerclient"
 	"github.com/spf13/cobra"
 )
 
@@ -18,45 +14,10 @@ var PoweroffCommand = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Aliases: []string{"powerdown"},
 	Run: func(cmd *cobra.Command, args []string) {
-		powerOff()
+		ddevapp.PowerOff()
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(PoweroffCommand)
-}
-
-func powerOff() {
-	apps, err := ddevapp.GetProjects(true)
-	if err != nil {
-		util.Failed("Failed to get project(s): %v", err)
-	}
-
-	// Remove any custom certs that may have been added
-	_, _, err = dockerutil.RunSimpleContainer(version.GetWebImage(), "", []string{"sh", "-c", "rm -f /mnt/ddev-global-cache/custom_certs/*"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, "", true, false, nil)
-	if err != nil {
-		util.Warning("Failed removing custom certs: %v", err)
-	}
-
-	// Iterate through the list of apps built above, removing each one.
-	for _, app := range apps {
-		if err := app.Stop(false, false); err != nil {
-			util.Failed("Failed to stop project %s: \n%v", app.GetName(), err)
-		}
-		util.Success("Project %s has been stopped.", app.GetName())
-	}
-
-	if err := ddevapp.RemoveSSHAgentContainer(); err != nil {
-		util.Error("Failed to remove ddev-ssh-agent: %v", err)
-	}
-	// Remove current global network ("ddev") plus the former "ddev_default"
-	removals := []string{"ddev_default"}
-	for _, networkName := range removals {
-		err = dockerutil.RemoveNetwork(networkName)
-		_, isNoSuchNetwork := err.(*docker.NoSuchNetwork)
-		// If it's a "no such network" there's no reason to report error
-		if err != nil && !isNoSuchNetwork {
-			util.Warning("Unable to remove network %s: %v", "ddev", err)
-		}
-	}
 }

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -202,7 +202,7 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 
 		okPoweroff := util.Confirm("It looks like you have a new DDEV version. During an upgrade it's important to `ddev poweroff`. May I do `ddev poweroff` before continuing? This does no harm and loses no data.")
 		if okPoweroff {
-			powerOff()
+			ddevapp.PowerOff()
 		}
 		return nil
 	}

--- a/pkg/ddevapp/compose_test.go
+++ b/pkg/ddevapp/compose_test.go
@@ -1,0 +1,59 @@
+package ddevapp_test
+
+import (
+	"fmt"
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/util"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestComposeV1 makes sure we can do basic actions with docker-compose v1
+func TestComposeV1(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("Skipping  because arm64 is not supported for docker-compose v1")
+	}
+	assert := asrt.New(t)
+	app := &ddevapp.DdevApp{}
+
+	// Make sure this leaves us in the original test directory
+	origDir, _ := os.Getwd()
+
+	site := TestSites[0]
+
+	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStart", site.Name))
+
+	_, err := exec.RunHostCommand(DdevBin, "poweroff")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		runTime()
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		err = globalconfig.ReadGlobalConfig()
+		require.NoError(t, err)
+		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = ""
+		err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+		require.NoError(t, err)
+	})
+
+	err = globalconfig.ReadGlobalConfig()
+	require.NoError(t, err)
+	globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = "v1.29.2"
+	err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+	require.NoError(t, err)
+	err = app.Init(site.Dir)
+	assert.NoError(err)
+
+	err = app.Start()
+	assert.NoError(err)
+
+}

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -35,7 +35,7 @@ func (app *DdevApp) WriteDockerComposeYAML() error {
 	if err != nil {
 		return err
 	}
-	fullContents, _, err := dockerutil.ComposeCmd(files, "convert")
+	fullContents, _, err := dockerutil.ComposeCmd(files, "config")
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -93,7 +93,7 @@ func fixupComposeYaml(yamlStr string, app *DdevApp) (map[string]interface{}, err
 		// Find any services that have bind-mount to app.AppRoot and make them relative
 		if serviceMap["volumes"] != nil {
 			volumes := serviceMap["volumes"].([]interface{})
-			for _, volume := range volumes {
+			for k, volume := range volumes {
 				// With docker-compose v1, the volume might not be a map, it might be
 				// old-style "/Users/rfay/workspace/d9/.ddev:/mnt/ddev_config:ro"
 				if volumeMap, ok := volume.(map[interface{}]interface{}); ok {
@@ -105,7 +105,7 @@ func fixupComposeYaml(yamlStr string, app *DdevApp) (map[string]interface{}, err
 				} else if volumeMap, ok := volume.(string); ok {
 					parts := strings.SplitN(volumeMap, ":", 2)
 					if parts[0] == app.AppRoot && len(parts) >= 2 {
-						volumeMap = "../" + ":" + parts[1]
+						volumes[k] = "../" + parts[1]
 					}
 				}
 			}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -628,13 +628,17 @@ func TestConfigValidate(t *testing.T) {
 	app.AdditionalHostnames = []string{"good", "b@d"}
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "invalid hostname")
+	if err != nil {
+		assert.Contains(err.Error(), "invalid hostname")
+	}
 
 	app.AdditionalHostnames = []string{}
 	app.AdditionalFQDNs = []string{"good.com", "b@d.com"}
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "invalid hostname")
+	if err != nil {
+		assert.Contains(err.Error(), "invalid hostname")
+	}
 
 	app.AdditionalFQDNs = []string{}
 	// Timezone validation isn't possible on Windows.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2050,7 +2050,7 @@ func deleteServiceVolumes(app *DdevApp) {
 				if err != nil {
 					util.Warning("could not remove volume %s: %v", volName, err)
 				} else {
-					util.Success("Deleting third-party persistent volume %s for service %s...", volName, s)
+					util.Success("Deleting third-party persistent volume %s", volName)
 				}
 			}
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -858,6 +858,7 @@ func (app *DdevApp) Start() error {
 	var err error
 
 	app.DockerEnv()
+	dockerutil.EnsureDdevNetwork()
 	volumesNeeded := []string{"ddev-global-cache", "ddev-" + app.Name + "-snapshots"}
 	for _, v := range volumesNeeded {
 		_, err = dockerutil.CreateVolume(v, "local", nil)

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -1,0 +1,43 @@
+package ddevapp
+
+import (
+	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/version"
+	"github.com/fsouza/go-dockerclient"
+)
+
+func PowerOff() {
+	apps, err := GetProjects(true)
+	if err != nil {
+		util.Failed("Failed to get project(s): %v", err)
+	}
+
+	// Remove any custom certs that may have been added
+	_, _, err = dockerutil.RunSimpleContainer(version.GetWebImage(), "", []string{"sh", "-c", "rm -f /mnt/ddev-global-cache/custom_certs/*"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, "", true, false, nil)
+	if err != nil {
+		util.Warning("Failed removing custom certs: %v", err)
+	}
+
+	// Iterate through the list of apps built above, removing each one.
+	for _, app := range apps {
+		if err := app.Stop(false, false); err != nil {
+			util.Failed("Failed to stop project %s: \n%v", app.GetName(), err)
+		}
+		util.Success("Project %s has been stopped.", app.GetName())
+	}
+
+	if err := RemoveSSHAgentContainer(); err != nil {
+		util.Error("Failed to remove ddev-ssh-agent: %v", err)
+	}
+	// Remove current global network ("ddev") plus the former "ddev_default"
+	removals := []string{"ddev_default"}
+	for _, networkName := range removals {
+		err = dockerutil.RemoveNetwork(networkName)
+		_, isNoSuchNetwork := err.(*docker.NoSuchNetwork)
+		// If it's a "no such network" there's no reason to report error
+		if err != nil && !isNoSuchNetwork {
+			util.Warning("Unable to remove network %s: %v", "ddev", err)
+		}
+	}
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3649 

* The new ddev v1.19 was using `docker-compose convert`, which was listed as an *alias* of `docker-compose config`, but in reality, `docker-compose convert` is not valid in docker-compose v1.
* I also noted that docker-compose v1 doesn't create a "name" for a volume, so volumes wouldn't be deleted if they don't have an explicit name. Rather than trying to work around that I just added a name in ddev-drupal9-solr, https://github.com/drud/ddev-drupal9-solr/commit/d00c4acaeea187238e6e9ec3871f6e954d093be6

## Manual Testing Instructions:

* Start a project with docker-compose v1 enabled globally

## Automated Testing Overview:

Added TestComposeV1


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3657"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

