### PR TITLE
[docs] Remove extra backtick in platform.sh instructions

### DIFF
--- a/docs/users/providers/platform.md
+++ b/docs/users/providers/platform.md
@@ -13,7 +13,7 @@ ddev's Platform.sh integration pulls database and files from an existing Platfor
 
    ```yaml
    web_environment:
-   - PLATFORMSH_CLI_TOKEN=abcdeyourtoken`
+   - PLATFORMSH_CLI_TOKEN=abcdeyourtoken
    ```
 
 3. `ddev restart`


### PR DESCRIPTION
## The Problem/Issue/Bug:
Stray backtick in the yaml example.

## How this PR Solves The Problem:
Removes it.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3802"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

