### PR TITLE
Dont' use compose project name with dots, add dot test

### DIFF
--- a/cmd/ddev/cmd/ssh_test.go
+++ b/cmd/ddev/cmd/ssh_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+// TestCmdSSH runs `ddev ssh` on basic apps, including with a dot and a dash in them
+func TestCmdSSH(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Create a temporary directory and change to it for the duration of this test.
+	testDir := testcommon.CreateTmpDir(t.Name())
+	origDir, _ := os.Getwd()
+
+	err := os.Chdir(testDir)
+	require.NoError(t, err)
+	app, err := ddevapp.NewApp(testDir, true)
+	assert.NoError(err)
+	// Projects with dots and dashes in name have been problematic at times, so use that
+	app.Name = t.Name() + "." + "betweendots" + "-" + "x"
+	err = app.WriteConfig()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		err = os.RemoveAll(testDir)
+		assert.NoError(err)
+	})
+
+	err = fileutil.AppendStringToFile("index.php", `
+<?php
+	mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+	$mysqli = new mysqli('db', 'db', 'db', 'db');
+	printf("Success accessing database... %s\n", $mysqli->host_info);
+	`)
+	require.NoError(t, err)
+	err = app.Start()
+	require.NoError(t, err)
+
+	_, err = testcommon.EnsureLocalHTTPContent(t, app.GetPrimaryURL(), "Success accessing database")
+	assert.NoError(err)
+
+	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: "pwd",
+	})
+	require.NoError(t, err)
+	assert.Equal("/var/www/html\n", stdout)
+
+	b := util.FindBashPath()
+	out, err := exec.RunHostCommand(b, "-c", fmt.Sprintf("echo pwd | %s ssh", DdevBin))
+	assert.NoError(err)
+	assert.Equal("/var/www/html\n", out)
+
+}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1718,8 +1718,10 @@ func (app *DdevApp) DockerEnv() {
 	envVars := map[string]string{
 		// Without COMPOSE_DOCKER_CLI_BUILD=0, docker-compose makes all kinds of mess
 		// of output. BUILDKIT_PROGRESS doesn't help either.
-		"COMPOSE_DOCKER_CLI_BUILD":      "0",
-		"COMPOSE_PROJECT_NAME":          "ddev-" + app.Name,
+		"COMPOSE_DOCKER_CLI_BUILD": "0",
+		// The compose project name can no longer contain dots
+		// https://github.com/compose-spec/compose-go/pull/197
+		"COMPOSE_PROJECT_NAME":          "ddev-" + strings.Replace(app.Name, `.`, "", -1),
 		"COMPOSE_CONVERT_WINDOWS_PATHS": "true",
 		"DDEV_SITENAME":                 app.Name,
 		"DDEV_TLD":                      app.ProjectTLD,


### PR DESCRIPTION
## The Problem/Issue/Bug:

With docker-compose 2.5.1...

* https://github.com/drud/ddev/pull/3851#issuecomment-1132745998 (discussion)
* https://github.com/docker/compose/issues/8881
* https://github.com/compose-spec/compose-go/pull/197

Bottom line is that `ddev ssh` and `ddev exec` (possibly other things) don't work if COMPOSE_PROJECT_NAME has a dot in it. You get:

```
$ ddev ssh
service "web" is not running container #1
Failed to ddev ssh web: exit status 1
```

I imagine since ddev was using COMPOSE_PROJECT_NAME initially with `docker-compose config`, which inserts `name` into the .ddev-docker-compose-full.yaml (without dots) and then uses that .ddev-docker-compose-full again with COMPOSE_PROJECT_NAME set (and with a dot in it), that it triggers an obscure edge case.  It's easier to remove the dot here than to chase it in compose.

## How this PR Solves The Problem:

* Remove the dot
* Add a test that uses project names with dots in them.

## Manual Testing Instructions:

* https://github.com/drud/ddev/pull/3851#issuecomment-1132745998

## Automated Testing Overview:

* Added TestCmdSSH




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3859"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

