### PR TITLE
Change default TYPO3 mysql/mariadb driver to mysqli

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -66,7 +66,7 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 			return err
 		}
 	}
-	dbDriver := "pdo_mysql"
+	dbDriver := "mysqli" // mysqli is the driver used in default LocalConfiguration.php
 	if app.Database.Type == nodeps.Postgres {
 		dbDriver = "pdo_pgsql"
 	}


### PR DESCRIPTION

## The Problem/Issue/Bug:

See https://stackoverflow.com/questions/71509163/php-warning-in-typo3databasebackend-line-158-after-updating-ddev-to-1-19

A default TYPO3 v11 install shows this warning on the BE pages:  
> Core: Error handler (BE): PHP Warning: gzuncompress(): need dictionary in /var/www/html/public/typo3/sysext/core/Classes/Cache/Backend/Typo3DatabaseBackend.php line 157

## How this PR Solves The Problem:

The TYPO3-generated LocalConfiguration.php uses driver mysqli, not pdo_mysql. Use the one TYPO3 uses.

## Manual Testing Instructions:

- [ ] Open BE of TYPO3 v11. Look for no warning
- [ ] Inspect AdditionalConfiguration.php for the driver being mysqli

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3734"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

