### PR TITLE
[docs] Remove unnecessary information from TYPO3 quickstart

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -233,8 +233,7 @@ ddev launch
 ```bash
 git clone https://github.com/example/example-site
 cd example-site
-# adapt docroot= as needed
-ddev config --project-type=typo3 --docroot=public
+ddev config
 ddev composer install
 ddev launch
 ```

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -228,9 +228,9 @@ ddev exec touch public/FIRST_INSTALL
 ddev launch
 ```
 
-**On TYPO3 versions < 9 an install may fail if you use the https URL to install because the allowed proxy is not configured yet ("Trusted hosts pattern mismatch"). Please use "http" instead of "https" for the URL while doing the install.**
+**Note**
 
-To connect to the database within the database container directly, please see the [developer tools page](developer-tools.md#using-development-tools-on-the-host-machine).
+On TYPO3 versions < 9 an install may fail if you use the https URL to install because the allowed proxy is not configured yet ("Trusted hosts pattern mismatch"). Please use "http" instead of "https" for the URL while doing the install.
 
 #### TYPO3 Git Clone Example
 

--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -228,10 +228,6 @@ ddev exec touch public/FIRST_INSTALL
 ddev launch
 ```
 
-**Note**
-
-On TYPO3 versions < 9 an install may fail if you use the https URL to install because the allowed proxy is not configured yet ("Trusted hosts pattern mismatch"). Please use "http" instead of "https" for the URL while doing the install.
-
 #### TYPO3 Git Clone Example
 
 ```bash


### PR DESCRIPTION
## The Problem/Issue/Bug:

That page is too convoluted already. Information that is not specific to a framework should not be unnecessarily repeated there.

## How this PR Solves The Problem:

This removes information unspecific to TYPO3 from that section.

As a drive-by change it beautifies the big bold block for legacy TYPO3
installation.






<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3780"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

