### PR TITLE
v1.19.0 release prep final steps

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -155,9 +155,16 @@ jobs:
       CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
     steps:
+      # The upload-artifacts section often fails. This may give us a recovery technique
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 45
+        with:
+          limit-access-to-actor: true
+
       - uses: actions/checkout@v3
         with:
-          # We need to get all branches and tags for git describe to work properly
           fetch-depth: 0
       - name: Restore build-most builds
         uses: actions/cache@v2

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -177,8 +177,9 @@ mkdir my-drupal9-site
 cd my-drupal9-site
 ddev config --project-type=drupal9 --docroot=web --create-docroot
 ddev start
-ddev composer create "drupal/recommended-project"
-ddev composer require drush/drush
+ddev composer create "drupal/recommended-project" --no-install
+ddev composer require drush/drush --no-install
+ddev composer install
 ddev drush site:install -y
 ddev drush uli
 ddev launch
@@ -221,7 +222,8 @@ mkdir my-typo3-site
 cd my-typo3-site
 ddev config --project-type=typo3 --docroot=public --create-docroot
 ddev start
-ddev composer create "typo3/cms-base-distribution"
+ddev composer create "typo3/cms-base-distribution" --no-install
+ddev composer install
 ddev exec touch public/FIRST_INSTALL
 ddev launch
 ```

--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -46,15 +46,22 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o 
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io
 sudo groupadd docker && sudo usermod -aG docker $USER
+
 ```
 
-* You have to start docker-ce yourself on login, or use a script to do it, etc.
-To start it from git-bash on Windows you can use `echo "wsl.exe -u root service docker status > /dev/null || wsl.exe -u root service docker start > /dev/null" > ~/.bashrc`.
-* **Chocolatey:** We recommend using [Chocolatey](https://chocolatey.org/install) for installing required Windows apps like mkcert. In an administrative PowerShell, `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))`
+* You have to start docker-ce yourself on login, or use a script to do it. To have it start on entry to git-bash, a startup line to your (windows-side) `~/.bashrc` with:
+
+  ```bash
+  echo "wsl.exe -u root service docker status > /dev/null || wsl.exe -u root service docker start > /dev/null" >> ~/.bashrc
+  ```
+
+  You can then `source ~/.bashrc` to start immediately, or it should start the next time you open git-bash.
+* [Install mkcert](https://github.com/FiloSottile/mkcert#windows) on the Windows side; this may be easiest with [Chocolatey](https://chocolatey.org/install): In an administrative PowerShell, `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))`
 * In an administrative PowerShell: `choco install -y mkcert`
 * In an administrative PowerShell, run `mkcert -install` and answer the prompt allowing the installation of the Certificate Authority.
 * In an administrative PowerShell, run the command `setx CAROOT "$(mkcert -CAROOT)"; If ($Env:WSLENV -notlike "*CAROOT/up:*") { setx WSLENV "CAROOT/up:$Env:WSLENV" }`. This will set WSL2 to use the Certificate Authority installed on the Windows side.
 * Double-check in Ubuntu (or your distro): `echo $CAROOT` should show something like `/mnt/c/Users/<you>/AppData/Local/mkcert`
+* Inside your WSL2 distro, `mkcert -install`..
 
 ### Linux Installation: Docker
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -76,7 +76,7 @@ func init() {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
 		nodeps.AppTypeDrupal9: {
-			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
+			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: drupal9ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
 		nodeps.AppTypeDrupal10: {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal10App, postImportDBAction: nil, configOverrideAction: drupal10ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -65,11 +65,12 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeDrupal6:   nodeps.PHP56,
 		nodeps.AppTypeDrupal7:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal8:   nodeps.PHPDefault,
-		nodeps.AppTypeDrupal9:   nodeps.PHPDefault,
+		nodeps.AppTypeDrupal9:   nodeps.PHP80,
 		nodeps.AppTypeDrupal10:  nodeps.PHP81,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:  nodeps.PHPDefault,
 		nodeps.AppTypeMagento:   nodeps.PHPDefault,
+		nodeps.AppTypeLaravel:   nodeps.PHP80,
 	}
 
 	for appType, expectedPHPVersion := range appTypes {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -346,6 +346,12 @@ func drupal6ConfigOverrideAction(app *DdevApp) error {
 	return nil
 }
 
+// drupal0ConfigOverrideAction overrides php_version for D10, requires PHP8.0
+func drupal9ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP80
+	return nil
+}
+
 // drupal10ConfigOverrideAction overrides php_version for D10, requires PHP8.0
 func drupal10ConfigOverrideAction(app *DdevApp) error {
 	app.PHPVersion = nodeps.PHP81


### PR DESCRIPTION
* On uploading artifacts, drop into tmate on failure. Unfortunately GitHub fails quite often uploading artifacts, and it may be easier to solve by going into the build.
* Minor docs updates to installing docker inside WSL2
* Make PHP 8.0 the default version for Drupal9, since it insists on that.
* Minor fixup to Quickstart docs to use `--no-install` with `ddev composer create`

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3684"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

