### PR TITLE
[tests only] Refresh colima/homebrew caches to get new

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Homebrew cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-homebrew-cache-3
+          cache-name: cache-homebrew-cache-4
         with:
           path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-build-${{ env.cache-name }}
@@ -71,7 +71,7 @@ jobs:
       - name: Lima cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-lima-2
+          cache-name: cache-lima-4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.lima
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install Colima and deps (macOS)
         if: matrix.os == 'macos-11'
-        run: ./.github/workflows/macos-colima-setup.sh
+        run: ./.github/workflows/macos-colima-setup.sh && colima version
 
       - name: Build ddev
         run: | 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Colima has a new version v0.4.* that requires starting from scratch, so we need to get rid of the existing cache.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3841"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

