### PR TITLE
Use acli to sync database from Acquia

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
@@ -41,8 +41,8 @@ db_pull_command:
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    pushd /var/www/html/.ddev/.downloads >/dev/null
-    drush @${project_id} sql-dump -n --alias-path=~/.drush --extra-dump=--no-tablespaces --gzip >db.sql.gz
+    acli pull:db --on-demand --no-import -- @${project_id}
+    mv /tmp/*.sql.gz /var/www/html/.ddev/.downloads/db.sql.gz
 
 files_pull_command:
   command: |


### PR DESCRIPTION
## The Problem/Issue/Bug:

Acquia Cloud may default to outdated drush versions. Additionally, Drush/Ddev integration has a known problem of including error output in sql-dump (see https://github.com/drud/ddev/issues/2839). Therefore if there happens to be a missmatch of the drush version, the gzipped database file may contain error text like this:

```
Deprecated: Required parameter $args follows optional parameter $command in /usr/local/drush9/vendor/drush/drush/includes/batch.inc on line 115

Deprecated: Required parameter $options follows optional parameter $command in /usr/local/drush9/vendor/drush/drush/includes/batch.inc on line 115
```

Resulting in an error running the pull command:

```
Pull failed: failed to extract provided archive: gzip: invalid header
```

## How this PR Solves The Problem:

1. Replace `drush sql-dump` with `acli pull:db`.  

   Using the `--no-import` option, `acli pull:db` sends the db snapshot file to the /tmp/ folder with a special name.  Therefore the `pushd` to the .downloads folder is no longer necessary.  But also, worth pointing out we have no control over the filename unfortunately, or piping the output elsewhere. Therefore, this script assumes there's not going to be another `sql.gz` in the tmp folder.  Maybe we should `rm /tmp/*.sql.gz`.

2. Maybe replace `drush rsync` with `acli pull:files` as well?

   It would be nice to consider this for consistency, however `acli pull:files` has no option to exclude js,css,styles folders, like the existing `drush rsync` command does. Therefore, this change has been excluded from the PR.

## Manual Testing Instructions:

Create a drupal 9 project linked to an acquia environment.
mv .ddev/providers/acquia.yaml.example .ddev/providers/acquia.yaml
Update the `project_id` in .ddev/providers/acquia.yaml
Execute `ddev pull acquia`.


## Automated Testing Overview:

Not sure there is a way to wire up automated tests for this, to be honest.

## Related Issue Link(s):

## Release/Deployment notes:

Nothing else should be affected.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3869"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

