### PR TITLE
Use altered rsync for composer create on Windows, fixes #3712

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -124,7 +124,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 
 		rsyncArgs := "-rltgopD" // Same as -a
 		if runtime.GOOS == "windows" {
-			rsyncArgs = "-rltD" // on windows can't do perms, owner, group
+			rsyncArgs = "-rlD" // on windows can't do perms, owner, group, times
 		}
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "web",

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -124,7 +124,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 
 		rsyncArgs := "-rltgopD" // Same as -a
 		if runtime.GOOS == "windows" {
-			rsyncArgs = "-rltgoD" // on windows can't do perms
+			rsyncArgs = "-rltD" // on windows can't do perms, owner, group
 		}
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "web",

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -122,9 +122,13 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 
 		output.UserOut.Printf("Moving installation to composer root")
 
+		rsyncArgs := "-rltgopD" // Same as -a
+		if runtime.GOOS == "windows" {
+			rsyncArgs = "-rltgoD" // on windows can't do perms
+		}
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
-			Cmd:     fmt.Sprintf(`rsync -a "%s/" "%s/"`, containerInstallPath, app.GetComposerRoot(true, false)),
+			Cmd:     fmt.Sprintf(`rsync %s "%s/" "%s/"`, rsyncArgs, containerInstallPath, app.GetComposerRoot(true, false)),
 			Dir:     "/var/www/html",
 		})
 

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/drud/ddev/pkg/ddevapp"
@@ -65,26 +65,36 @@ func TestComposerCmd(t *testing.T) {
 		// These two often fail on Windows with NFS, also Colima
 		// It appears to be something about composer itself?
 
-		if !(dockerutil.IsColima() || (runtime.GOOS == "windows" && (app.NFSMountEnabled || app.NFSMountEnabledGlobal))) {
-			// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
-			args := []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "psr/log:1.1.0"}
-			out, err = exec.RunHostCommand(DdevBin, args...)
-			assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
-			assert.Contains(out, "Created project in ")
-			assert.FileExists(filepath.Join(tmpDir, composerRoot, "Psr/Log/LogLevel.php"))
+		//if !(dockerutil.IsColima() || (runtime.GOOS == "windows" && (app.NFSMountEnabled || app.NFSMountEnabledGlobal))) {
+		// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
+		args := []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "--no-install", "psr/log:1.1.0"}
+		out, err = exec.RunHostCommand(DdevBin, args...)
+		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
+		assert.Contains(out, "Created project in ")
+		assert.FileExists(filepath.Join(tmpDir, composerRoot, "composer.json"))
 
-			err = app.StartAndWait(5)
-			assert.NoError(err)
-			// ddev composer create --prefer-dist --no-dev --no-install psr/log:1.1.0
-			args = []string{"composer", "create", "--prefer-dist", "--no-dev", "--no-install", "psr/log:1.1.0"}
-			out, err = exec.RunHostCommand(DdevBin, args...)
-			assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
-			assert.Contains(out, "Created project in ")
-			assert.FileExists(filepath.Join(tmpDir, composerRoot, "Psr/Log/LogLevel.php"))
-		}
+		args = []string{"composer", "config", "--append", "--", "allow-plugins", "true"}
+		_, err = exec.RunHostCommand(DdevBin, args...)
+		assert.NoError(err)
+
+		args = []string{"composer", "install"}
+		_, err = exec.RunHostCommand(DdevBin, args...)
+		assert.NoError(err)
+
+		assert.FileExists(filepath.Join(tmpDir, composerRoot, "Psr/Log/LogLevel.php"))
+
+		err = app.StartAndWait(5)
+		require.NoError(t, err)
+		// ddev composer create --prefer-dist --no-dev --no-install psr/log:1.1.0
+		args = []string{"composer", "create", "--prefer-dist", "--no-dev", "--no-install", "psr/log:1.1.0"}
+		out, err = exec.RunHostCommand(DdevBin, args...)
+		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
+		assert.Contains(out, "Created project in ")
+		assert.FileExists(filepath.Join(tmpDir, composerRoot, "Psr/Log/LogLevel.php"))
+		//}
 
 		// Test a composer require, with passthrough args
-		args := []string{"composer", "require", "sebastian/version", "--no-plugins", "--ansi"}
+		args = []string{"composer", "require", "sebastian/version", "--no-plugins", "--ansi"}
 		out, err = exec.RunHostCommand(DdevBin, args...)
 		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 		assert.Contains(out, "Generating autoload files")

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -65,7 +65,6 @@ func TestComposerCmd(t *testing.T) {
 		// These two often fail on Windows with NFS, also Colima
 		// It appears to be something about composer itself?
 
-		//if !(dockerutil.IsColima() || (runtime.GOOS == "windows" && (app.NFSMountEnabled || app.NFSMountEnabledGlobal))) {
 		// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
 		args := []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "--no-install", "psr/log:1.1.0"}
 		out, err = exec.RunHostCommand(DdevBin, args...)
@@ -91,7 +90,6 @@ func TestComposerCmd(t *testing.T) {
 		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 		assert.Contains(out, "Created project in ")
 		assert.FileExists(filepath.Join(tmpDir, composerRoot, "Psr/Log/LogLevel.php"))
-		//}
 
 		// Test a composer require, with passthrough args
 		args = []string{"composer", "require", "sebastian/version", "--no-plugins", "--ansi"}


### PR DESCRIPTION
## The Problem/Issue/Bug:

On traditional Windows, it's not possible to change permissions on a mounted file, so the `rsync -a` in `ddev composer create` fails:
* #3712 

## How this PR Solves The Problem:

Don't try to set permissions on Windows, use lesser rsync command

## TODO:

- [x] If TestComposer still can't run reliably on Windows, exclude it again and rely on manual testing.

## Manual Testing Instructions:

- [x] With NFS enabled, `ddev composer create -y drupal/recommended-project`
- [x] With NFS disabled, same

## Automated Testing Overview:

This has always been excluded on Windows, but I attempted to simplify the test section to see if maybe it can be tested on Windows and we'd have caught and error like this. It may not work

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3720"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

