### PR TITLE
Determine if the command requires Docker running, fixes #3336

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -154,7 +154,7 @@ func init() {
 	// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
 	_, err := version.GetDockerVersion()
 	if err != nil {
-		util.Failed("Could not connect to Docker. Please ensure Docker is installed and running.")
+		util.Failed("Could not connect to a docker provider. Please start or install a docker provider.\nFor installation help go to: https://ddev.readthedocs.io/en/latest/users/docker_installation/")
 	}
 
 	// Populate custom/script commands so they're visible

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -159,6 +159,20 @@ func init() {
 			util.Warning("populateExamplesAndCommands() failed: %v", err)
 		}
 
+		// Determine if Docker is running and if the command requires Docker.
+		// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
+		// Determine if Docker is running by getting the version.
+		_, err = version.GetDockerVersion()
+		if err != nil {
+
+			// We don't use the first arg from the command line.
+			commands := os.Args[1:]
+			if commandRequiresDocker(commands) {
+				util.Failed("Could not connect to Docker. Please ensure Docker is installed and running.")
+			}
+
+		}
+
 		err = addCustomCommands(RootCmd)
 		if err != nil {
 			util.Warning("Adding custom/shell commands failed: %v", err)

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 )
 
 // getRequestedProjects will collect and return the requested projects from command line arguments and flags.
@@ -59,4 +60,28 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 	}
 
 	return requestedProjects, nil
+}
+
+// commandRequiresDocker are commands that can be run without a Docker runtime.
+func commandRequiresDocker(commands []string) bool {
+
+	// List of commands that do not rely on Docker running.
+	allowedCommands := []string{
+		"version",
+		"-v",
+		"--version",
+		"--help",
+		"-h",
+		"get",
+		"hostname",
+		"list",
+		"config",
+	}
+	for _, command := range commands {
+		// If an allowed command, return false that Docker is not required.
+		if nodeps.ArrayContainsString(allowedCommands, command) {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/nodeps"
 )
 
 // getRequestedProjects will collect and return the requested projects from command line arguments and flags.
@@ -60,28 +59,4 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 	}
 
 	return requestedProjects, nil
-}
-
-// commandRequiresDocker are commands that can be run without a Docker runtime.
-func commandRequiresDocker(commands []string) bool {
-
-	// List of commands that do not rely on Docker running.
-	allowedCommands := []string{
-		"version",
-		"-v",
-		"--version",
-		"--help",
-		"-h",
-		"get",
-		"hostname",
-		"list",
-		"config",
-	}
-	for _, command := range commands {
-		// If an allowed command, return false that Docker is not required.
-		if nodeps.ArrayContainsString(allowedCommands, command) {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
For custom commands and when Docker Desktop isn't running ddev tells me "Error: unknown command 'drush' for 'ddev'  Run 'ddev --help' for usage."
(This is a Cobra error message)

## How this PR Solves The Problem:
This check that Docker is running in root init for commands.

## Manual Testing Instructions:
Turn Docker off and try running a command and a custom command.


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
No test provided. I can provide tests with assistance.

## Related Issue Link(s):
#3336 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
No


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3746"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

