### PR TITLE
Move yarn command from host to web (#3741)

### DIFF
--- a/docs/users/performance.md
+++ b/docs/users/performance.md
@@ -65,9 +65,11 @@ In general, it's best practice on most projects to do significant git operations
 ddev mutagen sync || true
 ```
 
-### Syncing after yarn actions
+### Syncing after yarn, npm, pnpm actions
 
-Yarn actions can also set off massive filesystem changes. The `ddev yarn` command mitigates this problem by doing a mutagen sync after taking the action. So you can use `ddev yarn install` instead of using yarn directly, and it will take care of this for you. Alternately, you can just `ddev mutagen sync` after doing any similar action that has large filesystem consequences.
+Actions by those programs can also set off massive filesystem changes. 
+
+You should run `ddev mutagen sync` in order to get things into sync, or simply wait.
 
 <a name="mutagen-config"></a>
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -579,6 +579,17 @@ func (app *DdevApp) FixObsolete() {
 			}
 		}
 	}
+
+	// Remove old global commands
+	for _, command := range []string{"host/yarn"} {
+		cmdPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/", command)
+		if _, err := os.Stat(cmdPath); err == nil {
+			err1 := os.Remove(cmdPath)
+			if err1 != nil {
+				util.Warning("attempted to remove %s but failed, you may want to remove it manually: %v", cmdPath, err)
+			}
+		}
+	}
 }
 
 type composeYAMLVars struct {

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/yarn
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/yarn
@@ -1,8 +1,9 @@
 #!/bin/bash
+
 #ddev-generated
 ## Description: Run yarn inside the web container in the root of the project (Use --cwd for another directory)
 ## Usage: yarn [flags] [args]
 ## Example: "ddev yarn install" or "ddev yarn add learna" or "ddev yarn --cwd web/core add learna"
+## ExecRaw: true
 
-ddev exec --raw bash -ic "yarn '$@'"
-ddev mutagen sync 2>/dev/null
+yarn "$@"


### PR DESCRIPTION
## The Problem/Issue/Bug:

https://github.com/drud/ddev/issues/3741

## How this PR Solves The Problem:

Executes the command right inside the web container so no further CLI parameter tweaking is necessary.

## Manual Testing Instructions:

`yarn gulp <someTaskName>`


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3836"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

