### PR TITLE
Make tests working from foreign repositories

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -1,6 +1,6 @@
 name: Colima tests
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "go.*"
       - "pkg/**"
@@ -27,7 +27,7 @@ defaults:
 
 env:
   DDEV_DEBUG: true
-  DDEV_GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
+  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   tests:

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -5,7 +5,7 @@ on:
     types: [completed]
 jobs:
   pr_comment:
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: startsWith(github.event.workflow_run.event, 'pull_request') && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,7 +5,7 @@ defaults:
     shell: bash
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "go.*"
       - "pkg/**"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "go.*"
       - "pkg/**"
@@ -23,7 +23,7 @@ env:
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
-  DDEV_GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
+  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   tests:


### PR DESCRIPTION
## The Problem/Issue/Bug:

Access to secrets is denied by default for PRs from foreign repositories and all tests using these will fail therefor.

## How this PR Solves The Problem:

The solution is to use the `pull_request_target` event instead of the simple `pull_request` event. This changes the behavior of the workflows for security reasons, the workflow is not loaded from the PR but always the base of it. This makes sure nobody can get access to the token and abuse it.

## Manual Testing Instructions:

Merge this PR and create a new PR from a foreign repository to verifiy if the tests are working as expected now.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3671"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

