### PR TITLE
More accurately reflect necessary setup for D9.

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -192,7 +192,7 @@ Note that the git URL shown below is an example only, you'll need to use your ow
 ```bash
 git clone https://github.com/example/example-site
 cd example-site
-ddev config --project-type=drupal9
+ddev config --project-type=drupal9 --docroot=web --create-docroot
 ddev composer install
 ddev launch
 ```

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -192,7 +192,6 @@ Note that the git URL shown below is an example only, you'll need to use your ow
 ```bash
 git clone https://github.com/example/example-site
 cd example-site
-# add `--docroot=web` to the `ddev config` command below if appropriate
 ddev config --project-type=drupal9
 ddev composer install
 ddev launch

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -192,7 +192,8 @@ Note that the git URL shown below is an example only, you'll need to use your ow
 ```bash
 git clone https://github.com/example/example-site
 cd example-site
-ddev config --auto
+# add `--docroot=web` to the `ddev config` command below if appropriate
+ddev config --project-type=drupal9
 ddev composer install
 ddev launch
 ```


### PR DESCRIPTION
## The Problem/Issue/Bug:
When the user clones a lean repository but has not yet run the
`composer install` command, then using `ddev config --auto` will not
work because the files that the detection needs are not yet present.

## How this PR Solves The Problem:
Updates the documentation that users were following and not having luck with.

## Manual Testing Instructions:
Clone a lean repository for a Drupal 9 site (say, from a Pantheon site using Integrated Composer). Run `ddev config --auto` before doing a `composer install`. Note that the generated config.yaml will not be Drupal 9.

## Automated Testing Overview:
Documentation update only.

## Related Issue Link(s):
Issue not filed. Discussed in Drupal Slack: https://drupal.slack.com/archives/C5TQRQZRR/p1646971651968869

## Release/Deployment notes:
n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3690"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

