### PR TITLE
Fix piles of dead containers from the docker build process

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,13 @@
 image: drud/ddev-gitpod-base:latest
 tasks:
   - name: build-run
-#    init: |
-#      # Compile ddev
-#      make
-#      cd /tmp && ddev config --auto
-#      ddev debug download-images
-#      ddev delete -Oy tmp
-#      mkcert -install
+    init: |
+      # Compile ddev
+      make
+      cd /tmp && ddev config --auto
+      ddev debug download-images
+      ddev delete -Oy tmp
+      mkcert -install
     command: |
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,13 @@
 image: drud/ddev-gitpod-base:latest
 tasks:
   - name: build-run
-    init: |
-      # Compile ddev
-      make
-      cd /tmp && ddev config --auto
-      ddev debug download-images
-      ddev delete -Oy tmp
-      mkcert -install
+#    init: |
+#      # Compile ddev
+#      make
+#      cd /tmp && ddev config --auto
+#      ddev debug download-images
+#      ddev delete -Oy tmp
+#      mkcert -install
     command: |
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,26 +8,26 @@ tasks:
 #      ddev debug download-images
 #      ddev delete -Oy tmp
 #      mkcert -install
-#    command: |
-#      export DDEV_NONINTERACTIVE=true
-#      DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
-#      DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
-#      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
-#      reponame=${DDEV_REPO##*/}
-#      mkdir -p /workspace/${reponame} && cd /workspace/${reponame}
-#      if [ ! -d /workspace/${reponame}/.git ]; then
-#        git clone ${DDEV_REPO} /workspace/${reponame}
-#      fi
-#      if [ ! -f .ddev/config.yaml ]; then
-#        ddev config --auto
-#      fi
-#      ddev stop -a
-#      ddev start -y
-#      if [ -d "/tmp/${DDEV_ARTIFACTS##*/}" ]; then
-#        ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
-#        ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
-#      fi
-#      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+    command: |
+      export DDEV_NONINTERACTIVE=true
+      DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
+      DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
+      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
+      reponame=${DDEV_REPO##*/}
+      mkdir -p /workspace/${reponame} && cd /workspace/${reponame}
+      if [ ! -d /workspace/${reponame}/.git ]; then
+        git clone ${DDEV_REPO} /workspace/${reponame}
+      fi
+      if [ ! -f .ddev/config.yaml ]; then
+        ddev config --auto
+      fi
+      ddev stop -a
+      ddev start -y
+      if [ -d "/tmp/${DDEV_ARTIFACTS##*/}" ]; then
+        ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
+        ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
+      fi
+      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,26 +8,26 @@ tasks:
 #      ddev debug download-images
 #      ddev delete -Oy tmp
 #      mkcert -install
-    command: |
-      export DDEV_NONINTERACTIVE=true
-      DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
-      DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
-      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
-      reponame=${DDEV_REPO##*/}
-      mkdir -p /workspace/${reponame} && cd /workspace/${reponame}
-      if [ ! -d /workspace/${reponame}/.git ]; then
-        git clone ${DDEV_REPO} /workspace/${reponame}
-      fi
-      if [ ! -f .ddev/config.yaml ]; then
-        ddev config --auto
-      fi
-      ddev stop -a
-      ddev start -y
-      if [ -d "/tmp/${DDEV_ARTIFACTS##*/}" ]; then
-        ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
-        ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
-      fi
-      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+#    command: |
+#      export DDEV_NONINTERACTIVE=true
+#      DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
+#      DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
+#      git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
+#      reponame=${DDEV_REPO##*/}
+#      mkdir -p /workspace/${reponame} && cd /workspace/${reponame}
+#      if [ ! -d /workspace/${reponame}/.git ]; then
+#        git clone ${DDEV_REPO} /workspace/${reponame}
+#      fi
+#      if [ ! -f .ddev/config.yaml ]; then
+#        ddev config --auto
+#      fi
+#      ddev stop -a
+#      ddev start -y
+#      if [ -d "/tmp/${DDEV_ARTIFACTS##*/}" ]; then
+#        ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
+#        ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
+#      fi
+#      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:
   extensions:

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1485,7 +1485,6 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 	}
 	args = append(args, shell, "-c", opts.Cmd)
 
-	util.Debug("ExecWithTty: docker-compose %v", args)
 	return dockerutil.ComposeWithStreams([]string{app.DockerComposeFullRenderedYAMLPath()}, os.Stdin, os.Stdout, os.Stderr, args...)
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -81,7 +81,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.2.2"
+var RequiredDockerComposeVersion = "v2.2.3"
 
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""


### PR DESCRIPTION
## The Problem/Issue/Bug:

We noticed in v1.19.0-rc2 and earlier versions that on gitpod every startup left a pile of dead containers. 

It seems this is a result of 
* https://github.com/docker/compose/pull/9012
which was fixed between docker-compose v2.2.2 and v2.2.3.

## How this PR Solves The Problem:

* This changes docker-compose version from v2.2.2 to v2.2.3
* Make sure that `ddev ssh` and related don't try to use docker-compose without -T arg if there's no tty

## Manual Testing Instructions:

- [x] Start up gitpod, for example with https://drud.github.io/ddev-gitpod-launcher/, and see if there are a bunch of dead containers.
- [x] Make sure things work in general.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3677"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

