### PR TITLE
Clarify that `delete images` wont operate on 3rd party images

### DIFF
--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -18,8 +18,8 @@ import (
 // DeleteImagesCmd implements the ddev delete images command
 var DeleteImagesCmd = &cobra.Command{
 	Use:   "images",
-	Short: "Deletes ddev docker images not in use by current ddev version",
-	Long:  "with --all it deletes all ddev docker images",
+	Short: "Deletes drud/ddev-* docker images not in use by current ddev version",
+	Long:  "with --all it deletes all drud/ddev-* docker images",
 	Example: `ddev delete images
 ddev delete images -y
 ddev delete images --all`,


### PR DESCRIPTION
## The Problem/Issue/Bug:
Our additional service uses an image called `massgov/mysql-sanitized`. We had hoped it would be deleted with a `ddev delete images` since it is known to ddev via a compose file. But it isn't.

We solved our need with `~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml down --rmi all`

## How this PR Solves The Problem:
Improve docs

## Manual Testing Instructions:
N/A

## Automated Testing Overview:
N/A

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3770"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

