### PR TITLE
Improve `ddev nvm` persistence and availability, starting with no internet

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
@@ -18,25 +18,6 @@ fi
 # set a fancy prompt (non-color, overwrite the one in /etc/profile)
 PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 
-# Commented out, don't overwrite xterm -T "title" -n "icontitle" by default.
-# If this is an xterm set the title to user@host:dir
-#case "$TERM" in
-#xterm*|rxvt*)
-#    PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME}: ${PWD}\007"'
-#    ;;
-#*)
-#    ;;
-#esac
-
-# enable bash completion in interactive shells
-#if ! shopt -oq posix; then
-#  if [ -f /usr/share/bash-completion/bash_completion ]; then
-#    . /usr/share/bash-completion/bash_completion
-#  elif [ -f /etc/bash_completion ]; then
-#    . /etc/bash_completion
-#  fi
-#fi
-
 # if the command-not-found package is installed, use it
 if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-not-found ]; then
 	function command_not_found_handle {
@@ -55,3 +36,6 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
 fi
 
 export HISTFILE=/mnt/ddev-global-cache/bashhistory/${HOSTNAME}/bash_history
+
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
@@ -1,1 +1,4 @@
 export PATH="~/bin:$PATH:/var/www/html/vendor/bin:/var/www/html/bin"
+
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -81,7 +81,7 @@ sudo mkdir -p ${TERMINUS_CACHE_DIR}
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory,nvm_dir}/${HOSTNAME}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 sudo ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR}
-install_nvm.sh
+if [ ! -f /usr/local/nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # /mnt/ddev_config/.homeadditions may be either
 # a bind-mount, or a volume mount, but we don't care,

--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -117,7 +117,3 @@ for f in /etc/bashrc/*.bashrc; do
 done
 
 for i in $(\ls $HOME/.bashrc.d/* 2>/dev/null); do source $i; done
-
-export NVM_DIR="/usr/local/nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion

--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -117,3 +117,7 @@ for f in /etc/bashrc/*.bashrc; do
 done
 
 for i in $(\ls $HOME/.bashrc.d/* 2>/dev/null); do source $i; done
+
+export NVM_DIR="/usr/local/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -78,7 +78,7 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory,nvm_dir}/${HOSTNAME}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 sudo ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR}
-install_nvm.sh
+if [ ! -f /usr/local/nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # This will need to be done by a separate container with privileges
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var DockerComposeFileFormatVersion = "3.6"
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.19.0-rc1" // Note that this can be overridden by make
+var WebTag = "20220304_nvm" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* nvm-selected default node version wasn't shown in `ddev exec node --version`
* Startup with no internet caused failure

## How this PR Solves The Problem:

## Manual Testing Instructions:

- [x] `ddev nvm install 6 && ddev nvm alias default 6` and then `ddev exec node --version`; `ddev restart` and `ddev exec node --version`
- [x] Start a project with existing nvm with no internet available
- [x] Start a project with no existing nvm setup (fresh clean project) with no internet available

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3664"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

