### PR TITLE
Don't use invalid resp.Rate when nil - ddev get when no inteernet

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -111,7 +111,11 @@ ddev get --list --all
 			client := getGithubClient(ctx)
 			releases, resp, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{})
 			if err != nil {
-				util.Failed("Unable to get releases for %v: %v\nresp.Rate=%v", repo, err, resp.Rate)
+				var rate github.Rate
+				if resp != nil {
+					rate = resp.Rate
+				}
+				util.Failed("Unable to get releases for %v: %v\nresp.Rate=%v", repo, err, rate)
 			}
 			if len(releases) == 0 {
 				util.Failed("No releases found for %v", repo)


### PR DESCRIPTION
## The Problem/Issue/Bug:

There's a piece of code I ran into when using ddev on a flight with no wifi... it gives a SEGFAULT. 

This fixes it. Tested on the plane



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3736"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

