### PR TITLE
Use bin/magento in magento command, fixes #3699

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/magento
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/magento
@@ -7,10 +7,10 @@
 ## ProjectTypes: magento2
 ## ExecRaw: true
 
-if ! command -v magento >/dev/null; then
-  echo 'magento is not available in your in-container $PATH'
+if ! command -v bin/magento >/dev/null; then
+  echo 'bin/magento is not available in your installation.'
+  echo 'Please verify that you installed the shop in your working dir.'
   exit 1
 fi
 
-magento "$@"
-
+bin/magento "$@"


### PR DESCRIPTION

## The Problem/Issue/Bug:

* #3699

Currently the command looks for a script/binary "magento"
in the $PATH which is not available in a general Magento installation.
Change the script to use the shipped bin/magento.
If Magento is not installed via "composer install", the "bin/magento"
script is not available. So the check if ok with the right path.

## How this PR Solves The Problem:

Fix the path to magento script.

## Manual Testing Instructions:

Start a Magento project with a Magento installation in a sub-directory and set working_dir.


## Automated Testing Overview:

Automatic test requires a Magento installation or a dummy script. Let's see if we can add that in the future.

## Release/Deployment notes:

Issue was introduced in ddev v1.19.0.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3700"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

