### PR TITLE
Clarify that only images from drud/ddev are deleted

### DIFF
--- a/cmd/ddev/cmd/clean.go
+++ b/cmd/ddev/cmd/clean.go
@@ -16,7 +16,7 @@ var CleanCmd = &cobra.Command{
 	Use:   "clean [projectname ...]",
 	Short: "Removes items ddev has created",
 	Long: `Stops all running projects and then removes downloads and snapshots
-for the selected projects. Then clean will remove ddev images.
+for the selected projects. Then clean will remove drud/ddev-* images.
 
 Warning - This command will permanently delete your snapshots for the named project[s].
 

--- a/cmd/ddev/cmd/clean.go
+++ b/cmd/ddev/cmd/clean.go
@@ -16,7 +16,7 @@ var CleanCmd = &cobra.Command{
 	Use:   "clean [projectname ...]",
 	Short: "Removes items ddev has created",
 	Long: `Stops all running projects and then removes downloads and snapshots
-for the selected projects. Then clean will remove drud/ddev-* images.
+for the selected projects. Then clean will remove `drud/ddev-*` images.
 
 Warning - This command will permanently delete your snapshots for the named project[s].
 


### PR DESCRIPTION
See companion PR at #3770 

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3771"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

