### PR TITLE
Bump docker-compose to 2.3.3 to solve problems with ddev exec stdout capture, fixes #3698

### DIFF
--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/stretchr/testify/require"
@@ -103,9 +104,11 @@ func TestCmdExec(t *testing.T) {
 
 	assert.FileExists(filepath.Join(site.Dir, "TestCmdExec-touch-separate-args.txt"))
 
+	bashPath := util.FindBashPath()
 	// Make sure we can pipe things into ddev exec and have them work in stdin inside container
 	filename := t.Name() + "_junk.txt"
-	_, err = exec.RunHostCommand("sh", "-c", fmt.Sprintf("printf 'This file was piped into ddev exec' | %s exec 'cat >/var/www/html/%s'", DdevBin, filename))
+	ddevBinForBash := dockerutil.MassageWindowsHostMountpoint(DdevBin)
+	_, err = exec.RunHostCommand(bashPath, "-c", fmt.Sprintf(`printf "This file was piped into ddev exec" | %s exec "cat >/var/www/html/%s"`, ddevBinForBash, filename))
 	assert.NoError(err)
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
@@ -116,13 +119,13 @@ func TestCmdExec(t *testing.T) {
 	assert.Equal("This file was piped into ddev exec", string(content))
 
 	// Make sure that redirection of output from ddev exec works
-	bashPath := util.FindBashPath()
 	f, err := os.CreateTemp("", "")
 	err = f.Close()
 	assert.NoError(err)
 	defer os.Remove(f.Name()) // nolint: errcheck
 
-	_, err = exec.RunHostCommand(bashPath, "-c", fmt.Sprintf("%s exec ls -l /usr/local/bin/composer >%s", DdevBin, f.Name()))
+	bashTempName := dockerutil.MassageWindowsHostMountpoint(f.Name())
+	_, err = exec.RunHostCommand(bashPath, "-c", fmt.Sprintf("%s exec ls -l //usr/local/bin/composer >%s", ddevBinForBash, bashTempName))
 
 	out, err = fileutil.ReadFileIntoString(f.Name())
 	assert.NoError(err)

--- a/cmd/ddev/cmd/stop_test.go
+++ b/cmd/ddev/cmd/stop_test.go
@@ -21,6 +21,10 @@ import (
 func TestCmdStop(t *testing.T) {
 	assert := asrt.New(t)
 
+	t.Cleanup(func() {
+		err := addSites()
+		assert.NoError(err)
+	})
 	// Make sure we have running sites.
 	err := addSites()
 	require.NoError(t, err)

--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -29,9 +29,6 @@ func TestCmdXdebug(t *testing.T) {
 		assert.NoError(err)
 		_, err = exec.RunCommand(DdevBin, []string{"xdebug", "off"})
 		assert.NoError(err)
-		_, err = exec.RunCommand(DdevBin, []string{"stop"})
-		assert.NoError(err)
-
 		err := os.Chdir(pwd)
 		assert.NoError(err)
 	})

--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,12 @@ import (
 
 // TestCmdXdebug tests the `ddev xdebug` command
 func TestCmdXdebug(t *testing.T) {
+	if nodeps.IsMacM1() && dockerutil.IsDockerDesktop() {
+		// 2022-03-16: On Docker Desktop 4.6.0, Mac M1, the `ddev xdebug status` fails to return after
+		// turning `ddev xdebug on`. Seems to be new problem with docker desktop 4.6.0, seems to be only
+		// on mac M1. Unable to recreate locally.
+		t.Skip("Skipping test on Mac M1 Docker Desktop")
+	}
 	assert := asrt.New(t)
 
 	globalconfig.DdevVerbose = true

--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -13,6 +14,8 @@ import (
 // TestCmdXdebug tests the `ddev xdebug` command
 func TestCmdXdebug(t *testing.T) {
 	assert := asrt.New(t)
+
+	globalconfig.DdevVerbose = true
 
 	// TestDdevXdebugEnabled has already tested enough versions, so limit it here.
 	// and this is a pretty limited test, doesn't do much but turn on and off
@@ -31,41 +34,43 @@ func TestCmdXdebug(t *testing.T) {
 		assert.NoError(err)
 		err := os.Chdir(pwd)
 		assert.NoError(err)
+		_ = os.Setenv("DDEV_VERBOSE", "")
+		globalconfig.DdevVerbose = false
 	})
 
 	// An odd bug in v1.16.2 popped up only when composer version was set, might as well set it here
-	_, err = exec.RunCommand(DdevBin, []string{"config", "--composer-version=2"})
+	_, err = exec.RunHostCommand(DdevBin, "config", "--composer-version=2")
 	assert.NoError(err)
 
 	for _, phpVersion := range phpVersions {
 		t.Logf("Testing xdebug command in php%s", phpVersion)
-		_, err := exec.RunCommand(DdevBin, []string{"config", "--php-version", phpVersion})
+		_, err := exec.RunHostCommand(DdevBin, "config", "--php-version", phpVersion)
 		require.NoError(t, err)
 
-		_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
+		_, err = exec.RunHostCommand(DdevBin, "start", "-y")
 		assert.NoError(err, "failed ddev start with php=%v: %v", phpVersion, err)
 
-		out, err := exec.RunCommand(DdevBin, []string{"xdebug", "status"})
+		out, err := exec.RunHostCommand(DdevBin, "xdebug", "status")
 		assert.NoError(err, "failed ddev xdebug status with php=%v: %v", phpVersion, err)
 		assert.Contains(string(out), "xdebug disabled")
 
-		out, err = exec.RunCommand(DdevBin, []string{"xdebug", "on"})
+		out, err = exec.RunHostCommand(DdevBin, "xdebug", "on")
 		assert.NoError(err)
 		assert.Contains(string(out), "Enabled xdebug")
 
-		out, err = exec.RunCommand(DdevBin, []string{"xdebug", "status"})
+		out, err = exec.RunHostCommand(DdevBin, "xdebug", "status")
 		assert.NoError(err)
 		assert.Contains(string(out), "xdebug enabled")
 
-		out, err = exec.RunCommand(DdevBin, []string{"xdebug", "off"})
+		out, err = exec.RunHostCommand(DdevBin, "xdebug", "off")
 		assert.NoError(err)
 		assert.Contains(string(out), "Disabled xdebug")
 
-		out, err = exec.RunCommand(DdevBin, []string{"xdebug", "status"})
+		out, err = exec.RunHostCommand(DdevBin, "xdebug", "status")
 		assert.NoError(err)
 		assert.Contains(string(out), "xdebug disabled")
 
-		_, err = exec.RunCommand(DdevBin, []string{"stop"})
+		_, err = exec.RunHostCommand(DdevBin, "stop")
 		assert.NoError(err, "failed ddev stop with php=%v: %v", phpVersion, err)
 	}
 }

--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -47,7 +47,7 @@ func TestCmdXdebug(t *testing.T) {
 		_, err := exec.RunHostCommand(DdevBin, "config", "--php-version", phpVersion)
 		require.NoError(t, err)
 
-		_, err = exec.RunHostCommand(DdevBin, "start", "-y")
+		_, err = exec.RunHostCommand(DdevBin, "restart")
 		assert.NoError(err, "failed ddev start with php=%v: %v", phpVersion, err)
 
 		out, err := exec.RunHostCommand(DdevBin, "xdebug", "status")

--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -14,7 +14,9 @@ import (
 func TestCmdXdebug(t *testing.T) {
 	assert := asrt.New(t)
 
-	phpVersions := nodeps.ValidPHPVersions
+	// TestDdevXdebugEnabled has already tested enough versions, so limit it here.
+	// and this is a pretty limited test, doesn't do much but turn on and off
+	phpVersions := []string{nodeps.PHP80, nodeps.PHP81}
 
 	pwd, _ := os.Getwd()
 	v := TestSites[0]
@@ -27,6 +29,9 @@ func TestCmdXdebug(t *testing.T) {
 		assert.NoError(err)
 		_, err = exec.RunCommand(DdevBin, []string{"xdebug", "off"})
 		assert.NoError(err)
+		_, err = exec.RunCommand(DdevBin, []string{"stop"})
+		assert.NoError(err)
+
 		err := os.Chdir(pwd)
 		assert.NoError(err)
 	})
@@ -35,7 +40,7 @@ func TestCmdXdebug(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"config", "--composer-version=2"})
 	assert.NoError(err)
 
-	for phpVersion := range phpVersions {
+	for _, phpVersion := range phpVersions {
 		t.Logf("Testing xdebug command in php%s", phpVersion)
 		_, err := exec.RunCommand(DdevBin, []string{"config", "--php-version", phpVersion})
 		require.NoError(t, err)

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -202,10 +202,10 @@ For example, if your Dockerfile were
 ```dockerfile
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
-RUN npm install --global gulp-cli
+RUN npm install --global forever
 ```
 
-You could test it with `ddev ssh`, `sudo -s` and then `npm install --global gulp-cli`
+You could test it with `ddev ssh`, `sudo -s` and then `npm install --global forever`
 
 The error messages you get will be more informative than messages that come when the Dockerfile is processed.
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -6,7 +6,6 @@ services:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-db
     build:
       context: '{{ .DBBuildContext }}'
-      dockerfile: '{{ .DBBuildDockerfile }}'
       args:
         BASE_IMAGE: $DDEV_DBIMAGE
         username: '{{ .Username }}'
@@ -81,7 +80,6 @@ services:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
     build:
       context: '{{ .WebBuildContext }}'
-      dockerfile: '{{ .WebBuildDockerfile }}'
       args:
         BASE_IMAGE: $DDEV_WEBIMAGE
         username: '{{ .Username }}'

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -116,7 +116,7 @@ func TestComposerVersion(t *testing.T) {
 		_ = os.RemoveAll(testDir)
 	})
 
-	// Make sure base version (default) is composer v1
+	// Make sure base version (default) is composer v2
 	err = app.Start()
 	require.NoError(t, err)
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})
@@ -125,7 +125,7 @@ func TestComposerVersion(t *testing.T) {
 
 	// Make sure it does the right thing with latest 2.x
 	app.ComposerVersion = "1"
-	err = app.Start()
+	err = app.Restart()
 	require.NoError(t, err)
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})
 	assert.NoError(err)
@@ -133,7 +133,7 @@ func TestComposerVersion(t *testing.T) {
 
 	// With version "2" we should be back to latest v2
 	app.ComposerVersion = "2"
-	err = app.Start()
+	err = app.Restart()
 	require.NoError(t, err)
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})
 	assert.NoError(err)
@@ -141,7 +141,7 @@ func TestComposerVersion(t *testing.T) {
 
 	// With explicit version, we should get that version
 	app.ComposerVersion = "2.0.1"
-	err = app.Start()
+	err = app.Restart()
 	require.NoError(t, err)
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})
 	assert.NoError(err)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -802,7 +802,7 @@ RUN printf "# TYPE DATABASE USER CIDR-ADDRESS  METHOD \nhost  all  all 0.0.0.0/0
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests less procps pv vim
 `
 
-		err = fileutil.CopyEmbedAssets(bundledAssets, "healthcheck", app.GetConfigPath(".dbiamgeBuild"))
+		err = fileutil.CopyEmbedAssets(bundledAssets, "healthcheck", app.GetConfigPath(".dbimageBuild"))
 		if err != nil {
 			return "", err
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
+	copy2 "github.com/otiai10/copy"
 	"os"
 	"path/filepath"
 	"sort"
@@ -216,7 +217,8 @@ func (app *DdevApp) WriteConfig() error {
 # or packages or anything else to your webimage
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
-RUN npm install --global gulp-cli
+
+RUN npm install --global forever
 `)
 
 	err = WriteImageDockerfile(app.GetConfigPath("web-build")+"/Dockerfile.example", contents)
@@ -698,10 +700,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		Username:              username,
 		UID:                   uid,
 		GID:                   gid,
-		WebBuildContext:       "./web-build",
-		DBBuildContext:        "./db-build",
-		WebBuildDockerfile:    "../.webimageBuild/Dockerfile",
-		DBBuildDockerfile:     "../.dbimageBuild/Dockerfile",
+		WebBuildContext:       "./.webimageBuild",
+		DBBuildContext:        "./.dbimageBuild",
 		AutoRestartContainers: globalconfig.DdevGlobalConfig.AutoRestartContainers,
 		FailOnHookFail:        app.FailOnHookFail || app.FailOnHookFailGlobal,
 		WebWorkingDir:         app.GetWorkingDir("web", ""),
@@ -772,7 +772,19 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN (apt-get remove -y nodejs || true) && (apt purge nodejs || true) && curl -sSL --fail https://deb.nodesource.com/setup_%s.x | bash - && apt-get install nodejs && npm config set unsafe-perm true && npm install --global gulp-cli yarn", app.NodeJSVersion)
 	}
+
+	// Assets in the web-build directory copied to .webimageBuild so .webimageBuild can be "context"
+	err = copy2.Copy(app.GetConfigPath("web-build/"), app.GetConfigPath(".webimageBuild/"))
+	if err != nil {
+		return "", err
+	}
 	err = WriteBuildDockerfile(app.GetConfigPath(".webimageBuild/Dockerfile"), app.GetConfigPath("web-build/Dockerfile"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)
+	if err != nil {
+		return "", err
+	}
+
+	// Assets in the db-build directory copied to .dbimageBuild so .dbimageBuild can be "context"
+	err = copy2.Copy(app.GetConfigPath("db-build/"), app.GetConfigPath(".dbimageBuild/"))
 	if err != nil {
 		return "", err
 	}
@@ -790,7 +802,7 @@ RUN printf "# TYPE DATABASE USER CIDR-ADDRESS  METHOD \nhost  all  all 0.0.0.0/0
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests less procps pv vim
 `
 
-		err = fileutil.CopyEmbedAssets(bundledAssets, "healthcheck", app.GetConfigPath("db-build"))
+		err = fileutil.CopyEmbedAssets(bundledAssets, "healthcheck", app.GetConfigPath(".dbiamgeBuild"))
 		if err != nil {
 			return "", err
 		}
@@ -1043,7 +1055,7 @@ func PrepDdevDirectory(dir string) error {
 		}
 	}
 
-	err := CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-*.yaml", ".*downloads", ".global_commands", ".homeadditions", ".sshimageBuild", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/xdebug", "commands/web/live", "config.*.y*ml", "db-build/postgres_healthcheck.sh", "db_snapshots", "import-db", "import.yaml", "mutagen", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "sequelpro.spf", "xhprof", "**/README.*")
+	err := CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-*.yaml", ".*downloads", ".global_commands", ".homeadditions", ".sshimageBuild", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/xdebug", "commands/web/live", "config.*.y*ml", "db_snapshots", "import-db", "import.yaml", "mutagen", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "sequelpro.spf", "xhprof", "**/README.*")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -953,7 +953,7 @@ func TestExtraPackages(t *testing.T) {
 	// Now add the packages and start again, they should be in there
 	app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-" + addedPackage}
 	app.DBImageExtraPackages = []string{"ncdu"}
-	err = app.Start()
+	err = app.Restart()
 	require.NoError(t, err)
 
 	stdout, stderr, err := app.Exec(&ExecOpts{

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -892,7 +892,6 @@ func TestPostgresConfigOverride(t *testing.T) {
 	})
 	assert.NoError(err)
 	assert.Equal(" 200\n\n", out, "out: %s, stderr: %s", out, stderr)
-
 }
 
 // TestExtraPackages tests to make sure that *extra_packages config.yaml directives

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3402,6 +3402,9 @@ func verifyNFSMount(t *testing.T, app *ddevapp.DdevApp) {
 
 // TestHostDBPort tests to make sure that the host_db_port specification has the intended effect
 func TestHostDBPort(t *testing.T) {
+	if dockerutil.IsColima() {
+		t.Skip("Skipping test on colima because of constant port problems")
+	}
 	assert := asrt.New(t)
 	runTime := util.TimeTrack(time.Now(), t.Name())
 	defer runTime()

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -36,7 +36,7 @@ func TestNodeJSVersions(t *testing.T) {
 
 	for _, v := range nodeps.GetValidNodeVersions() {
 		app.NodeJSVersion = v
-		err = app.Start()
+		err = app.Restart()
 		assert.NoError(err)
 		out, _, err := app.Exec(&ddevapp.ExecOpts{
 			Cmd: "node --version",

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -1,12 +1,14 @@
 package ddevapp_test
 
 import (
+	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
@@ -33,6 +35,15 @@ func TestNodeJSVersions(t *testing.T) {
 		err = app.Stop(true, false)
 		assert.NoError(err)
 	})
+
+	err = app.Start()
+	require.NoError(t, err)
+	// As of v1.19.0, the nvm_dir doesn't get cleaned up on delete,
+	//so on a machine where this test has run before this will fail, as nvm has been set up
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Cmd: fmt.Sprintf("rm -rf /mnt/ddev-global-cache/nvm_dir/%s-web", site.Name),
+	})
+	assert.NoError(err)
 
 	for _, v := range nodeps.GetValidNodeVersions() {
 		app.NodeJSVersion = v

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"github.com/drud/ddev/pkg/globalconfig"
 	"os"
 	"os/exec"
 	"strings"
@@ -53,6 +54,9 @@ func RunInteractiveCommand(command string, args []string) error {
 // RunHostCommand executes a command on the host and returns the
 // combined stdout/stderr results and error
 func RunHostCommand(command string, args ...string) (string, error) {
+	if globalconfig.DdevVerbose {
+		output.UserOut.Printf("RunHostCommand: " + command + " " + strings.Join(args, " "))
+	}
 	o, err := exec.Command(command, args...).CombinedOutput()
 	return string(o), err
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -58,5 +58,9 @@ func RunHostCommand(command string, args ...string) (string, error) {
 		output.UserOut.Printf("RunHostCommand: " + command + " " + strings.Join(args, " "))
 	}
 	o, err := exec.Command(command, args...).CombinedOutput()
+	if globalconfig.DdevVerbose {
+		output.UserOut.Printf("RunHostCommand returned. output=%v err=%v", string(o), err)
+	}
+
 	return string(o), err
 }

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -135,9 +136,9 @@ func TestValidTestSite(t *testing.T) {
 
 // TestGetLocalHTTPResponse() brings up a project and hits a URL to get the response
 func TestGetLocalHTTPResponse(t *testing.T) {
-	//if runtime.GOOS == "windows" || nodeps.IsMacM1() || dockerutil.IsColima() {
-	//	t.Skip("Skipping on Windows/Mac M1/Colima as we always seem to have port conflicts")
-	//}
+	if runtime.GOOS == "windows" || nodeps.IsMacM1() || dockerutil.IsColima() {
+		t.Skip("Skipping on Windows/Mac M1/Colima as we always seem to have port conflicts")
+	}
 	// We have to get globalconfig read so CA is known and installed.
 	err := globalconfig.ReadGlobalConfig()
 	require.NoError(t, err)

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 )
 
@@ -136,9 +135,9 @@ func TestValidTestSite(t *testing.T) {
 
 // TestGetLocalHTTPResponse() brings up a project and hits a URL to get the response
 func TestGetLocalHTTPResponse(t *testing.T) {
-	if runtime.GOOS == "windows" || nodeps.IsMacM1() || dockerutil.IsColima() {
-		t.Skip("Skipping on Windows/Mac M1/Colima as we always seem to have port conflicts")
-	}
+	//if runtime.GOOS == "windows" || nodeps.IsMacM1() || dockerutil.IsColima() {
+	//	t.Skip("Skipping on Windows/Mac M1/Colima as we always seem to have port conflicts")
+	//}
 	// We have to get globalconfig read so CA is known and installed.
 	err := globalconfig.ReadGlobalConfig()
 	require.NoError(t, err)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -81,7 +81,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.2.3"
+var RequiredDockerComposeVersion = "v2.3.3"
 
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
@@ -253,8 +253,8 @@ func GetLiveDockerComposeVersion() (string, error) {
 	}
 	v := strings.Trim(string(out), "\r\n")
 
-	// docker-compose v1 returns a version without the prefix "v", so add it.
-	if strings.HasPrefix(v, "1") {
+	// docker-compose v1 and v2.3.3 return a version without the prefix "v", so add it.
+	if !strings.HasPrefix(v, "v") {
 		v = "v" + v
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

In v1.19.0 it is impossible to capture stdout from `ddev exec`. For example `ddev exec ls -lR >/dev/null` will display the output. This seems to be a regression in docker-compose v2.2.3, which was used in ddev v1.19.0

Pointed out in:

* https://github.com/drud/ddev-contrib/issues/206

## How this PR Solves The Problem:

Bump to docker-compose v2.3.3, seems to solve it.

## Manual Testing Instructions:

`ddev exec ls -l >/tmp/out.txt` should show nothing. And you should find the output in /tmp/out.txt

## Automated Testing Overview:

* I added to TestCmdExec a section that deliberately redirects output to a file. However, I wasn't able to recreate the actual behavior that we all saw even when I ran the test against v1.19.0 (and docker-compose v2.2.3). The test succeeded. I assume this must have something to do with pty detection by docker-compose.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3689"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

