### PR TITLE
Update method descriptions to resolve port conflicts

### DIFF
--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -44,9 +44,8 @@ This means there is another webserver listening on the named port(s) and ddev ca
 
 To resolve this conflict, choose one of two methods:
 
-1. If you are using another local development environment (MAMP, WAMP, lando, etc.) that uses these ports, consider stopping it.
-2. Fix port conflicts by configuring your project to use different ports.
-3. Fix port conflicts by stopping the competing application.
+1. Fix port conflicts by configuring your project to use different ports.
+2. Fix port conflicts by stopping the competing application.
 
 ### Method 1: Fix port conflicts by configuring your project to use different ports
 
@@ -75,7 +74,7 @@ phpmyadmin_port: 8302
 
 ### Method 2: Fix port conflicts by stopping the competing application
 
-Alternatively, stop the other application.
+Alternatively, if you are using another application or local development environment (MAMP, WAMP, lando, etc.) that uses these ports, consider stopping it.
 
 Probably the most common conflicting application is Apache running locally. It can often be stopped gracefully (but temporarily) with:
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
The methods at https://ddev.readthedocs.io/en/latest/users/troubleshooting/#webserver-ports-are-already-occupied-by-another-webserver list 3 separate options, but methods 1 and 3 are essentially the same. Also, the "Method x" headers aren't aligned with the actual method numbers (i.e. "Method 1" describes method 2).

## How this PR Solves The Problem:
Removes Method 1, and adds the description to the new Method 2 section.

## Manual Testing Instructions:
View the troubleshooting page

## Automated Testing Overview:
This is only a documentation update - no tests needed.

## Related Issue Link(s):
n/a

## Release/Deployment notes:
n/a

