### PR TITLE
[tests only] Use working version of artifact commenter

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -1,61 +1,54 @@
-name: Comment on PR with artifacts links
+name: Add download link to PR
 on:
   workflow_run:
     workflows: ['PR Build']
     types: [completed]
 jobs:
   pr_comment:
-    if: startsWith(github.event.workflow_run.event, 'pull_request') && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
-        with:
-          # This snippet is public-domain, taken from
-          # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
-          script: |
-            async function upsertComment(owner, repo, issue_number, purpose, body) {
-              const {data: comments} = await github.rest.issues.listComments(
-                {owner, repo, issue_number});
-
-              const marker = `<!-- bot: ${purpose} -->`;
-              body = marker + "\n" + body;
-
-              const existing = comments.filter((c) => c.body.includes(marker));
-              if (existing.length > 0) {
-                const last = existing[existing.length - 1];
-                core.info(`Updating comment ${last.id}`);
-                await github.rest.issues.updateComment({
-                  owner, repo,
-                  body,
-                  comment_id: last.id,
-                });
-              } else {
-                core.info(`Creating a comment in issue / PR #${issue_number}`);
-                await github.rest.issues.createComment({issue_number, body, owner, repo});
+    - uses: actions/github-script@v3
+      with:
+        # This snippet is public-domain, taken from
+        # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
+        script: |
+          const {owner, repo} = context.repo;
+          const run_id = ${{github.event.workflow_run.id}};
+          const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
+          const pull_user_id = ${{github.event.sender.id}};
+          
+          const issue_number = await (async () => {
+            const pulls = await github.pulls.list({owner, repo});
+            for await (const {data} of github.paginate.iterator(pulls)) {
+              for (const pull of data) {
+                if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
+                  return pull.number;
+                }
               }
             }
-
-            const {owner, repo} = context.repo;
-            const run_id = ${{github.event.workflow_run.id}};
-
-            const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
-            if (!pull_requests.length) {
-              return core.error("This workflow doesn't match any pull requests!");
-            }
-
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
-            if (!artifacts.length) {
-              return core.error(`No artifacts found`);
-            }
-            let body = `Download the artifacts for this pull request:\n`;
-            for (const art of artifacts) {
-              body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
-            }
-
-            core.info("Review thread message body:", body);
-
-            for (const pr of pull_requests) {
-              await upsertComment(owner, repo, pr.number,
-                "nightly-link", body);
-            }
+          })();
+          if (issue_number) {
+            core.info(`Using pull request ${issue_number}`);
+          } else {
+            return core.error(`No matching pull request found`);
+          }
+          
+          const {data: {artifacts}} = await github.actions.listWorkflowRunArtifacts({owner, repo, run_id});
+          if (!artifacts.length) {
+            return core.error(`No artifacts found`);
+          }
+          let body = `Download the artifacts for this pull request:\n`;
+          for (const art of artifacts) {
+            body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+          }
+          
+          const {data: comments} = await github.issues.listComments({repo, owner, issue_number});
+          const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
+          if (existing_comment) {
+            core.info(`Updating comment ${existing_comment.id}`);
+            await github.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});
+          } else {
+            core.info(`Creating a comment`);
+            await github.issues.createComment({repo, owner, issue_number, body});
+          }


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/oprypin/nightly.link/issues/37

## How this PR Solves The Problem:

Use the older version that works.

This was also not working here for(ever) because we were using pull_request_target in the "PR Build", so it didn't match the code needed here. 



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3810"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

