### PR TITLE
Try docker-compose 2.6.0 in a test run

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -562,7 +562,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.5.1"
+var RequiredDockerComposeVersion = "v2.6.0"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Problem/Issue/Bug:

docker-compose 2.6.0 was released

## How this PR Solves The Problem:

Try it out in test run



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3887"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

