### PR TITLE
`ddev debug capabilities` provides an easy way to test capabilities without version compare

### DIFF
--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/output"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// DebugCapabilitiesCmd implements the ddev debug capabilities command
+var DebugCapabilitiesCmd = &cobra.Command{
+	Use:   "capabilities",
+	Short: "Show capabilities of this version of ddev",
+	Run: func(cmd *cobra.Command, args []string) {
+		capabilities := []string{"multiple-dockerfiles", "interactive-project-selection"}
+		output.UserOut.WithField("raw", capabilities).Print(strings.Join(capabilities, "\n"))
+	},
+}
+
+func init() {
+	DebugCmd.AddCommand(DebugCapabilitiesCmd)
+}

--- a/cmd/ddev/cmd/debug-capabilities_test.go
+++ b/cmd/ddev/cmd/debug-capabilities_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"github.com/drud/ddev/pkg/nodeps"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -17,11 +18,17 @@ func TestDebugCapabilitiesCmd(t *testing.T) {
 	assert.NoError(err)
 	assert.Contains(out, "multiple-dockerfiles")
 
-	out, err = exec.RunHostCommand(DdevBin, "debug", "capabilities", "--json")
+	out, err = exec.RunHostCommand(DdevBin, "debug", "-j", "capabilities")
 	assert.NoError(err)
 
-	jsonCapabilities := make([]string, 20)
+	jsonCapabilities := make(map[string]interface{})
 	err = json.Unmarshal([]byte(out), &jsonCapabilities)
 	require.NoError(t, err)
-	//assert.True(out, "multiple-dockerfiles")
+	caps, ok := jsonCapabilities["raw"]
+	require.True(t, ok, "raw section wasn't found in jsonCapabilities: %v", out)
+	sArr := []string{}
+	for _, x := range caps.([]interface{}) {
+		sArr = append(sArr, x.(string))
+	}
+	require.True(t, nodeps.ArrayContainsString(sArr, "multiple-dockerfiles"))
 }

--- a/cmd/ddev/cmd/debug-capabilities_test.go
+++ b/cmd/ddev/cmd/debug-capabilities_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"encoding/json"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/drud/ddev/pkg/exec"
+)
+
+// TestDebugCapabilitiesCmd tests that ddev debug capabilities works
+func TestDebugCapabilitiesCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	out, err := exec.RunHostCommand(DdevBin, "debug", "capabilities")
+	assert.NoError(err)
+	assert.Contains(out, "multiple-dockerfiles")
+
+	out, err = exec.RunHostCommand(DdevBin, "debug", "capabilities", "--json")
+	assert.NoError(err)
+
+	jsonCapabilities := make([]string, 20)
+	err = json.Unmarshal([]byte(out), &jsonCapabilities)
+	require.NoError(t, err)
+	//assert.True(out, "multiple-dockerfiles")
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

DDEV add-ons need a way to check to see if the ddev version running is up to the task. For example, several add-ons will soon need the multiple Dockerfiles feature that just went in. 

This could be checked with a version check, but the version checking capability in bash is awful, and it's hard to understand where else to put it in most add-ons.

## How this PR Solves The Problem:

Add `ddev debug capabilities` to be able to test for a capability, like `multiple-dockerfiles`.

## Manual Testing Instructions:

`ddev debug capabilities`
`ddev debug capabilities -`

## Automated Testing Overview:

Added TestDebugCapabilitiesCmd



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3879"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

