### PR TITLE
[tests only] Cancel workflow on PR or master when another push comes

### DIFF
--- a/.github/workflows/cancel-previous-workflow.yml
+++ b/.github/workflows/cancel-previous-workflow.yml
@@ -1,0 +1,13 @@
+name: Cancel Previous Workflow
+on:
+  workflow_run:
+    workflows: ["Tests", "PR Build", "Colima tests", "Container tests", "Check docs", "golangci-lint", "Master branch build/release (signed)"]
+    types:
+    - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/cancel-previous-workflow.yml
+++ b/.github/workflows/cancel-previous-workflow.yml
@@ -1,7 +1,7 @@
 name: Cancel Previous Workflow
 on:
   workflow_run:
-    workflows: ["Tests", "PR Build", "Colima tests", "Container tests", "Check docs", "golangci-lint", "Master branch build/release (signed)"]
+    workflows: ["Tests", "PR Build", "Colima tests", "Container tests", "Check docs", "golangci-lint", "Master branch build/release (signed)", "CodeQL"]
     types:
     - requested
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'python' ]
+        language: [ 'go' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,31 +50,18 @@ jobs:
       DDEV_NONINTERACTIVE: "true"
       DDEV_TEST_USE_MUTAGEN: ${{ matrix.mutagen }}
       DDEV_TEST_NO_BIND_MOUNTS: ${{ matrix.no-bind-mounts }}
+      GOTEST_SHORT: "8"
     steps:
       - uses: actions/checkout@v3
-
-#      - name: GOTEST_SHORT setup - use "true" except for testfullsitesetup
-#        run: |
-#          if [ "${{ matrix.tests }}" != "testfullsitesetup" ]; then
-#            echo "GOTEST_SHORT=true" >> $GITHUB_ENV
-#          fi
 
       - name: Install Docker and deps (Linux)
         if: matrix.os == 'ubuntu-20.04'
         run: ./.github/workflows/linux-setup.sh
 
-      #      - name: Install Docker and deps (macOS)
-      #        if: matrix.os == 'macos-latest'
-      #        run: ./.github/workflows/macos-setup.sh
-
       - uses: actions/setup-go@v3
         if: matrix.os == 'ubuntu-20.04'
         with:
           go-version: 1.*
-
-      #      - name: Clean up self-hosted runners if necessary
-      #        if: matrix.os[1] == 'self-hosted'
-      #        run: .github/workflows/selfhosted-maintenance.sh
 
       - name: DDEV tests
         run: |


### PR DESCRIPTION
## The Problem/Issue/Bug:

The default way GitHub Actions works is that a new push just creates a new set of test runs, which very quickly uses up all the available runners (20 total concurrent jobs, 5 macOS), https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration

## How this PR Solves The Problem:

* Change to cancel previous workflow when a new push comes in on forked PR or master.
* Limit the size of tests run in the main tests.yml matrix. They were too big.
* Limit scope of codeql.yml to just golang



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3884"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

