### PR TITLE
[DOCS] Add info about mutagen global enable option, fixes #3821

### DIFF
--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -38,8 +38,7 @@ You can also enable mutagen globally (recommended) with `ddev config global --mu
 
 Note that the nfs-mount-enabled feature is automatically turned off if you're using mutagen.
 
-You can run mutagen on all your projects, there's no limit. To configure it globally, `ddev config global --mutagen-enabled`.
-> You can not disable mutagen for a specific project if it's enabled globally.
+You can run mutagen on all your projects, there's no limit. To configure it globally, `ddev config global --mutagen-enabled`, but you cannot disable mutagen on individual projects if it's enabled globally (the global configuration wins).
 
 ### Caveats about Mutagen Integration
 

--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -39,6 +39,7 @@ You can also enable mutagen globally (recommended) with `ddev config global --mu
 Note that the nfs-mount-enabled feature is automatically turned off if you're using mutagen.
 
 You can run mutagen on all your projects, there's no limit. To configure it globally, `ddev config global --mutagen-enabled`.
+> You can not disable mutagen for a specific project if it's enabled globally.
 
 ### Caveats about Mutagen Integration
 


### PR DESCRIPTION
The recommended way is to enable mutagen per-project 
if you don't want it enabled in each DDEV project.

Fixes: #3821

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3822"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

