### PR TITLE
Try using docker-compose 2.3.4

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -81,7 +81,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.3.3"
+var RequiredDockerComposeVersion = "v2.3.4"
 
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""


### PR DESCRIPTION
## The Problem/Issue/Bug:

[compose v2.3.4](https://github.com/docker/compose/releases/tag/v2.3.4) hopes to fixes some regressions in the docker build process, where build didn't happen after new images were pulled, or when Dockerfile changes. 

This just tries it out.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3730"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

