### PR TITLE
Automatically run unknown commands in the web container

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -185,6 +185,11 @@ func TestCustomCommands(t *testing.T) {
 	app.Type = nodeps.AppTypePHP
 	err = app.WriteConfig()
 	assert.NoError(err)
+	// Drush may still be installed in /usr/local/bin, get rid of it
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Cmd: "rm -f /usr/local/bin/drush",
+	})
+	assert.NoError(err)
 
 	// Make sure that all the official ddev-provided custom commands are usable by just checking help
 	for _, c := range []string{"launch", "mysql", "php", "xdebug"} {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Currently to run a command in the web container a proper custom command has to be defined. It would be nice if unknown commands are just forwarded to the web container without the need of defining a custom command. If the command is not found it still can fail later.

## How this PR Solves The Problem:

Unknown commands are simply forwarded to the web container and if found the exit code is properly returned.

If the command is not found an error is shown like it's done before.

## Manual Testing Instructions:

- run `ddev ls`, the content of `var/www/html` should be listed
- run `ddev invalid`, an error should be shown

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3695"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

