### PR TITLE
Make docker disk check work on fedora, fixes #3703

### DIFF
--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -74,7 +74,7 @@ Docker installation on Linux depends on what flavor you're using. Where possible
 * [Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
 * [CentOS](https://docs.docker.com/install/linux/docker-ce/centos/)
 * [Debian](https://docs.docker.com/install/linux/docker-ce/debian/)
-* [Fedora](https://docs.docker.com/install/linux/docker-ce/fedora/). Recent versions of Fedora (32, 33+) require a [different approach, installing the original CGroups](https://fedoramagazine.org/docker-and-fedora-32/). In addition, you must [disable SELinux](https://www.cyberciti.biz/faq/disable-selinux-on-centos-7-rhel-7-fedora-linux/).
+* [Fedora](https://docs.docker.com/install/linux/docker-ce/fedora/)
 * [binaries](https://docs.docker.com/install/linux/docker-ce/binaries/)
 
 #### Linux Post-installation steps (required)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1110,7 +1110,7 @@ func Exec(containerID string, command string, uid string) (string, string, error
 
 // CheckAvailableSpace outputs a warning if docker space is low
 func CheckAvailableSpace() {
-	_, out, _ := RunSimpleContainer(version.GetWebImage(), "", []string{"sh", "-c", `df / | awk '/overlay/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, nil)
+	_, out, _ := RunSimpleContainer(version.GetWebImage(), "", []string{"sh", "-c", `df / | awk '!/Mounted/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, nil)
 	out = strings.Trim(out, "% \r\n")
 	parts := strings.Split(out, " ")
 	if len(parts) != 2 {


### PR DESCRIPTION
## The Problem/Issue/Bug:
* #3703 

## How this PR Solves The Problem:

* Use a more robust way to access the output of `df /`
* Update/remove some obsolete docs instructions about fedora

## Manual Testing Instructions:

`ddev start` on fedora, look for the complaint about not being able to check.

## Automated Testing Overview:

No testing is in place for fedora, and won't be.

\

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3704"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

