### PR TITLE
Dynamic and appropriate container wait timeout, fixes #3819

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -628,7 +628,7 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	}
 
 	if cmd.Flag("default-container-timeout").Changed {
-		app.DefaultContainerTimeout, _ = cmd.Flags().GetInt("default-container-timeout")
+		app.DefaultContainerTimeout, _ = cmd.Flags().GetString("default-container-timeout")
 	}
 
 	if cmd.Flag("database").Changed {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -323,6 +323,7 @@ func init() {
 	ConfigCommand.Flags().Bool("bind-all-interfaces", false, `Bind host ports on all interfaces, not just on localhost network interface`)
 	ConfigCommand.Flags().String("database", "", fmt.Sprintf(`Specify the database type:version to use. Defaults to mariadb:%s`, nodeps.MariaDBDefaultVersion))
 	ConfigCommand.Flags().String("nodejs-version", "", fmt.Sprintf(`Specify the nodejs version to use if you don't want the default NodeJS %s`, nodeps.NodeJSDefault))
+	ConfigCommand.Flags().Int("default-container-timeout", 120, `default time in seconds that ddev waits for all containers to become ready on start`)
 	RootCmd.AddCommand(ConfigCommand)
 
 	// Add hidden pantheon subcommand for people who have it in their fingers
@@ -624,6 +625,10 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 
 	if cmd.Flag("bind-all-interfaces").Changed {
 		app.BindAllInterfaces, _ = cmd.Flags().GetBool("bind-all-interfaces")
+	}
+
+	if cmd.Flag("default-container-timeout").Changed {
+		app.DefaultContainerTimeout, _ = cmd.Flags().GetInt("default-container-timeout")
 	}
 
 	if cmd.Flag("database").Changed {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/drud/ddev/pkg/fileutil"
@@ -196,6 +197,7 @@ func TestConfigSetValues(t *testing.T) {
 	timezone := "America/Chicago"
 	webEnv := "SOMEENV=some+val"
 	nodejsVersion := "14"
+	defaultContainerTimeout := 100
 
 	args := []string{
 		"config",
@@ -228,6 +230,7 @@ func TestConfigSetValues(t *testing.T) {
 		"--project-tld", projectTLD,
 		"--web-environment", webEnv,
 		"--nodejs-version", nodejsVersion,
+		"--default-container-timeout", strconv.FormatInt(int64(defaultContainerTimeout), 10),
 		fmt.Sprintf("--use-dns-when-possible=%t", useDNSWhenPossible),
 		"--timezone", timezone,
 	}
@@ -276,6 +279,7 @@ func TestConfigSetValues(t *testing.T) {
 	require.NotEmpty(t, app.WebEnvironment)
 	assert.Equal(webEnv, app.WebEnvironment[0])
 	assert.Equal(nodejsVersion, app.NodeJSVersion)
+	assert.Equal(defaultContainerTimeout, app.DefaultContainerTimeout)
 
 	// Test that container images, working dirs and composer root dir can be unset with default flags
 	args = []string{

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -645,6 +645,7 @@ type composeYAMLVars struct {
 	HostUploadDir             string
 	GitDirMount               bool
 	IsGitpod                  bool
+	DefaultContainerTimeout   int
 }
 
 // RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.
@@ -726,6 +727,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		ContainerUploadDir:    app.GetContainerUploadDirFullPath(),
 		GitDirMount:           false,
 		IsGitpod:              nodeps.IsGitpod(),
+		// Default max time we wait for containers to be healthy
+		DefaultContainerTimeout: app.DefaultContainerTimeout,
 	}
 	// We don't want to bind-mount git dir if it doesn't exist
 	if fileutil.IsDirectory(filepath.Join(app.AppRoot, ".git")) {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -124,6 +124,10 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	if app.Database.Type == "" {
 		app.Database = DatabaseDefault
 	}
+	if app.DefaultContainerTimeout == "" {
+		app.DefaultContainerTimeout = nodeps.DefaultDefaultContainerTimeout
+	}
+
 	app.SetApptypeSettingsPaths()
 
 	// Rendered yaml is not there until after ddev config or ddev start
@@ -169,6 +173,9 @@ func (app *DdevApp) WriteConfig() error {
 	}
 	if appcopy.ProjectTLD == nodeps.DdevDefaultTLD {
 		appcopy.ProjectTLD = ""
+	}
+	if appcopy.DefaultContainerTimeout == nodeps.DefaultDefaultContainerTimeout {
+		appcopy.DefaultContainerTimeout = ""
 	}
 
 	// We now want to reserve the port we're writing for HostDBPort and HostWebserverPort and so they don't
@@ -645,7 +652,7 @@ type composeYAMLVars struct {
 	HostUploadDir             string
 	GitDirMount               bool
 	IsGitpod                  bool
-	DefaultContainerTimeout   int
+	DefaultContainerTimeout   string
 }
 
 // RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1300,10 +1300,9 @@ func (app *DdevApp) FindAllImages() ([]string, error) {
 // FindMaxTimeout looks through all services and returns the max timeout found
 // Defaults to 120s
 func (app *DdevApp) FindMaxTimeout() int {
-	const defaultContainerTimeout = 120
-	maxTimeout := defaultContainerTimeout
+	maxTimeout := app.DefaultContainerTimeout
 	if app.ComposeYaml == nil {
-		return defaultContainerTimeout
+		return app.DefaultContainerTimeout
 	}
 	if y, ok := app.ComposeYaml["services"]; ok {
 		for _, v := range y.(map[interface{}]interface{}) {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -36,9 +36,6 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
-// containerWaitTimeout is the max time we wait for all containers to become ready.
-var containerWaitTimeout = 61
-
 // SiteRunning defines the string used to denote running sites.
 const SiteRunning = "running"
 
@@ -128,6 +125,7 @@ type DdevApp struct {
 	DisableSettingsManagement bool                   `yaml:"disable_settings_management,omitempty"`
 	WebEnvironment            []string               `yaml:"web_environment"`
 	NodeJSVersion             string                 `yaml:"nodejs_version"`
+	DefaultContainerTimeout   int                    `yaml:"default_container_timeout"`
 	ComposeYaml               map[string]interface{} `yaml:"-"`
 }
 
@@ -1302,10 +1300,10 @@ func (app *DdevApp) FindAllImages() ([]string, error) {
 // FindMaxTimeout looks through all services and returns the max timeout found
 // Defaults to 120s
 func (app *DdevApp) FindMaxTimeout() int {
-	const defaultTimeout = 120
-	maxTimeout := defaultTimeout
+	const defaultContainerTimeout = 120
+	maxTimeout := defaultContainerTimeout
 	if app.ComposeYaml == nil {
-		return defaultTimeout
+		return defaultContainerTimeout
 	}
 	if y, ok := app.ComposeYaml["services"]; ok {
 		for _, v := range y.(map[interface{}]interface{}) {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -125,7 +125,7 @@ type DdevApp struct {
 	DisableSettingsManagement bool                   `yaml:"disable_settings_management,omitempty"`
 	WebEnvironment            []string               `yaml:"web_environment"`
 	NodeJSVersion             string                 `yaml:"nodejs_version"`
-	DefaultContainerTimeout   int                    `yaml:"default_container_timeout"`
+	DefaultContainerTimeout   string                 `yaml:"default_container_timeout,omitempty"`
 	ComposeYaml               map[string]interface{} `yaml:"-"`
 }
 
@@ -1289,7 +1289,6 @@ func (app *DdevApp) FindAllImages() ([]string, error) {
 					}
 				}
 				images = append(images, i.(string))
-
 			}
 		}
 	}
@@ -1298,11 +1297,12 @@ func (app *DdevApp) FindAllImages() ([]string, error) {
 }
 
 // FindMaxTimeout looks through all services and returns the max timeout found
-// Defaults to 120s
+// Defaults to 120
 func (app *DdevApp) FindMaxTimeout() int {
-	maxTimeout := app.DefaultContainerTimeout
+	const defaultContainerTimeout = 120
+	maxTimeout := defaultContainerTimeout
 	if app.ComposeYaml == nil {
-		return app.DefaultContainerTimeout
+		return defaultContainerTimeout
 	}
 	if y, ok := app.ComposeYaml["services"]; ok {
 		for _, v := range y.(map[interface{}]interface{}) {

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -91,7 +91,13 @@ func StartDdevRouter() error {
 
 	// ensure we have a happy router
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
+	// Normally the router comes right up, but when
+	// it has to do let's encrypt updates, it can take
+	// some time.
 	routerWaitTimeout := 60
+	if globalconfig.DdevGlobalConfig.UseLetsEncrypt {
+		routerWaitTimeout = 180
+	}
 	logOutput, err := dockerutil.ContainerWait(routerWaitTimeout, label)
 	if err != nil {
 		return fmt.Errorf("ddev-router failed to become ready; debug with 'docker logs ddev-router'; logOutput=%s, err=%v", logOutput, err)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -91,7 +91,8 @@ func StartDdevRouter() error {
 
 	// ensure we have a happy router
 	label := map[string]string{"com.docker.compose.service": "ddev-router"}
-	logOutput, err := dockerutil.ContainerWait(containerWaitTimeout, label)
+	routerWaitTimeout := 60
+	logOutput, err := dockerutil.ContainerWait(routerWaitTimeout, label)
 	if err != nil {
 		return fmt.Errorf("ddev-router failed to become ready; debug with 'docker logs ddev-router'; logOutput=%s, err=%v", logOutput, err)
 	}

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -174,6 +174,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	// For mariadb/mysql restart container and wait for restore
 	if status == SiteRunning || status == SitePaused {
 		util.Success("Stopping db container for snapshot restore of '%s'...", snapshotFile)
+		util.Success("With large snapshots this may take a long time. This will wait %d seconds (max of all container timeouts) but you can increase it by changing default_container_timeout.", app.FindMaxTimeout())
 		dbContainer, err := GetContainer(app, "db")
 		if err != nil || dbContainer == nil {
 			return fmt.Errorf("no container found for db; err=%v", err)

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -170,11 +170,12 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	}
 
 	status, _ := app.SiteStatus()
+	start := time.Now()
 
 	// For mariadb/mysql restart container and wait for restore
 	if status == SiteRunning || status == SitePaused {
 		util.Success("Stopping db container for snapshot restore of '%s'...", snapshotFile)
-		util.Success("With large snapshots this may take a long time. This will wait %d seconds (max of all container timeouts) but you can increase it by changing default_container_timeout.", app.FindMaxTimeout())
+		util.Success("With large snapshots this may take a long time.\nThis will normally time out after %d seconds (max of all container timeouts)\nbut you can increase it by changing default_container_timeout.", app.FindMaxTimeout())
 		dbContainer, err := GetContainer(app, "db")
 		if err != nil || dbContainer == nil {
 			return fmt.Errorf("no container found for db; err=%v", err)
@@ -250,7 +251,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 			fmt.Print(".")
 		}
 	}
-	util.Success("\nRestored database snapshot %s", snapshotName)
+	util.Success("\nDatabase snapshot %s was restored in %v", snapshotName, time.Since(start))
 	err = app.ProcessHooks("post-restore-snapshot")
 	if err != nil {
 		return fmt.Errorf("failed to process post-restore-snapshot hooks: %v", err)

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -61,7 +61,8 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 
 	// ensure we have a happy sshAuth
 	label := map[string]string{"com.docker.compose.project": SSHAuthName}
-	_, err = dockerutil.ContainerWait(containerWaitTimeout, label)
+	sshWaitTimeout := 60
+	_, err = dockerutil.ContainerWait(sshWaitTimeout, label)
 	if err != nil {
 		return fmt.Errorf("ddev-ssh-agent failed to become ready; debug with 'docker logs ddev-ssh-agent'; error: %v", err)
 	}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -179,6 +179,10 @@ const ConfigInstructions = `
 # will be available on the local network if the host firewall
 # allows it.
 
+# default_container_timeout: 120
+# The default time that ddev waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
 # Many ddev commands can be extended to run tasks before or after the
 # ddev command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -106,6 +106,7 @@ const (
 	DdevDefaultMailhogHTTPSPort = "8026"
 	// DdevDefaultTLD is the top-level-domain used by default, can be overridden
 	DdevDefaultTLD                  = "ddev.site"
+	DefaultDefaultContainerTimeout  = "120"
 	InternetDetectionTimeoutDefault = 750
 	MinimumDockerSpaceWarning       = 5000000 // 5GB in KB (to compare against df reporting in KB)
 )


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3819 
There was a fixed 61-second timeout waiting for containers to become ready

## How this PR Solves The Problem:

Use the actual max of timeouts in `docker-compose.*.yaml` and add a new config element

## Manual Testing Instructions:

- [ ] Import large databases
- [ ] Increase the timeout as needed using `default_container_timeout`

## Automated Testing Overview:

Added to config, not much else

