### PR TITLE
On traditional Windows, don't use pv on mounted file (ddev import-db)

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -547,7 +547,10 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 	// default insideContainerImportPath is the one mounted from .ddev directory
 	insideContainerImportPath := path.Join("/mnt/ddev_config/", filepath.Base(dbPath))
 	// But if we don't have bind mounts, we have to copy dump into the container
-	if globalconfig.DdevGlobalConfig.NoBindMounts {
+	// But do it on Windows as well. On Docker Desktop 4.8.2+(?) there seems to be a buffer
+	// overflow bug in pv, where it outputs all kinds of nonsense when reading a file on a
+	// mounted directory (/mnt/ddev_config).
+	if globalconfig.DdevGlobalConfig.NoBindMounts || runtime.GOOS == "windows" {
 		dbContainerName := GetContainerName(app, "db")
 		if err != nil {
 			return err


### PR DESCRIPTION
## The Problem/Issue/Bug:

There is an obscure bug apparently in pv (used in `ddev import-db` inside the db container) where on Windows 11 it has a buffer overflow ([link](https://gist.github.com/rfay/18ed619edc366a73b289bd23bfb70bbc)). 

## How this PR Solves The Problem:

On windows, don't use the mounted database export, but instead push it into the container in the way we do with `--no-project-mount`

## Manual Testing Instructions:

- [ ] Do a `ddev import-db` using mariadb:10.3 on a known fussy machine like tb-win11-5

## Automated Testing Overview:

This has not shown up in automated testing except on the new tb-win11-5. I was able to recreate it on another Windows 11 machine by doing a full uninstall/reinstall of Docker Desktop 4.8.2 

Hopefully we can get this tested on tb-win11-5 as well as other machines that weren't misbehaving.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3873"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

