### PR TITLE
Don't try to use docker client for ddev --version, fixes #3794

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -89,9 +89,11 @@ func GetDockerClient() *docker.Client {
 
 	// This section is skipped if $DOCKER_HOST is set
 	if DockerHost == "" {
-		DockerContext, DockerHost, err = GetDockerContext()
-		if err != nil {
-			util.Failed("Unable to get docker context: %v", err)
+		if len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "version" && os.Args[1] != "help" {
+			DockerContext, DockerHost, err = GetDockerContext()
+			if err != nil {
+				util.Failed("Unable to get docker context: %v", err)
+			}
 		}
 	}
 	// Respect DOCKER_HOST in case it's set, otherwise use host we got from context


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3794 

When docker (client) is not in $PATH, `ddev --version` fails, and `ddev --version` is used as the test in `brew install`. And in the context of `brew install` docker is not in the $PATH.

## How this PR Solves The Problem:

Just look and see if we're trying to do `ddev --version`, `ddev version`, `ddev help` before trying to use docker. 

This replaces the alternate approach in 
* #3796

## Manual Testing Instructions:

- [ ] Take docker out of $PATH and `ddev --version`
- [ ] `brew install --HEAD ddev`

## Automated Testing Overview:

I think that github.com/drud/homebrew-ddev should have basic tests... make sure that a homebrew install can be done.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3798"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

