### PR TITLE
[docs] don't suggest --web-environment, use --web-environment-add instead

### DIFF
--- a/docs/users/blackfire-profiling.md
+++ b/docs/users/blackfire-profiling.md
@@ -7,7 +7,7 @@ DDEV-Local has built-in [blackfire.io](https://blackfire.io) integration.
 1. Create an account on [blackfire.io](https://blackfire.io)
 2. Install the Chrome or Firefox [browser plugin](https://blackfire.io/docs/profiling-cookbooks/profiling-http-via-browser).
 3. Get the Server ID, Server Token, Client ID, and Client Token from your Account->Credentials or environment on blackfire.io.
-4. Configure ddev with the credentials, `ddev config global --web-environment="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`. It's easiest to do this globally, but you can do the same thing at the project-level using `ddev config --web-environment`. (Note that you can also just manually edit the relevant config file.)
+4. Configure ddev with the credentials, `ddev config global --web-environment-add="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`. It's easiest to do this globally, but you can do the same thing at the project-level using `ddev config --web-environment-add`. (It may be easier to manually edit the relevant config file, `.ddev/config.yaml` or `~/.ddev/global_config.yaml`.)
 5. `ddev start`
 6. `ddev blackfire on` to enable, `ddev blackfire off` to disable, `ddev blackfire status` to see status.
 7. With Blackfire enabled, you can use the [browser extension](https://blackfire.io/docs/profiling-cookbooks/profiling-http-via-browser).
@@ -28,7 +28,7 @@ The Blackfire CLI is built into the web container, so no installation needs to t
 
     ```
 
-   It can also be done with `ddev config global --web-environment="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`, but if there are already environment variables there they will be deleted.
+   It can also be done with `ddev config global --web-environment-add="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`, but if there are already environment variables there they will be deleted.
 2. `ddev start`
 3. `ddev blackfire on`
 4. Click the "blackfire" browser extension to profile

--- a/docs/users/extend/customization-extendibility.md
+++ b/docs/users/extend/customization-extendibility.md
@@ -32,7 +32,7 @@ web_environment:
 - SOMEOTHERENV=someotherval
 ```
 
-You can also use `ddev config global --web-environment="SOMEENV=someval"` or `ddev config --web-environment="SOMEENV=someval"` for the same purpose. The command just sets the values in the configuration files. (Using this command overwrites all the web_environment values, so if you need to add additional values to those that are already configured, use `--web-environment-add`, or edit `config.yaml` or `global_config.yaml`.)
+You can also use `ddev config global --web-environment-add="SOMEENV=someval"` or `ddev config --web-environment-add="SOMEENV=someval"` for the same purpose. The command just sets the values in the configuration files. (The `--web-environment` option is also available, but it overwrites existing contents. Alternately, edit `.ddev/config.yaml` or `~/.ddev/global_config.yaml`.)
 
 The docker-compose web environment can also provide env file support. To enable this you would create a new docker-compose yaml partial, for example `.ddev/docker-compose.env-file.yaml` with contents:
 


### PR DESCRIPTION

## The Problem/Issue/Bug:

`--web-environment` overwrites existing content of config files; --web-environment-add is normally better.

## How this PR Solves The Problem:

Update doc

