### PR TITLE
Use recent ddev version for gitpod [skip ci]

### DIFF
--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -9,7 +9,7 @@ RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.17.
 
 USER gitpod
 
-RUN curl -sL -o /tmp/install_ddev.sh https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash /tmp/install_ddev.sh
+RUN curl -sL -o /tmp/install_ddev.sh https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash /tmp/install_ddev.sh v1.19.0-rc1
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Current gitpod doesn't work quite right with older ddev, so this puts ddev v1.19.0-rc1 inside the ddev-gitpod-base image



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3661"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

