### PR TITLE
[Tests only] Turn off some tests that commonly fail on mac M1

### DIFF
--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/cmd/ddev/cmd"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -17,6 +18,10 @@ import (
 
 // TestCmdAuthSSH runs `ddev auth ssh` and checks that it actually worked out.
 func TestCmdAuthSSH(t *testing.T) {
+	if nodeps.IsMacM1() {
+		t.Skip("Skipping TestCmdAuthSSH on Mac M1 because of useless Docker Desktop failures to connect")
+	}
+
 	assert := asrt.New(t)
 	if !util.IsCommandAvailable("expect") {
 		t.Skip("Skipping TestCmdAuthSSH because expect scripting tool is not available")

--- a/cmd/ddev/cmd/ssh_test.go
+++ b/cmd/ddev/cmd/ssh_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
@@ -15,6 +16,9 @@ import (
 
 // TestCmdSSH runs `ddev ssh` on basic apps, including with a dot and a dash in them
 func TestCmdSSH(t *testing.T) {
+	if nodeps.IsMacM1() {
+		t.Skip("Skipping TestCmdSSH on Mac M1 because of useless Docker Desktop failures to connect")
+	}
 	assert := asrt.New(t)
 
 	// Create a temporary directory and change to it for the duration of this test.

--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
@@ -17,6 +18,10 @@ import (
 
 // TestHardenedStart makes sure we can do a start and basic use with hardened images
 func TestHardenedStart(t *testing.T) {
+	if nodeps.IsMacM1() {
+		t.Skip("Skipping TestHardenedStart on Mac M1 because of useless Docker Desktop failures to connect")
+	}
+
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Some tests commonly fail on mac M1 (Docker Desktop) due to failure to connect, per
* https://github.com/docker/for-mac/issues/5407

## How this PR Solves The Problem:

Turn off a few tests.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3866"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

