### PR TITLE
[Tests only] TestComposerVersion fixup for composer 2.3.x

### DIFF
--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -121,9 +121,9 @@ func TestComposerVersion(t *testing.T) {
 	require.NoError(t, err)
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})
 	assert.NoError(err)
-	assert.Contains(stdout, "Composer version 2")
+	assert.True(strings.HasPrefix(stdout, "Composer 2") || strings.HasPrefix(stdout, "Composer version 2"), "composer version not the expected composer 2: %v", stdout)
 
-	// Make sure it does the right thing with latest 2.x
+	// Make sure it does the right thing with 1.x
 	app.ComposerVersion = "1"
 	err = app.Restart()
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestComposerVersion(t *testing.T) {
 	require.NoError(t, err)
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})
 	assert.NoError(err)
-	assert.Contains(stdout, "Composer version 2")
+	assert.True(strings.HasPrefix(stdout, "Composer 2") || strings.HasPrefix(stdout, "Composer version 2"), "composer version not the expected composer 2: %v", stdout)
 
 	// With explicit version, we should get that version
 	app.ComposerVersion = "2.0.1"

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -137,7 +137,7 @@ func TestComposerVersion(t *testing.T) {
 	require.NoError(t, err)
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{Cmd: "composer --version"})
 	assert.NoError(err)
-	assert.True(strings.HasPrefix(stdout, "Composer 2") || strings.HasPrefix(stdout, "Composer version 2"), "composer version not the expected composer 2: %v", stdout)
+	assert.True(strings.HasPrefix(stdout, "Composer 2") || strings.HasPrefix(stdout, "Composer version 2"), "composer version doesn't start with the expected value: %v", stdout)
 
 	// With explicit version, we should get that version
 	app.ComposerVersion = "2.0.1"


### PR DESCRIPTION
In Composer 2.3.x they changed the output of composer --version
and it broke TestComposerVersion



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3739"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

