### PR TITLE
Fix magento 2 quickstart and set php default to 8.1, fixes #3852

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -272,15 +272,17 @@ Normal details of a composer build for Magento 2 are on [Magento 2 site](https:/
 
 ```bash
 mkdir ddev-magento2 && cd ddev-magento2
-ddev config --project-type=magento2 --docroot=pub --create-docroot
+ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --create-docroot --disable-settings-management
 ddev get drud/ddev-elasticsearch
 ddev start
-ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition
-ddev magento setup:install --base-url='${DDEV_PRIMARY_URL}' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
+ddev composer create --no-install --repository=https://repo.magento.com/ magento/project-community-edition -y
+ddev composer install
+rm -f app/etc/env.php
+# Change the base-url below to your project's URL
+ddev magento setup:install --base-url='https://ddev-magento2.ddev.site/' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
 ddev magento deploy:mode:set developer
 ddev magento module:disable Magento_TwoFactorAuth
-ddev magento setup:di:compile
-ddev magento cache:flush
+ddev config --disable-settings-management=false
 ```
 
 Of course, change the admin name and related information is needed.

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -94,7 +94,7 @@ func init() {
 			settingsCreator: createMagentoSettingsFile, uploadDir: getMagentoUploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagentoSiteSettingsPaths, appTypeDetect: isMagentoApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction,
 		},
 		nodeps.AppTypeMagento2: {
-			settingsCreator: createMagento2SettingsFile, uploadDir: getMagento2UploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagento2SiteSettingsPaths, appTypeDetect: isMagento2App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction,
+			settingsCreator: createMagento2SettingsFile, uploadDir: getMagento2UploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagento2SiteSettingsPaths, appTypeDetect: isMagento2App, postImportDBAction: nil, configOverrideAction: magento2ConfigOverrideAction, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction,
 		},
 		nodeps.AppTypeLaravel:   {appTypeDetect: isLaravelApp, postStartAction: laravelPostStartAction, configOverrideAction: laravelConfigOverrideAction},
 		nodeps.AppTypeShopware6: {appTypeDetect: isShopware6App, apptypeSettingsPaths: setShopware6SiteSettingsPaths, uploadDir: getShopwareUploadDir, configOverrideAction: nil, postStartAction: shopware6PostStartAction, importFilesAction: shopware6ImportFilesAction},

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -70,6 +70,7 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:  nodeps.PHPDefault,
 		nodeps.AppTypeMagento:   nodeps.PHPDefault,
+		nodeps.AppTypeMagento2:  nodeps.PHP81,
 		nodeps.AppTypeLaravel:   nodeps.PHP80,
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -141,21 +141,25 @@ var (
 		},
 		// 7: magento2
 		// Note that testpkgmagento2 code is enormous and makes this really, really slow.
+		// Create a project named testpkgmagento2 and use the magento2 quickstart
+		// Look at app/env.php and login at the key given by "backend->frontname" with the admin
+		// credentials in the quickstart.
+		// Create a product named Unicycle with a picture called randy_4th_of_july_unicycle.jpg
 		{
 			Name: "testpkgmagento2",
-			// echo "This is a junk" >pub/junk.txt && tar -czf .tarballs/testpkgmagento2_code_no_media.magento2.4_try_4.tgz --exclude=.ddev --exclude=var --exclude=pub/media --exclude=.tarballs --exclude=app/etc/env.php .
-			SourceURL:                     "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2_code_no_media.magento2.4_try_4.tgz",
+			// echo "This is a junk" >pub/junk.txt && tar -czf .tarballs/testpkgmagento2_code_no_media.magento2.4.4.tgz --exclude=.ddev --exclude=var --exclude=pub/media --exclude=.tarballs --exclude=app/etc/env.php .
+			SourceURL:                     "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2_code_no_media.magento2.4.4.tgz",
 			ArchiveInternalExtractionPath: "",
-			// ddev export-db --gzip=false --file=.tarballs/db.sql && tar -czf .tarballs/testpkgmagento2.magento2.4.db_try_4.tgz -C .tarballs db.sql
-			DBTarURL: "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2.magento2.4.db_try_4.tgz",
-			// tar -czf .tarballs/testpkgmagento2_files.magento2.4_try_4.tgz -C pub/media .
-			FilesTarballURL:           "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2_files.magento2.4_try_4.tgz",
+			// ddev export-db --gzip=false --file=.tarballs/db.sql && tar -czf .tarballs/testpkgmagento2.magento2.4.4.db.tgz -C .tarballs db.sql
+			DBTarURL: "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2.magento2.4.4.db.tgz",
+			// tar -czf .tarballs/testpkgmagento2_files.magento2.4.4.tgz -C pub/media .
+			FilesTarballURL:           "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2_files.magento2.4.4.tgz",
 			FullSiteTarballURL:        "",
 			Docroot:                   "pub",
 			Type:                      nodeps.AppTypeMagento2,
 			Safe200URIWithExpectation: testcommon.URIWithExpect{URI: "/junk.txt", Expect: `This is a junk`},
 			DynamicURI:                testcommon.URIWithExpect{URI: "/index.php/unicycle.html", Expect: "Unicycle"},
-			FilesImageURI:             "/media/catalog/product/r/a/randy_4th_of_july_unicycle.jpg",
+			FilesImageURI:             "/media/catalog/product/r/a/randy_4th_of_july_unicycle_1.jpg",
 		},
 		// 8: drupal9
 		{

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -166,3 +166,9 @@ func createMagento2SettingsFile(app *DdevApp) (string, error) {
 func setMagento2SiteSettingsPaths(app *DdevApp) {
 	app.SiteSettingsPath = filepath.Join(app.AppRoot, app.Docroot, "..", "app", "etc", "env.php")
 }
+
+// Latest magento2 requires php8.1
+func magento2ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP81
+	return nil
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3852 

* Magento 2 quickstart doc broken
* Magento 2 now requires php 8.1

## How this PR Solves The Problem:

* Fix the quickstart docs (thanks @cmuench !)
* Set the default PHP version for magento2 to php8.1

## Manual Testing Instructions:

Walk through the quickstart and verify it.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3853"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

