### PR TITLE
Must pull image after calculating them, fixes #3648

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -911,11 +911,6 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
-	err = app.PullContainerImages()
-	if err != nil {
-		util.Warning("Unable to pull docker images: %v", err)
-	}
-
 	dockerutil.CheckAvailableSpace()
 
 	// Copy any homeadditions content into .ddev/.homeadditions
@@ -1018,6 +1013,12 @@ func (app *DdevApp) Start() error {
 	err = app.WriteDockerComposeYAML()
 	if err != nil {
 		return err
+	}
+
+	// This needs to be done after WriteDockerComposeYAML() to get the right images
+	err = app.PullContainerImages()
+	if err != nil {
+		util.Warning("Unable to pull docker images: %v", err)
 	}
 
 	err = app.CheckAddonIncompatibilities()

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -14,7 +14,7 @@ func PowerOff() {
 	}
 
 	// Remove any custom certs that may have been added
-	_, _, err = dockerutil.RunSimpleContainer(version.GetWebImage(), "", []string{"sh", "-c", "rm -f /mnt/ddev-global-cache/custom_certs/*"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, "", true, false, nil)
+	_, _, err = dockerutil.RunSimpleContainer(version.BusyboxImage, "", []string{"sh", "-c", "rm -f /mnt/ddev-global-cache/custom_certs/*"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, "", true, false, nil)
 	if err != nil {
 		util.Warning("Failed removing custom certs: %v", err)
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

In the case of changing additional services, etc, ddev could pull the wrong set of images. It needs to wait until after the .ddev-docker-compose-full.yaml is written to find out what images it's looking for.

## How this PR Solves The Problem:

* Move the pull until after the creation of yaml
* Also uses busybox for ddev poweroff instead of surprising people with a pull there. 

## Manual Testing Instructions:

- [x] Create a project that has a particular `docker-compose.*.yml`. Start it. Stop and change/add. Start, should pull new.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3668"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

