### PR TITLE
[tests only] Split the dbimage build into a matrix for performance and restart capability

### DIFF
--- a/.github/workflows/cancel-previous-workflow.yml
+++ b/.github/workflows/cancel-previous-workflow.yml
@@ -1,4 +1,4 @@
-name: Cancel Previous Workflow
+name: Cancel Redundant Workflow
 on:
   workflow_run:
     workflows: ["Tests", "PR Build", "Colima tests", "Container tests", "Check docs", "golangci-lint", "Master branch build/release (signed)", "CodeQL"]

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -1,0 +1,54 @@
+name: Push tagged db image
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Base tag for pushed dbimage (v1.19.4 for example)'
+        required: true
+        default: ""
+      debug_enabled:
+        description: 'Enable debug mode'
+        required: false
+        default: false
+env:
+  REGISTRY: docker.io
+  DOCKER_ORG: drud
+  TAG: "${{ github.event.inputs.tag }}"
+
+permissions:
+  contents: read
+
+jobs:
+  push-tagged-dbimage:
+    name: "push tagged dbimage"
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        type: [mariadb_5.5 mariadb_10.0 mariadb_10.1 mariadb_10.2 mariadb_10.3 mariadb_10.4 mariadb_10.5 mariadb_10.6 mariadb_10.7 mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7 mysql_8.0]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+    - name: Push ${{  github.event.inputs.image }} ddev-dbserver image ${TAG}
+      run: |
+        cd "containers/ddev-dbserver"
+        make ${{ matrix.tests }} PUSH=true VERSION="${TAG}"
+

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        type: [mariadb_5.5, mariadb_10.0, mariadb_10.1, mariadb_10.2, mariadb_10.3, mariadb_10.4, mariadb_10.5, mariadb_10.6, mariadb_10.7, mysql_5.5, mysql_5.6, mysql_5.7, mysql_8.0]
+        dbtype: [mariadb_5.5, mariadb_10.0, mariadb_10.1, mariadb_10.2, mariadb_10.3, mariadb_10.4, mariadb_10.5, mariadb_10.6, mariadb_10.7, mysql_5.5, mysql_5.6, mysql_5.7, mysql_8.0]
       fail-fast: false
 
     steps:
@@ -51,5 +51,5 @@ jobs:
     - name: Push ${{  github.event.inputs.image }} ddev-dbserver image ${TAG}
       run: |
         cd "containers/ddev-dbserver"
-        make ${{ matrix.tests }} PUSH=true VERSION="${TAG}"
+        make ${{ matrix.dbtype }} PUSH=true VERSION="${TAG}"
 

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        type: [mariadb_5.5 mariadb_10.0 mariadb_10.1 mariadb_10.2 mariadb_10.3 mariadb_10.4 mariadb_10.5 mariadb_10.6 mariadb_10.7 mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7 mysql_8.0]
+        type: [mariadb_5.5, mariadb_10.0, mariadb_10.1, mariadb_10.2, mariadb_10.3, mariadb_10.4, mariadb_10.5, mariadb_10.6, mariadb_10.7, mysql_5.5, mysql_5.6, mysql_5.7, mysql_8.0]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -48,7 +48,7 @@ jobs:
         limit-access-to-actor: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-    - name: Push ${{  github.event.inputs.image }} ddev-dbserver image ${TAG}
+    - name: Push ${{  github.event.inputs.image }}:${{ github.event.inputs.tag }}
       run: |
         cd "containers/ddev-dbserver"
         make ${{ matrix.dbtype }} PUSH=true VERSION="${TAG}"

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         type: [mariadb_5.5, mariadb_10.0, mariadb_10.1, mariadb_10.2, mariadb_10.3, mariadb_10.4, mariadb_10.5, mariadb_10.6, mariadb_10.7, mysql_5.5, mysql_5.6, mysql_5.7, mysql_8.0]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -48,7 +48,7 @@ jobs:
         limit-access-to-actor: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-    - name: Push ${{  github.event.inputs.image }}:${{ github.event.inputs.tag }}
+    - name: Push ${{  matrix.dbtype }}:${{ github.event.inputs.tag }}
       run: |
         cd "containers/ddev-dbserver"
         make ${{ matrix.dbtype }} PUSH=true VERSION="${TAG}"

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   push-tagged-dbimage:
     name: "push tagged dbimage"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         dbtype: [mariadb_5.5, mariadb_10.0, mariadb_10.1, mariadb_10.2, mariadb_10.3, mariadb_10.4, mariadb_10.5, mariadb_10.6, mariadb_10.7, mysql_5.5, mysql_5.6, mysql_5.7, mysql_8.0]

--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: 'Image to be pushed (ddev-php-base, ddev-webserver, etc)'
+        description: 'Image to be pushed (ddev-php-base, ddev-webserver, NOT ddev-dbserver)'
         required: true
         default: ddev-webserver
       tag:
-        description: Tag for pushed image (v1.19.3 for example)'
+        description: Tag for pushed image (v1.19.4 for example)'
         required: true
         default: ""
       debug_enabled:

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -20,6 +20,9 @@ TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
 container: build
 build: $(BUILD_TARGETS)
 
+mariadb_5.5: mariadb_5.5_amd64
+mariadb_10.0: mariadb_10.0_amd64
+mariadb_10.1: mariadb_10.1_both
 mariadb_10.2: mariadb_10.2_both
 mariadb_10.3: mariadb_10.3_both
 mariadb_10.4: mariadb_10.4_both

--- a/docs/developers/building-contributing.md
+++ b/docs/developers/building-contributing.md
@@ -2,7 +2,7 @@
 
 ## Testing latest commits
 
-You can download the latest artifacts from the master branch from [link](https://nightly.link/drud/ddev/workflows/master-build/master). On macOS and Linux you can `brew unlink ddev && brew install drud/ddev/ddev --HEAD --fetch-HEAD` to get the latest commit of ddev, even if it's not yet in a release. 
+You can download the latest artifacts from the master branch from [link](https://nightly.link/drud/ddev/workflows/master-build/master). On macOS and Linux you can `brew unlink ddev && brew install drud/ddev/ddev --HEAD --fetch-HEAD` to get the latest commit of ddev, even if it's not yet in a release.
 
 To download the latest version, you can visit the [master-build](https://github.com/drud/ddev/actions/workflows/master-build.yml) workflow and choose the latest item (or the one that matches a commit you want to test). You'll see the artifacts for each OS there on the bottom of the page.
 
@@ -12,7 +12,7 @@ And of course you can just see the latest build in action by visiting ddev on [g
 
 Each build of a PR has artifacts created in github, so you can click the details of the [PR Build](https://github.com/drud/ddev/actions/workflows/pr-build.yml) test, choose the PR you want to work with, and download the artifacts you need there.
 
-After you download and unzip the appropriate binary, you can place it in your $PATH. The easiest way to do this if you're using homebrew is `brew unlink ddev` and then `unzip ddev.zip && chmod +x ddev && mv ddev /usr/local/bin/ddev`. 
+After you download and unzip the appropriate binary, you can place it in your $PATH. The easiest way to do this if you're using homebrew is `brew unlink ddev` and then `unzip ddev.zip && chmod +x ddev && mv ddev /usr/local/bin/ddev`.
 
 You can verify that the replacement worked via `ddev -v`. The output should be something like `ddev version v1.19.1-42-g5334d3c1` (instead of the regular `ddev version v1.19.1`).
 
@@ -66,22 +66,30 @@ If you make changes to a docker image (like ddev-webserver), it won't have any e
 * Push an image with a specific tag by going to the image directory (like containers/ddev-webserver) by just doing `make container VERSION=<branchname>` in the containers/ddev-webserver directory.
 * Multi-arch images require you to have a buildx builder, so `docker buildx create --name ddev-builder-multi --use`
 * You can't push until you `docker login`.
-* Push a container to hub.docker.com. Push with the tag that matches your branch. Pushing to `<yourorg>/ddev-webserver` repo is easy to accomplish with `make push DOCKER_ORG=<yourorg> VERSION=<branchname>` **in the container directory**. You might have to use other techniques to push to another repo. 
+* Push a container to hub.docker.com. Push with the tag that matches your branch. Pushing to `<yourorg>/ddev-webserver` repo is easy to accomplish with `make push DOCKER_ORG=<yourorg> VERSION=<branchname>` **in the container directory**. You might have to use other techniques to push to another repo.
 * Update pkg/version/version.go with the WebImg and WebTag that relate to the docker image you pushed.
 
 ### Local builds and pushes
 
 * If you just want to work locally and do a quick build for your own architecture, you can:
     * `make VERSION=<version>`
-    * for `ddev-dbserver`: `make mariadb_10.3_both VERSION=<version>` etc.
+    * for `ddev-dbserver`: `make mariadb_10.3 VERSION=<version>` etc.
 
 ### Pushes using GitHub Actions
 
 To manually push using GitHub Actions,
 
+#### For most images
+
 * Visit [Actions->Push Tagged Image](https://github.com/drud/ddev/actions/workflows/push-tagged-image.yml)
 * Click "Run workflow" in the blue band near the top.
 * Choose the branch, usually `master` and then the image to be pushed, `ddev-webserver`, `ddev-dbserver`, etc. Also you can use `all` to build and push all of them. Include a tag for the pushed image and GitHub will do all the work.
+
+#### For ddev-dbserver
+
+* Visit [Actions->Push Tagged db Image](https://github.com/drud/ddev/actions/workflows/push-tagged-dbimage.yml)
+* Click "Run workflow" in the blue band near the top.
+* Choose the branch, usually `master`. Include a tag for the pushed image and GitHub will do all the work.
 
 ## Building
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* The dbimage build takes forever, doing each build sequentially (currently 13 images)
* To restart after a weird failure you have to restart the whole thing.

## How this PR Solves The Problem:

* Build them in parallel, and you can restart failed jobs as needed.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3885"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

