### PR TITLE
Fix ddev-gitpod image build: Don't try to use ddev config in gitpod image

### DIFF
--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -16,7 +16,7 @@ RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
 RUN echo ". /usr/share/autojump/autojump.sh" >> ~/.bashrc
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
-RUN ddev config global --omit-containers=ddev-router,dba,ddev-ssh-agent
+RUN mkdir -p ~/.ddev && echo "omit_containers: [ddev-router,ddev-ssh-agent]" >> ~/.ddev/global_config.yaml
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 # a gcc instance named gcc-5 is required for some vscode installations


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev config` no longer works without docker available.
And the Dockerfile for the gitpod image used it.

## How this PR Solves The Problem:

Instead of using `ddev config global` just output a starter global_config.yaml

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3816"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

