### PR TITLE
Don't skip docker setup for ddev version

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -153,7 +153,7 @@ func init() {
 	// Determine if Docker is running by getting the version.
 	// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
 	_, err := version.GetDockerVersion()
-	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "version" && os.Args[1] != "help" {
+	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "help" {
 		util.Failed("Could not connect to a docker provider. Please start or install a docker provider.\nFor installation help go to: https://ddev.readthedocs.io/en/latest/users/docker_installation/")
 	}
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -89,7 +89,7 @@ func GetDockerClient() *docker.Client {
 
 	// This section is skipped if $DOCKER_HOST is set
 	if DockerHost == "" {
-		if len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "version" && os.Args[1] != "help" {
+		if len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "help" {
 			DockerContext, DockerHost, err = GetDockerContext()
 			if err != nil {
 				util.Failed("Unable to get docker context: %v", err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev version` isn't working properly

## How this PR Solves The Problem:

Don't exclude `ddev version` from the docker setup initializations.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3805"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

