### PR TITLE
Make brew install --HEAD ddev work, fixes #3794 [skip ci]

### DIFF
--- a/.ci-scripts/bump_homebrew.sh
+++ b/.ci-scripts/bump_homebrew.sh
@@ -44,7 +44,8 @@ class Ddev < Formula
   depends_on "nss" => :run
   depends_on "go" => :build
   depends_on "make" => :build
-
+  depends_on "docker" => :build
+  
   bottle do
     root_url "https://github.com/${GITHUB_USERNAME}/${PROJECT_NAME}/releases/download/${VERSION_NUMBER}/"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "${LINUX_BOTTLE_SHA}"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3794

I don't completely understand this, but adding a build-time dependency on the docker formula sorts it out. It would also work to remove the `ddev --version` test. 

## How this PR Solves The Problem:

* Add the homebrew docker formula as a build-time dependency. This shouldn't affect anybody in normal use (not --HEAD)
* I pushed this directly to homebrew-ddev
* This PR adds that so it will go into next automated push.

## Manual Testing Instructions:

`brew update && brew install --HEAD drud/ddev/ddev`



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3796"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

