### PR TITLE
Add `ddev npm` command

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -187,7 +187,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err)
 
 	// Make sure that all the official ddev-provided custom commands are usable by just checking help
-	for _, c := range []string{"launch", "mysql", "php", "xdebug"} {
+	for _, c := range []string{"launch", "mysql", "npm", "php", "xdebug", "yarn"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.NoError(err, "Failed to run ddev %s -h", c)
 	}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/npm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/npm
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: Run npm inside the web container
+## Usage: npm [flags] [args]
+## Example: "ddev npm install" or "ddev npm update"
+## ExecRaw: true
+
+npm "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/npm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/npm
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#ddev-generated
 ## Description: Run npm inside the web container
 ## Usage: npm [flags] [args]
 ## Example: "ddev npm install" or "ddev npm update"


### PR DESCRIPTION
## The Problem/Issue/Bug:
npm is a common development tool and it can be exhausting having to type ddev exec npm ... each time.

## How this PR Solves The Problem:
Enabling a global command to pass this into the web container makes it a much smoother task.

## Manual Testing Instructions:

## Automated Testing Overview:

## Related Issue Link(s):

## Release/Deployment notes:


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3886"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

