### PR TITLE
ddev snapshot -a should snapshot all apps and not fail just because one isn't running, fixes #3707

### DIFF
--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -48,6 +48,9 @@ ddev snapshot --all`,
 			case snapshotCleanup:
 				deleteAppSnapshot(app)
 			default:
+				if app.SiteStatus() != "running" {
+					continue
+				}
 				createAppSnapshot(app)
 			}
 		}

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -48,9 +48,6 @@ ddev snapshot --all`,
 			case snapshotCleanup:
 				deleteAppSnapshot(app)
 			default:
-				if app.SiteStatus() != "running" {
-					continue
-				}
 				createAppSnapshot(app)
 			}
 		}
@@ -70,10 +67,30 @@ func listAppSnapshots(app *ddevapp.DdevApp) {
 }
 
 func createAppSnapshot(app *ddevapp.DdevApp) {
+
+	appStatus := app.SiteStatus()
+	// If the app is not running, then start it to create a snapshot.
+	if appStatus != ddevapp.SiteRunning {
+		util.Warning("Project %s is %s, starting it to create a snapshot", app.GetName(), appStatus)
+		if err := app.Start(); err != nil {
+			util.Failed("Failed to start %s: %v", app.GetName(), err)
+		}
+	}
 	if snapshotNameOutput, err := app.Snapshot(snapshotName); err != nil {
 		util.Failed("Failed to snapshot %s: %v", app.GetName(), err)
 	} else {
 		util.Success("Created database snapshot %s", snapshotNameOutput)
+	}
+	// Return the app to its previous state, stopped or paused.
+	if appStatus == ddevapp.SiteStopped {
+		if err := app.Stop(false, false); err != nil {
+			util.Failed("Failed to stop %s: %v", app.GetName(), err)
+		}
+	}
+	if appStatus == ddevapp.SitePaused {
+		if err := app.Pause(); err != nil {
+			util.Failed("Failed to pause %s: %v", app.GetName(), err)
+		}
 	}
 }
 
@@ -110,7 +127,7 @@ func deleteAppSnapshot(app *ddevapp.DdevApp) {
 }
 
 func init() {
-	DdevSnapshotCommand.Flags().BoolVarP(&snapshotAll, "all", "a", false, "Snapshot all running projects")
+	DdevSnapshotCommand.Flags().BoolVarP(&snapshotAll, "all", "a", false, "Snapshot all projects. Will start the project if it is stopped or paused")
 	DdevSnapshotCommand.Flags().BoolVarP(&snapshotList, "list", "l", false, "List snapshots")
 	DdevSnapshotCommand.Flags().BoolVarP(&snapshotCleanup, "cleanup", "C", false, "Cleanup snapshots")
 	DdevSnapshotCommand.Flags().BoolVarP(&snapshotCleanupNoConfirm, "yes", "y", false, "Yes - skip confirmation prompt")


### PR DESCRIPTION
## The Problem/Issue/Bug:
`ddev snapshot --help` command says ddev snapshot --all should only snapshot running projects.
It still tries to snapshot a stopped project and then fails.

## How this PR Solves The Problem:
`ddev snapshot --all` will now start any stopped or paused apps and create a snapshot and then place the app back to its original state of stopped or paused.

## Manual Testing Instructions:

- Have three or more projects
- Stop one project and pause another and start the others
- Execute ddev snapshot --all
- Will create a snapshot of all projects
- Project stopped or paused will be set back to stopped or paused after snapshots

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
Run existing tests

## Related Issue Link(s):
#3707

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
No deployment changes


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3749"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

