### PR TITLE
Add ddev debug refresh command to solve composer issues

### DIFF
--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -27,6 +27,12 @@ var DebugRefreshCmd = &cobra.Command{
 			util.Failed("Failed to get project: %v", err)
 		}
 
+		if app.SiteStatus() != ddevapp.SiteRunning {
+			if err = app.Start(); err != nil {
+				util.Failed("Failed to start %s: %v", app.Name, err)
+			}
+		}
+
 		app.DockerEnv()
 		if err = app.WriteDockerComposeYAML(); err != nil {
 			util.Failed("Failed to get compose-config: %v", err)
@@ -38,6 +44,11 @@ var DebugRefreshCmd = &cobra.Command{
 		if err != nil {
 			util.Failed("Failed to execute docker-compose -f %s build --no-cache: %v", err)
 		}
+		err = app.Restart()
+		if err != nil {
+			util.Failed("Failed to restart project: %v", err)
+		}
+
 		util.Success("Refreshed docker cache for project %s", app.Name)
 	},
 }

--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// DebugRefreshCmd implements the ddev debug refresh command
+var DebugRefreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Refreshes docker cache for project",
+	Run: func(cmd *cobra.Command, args []string) {
+		projectName := ""
+
+		if len(args) > 1 {
+			util.Failed("This command only takes one optional argument: project name")
+		}
+
+		if len(args) == 1 {
+			projectName = args[0]
+		}
+
+		app, err := ddevapp.GetActiveApp(projectName)
+		if err != nil {
+			util.Failed("Failed to get project: %v", err)
+		}
+
+		app.DockerEnv()
+		if err = app.WriteDockerComposeYAML(); err != nil {
+			util.Failed("Failed to get compose-config: %v", err)
+		}
+
+		util.Debug("Executing docker-compose -f %s build --no-cache", app.DockerComposeFullRenderedYAMLPath())
+		_, _, err = dockerutil.ComposeCmd([]string{app.DockerComposeFullRenderedYAMLPath()}, "build", "--no-cache")
+
+		if err != nil {
+			util.Failed("Failed to execute docker-compose -f %s build --no-cache: %v", err)
+		}
+		util.Success("Refreshed docker cache for project %s", app.Name)
+	},
+}
+
+func init() {
+	DebugCmd.AddCommand(DebugRefreshCmd)
+}

--- a/cmd/ddev/cmd/debug-refresh_test.go
+++ b/cmd/ddev/cmd/debug-refresh_test.go
@@ -43,6 +43,10 @@ RUN shuf -i 0-99999 -n1 > /random.txt
 `)
 	require.NoError(t, err)
 
+	// This is normally done in root's init() - probably shouldn't be.
+	err = ddevapp.PopulateExamplesCommandsHomeadditions("")
+	require.NoError(t, err)
+
 	err = app.Start()
 	require.NoError(t, err)
 

--- a/cmd/ddev/cmd/debug-refresh_test.go
+++ b/cmd/ddev/cmd/debug-refresh_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/fileutil"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+
+	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/testcommon"
+)
+
+// TestDebugRefreshCmd tests that ddev debug refresh actually clears docker caache
+func TestDebugRefreshCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Create a temporary directory and switch to it.
+	origDir, _ := os.Getwd()
+	tmpdir := testcommon.CreateTmpDir(t.Name())
+
+	err := os.Chdir(tmpdir)
+	assert.NoError(err)
+	_, err = exec.RunHostCommand(DdevBin, "config", "--auto")
+	assert.NoError(err)
+
+	app, err := ddevapp.GetActiveApp("")
+	assert.NoError(err)
+
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		err := os.RemoveAll(tmpdir)
+		assert.NoError(err)
+	})
+
+	err = fileutil.AppendStringToFile(app.GetConfigPath("web-build/Dockerfile"), `
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+RUN shuf -i 0-99999 -n1 > /random.txt
+`)
+	require.NoError(t, err)
+
+	err = app.Start()
+	require.NoError(t, err)
+
+	origRandom, _, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: "cat /random.txt",
+	})
+	require.NoError(t, err)
+
+	// Make sure that in the ordinary case, the original cache/Dockerfile is same
+	err = app.Restart()
+	require.NoError(t, err)
+	newRandom, _, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: "cat /random.txt",
+	})
+	require.NoError(t, err)
+	assert.Equal(origRandom, newRandom)
+
+	// Now run ddev debug refresh to blow away the docker cache
+	_, err = exec.RunHostCommand(DdevBin, "debug", "refresh")
+	require.NoError(t, err)
+
+	// Now with refresh having been done, we should see a new value for random
+	err = app.Restart()
+	require.NoError(t, err)
+	freshRandom, _, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: "cat /random.txt",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(origRandom, freshRandom)
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Docker cache can be pretty confusing, and it turns out that Dockerfile RUN commands like `composer self-update` can be cached *across all projects*, which means that composer isn't even updated on a new project.

## How this PR Solves The Problem:

This adds a `ddev debug refresh` command that does a `docker-compose build --no-cache`, hopefully allowing a reset of this situation.

## Manual Testing Instructions:

- [x] Create a .ddev/web-build/Dockerfile with 
```dockerfile
ARG BASE_IMAGE
FROM $BASE_IMAGE
RUN shuf -i 0-99999 -n1 > /random.txt
```
- [x] `ddev start` and verify the value in `ddev exec cat /random.txt`
- [x] A `ddev restart` should leave it unchanged
- [x] `ddev debug refresh`
- [x] Now `ddev exec cat /random.txt` should be different

## Automated Testing Overview:

Added TestDebugRefreshCmd

## Related Issue Link(s):




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3808"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

