### PR TITLE
ddev-router should only output one upstream per container port

### DIFF
--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -124,7 +124,7 @@ server {
 
         {{/* jonaseberle/github-action-setup-ddev version */}}
         {{ range $containerNetwork := $container.Networks }}
-            {{ if (and (ne $containerNetwork.Name "ingress") (or (eq $containerNetwork.Name $containerNetwork.Name) (eq $containerNetwork.Name "host"))) }}
+            {{ if eq $containerNetwork.Name "ddev_default" }}
                 {{/* If only 1 port exposed, use that */}}
                 {{ if eq $addrLen 1 }}
                     {{ $address := index $container.Addresses 0 }}

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -35,7 +35,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.19.0" // Note that this can be overridden by make
+var RouterTag = "20220522_router_use_only_ddev_default" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "drud/ddev-ssh-agent"


### PR DESCRIPTION
## The Problem/Issue/Bug:

@deviantintegral pointed out in Discord that ddev-router is creating two upstream hosts for every port, resulting in inappropriate round-robin behavior of the reverse-proxy nginx inside ddev-router. https://discord.com/channels/664580571770388500/976181828341866526

More discussion in the PR that probably introduced this behavior inadvertently:

* https://github.com/drud/ddev/pull/3403#issuecomment-1132892462

Upstreams in ddev router (shown by `ddev debug router-nginx-config`) show both of the IP addresses (for the two networks that the container belongs to), resulting in inappropriate round-robin behavior, as if there were actually two different containers out there:

```
        upstream d7.ddev.site-80 {
        keepalive 100;
            # Container=ddev-d7-web 172.21.0.5:80
            server ddev-d7-web:80;
            # Container=ddev-d7-web 172.19.0.8:80
            server ddev-d7-web:80;
        }
```

Instead, with this PR, the upstream definitions show only the ddev_default network IP address:
```
        upstream d7.ddev.site-80 {
        keepalive 100;
            # Container=ddev-d7-web 172.19.0.8:80
            server ddev-d7-web:80;
        }
```


## How this PR Solves The Problem:

Only evaluate the network named ddev_default

## Manual Testing Instructions:

`ddev poweroff && ddev start`
Review `ddev debug router-nginx-config`

## Automated Testing Overview:

I think this is OK as long as it passes existing tests. 




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3861"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

