### PR TITLE
Add interactive project selection to start and stop command

### DIFF
--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -364,3 +364,32 @@ func GetProjects(activeOnly bool) ([]*DdevApp, error) {
 
 	return appSlice, nil
 }
+
+// GetInactiveProjects returns projects that are currently running
+func GetInactiveProjects() ([]*DdevApp, error) {
+	var inactiveApps []*DdevApp
+
+	apps, err := GetProjects(false)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, app := range apps {
+		if app.SiteStatus() != SiteRunning {
+			inactiveApps = append(inactiveApps, app)
+		}
+	}
+
+	return inactiveApps, nil
+}
+
+// ExtractProjectNames returns a list of names by a bunch of projects
+func ExtractProjectNames(apps []*DdevApp) []string {
+	var names []string
+	for _, app := range apps {
+		names = append(names, app.Name)
+	}
+
+	return names
+}

--- a/pkg/ddevapp/utils_test.go
+++ b/pkg/ddevapp/utils_test.go
@@ -1,0 +1,38 @@
+package ddevapp_test
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/exec"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGetInactiveProjects(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Make sure we have no running sites.
+	// Pause all sites.
+	_, err := exec.RunCommand(DdevBin, []string{"pause", "--all"})
+	require.NoError(t, err)
+
+	apps, err := ddevapp.GetInactiveProjects()
+	require.NoError(t, err)
+
+	assert.Greater(len(apps), 0)
+}
+
+func TestExtractProjectNames(t *testing.T) {
+	var apps []*ddevapp.DdevApp
+
+	assert := asrt.New(t)
+
+	apps = append(apps, &ddevapp.DdevApp{Name: "bar"})
+	apps = append(apps, &ddevapp.DdevApp{Name: "foo"})
+	apps = append(apps, &ddevapp.DdevApp{Name: "zoz"})
+
+	names := ddevapp.ExtractProjectNames(apps)
+	expectedNames := []string{"bar", "foo", "zoz"}
+
+	assert.Equal(expectedNames, names)
+}

--- a/pkg/ddevapp/utils_test.go
+++ b/pkg/ddevapp/utils_test.go
@@ -5,15 +5,32 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"os"
 	"testing"
 )
 
 func TestGetInactiveProjects(t *testing.T) {
 	assert := asrt.New(t)
 
-	// Make sure we have no running sites.
-	// Pause all sites.
-	_, err := exec.RunCommand(DdevBin, []string{"pause", "--all"})
+	origDir, _ := os.Getwd()
+	app := &ddevapp.DdevApp{}
+
+	site := TestSites[0]
+
+	t.Cleanup(func() {
+		err := os.Chdir(origDir)
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+	})
+	// Make sure we have one app in existence
+	err := app.Init(site.Dir)
+	require.NoError(t, err)
+	err = app.Start()
+	require.NoError(t, err)
+
+	// Stop all sites
+	_, err = exec.RunCommand(DdevBin, []string{"stop", "--all"})
 	require.NoError(t, err)
 
 	apps, err := ddevapp.GetInactiveProjects()


### PR DESCRIPTION
## The Problem/Issue/Bug: 
As a user I want to start a project by name. If the current working dir is not the project root, then I need to know the project name. Then I have to use `ddev list` to find the right name. Developers are lazy. So they have to copy the name to the clipboard.

## How this PR Solves The Problem: 
Provide an interactive selection of the project by adding a parameter `-s` to the `start` and `stop` command.

## Manual Testing Instructions:
Run `ddev start -s` or `ddev stop -s`

## Automated Testing Overview:
There are two new function in ddevapp.
- `ddevapp.ExtractProjectNames`
- `ddevapp.GetInactiveProjects`

There is a new file util_test.go which covers both new functions.
For the interactive command is currently no test available, because I do not know how we can test it.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3760"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

