### PR TITLE
Don't show download progress bar when in json mode

### DIFF
--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"golang.org/x/term"
 	"io"
 	"net/http"
 	"os"
@@ -16,6 +17,9 @@ import (
 
 // DownloadFile retrieves a file.
 func DownloadFile(destPath string, url string, progressBar bool) (err error) {
+	if output.JSONOutput || !term.IsTerminal(int(os.Stdin.Fd())) {
+		progressBar = false
+	}
 	// Create the file
 	out, err := os.Create(destPath)
 	if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

@nico-loeber and @jonaseberle  discovered that when docker-compose is getting updated non-json output is output as a progress bar for the download. 
* https://github.com/php-perfect/ddev-intellij-plugin/issues/56

In json mode ddev can show non-json output if downloading a file, especially docker-compose or mutagen. 

`rm -f ~/.ddev/bin/docker-compose && ddev start -j` will show non-json output as described in the issue:

```
$ ddev version --json-output
{
    "level": "info",
    "msg": "Downloading https://github.com/docker/compose/releases/download/v2.5.1/docker-compose-linux-x86_64 ...",
    "time": "2022-05-22T12:42:34+02:00"
}
docker-compose 25.30 MiB / 25.30 MiB [=======================================================================================================] 100.00% 5s
{
    "level": "info",
    "msg": "Download complete.",
    "time": "2022-05-22T12:42:40+02:00"
}
```

## How this PR Solves The Problem:

Turn off the progress bar when in json mode or not attached to terminal.

## Manual Testing Instructions:

`rm -f ~/.ddev/bin/docker-compose && ddev start -j` 


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3860"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

