### PR TITLE
Composer should fail if patches fail

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1789,6 +1789,7 @@ func (app *DdevApp) DockerEnv() {
 		// Without COMPOSE_DOCKER_CLI_BUILD=0, docker-compose makes all kinds of mess
 		// of output. BUILDKIT_PROGRESS doesn't help either.
 		"COMPOSE_DOCKER_CLI_BUILD": "0",
+		"COMPOSER_EXIT_ON_PATCH_FAILURE":"1",
 		// The compose project name can no longer contain dots
 		// https://github.com/compose-spec/compose-go/pull/197
 		"COMPOSE_PROJECT_NAME":          "ddev-" + strings.Replace(app.Name, `.`, "", -1),

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1788,8 +1788,8 @@ func (app *DdevApp) DockerEnv() {
 	envVars := map[string]string{
 		// Without COMPOSE_DOCKER_CLI_BUILD=0, docker-compose makes all kinds of mess
 		// of output. BUILDKIT_PROGRESS doesn't help either.
-		"COMPOSE_DOCKER_CLI_BUILD": "0",
-		"COMPOSER_EXIT_ON_PATCH_FAILURE":"1",
+		"COMPOSE_DOCKER_CLI_BUILD":       "0",
+		"COMPOSER_EXIT_ON_PATCH_FAILURE": "1",
 		// The compose project name can no longer contain dots
 		// https://github.com/compose-spec/compose-go/pull/197
 		"COMPOSE_PROJECT_NAME":          "ddev-" + strings.Replace(app.Name, `.`, "", -1),


### PR DESCRIPTION
## The Problem/Issue/Bug:

It's a great thing to get information on failing patches immediately.

## How this PR Solves The Problem:
Uses https://github.com/cweagans/composer-patches/blob/1.x/src/Patches.php#L285

## Manual Testing Instructions:

Apply a broken patch on the codebase and see the exit code of `ddev composer install`

## Automated Testing Overview:
-

## Related Issue Link(s):

## Release/Deployment notes:

As it might be a breaking change for some, we might need to wire it into the config and make it adjustable.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3795"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

