### PR TITLE
Add a config --web-environment-add command which appends environment variables to the web container configuration

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/version"
 	"github.com/spf13/cobra"
+	"sort"
 	"strings"
 )
 
@@ -55,6 +56,28 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 			globalconfig.DdevGlobalConfig.WebEnvironment = []string{}
 		} else {
 			globalconfig.DdevGlobalConfig.WebEnvironment = strings.Split(env, ",")
+		}
+		dirty = true
+	}
+
+	if cmd.Flag("web-environment-add").Changed {
+		env := strings.Replace(webEnvironmentGlobal, " ", "", -1)
+		if env == "" {
+			globalconfig.DdevGlobalConfig.WebEnvironment = []string{}
+		} else {
+			envspl := strings.Split(env, ",")
+			conc := append(globalconfig.DdevGlobalConfig.WebEnvironment, envspl...)
+			// Convert to a hashmap to remove duplicate values.
+			hashmap := make(map[string]string)
+			for i := 0; i < len(conc); i++ {
+				hashmap[conc[i]] = conc[i]
+			}
+			keys := []string{}
+			for key := range hashmap {
+				keys = append(keys, key)
+			}
+			globalconfig.DdevGlobalConfig.WebEnvironment = keys
+			sort.Strings(globalconfig.DdevGlobalConfig.WebEnvironment)
 		}
 		dirty = true
 	}
@@ -184,6 +207,7 @@ func handleGlobalConfig(cmd *cobra.Command, args []string) {
 func init() {
 	configGlobalCommand.Flags().StringVarP(&omitContainers, "omit-containers", "", "", "For example, --omit-containers=dba,ddev-ssh-agent")
 	configGlobalCommand.Flags().StringVarP(&webEnvironmentGlobal, "web-environment", "", "", `Set the environment variables in the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`)
+	configGlobalCommand.Flags().StringVarP(&webEnvironmentGlobal, "web-environment-add", "", "", `Append environment variables to the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`)
 	configGlobalCommand.Flags().Bool("nfs-mount-enabled", false, "Enable NFS mounting on all projects globally")
 	configGlobalCommand.Flags().BoolVarP(&instrumentationOptIn, "instrumentation-opt-in", "", false, "instrumentation-opt-in=true")
 	configGlobalCommand.Flags().Bool("router-bind-all-interfaces", false, "router-bind-all-interfaces=true")

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -75,4 +75,10 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.True(globalconfig.DdevGlobalConfig.DisableHTTP2)
 	assert.True(globalconfig.DdevGlobalConfig.SimpleFormatting)
 	assert.Equal("bright", globalconfig.DdevGlobalConfig.TableStyle)
+
+	// Test that variables can be appended to the web environment
+	args = []string{"config", "global", `--web-environment-add="FOO=bar"`}
+	out, err = exec.RunCommand(DdevBin, args)
+	assert.NoError(err)
+	assert.Contains(string(out), "web-environment=[\"FOO=bar\",\"SOMEENV=some+val\"]")
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -557,7 +557,7 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 				hashmap[conc[i]] = conc[i]
 			}
 			keys := []string{}
-			for key, _ := range hashmap {
+			for key := range hashmap {
 				keys = append(keys, key)
 			}
 			app.WebEnvironment = keys

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -333,6 +333,45 @@ func TestConfigSetValues(t *testing.T) {
 
 	assert.Equal(app.WebImage, "")
 	assert.Equal(len(app.WorkingDir), 0)
+
+	// Test that variables can be appended to the web environment
+	args = []string{
+		"config",
+		"--web-environment-add", webEnv,
+	}
+
+	_, err = exec.RunHostCommand(DdevBin, args...)
+	assert.NoError(err)
+
+	configContents, err = os.ReadFile(configFile)
+	assert.NoError(err, "Unable to read %s: %v", configFile, err)
+
+	app = &ddevapp.DdevApp{}
+	err = yaml.Unmarshal(configContents, app)
+	assert.NoError(err, "Could not unmarshal %s: %v", configFile, err)
+
+	assert.Equal(1, len(app.WebEnvironment))
+	assert.Equal([]string{webEnv}, app.WebEnvironment)
+
+	args = []string{
+		"config",
+		"--web-environment-add", "FOO=bar, BAR=baz",
+	}
+
+	_, err = exec.RunHostCommand(DdevBin, args...)
+	assert.NoError(err)
+
+	configContents, err = os.ReadFile(configFile)
+	assert.NoError(err, "Unable to read %s: %v", configFile, err)
+
+	app = &ddevapp.DdevApp{}
+	err = yaml.Unmarshal(configContents, app)
+	assert.NoError(err, "Could not unmarshal %s: %v", configFile, err)
+
+	assert.Equal(3, len(app.WebEnvironment))
+	assert.Equal("BAR=baz", app.WebEnvironment[0])
+	assert.Equal("FOO=bar", app.WebEnvironment[1])
+	assert.Equal(webEnv, app.WebEnvironment[2])
 }
 
 // TestConfigInvalidProjectname tests to make sure that invalid projectnames

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -32,7 +32,7 @@ web_environment:
 - SOMEOTHERENV=someotherval
 ```
 
-You can also use `ddev config global --web-environment="SOMEENV=someval"` or `ddev config --web-environment="SOMEENV=someval"` for the same purpose. The command just sets the values in the configuration files. (Using this command overwrites all the web_environment values, so if you need to add additional values to those that are already configured, edit the `config.yaml` or `global_config.yaml`.)
+You can also use `ddev config global --web-environment="SOMEENV=someval"` or `ddev config --web-environment="SOMEENV=someval"` for the same purpose. The command just sets the values in the configuration files. (Using this command overwrites all the web_environment values, so if you need to add additional values to those that are already configured, use `--web-environment-add`, or edit `config.yaml` or `global_config.yaml`.)
 
 The docker-compose web environment can also provide env file support. To enable this you would create a new docker-compose yaml partial, for example `.ddev/docker-compose.env-file.yaml` with contents:
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
* #3691

Allows a user to append environment variables to a web container rather than overwriting them all. See #3691


## How this PR Solves The Problem:
Adds a `--web-environment-add` option to `ddev config`

## Manual Testing Instructions:
```
$ composer create-project drupal/recommended-project ddev-test
$ cd ddev-test
$ ddev config
$ ddev config --web-environment="FOO=bar"
$ cat .ddev/config.yaml 
.
web_environment:
- FOO=bar
.
$ ddev config --web-environment="BAR=baz"
$ cat .ddev/config.yaml
.
web_environment:
- BAR=baz
- FOO=bar
.
```

## Automated Testing Overview:
Test added to `cmd/ddev/cmd/config.go`

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3697"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

