### PR TITLE
Update typo "Pull path" vs "Full path"

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -442,7 +442,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 			extPathPrompt = true
 		}
 		output.UserOut.Println("Provide the path to the database you want to import.")
-		fmt.Print("Pull path: ")
+		fmt.Print("Full path: ")
 
 		imPath = util.GetInput("")
 	}


### PR DESCRIPTION
Pull path is misleading. I think it should be full path?

## The Problem/Issue/Bug:

Typo

## How this PR Solves The Problem:
Fixes typo




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3663"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

