### PR TITLE
Remove building image tarballs [skip ci]

### DIFF
--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -15,11 +15,12 @@ BASE_DIR=$PWD
 mkdir -p $ARTIFACTS || (sudo mkdir -p $ARTIFACTS && sudo chmod 777 $ARTIFACTS)
 export VERSION=$(git describe --tags --always --dirty)
 
+# 2022-03-10: The image tarballs were for drud/quicksprint, which is currently in retirement
 # If the version does not have a dash in it, it's not prerelease,
 # so build image tarballs
-if [ "${VERSION}" = "${VERSION%%-*}" ]; then
-  BUILD_IMAGE_TARBALLS=true
-fi
+#if [ "${VERSION}" = "${VERSION%%-*}" ]; then
+#  BUILD_IMAGE_TARBALLS=true
+#fi
 
 BUILTPATH=.gotmp/bin/$(go env GOOS)_$(go env GOARCH)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

We don't need to take a really long time to build image tarballs since the consumer was drud/quicksprint.

Remove it

