### PR TITLE
Improve message when an add-on times out due to healthcheck

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1854,8 +1854,7 @@ func (app *DdevApp) WaitByLabels(labels map[string]string) error {
 	waitTime := containerWaitTimeout
 	err := dockerutil.ContainersWait(waitTime, labels)
 	if err != nil {
-		// TODO: Improve this error message
-		return fmt.Errorf("container failed to become healthy: err=%v", err)
+		return fmt.Errorf("container(s) failed to become healthy after %d seconds. This may be just a problem with the healthcheck and not a functional problem. %v", waitTime, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

Container timeout due to healthcheck didn't give enough information

## How this PR Solves The Problem:

Figure out what container(s) aren't healthy and give info about that.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3737"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

