### PR TITLE
Allow choosing a different database when opening sequelace, fixes #3847

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -3,11 +3,13 @@
 #ddev-generated
 ## Description: Run sequelace with current project database
 ## Usage: sequelace
-## Example: "ddev sequelace"
+## Example: "ddev sequelace" or "ddev sequelace database2" to open a database named "database2".
 ## OSTypes: darwin
 ## HostBinaryExists: /Applications/Sequel ace.app
 
-query="mysql://root:root@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
+DATABASE="${1:-db}"
+
+query="mysql://root:root@127.0.0.1:${DDEV_HOST_DB_PORT}/${DATABASE}"
 
 set -x
 open "$query" -a "/Applications/Sequel Ace.app/Contents/MacOS/Sequel Ace"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Sometime you use multiple databases in a project (e.g. for migration). 
Currently, using ddev sequelace opens directly the default database "db" so the user has to switch manually to the database she/he would like to use.

## How this PR Solves The Problem:

This adds an option to ```ddev sequelace``` to specify a database name different from "db" so the command directly opens the database.

## Manual Testing Instructions:

* create a simple project with DDEV
* add another database to the project
* run ```ddev sequelace <database name>```

## Related Issue Link(s):

* https://github.com/drud/ddev/issues/3847


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3848"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

