### PR TITLE
Update ddev list and ddev describe to try to not break URLs

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -82,8 +82,8 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 				WidthMax: 10,
 			},
 			{
-				Name:     "URL/Port",
-				WidthMax: int(urlPortWidth),
+				Name: "URL/Port",
+				//WidthMax: int(urlPortWidth),
 			},
 			{
 				Name:     "Info",

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -96,8 +96,8 @@ func CreateAppTable(out *bytes.Buffer) table.Writer {
 
 		t.SetColumnConfigs([]table.ColumnConfig{
 			{
-				Name:     "Name",
-				WidthMax: nameWidth,
+				Name: "Name",
+				//WidthMax: nameWidth,
 			},
 			{
 				Name:     "Type",
@@ -108,8 +108,8 @@ func CreateAppTable(out *bytes.Buffer) table.Writer {
 				WidthMax: locationWidth,
 			},
 			{
-				Name:     "URL",
-				WidthMax: urlWidth,
+				Name: "URL",
+				//WidthMax: urlWidth,
 			},
 			{
 				Name:     "Status",


### PR DESCRIPTION
## The Problem/Issue/Bug:

See 
* https://github.com/jedib0t/go-pretty/issues/191

`ddev list` and `ddev describe` sometimes inappropriately wrap URLs

## How this PR Solves The Problem:

Remove the max width for those URL columns.

## Manual Testing Instructions:

- [x] `ddev list` with projects with longer URLs
- [x] `ddev describe` a project with longer URLs



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3669"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

