### PR TITLE
[tests only] Fix TestShareCmd - args for ngrok changed in 3.x

### DIFF
--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -35,7 +35,7 @@ func TestShareCmd(t *testing.T) {
 	defer site.Chdir()()
 
 	// Configure ddev/ngrok to use json output to stdout
-	cmd := exec.Command(DdevBin, "config", "--ngrok-args", "-log stdout -log-format=json")
+	cmd := exec.Command(DdevBin, "config", "--ngrok-args", "--log stdout --log-format=json")
 	err := cmd.Start()
 	require.NoError(t, err)
 	err = cmd.Wait()


### PR DESCRIPTION
## The Problem/Issue/Bug:

ngrok 3.0.2 changed the args from single hyphen to double, so TestShareCmd has to change



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3790"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

