### PR TITLE
ddev clean: Do poweroff later so it's not scary. Check for projects first, fixes #3892

### DIFF
--- a/cmd/ddev/cmd/clean.go
+++ b/cmd/ddev/cmd/clean.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	"github.com/drud/ddev/pkg/ddevapp"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
@@ -36,15 +36,12 @@ Additional commands that can help clean up resources:
 			util.Failed("No project provided. See ddev clean --help for usage")
 		}
 
-		util.Success("Powering off ddev to avoid conflicts")
-		ddevapp.PowerOff()
-
-		util.Warning("Warning - Snapshots for the following project[s] will be permanently deleted")
-
 		projects, err := getRequestedProjects(args, cleanAll)
 		if err != nil {
-			util.Failed("Failed to get project(s): %v", err)
+			util.Failed("Failed to get project(s) '%v': %v", args, err)
 		}
+
+		util.Warning("Warning - Snapshots for the following project[s] will be permanently deleted")
 
 		// Show the user how many snapshots per project that will be deleted
 		for _, project := range projects {
@@ -69,6 +66,10 @@ Additional commands that can help clean up resources:
 		if strings.ToLower(confirm) != "y" {
 			return
 		}
+
+		util.Success("Powering off ddev to avoid conflicts.")
+		ddevapp.PowerOff()
+
 		globalDdevDir := globalconfig.GetGlobalDdevDir()
 		_ = os.RemoveAll(filepath.Join(globalDdevDir, "testcache"))
 		_ = os.RemoveAll(filepath.Join(globalDdevDir, "bin"))

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -48,7 +48,7 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 			if p != nil && p.AppRoot != "" {
 				requestedProjectsMap[name] = &ddevapp.DdevApp{Name: name}
 			} else {
-				return nil, fmt.Errorf("could not find requested project %s, you may need to use \"ddev start\" to add it to the project catalog", name)
+				return nil, fmt.Errorf("could not find requested project '%s', you may need to use \"ddev start\" to add it to the project catalog", name)
 			}
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3892 

The OP in #3892 was surprised by the `ddev poweroff` happening before the y/n prompt and thought all their projects were being deleted. 

## How this PR Solves The Problem:

Check for valid project and do poweroff *after* the y/n prompt.

## Manual Testing Instructions:

`ddev clean .` - or some other permutations.

## Automated Testing Overview:

I think existing is ok.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3901"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

