### PR TITLE
More precise output for xhprof enable

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/enable_xhprof
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/enable_xhprof
@@ -5,5 +5,5 @@ mkdir -p ${XHPROF_OUTPUT_DIR}
 phpenmod xhprof
 killall -USR2 php-fpm 2>/dev/null || true
 echo "Enabled xhprof.
-After each web request you can see all runs, most recent first, at
+After each web request or CLI process you can see all runs, most recent first, at
 ${DDEV_PRIMARY_URL}/xhprof"


### PR DESCRIPTION
## The Problem/Issue/Bug:
`ddev xhprof on` states that it generates a profile for web requests.

## How this PR Solves The Problem:
It makes a precision that it works for CLI processes too.

## Manual Testing Instructions:
`ddev xhprof on` should have a more precise output now.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3752"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

