### PR TITLE
Revert "Bump actions/github-script from 3 to 6 (#3826)"

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v3
       with:
         # This snippet is public-domain, taken from
         # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml


### PR DESCRIPTION
This reverts commit 2aa08b47c6180c9d5a2be6e3d95757a64470de17.

## The Problem/Issue/Bug:

pr-artifacts-comment was working until dependabot upgraded things.

Revert.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3835"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

