### PR TITLE
[tests] Fix TestDockerComposeDownload to handle version with or without v

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -103,6 +103,8 @@ jobs:
             docker pull $image
           done >/dev/null
 
+      - name: "show versions"
+        run: "set -x && ddev version && docker version && docker-compose version && go version"
 
       - name: time make "${{ matrix.tests }}"
         run: |

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -105,4 +105,5 @@ func TestDockerComposeDownload(t *testing.T) {
 		parsedFoundVersion = "v" + parsedFoundVersion
 	}
 	assert.Equal(parsedFoundVersion, activeVersion)
+	t.Logf("parsedFoundVersion=%s activeVersion=%s", parsedFoundVersion, activeVersion)
 }

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -101,7 +101,7 @@ func TestDockerComposeDownload(t *testing.T) {
 	out, err := exec2.RunHostCommand(path, "version", "--short")
 	assert.NoError(err)
 	parsedFoundVersion := strings.Trim(string(out), "\r\n")
-	if strings.HasPrefix(parsedFoundVersion, "1") {
+	if !strings.HasPrefix(parsedFoundVersion, "v") {
 		parsedFoundVersion = "v" + parsedFoundVersion
 	}
 	assert.Equal(parsedFoundVersion, activeVersion)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -236,18 +236,16 @@ func GetLiveDockerComposeVersion() (string, error) {
 		return DockerComposeVersion, nil
 	}
 
-	path, err := globalconfig.GetDockerComposePath()
+	composePath, err := globalconfig.GetDockerComposePath()
 	if err != nil {
 		return "", err
 	}
 
-	DockerComposePath := path
-
-	if !fileutil.FileExists(DockerComposePath) {
+	if !fileutil.FileExists(composePath) {
 		DockerComposeVersion = ""
 		return DockerComposeVersion, nil
 	}
-	out, err := exec.Command(DockerComposePath, "version", "--short").Output()
+	out, err := exec.Command(composePath, "version", "--short").Output()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION

## The Problem/Issue/Bug:

docker-compose 2.3.3 uses a version without the 'v' on the front. TestDockerComposeDownload didn't recognize that. Not sure how tests passed before. 

## How this PR Solves The Problem:

Handle version with or without v.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3716"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

