### PR TITLE
#3761 Fix file path references

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -767,7 +767,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 
 	_, _, userName := util.GetContainerUIDGid()
 
-	extraWebContent := fmt.Sprintf("\nRUN chmod 600 ~%s/.pgpass ~%s/.my.cnf", userName, userName)
+	extraWebContent := fmt.Sprintf("\nRUN chmod 600 /home/%s/.pgpass /home/%s/.my.cnf", userName, userName)
 	extraWebContent = extraWebContent + fmt.Sprintf("\nENV NVM_DIR=/home/%s/.nvm", userName)
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN (apt-get remove -y nodejs || true) && (apt purge nodejs || true) && curl -sSL --fail https://deb.nodesource.com/setup_%s.x | bash - && apt-get install nodejs && npm config set unsafe-perm true && npm install --global gulp-cli yarn", app.NodeJSVersion)


### PR DESCRIPTION
## The Problem/Issue/Bug:

`.webimageBuild/Dockerfile` has wrong file path references
https://github.com/drud/ddev/issues/3761




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3762"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

