### PR TITLE
Roll back github-action-markdown-link-check to 1.0.13

### DIFF
--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -36,7 +36,7 @@ jobs:
       #    - name: Debugging with tmate
       #      uses: mxschmitt/action-tmate@v3.1
       - name: "Check links in markdown"
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@v1.0.13
         with:
           use-quiet-mode: 'yes'
 #          use-verbose-mode: 'yes'

--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -36,7 +36,7 @@ jobs:
       #    - name: Debugging with tmate
       #      uses: mxschmitt/action-tmate@v3.1
       - name: "Check links in markdown"
-        uses: gaurav-nelson/github-action-markdown-link-check@v1.0.13
+        uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
         with:
           use-quiet-mode: 'yes'
 #          use-verbose-mode: 'yes'

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -19,6 +19,9 @@
       "pattern": "^https://nssm.cc/"
     },
     {
+      "pattern": "^https://www.php.net/manual/"
+    },
+    {
       "pattern": "^https://www.cyberciti.biz/"
     }
   ],


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/127

## How this PR Solves The Problem:

Roll it back to 1.0.13 to see if it sorts things out.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3706"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

