### PR TITLE
Add `--wide` flag to `ddev list`

### DIFF
--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -14,6 +14,9 @@ var activeOnly bool
 // continuousSleepTime is time to sleep between reads with --continuous
 var continuousSleepTime = 1
 
+// Allow the output to be wider than the terminal width
+var unlimitedOutputWidth bool
+
 // ListCmd represents the list command
 var ListCmd = &cobra.Command{
 	Use:   "list",
@@ -23,7 +26,7 @@ var ListCmd = &cobra.Command{
 ddev list --active-only
 ddev list -A`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ddevapp.List(activeOnly, continuous, continuousSleepTime)
+		ddevapp.List(activeOnly, continuous, continuousSleepTime, !unlimitedOutputWidth)
 	},
 }
 
@@ -31,6 +34,7 @@ func init() {
 	ListCmd.Flags().BoolVarP(&activeOnly, "active-only", "A", false, "If set, only currently active projects will be displayed.")
 	ListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted until the command is stopped.")
 	ListCmd.Flags().IntVarP(&continuousSleepTime, "continuous-sleep-interval", "I", 1, "Time in seconds between ddev list --continuous output lists.")
+	ListCmd.Flags().BoolVarP(&unlimitedOutputWidth, "wide", "w", false, "Unlimited output width")
 
 	RootCmd.AddCommand(ListCmd)
 }

--- a/pkg/ddevapp/list_test.go
+++ b/pkg/ddevapp/list_test.go
@@ -85,7 +85,7 @@ func TestListWithoutDir(t *testing.T) {
 	// This could be done otherwise, but we'd have to go find the site in the
 	// array first.
 	out := bytes.Buffer{}
-	table := ddevapp.CreateAppTable(&out)
+	table := ddevapp.CreateAppTable(&out, true)
 	for _, site := range apps {
 		desc, err := site.Describe(false)
 		if err != nil {
@@ -104,5 +104,5 @@ func TestListWithoutDir(t *testing.T) {
 // TestDdevList tests the ddevapp.List() functionality
 // It's only here for profiling at this point.
 func TestDdevList(t *testing.T) {
-	ddevapp.List(true, false, 1)
+	ddevapp.List(true, false, 1, true)
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
In our team, we use the command bellow in several hooks to check if the ddev container is running. 

    ddev list -A | grep '<projectname>' | grep 'running' --count

However, because the terminal is not wide enough, the `running` part is omitted from the first grep command and second grep always fails.

## How this PR Solves The Problem:
Add a `--wide` flag to the `ddev list` command to make sure the output is not truncated.

## Manual Testing Instructions:
```bash
$ ddev list -A
┌──────────┬─────────┬─────────────────────┬─────────────────────────────────────────────────────────┬────────┐
│ NAME     │ TYPE    │ LOCATION            │ URL                                                     │ STATUS │
├──────────┼─────────┼─────────────────────┼─────────────────────────────────────────────────────────┼────────┤
│ d9simple │ drupal9 │ /workspace/d9simple │ https://8080-jerodev-ddev-843s3hl1910.ws-eu44.gitpod.io │ OK     │
├──────────┼─────────┼─────────────────────┼─────────────────────────────────────────────────────────┼────────┤
│ Router   │         │ stopped             │                                                         │        │
└──────────┴─────────┴─────────────────────┴─────────────────────────────────────────────────────────┴────────┘
 
$ ddev list -A | grep d9simple
│ d9simple │ drupal9 │ /workspace/d9simple │ https://8080-jerodev-ddev-843s3hl ≈

$ ddev list -Aw | grep d9simple
│ d9simple │ drupal9 │ /workspace/d9simple │ https://8080-jerodev-ddev-843s3hl1910.ws-eu44.gitpod.io │ OK     │
```

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3820"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

