### PR TITLE
Exclude a couple of commonly failing tests (TestDdevStartMultipleHostnames and TestInternalAndExternalAccessToURL) [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -496,9 +496,9 @@ func TestDdevStart(t *testing.T) {
 
 // TestDdevStartMultipleHostnames tests start with multiple hostnames
 func TestDdevStartMultipleHostnames(t *testing.T) {
-	//if nodeps.IsMacM1() {
-	//	t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
-	//}
+	if nodeps.IsMacM1() {
+		t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
+	}
 
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
@@ -3126,9 +3126,9 @@ func TestWebserverType(t *testing.T) {
 // TestInternalAndExternalAccessToURL checks we can access content
 // from host and from inside container by URL (with port)
 func TestInternalAndExternalAccessToURL(t *testing.T) {
-	//if nodeps.IsMacM1() {
-	//	t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
-	//}
+	if nodeps.IsMacM1() || dockerutil.IsColima() {
+		t.Skip("Skipping on mac M1/Colima to ignore problems with 'connection reset by peer'")
+	}
 
 	assert := asrt.New(t)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Some tests (TestDdevStartMultipleHostnames and TestInternalAndExternalAccessToURL) just don't run predictably on M1 or Colima. Just exclude them, as they get covered elsewhere.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3674"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

