### PR TITLE
v1.19.0 docs updates, version history, etc.

### DIFF
--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -9,7 +9,7 @@ RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.17.
 
 USER gitpod
 
-RUN curl -sL -o /tmp/install_ddev.sh https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash /tmp/install_ddev.sh v1.19.0-rc1
+RUN curl -sL -o /tmp/install_ddev.sh https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash /tmp/install_ddev.sh
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc
 

--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -15,7 +15,7 @@ Reasons to use Colima include:
 * Preferring a CLI-focused approach to Docker Desktop's GUI focus.
 
 * Install colima with `brew install colima` using homebrew or see the other [installation options](https://github.com/abiosoft/colima/blob/main/INSTALL.md).
-* Start colima: `colima start --cpu 4 --memory 4 --port-interface 127.0.0.1` will set up a colima instance with 4 CPUs and 4GB of memory allocated. Your needs may vary. After the first start you can just use `colima start --port-interface 127.0.0.1`. (The `--port-interface` line makes colima not allow connections on network interfaces other than localhost).
+* Start colima: `colima start --cpu 4 --memory 4` will set up a colima instance with 4 CPUs and 4GB of memory allocated. Your needs may vary. After the first start you can just use `colima start`.
 * `colima status` will show colima's status.
 * After a computer restart you'll need to `colima start` again.
 * If you don't have Docker Desktop installed, you'll need the docker client, `brew install docker`.

--- a/docs/users/topics/version-history.md
+++ b/docs/users/topics/version-history.md
@@ -2,12 +2,23 @@
 
 This version history has been driven by what we hear from our wonderful community of users. If you have lobbying for a favorite item or think things should be re-prioritized, just lobby in the [issue queue](https://github.com/drud/ddev/issues). We listen. Or talk to us in any of the [support locations](https://ddev.readthedocs.io/en/stable/#support).
 
-### Coming... v1.19
+### Coming... v1.20
 
-Take a look at the [v1.19 milestone](https://github.com/drud/ddev/milestone/53) to see what's currently slated. Comment there on your favorites, or lobby for other things to be added.
+Take a look at the [v1.20 milestone](https://github.com/drud/ddev/milestone/54) to see what's currently slated. Comment there on your favorites, or lobby for other things to be added.
 
-### v1.18 (Released 2021-09-28)
+### v1.19 (Released 2022-03)
 
+- [x] `ddev get` and `ddev get --list` allow quick installation of maintained, tested add-ons.
+- [x] Postgresql support alongside MariaDB and MySQL.
+- [x] Run on any platform without Docker Desktop. Colima support for macOS and docker-inside-WSL2 for Windows.
+- [x] Database snapshots are now gzipped, resulting in perhaps 20x size difference. A snapshot that used to use 207MB on disk is now 5MB.
+- [x] New `ddev service enable`, `ddev service disable`, `ddev php`, `ddev debug test`, `ddev debug dockercheck` commands.
+- [x] Support for remote docker instances.
+
+### v1.18 (Released 2021-09-28) and v1.18.2 (2021-12-08)
+
+- [x] gitpod.io support
+- [x] Integrated docker-compose so docker updates don't break things.
 - [x] Mutagen support results in a huge speedup for macOS and traditional Windows users
 - [x] Support docker-compose v1 and v2
 - [x] Support MariaDB 10.6
@@ -15,6 +26,7 @@ Take a look at the [v1.19 milestone](https://github.com/drud/ddev/milestone/53) 
 - [x] Improved integration with PhpStorm on all platforms, including WSL
 - [x] xhprof support for performance profiling alongside blackfire.io support
 - [x] Base image for the ddev-webserver is now Debian 11 Bullseye
+- [x] mysql5.7 and mysql8.0 support on arm64 (mac M1) machines.
 
 ### v1.17 (Released 2021-04-07)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Minor docs updates for v1.19.0 release
* Change the ddev-gitpod-base image to use install_ddev.sh without an argument



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3675"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

