### PR TITLE
Don't always check for ddev version, stop using pull_request_target for #3794

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Homebrew cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-homebrew-cache-2
+          cache-name: cache-homebrew-cache-3
         with:
           path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-build-${{ env.cache-name }}

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -1,6 +1,6 @@
 name: Colima tests
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "go.*"
       - "pkg/**"

--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -8,7 +8,7 @@ brew uninstall go@1.15 || true
 brew unlink go || true
 brew uninstall go@1.17 || true
 brew uninstall postgresql || true
-brew update && brew install colima docker docker-compose go libpq mkcert mysql-client
+brew update >/dev/null && brew install colima docker docker-compose go libpq mkcert mysql-client
 brew link --force go libpq mysql-client
 
 # This command allows adding CA (in mkcert, etc) without the popup trust prompt

--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -2,13 +2,15 @@
 
 set -eu -o pipefail
 
+brew update >/dev/null
+
 # colima has golang as dependency, so is going to install go anyway.
 # So we have to get rid of it somehow.
 brew uninstall go@1.15 || true
 brew unlink go || true
 brew uninstall go@1.17 || true
 brew uninstall postgresql || true
-brew update >/dev/null && brew install colima docker docker-compose go libpq mkcert mysql-client
+brew install colima docker docker-compose go libpq mkcert mysql-client
 brew link --force go libpq mysql-client
 
 # This command allows adding CA (in mkcert, etc) without the popup trust prompt

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,7 +5,7 @@ defaults:
     shell: bash
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "go.*"
       - "pkg/**"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "go.*"
       - "pkg/**"

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -153,7 +153,7 @@ func init() {
 	// Determine if Docker is running by getting the version.
 	// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
 	_, err := version.GetDockerVersion()
-	if err != nil {
+	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "version" && os.Args[1] != "help" {
 		util.Failed("Could not connect to a docker provider. Please start or install a docker provider.\nFor installation help go to: https://ddev.readthedocs.io/en/latest/users/docker_installation/")
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

It turns out that yesterday's adjustment to allowing `ddev --version`, 
* #3798

didn't work for colima, which has to have the docker context set in most cases

Related still: 
* #3794 

This also changes the event everywhere to `pull_request` from `pull_request_target`, which I'm pretty sure it should be. With `pull_request_target` it's actually testing the upstream/master, which is not what we want.

## How this PR Solves The Problem:

Remove the version check for the same set of ddev commands

## Manual Testing Instructions:

- [x] `ddev start` with Colima. 
- [ ] `brew install --HEAD --fetch-head ddev` with Colima. This can't be done until this is pulled

## Release/Deployment notes:


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3803"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

