### PR TITLE
NGROK template settings are outdated.

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -153,7 +153,7 @@ const ConfigInstructions = `
 # If you prefer you can change this to "ddev.local" to preserve
 # pre-v1.9 behavior.
 
-# ngrok_args: --subdomain mysite --auth username:pass
+# ngrok_args: --basic-auth username:pass1234
 # Provide extra flags to the "ngrok http" command, see
 # https://ngrok.com/docs#http or run "ngrok http -h"
 


### PR DESCRIPTION
Fixes #3874

Recently, I was required to share a DDEV host. When I attempted to run it Chrome, I got scary "Deceptive site ahead" warning page.

One suggested solution was to update NGROK (I was on 2.x). I bumped up to NGROK `3.0.4` however, this broken the config setting template.

- The [switch has changed](https://ngrok.com/docs/secure-tunnels#http-tunnels-basic-auth): "--auth" => "--basic-auth".
- There is also a 8-character minimum requirement on passwords.

The "--subdomain mysite" requires a paid-plan, therefore I don't think it should be included in the example template. I think the template should provide an example that anyone can use as is.

## How this PR Solves The Problem:

- remove `--subdomain mysite`
- adds correct example switch `--basic-auth`
- extends example password to 8-characters

## Manual Testing Instructions:

- Add the following line in `./.ddev/config`

```
ngrok_args: --basic-auth username:pass1234
```

- Start a DDEV share

```shell
ddev share
```

- Attempt to access the site with the URL displayed in the terminal

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Side note:

The "Deceptive site ahead" warning page only appears in Chrome (`102.0.5005.63`).
It does NOT appear if I use Chrome in incognitive mode.

I also tested in other browsers I had available:
MS Edge: 101.0.1210.53
Firefox: 100.0.2
Opera: 87.0.4390.25

I'm not sure of the best way to document this since it's probably not a DDEV-issue.


## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

ngrok version 3.0.4
ddev version v1.19.2
OS: WSL Ubuntu via Win10