### PR TITLE
Remove need for `ARG BASE_IMAGE` etc and allow multiple Dockerfiles

### DIFF
--- a/docs/users/extend/customizing-images.md
+++ b/docs/users/extend/customizing-images.md
@@ -31,6 +31,8 @@ To test that a package will do what you want, you can `ddev ssh` and then `sudo 
 
 For more complex requirements, you can add .ddev/web-build/Dockerfile or .ddev/db-build/Dockerfile.
 
+These files' content will be appended to ddev's own Dockerfile.
+
 Examples of possible Dockerfiles are given in `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example` (These examples are created in your project when you `ddev config` the project.)
 
 You can use the .ddev/*-build/ directory as the Docker "context" directory as well. So for example if a file named README.txt exists in .ddev/web-build, you can use `ADD README.txt /` in the Dockerfile.
@@ -38,18 +40,12 @@ You can use the .ddev/*-build/ directory as the Docker "context" directory as we
 An example web image `.ddev/web-build/Dockerfile` might be:
 
 ```dockerfile
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
-
 RUN npm install -g gatsby-cli
 ```
 
 Another example would be installing phpcs globally (see [Stack Overflow answer](https://stackoverflow.com/questions/61870801/add-global-phpcs-and-drupal-coder-to-ddev-in-custom-dockerfile/61870802#61870802)):
 
 ```dockerfile
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
-
 ENV COMPOSER_HOME=/usr/local/composer
 
 # We try to avoid when possible relying on composer to download global, so in PHPCS case we can use the phar.

--- a/docs/users/extend/customizing-images.md
+++ b/docs/users/extend/customizing-images.md
@@ -40,7 +40,7 @@ These files' content will be appended to ddev's own Dockerfile for each image.
 
 Examples of possible Dockerfiles are given in `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example` (these examples are created in your project when you `ddev config` the project).
 
-You can use the .ddev/\*-build/ directory as the Docker "context" directory as well. So for example if a file named README.txt exists in .ddev/web-build, you can use `ADD README.txt /` in the Dockerfile.
+You can use the `.ddev/*-build` directory as the Docker "context" directory as well. So for example if a file named README.txt exists in `.ddev/web-build`, you can use `ADD README.txt /` in the Dockerfile.
 
 An example web image `.ddev/web-build/Dockerfile` might be:
 

--- a/docs/users/extend/customizing-images.md
+++ b/docs/users/extend/customizing-images.md
@@ -31,8 +31,8 @@ To test that a package will do what you want, you can `ddev ssh` and then `sudo 
 
 For more complex requirements, you can add:
 
-* `.ddev/web-build/Dockerfile` 
-* `.ddev/web-build/Dockerfile.*` 
+* `.ddev/web-build/Dockerfile`
+* `.ddev/web-build/Dockerfile.*`
 * `.ddev/db-build/Dockerfile`
 * `.ddev/db-build/Dockerfile.*`
 

--- a/docs/users/extend/customizing-images.md
+++ b/docs/users/extend/customizing-images.md
@@ -29,13 +29,18 @@ To test that a package will do what you want, you can `ddev ssh` and then `sudo 
 
 ### Adding extra Dockerfiles for webimage and dbimage
 
-For more complex requirements, you can add .ddev/web-build/Dockerfile or .ddev/db-build/Dockerfile.
+For more complex requirements, you can add:
 
-These files' content will be appended to ddev's own Dockerfile.
+* `.ddev/web-build/Dockerfile` 
+* `.ddev/web-build/Dockerfile.*` 
+* `.ddev/db-build/Dockerfile`
+* `.ddev/db-build/Dockerfile.*`
 
-Examples of possible Dockerfiles are given in `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example` (These examples are created in your project when you `ddev config` the project.)
+These files' content will be appended to ddev's own Dockerfile for each image.
 
-You can use the .ddev/*-build/ directory as the Docker "context" directory as well. So for example if a file named README.txt exists in .ddev/web-build, you can use `ADD README.txt /` in the Dockerfile.
+Examples of possible Dockerfiles are given in `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example` (these examples are created in your project when you `ddev config` the project).
+
+You can use the .ddev/\*-build/ directory as the Docker "context" directory as well. So for example if a file named README.txt exists in .ddev/web-build, you can use `ADD README.txt /` in the Dockerfile.
 
 An example web image `.ddev/web-build/Dockerfile` might be:
 

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -177,7 +177,7 @@ For ddev-router and ddev-ssh-agent, `docker logs ddev-router` and `docker logs d
   
 Run `ddev debug router-nginx-config` to print the Nginx configuration of the currently running ddev-router.
 
-## `ddev start` fails with "Failed to start [project name]: No such container: ddev-router"  
+## `ddev start` fails with "Failed to start [project name]: No such container: ddev-router"
 
 Deleting the images and re-pulling them generally solves this problem.  
   
@@ -200,8 +200,6 @@ The best approach for any significant Dockerfile is to `ddev ssh` and `sudo -s` 
 For example, if your Dockerfile were
 
 ```dockerfile
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
 RUN npm install --global forever
 ```
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -921,7 +921,7 @@ RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update 
 		for _, file := range files {
 			// We already have the main file, and it's not in the list anyway, so skip when we hit it.
 			// We'll skip the example file
-			if file == userDockerfilePath + "/Dockerfile.example" {
+			if file == userDockerfilePath+"/Dockerfile.example" {
 				continue
 			}
 			orderedFiles = append(orderedFiles, file)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -902,32 +902,17 @@ RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update 
 
 	// If there are user dockerfiles, appends its contents
 	if userDockerfilePath != "" {
-		main, err := filepath.Glob(userDockerfilePath + "/Dockerfile")
+		files, err := filepath.Glob(userDockerfilePath + "/Dockerfile*")
 		if err != nil {
 			return err
-		}
-
-		files, err := filepath.Glob(userDockerfilePath + "/Dockerfile.*")
-		if err != nil {
-			return err
-		}
-		orderedFiles := make([]string, 0)
-
-		// Make sure the main file goes first
-		if len(main) == 1 {
-			orderedFiles = append(orderedFiles, main[0])
 		}
 
 		for _, file := range files {
-			// We already have the main file, and it's not in the list anyway, so skip when we hit it.
 			// We'll skip the example file
 			if file == userDockerfilePath+"/Dockerfile.example" {
 				continue
 			}
-			orderedFiles = append(orderedFiles, file)
-		}
 
-		for _, file := range orderedFiles {
 			userContents, err := fileutil.ReadFileIntoString(file)
 			if err != nil {
 				return err

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -859,6 +859,7 @@ func WriteBuildDockerfile(fullpath string, userDockerfilePath string, extraPacka
 
 	// Normal starting content is just the arg and base image
 	contents := `
+### DDEV-injected base Dockerfile contents
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 `
@@ -900,7 +901,7 @@ RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update 
 
 	contents = contents + extraContent
 
-	// If there are user dockerfiles, appends its contents
+	// If there are user dockerfiles, appends their contents
 	if userDockerfilePath != "" {
 		files, err := filepath.Glob(userDockerfilePath + "/Dockerfile*")
 		if err != nil {
@@ -918,14 +919,14 @@ RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update 
 				return err
 			}
 
-			// Backward compatible fix, remove unncessary BASE_IMAGE references
+			// Backward compatible fix, remove unnecessary BASE_IMAGE references
 			re, err := regexp.Compile(`ARG BASE_IMAGE.*\n|FROM \$BASE_IMAGE.*\n`)
 			if err != nil {
 				return err
 			}
 
 			userContents = re.ReplaceAllString(userContents, "")
-			contents = contents + "\n" + userContents
+			contents = contents + "\n\n### From user file " + file + ":\n" + userContents
 		}
 	}
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1108,6 +1108,16 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 RUN touch /var/tmp/`+"added-by-"+item+".txt"))
 		assert.NoError(err)
+		// Add also Dockerfile.* alternatives
+		// Last one includes previously recommended ARG/FROM that needs to be removed
+		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test1"), []byte(`
+RUN touch /var/tmp/`+"added-by-"+item+"-test1.txt"))
+		assert.NoError(err)
+		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test2"), []byte(`
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+RUN touch /var/tmp/`+"added-by-"+item+"-test2.txt"))
+		assert.NoError(err)
 	}
 	// Start and make sure that the packages don't exist already
 	err = app.Start()
@@ -1118,6 +1128,16 @@ RUN touch /var/tmp/`+"added-by-"+item+".txt"))
 		_, _, err = app.Exec(&ExecOpts{
 			Service: item,
 			Cmd:     "ls /var/tmp/added-by-" + item + ".txt",
+		})
+		assert.NoError(err)
+		_, _, err = app.Exec(&ExecOpts{
+			Service: item,
+			Cmd:     "ls /var/tmp/added-by-" + item + "-test1.txt",
+		})
+		assert.NoError(err)
+		_, _, err = app.Exec(&ExecOpts{
+			Service: item,
+			Cmd:     "ls /var/tmp/added-by-" + item + "-test2.txt",
 		})
 		assert.NoError(err)
 	}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1113,6 +1113,8 @@ RUN touch /var/tmp/`+"added-by-"+item+".txt"))
 		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test1"), []byte(`
 RUN touch /var/tmp/`+"added-by-"+item+"-test1.txt"))
 		assert.NoError(err)
+
+		// The ARG BASE_IMAGE and FROM $BASE_IMAGE are left in here to test legacy behavior
 		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test2"), []byte(`
 ARG BASE_IMAGE
 FROM $BASE_IMAGE


### PR DESCRIPTION
* Automatically add the `ARG BASE_IMAGE` and `FROM $BASE_IMAGE` so the user doesn't have to remember those 
* Remove the need to add BASE_IMAGE to the Dockerfile and make sure that this won't create issues for already created Dockerfiles
* Add the capablity to have `Dockerfile.*`, like `Dockerfile.cron` and `Dockerfile.elasticsearch`, all of which will get built into the .ddev/webimageBuild/Dockerfile

Discord reference: https://discord.com/channels/664580571770388500/689166305315520541/979760093602123796

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3870"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Docs change: https://github.com/hanoii/ddev/blob/2022_hanoii_custom_dockerfile_last/docs/users/extend/customizing-images.md