### PR TITLE
Try to fix markdown link failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The general workflow for contributing to this project is outlined in this docume
 
 ## Create an Issue
 
-If you find a bug in this project, have trouble following the documentation, or have a question about the project, create an issue! There’s nothing to it and whatever issue you’re having, you’re likely not the only one, so others will find your issue helpful, too. For more information on how issues work, check out GitHub's [Issues guide](http://guides.github.com/features/issues). Or there are lots of [other places for immediate support](https://ddev.readthedocs.io/en/stable/#support-and-user-contributed-documentation).
+If you find a bug in this project, have trouble following the documentation, or have a question about the project, create an issue! There’s nothing to it and whatever issue you’re having, you’re likely not the only one, so others will find your issue helpful, too. For more information on how issues work, check out GitHub's [Issues guide](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues). Or there are lots of [other places for immediate support](https://ddev.readthedocs.io/en/stable/#support-and-user-contributed-documentation).
 
 ### Issues Pro Tips
 

--- a/docs/developers/building-contributing.md
+++ b/docs/developers/building-contributing.md
@@ -128,8 +128,8 @@ When changes are made to an image, they have to be temporarily pushed to a tag t
 
 ## Pull Request Pro Tips
 
-* **[Fork](http://guides.github.com/activities/forking/) the repository** and clone it locally. Connect your local to the original ‘upstream’ repository by adding it as a remote. - Pull in changes from ‘upstream’ often so that you stay up to date so that when you submit your pull request, merge conflicts - will be less likely. See more detailed instructions [here](https://help.github.com/articles/syncing-a-fork).
-* **Create a [branch](http://guides.github.com/introduction/flow/)** for your edits.
+* **[Fork](https://docs.github.com/en/get-started/quickstart/contributing-to-projects) the repository** and clone it locally. Connect your local to the original ‘upstream’ repository by adding it as a remote. - Pull in changes from ‘upstream’ often so that you stay up to date so that when you submit your pull request, merge conflicts - will be less likely. See more detailed instructions [here](https://help.github.com/articles/syncing-a-fork).
+* **Create a [branch](https://docs.github.com/en/get-started/quickstart/github-flow)** for your edits.
 * **Be clear** about what problem is occurring and how someone can recreate that problem or why your feature will help. Then be equally as clear about the steps you took to make your changes.
 * **It’s best to test**. Run your changes against any existing tests if they exist and create new ones when needed. Whether tests exist or not, make sure your changes don’t break the existing project.
 

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -22,7 +22,10 @@
       "pattern": "^https://www.php.net/manual/"
     },
     {
-      "pattern": "^https://(docs|guides).github.com/"
+      "pattern": "^https://(docs|guides|help).github.com/"
+    },
+    {
+      "pattern": "^https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok"
     },
     {
       "pattern": "^https://www.cyberciti.biz/"

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -22,6 +22,9 @@
       "pattern": "^https://www.php.net/manual/"
     },
     {
+      "pattern": "^https://(docs|guides).github.com/"
+    },
+    {
       "pattern": "^https://www.cyberciti.biz/"
     }
   ],


### PR DESCRIPTION
## The Problem/Issue/Bug:

There have been several new docs link-check failures recently, see
* https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/136

This just ignores the docs.github.com and guides.github.com links.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3787"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

