### PR TITLE
Make sure that errors and warnings are written to stderr

### DIFF
--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -52,7 +52,7 @@ to allow ddev to modify your hosts file. If you are connected to the internet an
 		// If requested, remove all inactive host names and exit
 		if removeInactive {
 			if len(args) > 0 {
-				output.UserOut.Fatal("Invalid arguments supplied. 'ddev hostname --remove-all' accepts no arguments.")
+				util.Failed("Invalid arguments supplied. 'ddev hostname --remove-all' accepts no arguments.")
 			}
 
 			util.Warning("Attempting to remove inactive hostnames which use TLD %s", nodeps.DdevDefaultTLD)
@@ -63,7 +63,7 @@ to allow ddev to modify your hosts file. If you are connected to the internet an
 
 		// If operating on one host name, two arguments are required
 		if len(args) != 2 {
-			output.UserOut.Fatal("Invalid arguments supplied. Please use 'ddev hostname [hostname] [ip]'")
+			util.Failed("Invalid arguments supplied. Please use 'ddev hostname [hostname] [ip]'")
 		}
 
 		hostname, ip := args[0], args[1]

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -161,7 +161,7 @@ func init() {
 	// Populate custom/script commands so they're visible
 	// We really don't want ~/.ddev or .ddev/homeadditions or .ddev/.globalcommands to have root ownership, breaks things.
 	if os.Geteuid() == 0 {
-		output.UserOut.Warning("Not populating custom commands or hostadditions because running with root privileges")
+		util.Warning("Not populating custom commands or hostadditions because running with root privileges")
 	} else {
 		err := ddevapp.PopulateExamplesCommandsHomeadditions("")
 		if err != nil {
@@ -177,7 +177,7 @@ func init() {
 
 func instrumentationNotSetUpWarning() {
 	if !output.JSONOutput && versionconstants.SegmentKey == "" && globalconfig.DdevGlobalConfig.InstrumentationOptIn {
-		output.UserOut.Warning("Instrumentation is opted in, but SegmentKey is not available. This usually means you have a locally-built ddev binary or one from a PR build. It's not an error. Please report it if you're using an official release build.")
+		util.Warning("Instrumentation is opted in, but SegmentKey is not available. This usually means you have a locally-built ddev binary or one from a PR build. It's not an error. Please report it if you're using an official release build.")
 	}
 }
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -112,7 +112,7 @@ func TestMain(m *testing.M) {
 	err = addSites()
 	if err != nil {
 		removeSites()
-		output.UserOut.Fatalf("addSites() failed: %v", err)
+		util.Failed("addSites() failed: %v", err)
 	}
 
 	log.Debugln("Running tests.")

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/drud/ddev/cmd/ddev/cmd"
-	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	"os"
 	"time"
@@ -15,7 +14,7 @@ func main() {
 	// Prevent running as root for most cases
 	// We really don't want ~/.ddev to have root ownership, breaks things.
 	if os.Geteuid() == 0 && len(os.Args) > 1 && os.Args[1] != "hostname" {
-		output.UserOut.Fatal("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
+		util.Failed("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
 	}
 
 	cmd.Execute()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1280,7 +1280,7 @@ func (app *DdevApp) GenerateWebserverConfig() error {
 	// Prevent running as root for most cases
 	// We really don't want ~/.ddev to have root ownership, breaks things.
 	if os.Geteuid() == 0 {
-		output.UserOut.Warning("not generating webserver config files because running with root privileges")
+		util.Warning("not generating webserver config files because running with root privileges")
 		return nil
 	}
 
@@ -1334,7 +1334,7 @@ func (app *DdevApp) GeneratePostgresConfig() error {
 	// Prevent running as root for most cases
 	// We really don't want ~/.ddev to have root ownership, breaks things.
 	if os.Geteuid() == 0 {
-		output.UserOut.Warning("not generating postgres config files because running with root privileges")
+		util.Warning("not generating postgres config files because running with root privileges")
 		return nil
 	}
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -422,7 +422,7 @@ func (app *DdevApp) GenerateMutagenYml() error {
 	// Prevent running as root for most cases
 	// We really don't want ~/.ddev to have root ownership, breaks things.
 	if os.Geteuid() == 0 {
-		output.UserOut.Warning("not generating mutagen config file because running with root privileges")
+		util.Warning("not generating mutagen config file because running with root privileges")
 		return nil
 	}
 	mutagenYmlPath := GetMutagenConfigFilePath(app)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Warnings and errors are not written to stderr consistently.

Apart from a general unpredictability, warnings can disturb automatically evaluated output.

## How this PR Solves The Problem:

To make the output more predictable all warnings and errors, I was able to find, are now written to stderr.

## Manual Testing Instructions:

Executing any ddev commands on the command line should still show exactly the same result.

To test if warnings are written to stderr you can run the command outputting the error / warning to show stdout only by adding `2>/dev/null`. 
For example `ddev describe 2>/dev/null` should now show a clean output. 

## Automated Testing Overview:
N/A

## Related Issue Link(s):
This will help to improve stability when using the [DDEV Integration plugin](https://github.com/php-perfect/ddev-intellij-plugin).

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3863"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

