### PR TITLE
Fix TestAcquiaPull as drush has new dependency

### DIFF
--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -97,7 +97,7 @@ func TestAcquiaPull(t *testing.T) {
 
 	// Make sure we have drush
 	_, _, err = app.Exec(&ExecOpts{
-		Cmd: "composer require --no-interaction drush/drush:* >/dev/null 2>/dev/null",
+		Cmd: "composer require --no-interaction drush/drush symfony/http-kernel>/dev/null 2>/dev/null",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

TestAcquiaPull has been failing all the time.

Drush now doesn't seem to explicitly require symfony/http-kernel so we just need to do that in the installation



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3789"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

