### PR TITLE
Try to fix colima install - homebrew with cache flush

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Homebrew cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-homebrew-cache-1
+          cache-name: cache-homebrew-cache-2
         with:
           path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-build-${{ env.cache-name }}
@@ -68,7 +68,7 @@ jobs:
       - name: Lima cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-lima-1
+          cache-name: cache-lima-2
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.lima

--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -5,10 +5,11 @@ set -eu -o pipefail
 # colima has golang as dependency, so is going to install go anyway.
 # So we have to get rid of it somehow.
 brew uninstall go@1.15 || true
+brew unlink go || true
 brew uninstall go@1.17 || true
 brew uninstall postgresql || true
-brew update && brew install colima docker docker-compose golang libpq mkcert mysql-client
-brew link --force libpq mysql-client
+brew update && brew install colima docker docker-compose libpq mkcert mysql-client
+brew link --force golang libpq mysql-client
 
 # This command allows adding CA (in mkcert, etc) without the popup trust prompt
 # Mentioned in https://github.com/actions/virtual-environments/issues/4519#issuecomment-970202641

--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -5,6 +5,7 @@ set -eu -o pipefail
 # colima has golang as dependency, so is going to install go anyway.
 # So we have to get rid of it somehow.
 brew uninstall go@1.15 || true
+brew uninstall go@1.17 || true
 brew uninstall postgresql || true
 brew update && brew install colima docker docker-compose golang libpq mkcert mysql-client
 brew link --force libpq mysql-client


### PR DESCRIPTION
## The Problem/Issue/Bug:

Colima install has been failing consistently apparently since go 1.18 release. Try to fix with fresh cache.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3777"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

