### PR TITLE
[Docs] Move 'ddev launch' above optional step (WP CLI quickstart)

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -84,15 +84,14 @@ ddev start
 
 ddev wp core download
 
+# finish the installation in your browser:
+
+ddev launch
+
 # optional: you can use the following installation command 
-# or finish the installation in the browser (see next step, run ddev launch)
 # (we need to use single quotes to get the primary site URL from .ddev/config.yaml as variable)
 
 ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_email=admin@example.com --prompt=admin_password
-
-# open the website (https://my-wp-site.ddev.site) in your browser:
-
-ddev launch
 
 # open WordPress admin dashboard in your browser:
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Since I did use this [quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage/#command-line-setup-example-using-wp-cli) many times, I experienced that installing WordPress in the browser window (user, password) is way more comfortable.  For new users the optional step described might be confusing. 

## How this PR Solves The Problem:

Moves the 'ddev launch' command above the (possibly confusing) optional step. 

## Manual Testing Instructions:

## Automated Testing Overview:

No tests, just docs.

## Related Issue Link(s):

See previous discussion https://github.com/drud/ddev/issues/3299

## Release/Deployment notes:
No



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3806"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

