### PR TITLE
Allow quoting of `ddev magento` command name and arguments, fixes #3743

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/magento
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/magento
@@ -13,4 +13,4 @@ if ! command -v bin/magento >/dev/null; then
   exit 1
 fi
 
-bin/magento "$@"
+bin/magento $*


### PR DESCRIPTION
#3743 `--help` flag not working within Magento 2 commands

## The Problem/Issue/Bug:
`bin/magento` commands via `ddev magento` not working with `--help` flag
## How this PR Solves The Problem:
The changes allow for the Magento 2 command name and argument to be wrapped in double quotes, allowing to pass the `--help` flag within.
## Manual Testing Instructions:
Run `ddev magento "setup:upgrade --help"`, expected output would be something like
```
Description:
  Upgrades the Magento application, DB data, and schema

Usage:
  setup:upgrade [options]

Options:
      --keep-generated                             Prevents generated files from being deleted.        
                                                   We discourage using this option except when deployin
g to production.
                                                   Consult your system integrator or administrator for 
more information.
      --convert-old-scripts[=CONVERT-OLD-SCRIPTS]  Allows to convert old scripts (InstallSchema, Upgrad
eSchema) to db_schema.xml format [default: false]
      --safe-mode[=SAFE-MODE]                      Safe installation of Magento with dumps on destructi
ve operations, like column removal
      --data-restore[=DATA-RESTORE]                Restore removed data from dumps
      --dry-run[=DRY-RUN]                          Magento Installation will be run in dry-run mode [de
fault: false]
      --magento-init-params=MAGENTO-INIT-PARAMS    Add to any command to customize Magento initializati
on parameters
                                                   For example: "MAGE_MODE=developer&MAGE_DIRS[base][pa
th]=/var/www/example.com&MAGE_DIRS[cache][path]=/var/tmp/cache"
  -h, --help                                       Display this help message
  -q, --quiet                                      Do not output any message
  -V, --version                                    Display this application version
      --ansi                                       Force ANSI output
      --no-ansi                                    Disable ANSI output
  -n, --no-interaction                             Do not ask any interactive question
  -v|vv|vvv, --verbose                             Increase the verbosity of messages: 1 for normal out
put, 2 for more verbose output and 3 for debug
```
## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
The PR slightly changes existing behaviour, no new tests are needed.
## Related Issue Link(s):
#3743 
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
None



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3745"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

