### PR TITLE
Fix TYPO3 Git clone example

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -232,14 +232,15 @@ ddev launch
 
 To connect to the database within the database container directly, please see the [developer tools page](developer-tools.md#using-development-tools-on-the-host-machine).
 
-To get started using ddev with a TYPO3 project, clone the project's repository and checkout its directory.
-
 #### TYPO3 Git Clone Example
 
 ```bash
 git clone https://github.com/example/example-site
 cd example-site
+# adapt docroot= as needed
+ddev config --project-type=typo3 --docroot=public
 ddev composer install
+ddev launch
 ```
 
 ### Backdrop Quickstart


### PR DESCRIPTION
## The Problem/Issue/Bug:

The example missed the `ddev config` step.

## How this PR Solves The Problem:

This removes a sentence that was not really necessary. It add `ddev config` and finally a `ddev launch` to be in line with the other examples.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3779"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

