### PR TITLE
Quiet down hook output

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -813,7 +813,7 @@ func (app *DdevApp) ComposeFiles() ([]string, error) {
 // ProcessHooks executes Tasks defined in Hooks
 func (app *DdevApp) ProcessHooks(hookName string) error {
 	if cmds := app.Hooks[hookName]; len(cmds) > 0 {
-		output.UserOut.Printf("Executing %s hook...", hookName)
+		output.UserOut.Debugf("Executing %s hook...", hookName)
 	}
 
 	for _, c := range app.Hooks[hookName] {

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -31,14 +31,15 @@ func LogSetUp() {
 	}
 
 	UserOutFormatter.DisableTimestamp = true
-	// Always use log.DebugLevel for UserOut
-	UserOut.Level = log.DebugLevel // UserOut will by default always output
-
-	// But we use custom DDEV_DEBUG-settable loglevel for log
+	// Use default log.InfoLevel for UserOut
+	UserOut.Level = log.InfoLevel // UserOut will by default always output
 	logLevel := log.InfoLevel
+
+	// But we use custom DDEV_DEBUG-settable loglevel for log; export DDEV_DEBUG=true
 	ddevDebug := os.Getenv("DDEV_DEBUG")
 	if ddevDebug != "" {
 		logLevel = log.DebugLevel
+		UserOut.Level = log.DebugLevel
 	}
 	log.SetLevel(logLevel)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

Hooks output is too chatty, low signal-to-noise ratio

## How this PR Solves The Problem:

Only output extra hook output if DDEV_DEBUG=true

## Manual Testing Instructions:

- [x] Create a hook that does output. Execute with and without DDEV_DEBUG=true

## Automated Testing Overview:

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3667"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

