### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -29,6 +29,9 @@ env:
   DDEV_DEBUG: true
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: colima-${{ matrix.tests }}-no-bind-mounts=${{ matrix.no-bind-mounts }}

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -22,6 +22,9 @@ env:
   # key is updated, see https://github.com/docker-library/mysql/issues/801
   DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION: "90"
 
+permissions:
+  contents: read
+
 jobs:
   container-build-and-test:
     name: ${{ matrix.os }} - Test container ${{ matrix.containers }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,8 +16,14 @@ on:
     - "pkg/**"
     - "cmd/**"
     - ".github/workflows/**"
+permissions:
+  contents: read
+
 jobs:
   golangci:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -146,9 +146,6 @@ jobs:
           key: ${{ github.sha }}-${{ github.ref }}-notarize-macos
 
   artifacts:
-    permissions:
-      actions: write  # for skx/github-action-publish-binaries to attach binaries to release artifacts
-      contents: read  # for actions/checkout to fetch code
     name: Upload artifacts
     runs-on: ubuntu-20.04
     needs: [build-most, sign-windows, notarize-macos]

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -14,6 +14,9 @@ env:
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
 
+permissions:
+  contents: read
+
 jobs:
   build-most:
     name: Build DDEV executables except Windows
@@ -143,6 +146,9 @@ jobs:
           key: ${{ github.sha }}-${{ github.ref }}-notarize-macos
 
   artifacts:
+    permissions:
+      actions: write  # for skx/github-action-publish-binaries to attach binaries to release artifacts
+      contents: read  # for actions/checkout to fetch code
     name: Upload artifacts
     runs-on: ubuntu-20.04
     needs: [build-most, sign-windows, notarize-macos]

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,6 +20,9 @@ env:
   DDEV_DEBUG: true
 
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build DDEV executables

--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -23,6 +23,9 @@ env:
   DOCKER_ORG: drud
   TAG: "${{ github.event.inputs.tag }}"
 
+permissions:
+  contents: read
+
 jobs:
   push-tagged-image:
     name: "push tagged image"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ env:
   DDEV_DEBUG: true
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     defaults:


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3763"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

