### PR TITLE
Downgrade drush8 to 8.4.8, refresh to get latest platform cli tool

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -42,7 +42,7 @@ ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ENV YQ_VERSION=v4.7.1
-ENV DRUSH_VERSION=8.4.10
+ENV DRUSH_VERSION=8.4.8
 ENV NODE_LTS=16
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER 1

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.19.2 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.19.3 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.19.3" // Note that this can be overridden by make
+var WebTag = "v1.19.3-1" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/drush-ops/drush/issues/4979 - The latest drush8 versions have odd output and some problems. Previous 8.4.8 seemed to work right for a long time. This is typically only used with Drupal 7 and lower PHP versions. It should be fine. 
* https://github.com/drud/ddev/issues/3867 - After previous image build platformsh-cli should fix #3867 

## How this PR Solves The Problem:

Downgrade drush8, rebuild

## Manual Testing Instructions:

- [x] `ddev exec 'cd /tmp && /usr/local/bin/drush8 --version` should get 8.4.8
- [x] `ddev exec platform self:update` should show nothing new





<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3882"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

