### PR TITLE
.webimageBuild and .dbimageBuild must be empty before using

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -824,14 +824,18 @@ RUN echo "*:*:db:db:db" > ~postgres/.pgpass && chown postgres:postgres ~postgres
 RUN printf "# TYPE DATABASE USER CIDR-ADDRESS  METHOD \nhost  all  all 0.0.0.0/0 md5\nlocal all all trust\nhost    replication    db             0.0.0.0/0  trust\nhost replication all 0.0.0.0/0 trust\nlocal replication all trust\nlocal replication all peer\n" >/etc/postgresql/pg_hba.conf
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests bzip2 less procps pv vim
 `
+	}
 
+	err = WriteBuildDockerfile(app.GetConfigPath(".dbimageBuild/Dockerfile"), app.GetConfigPath("db-build"), app.DBImageExtraPackages, "", extraDBContent)
+
+	// CopyEmbedAssets of postgres healthcheck has to be done after we WriteBuildDockerfile
+	// because that deletes the .dbimageBuild directory
+	if app.Database.Type == nodeps.Postgres {
 		err = fileutil.CopyEmbedAssets(bundledAssets, "healthcheck", app.GetConfigPath(".dbimageBuild"))
 		if err != nil {
 			return "", err
 		}
 	}
-
-	err = WriteBuildDockerfile(app.GetConfigPath(".dbimageBuild/Dockerfile"), app.GetConfigPath("db-build"), app.DBImageExtraPackages, "", extraDBContent)
 
 	if err != nil {
 		return "", err

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -224,7 +224,7 @@ func (app *DdevApp) WriteConfig() error {
 # or packages or anything else to your webimage
 # These additions will be appended last to ddev's own Dockerfile
 RUN npm install --global forever
-RUN echo "Built from $BASE_IMAGE" > /tmp/built-from.txt
+RUN echo "Built on $(date)" > /build-date.txt
 `)
 
 	err = WriteImageDockerfile(app.GetConfigPath("web-build")+"/Dockerfile.example", contents)
@@ -234,7 +234,7 @@ RUN echo "Built from $BASE_IMAGE" > /tmp/built-from.txt
 	contents = []byte(`
 # You can copy this Dockerfile.example to Dockerfile to add configuration
 # or packages or anything else to your dbimage
-RUN echo "Built from $BASE_IMAGE" > /tmp/built-from.txt
+RUN echo "Built on $(date)" > /build-date.txt
 `)
 
 	err = WriteImageDockerfile(app.GetConfigPath("db-build")+"/Dockerfile.example", contents)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -796,18 +796,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		extraWebContent = extraWebContent + "\nRUN bash /tmp/setup_node.sh && apt-get install nodejs && npm config set unsafe-perm true && npm install --global gulp-cli yarn"
 	}
 
-	// Assets in the web-build directory copied to .webimageBuild so .webimageBuild can be "context"
-	err = copy2.Copy(app.GetConfigPath("web-build/"), app.GetConfigPath(".webimageBuild/"))
-	if err != nil {
-		return "", err
-	}
 	err = WriteBuildDockerfile(app.GetConfigPath(".webimageBuild/Dockerfile"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)
-	if err != nil {
-		return "", err
-	}
-
-	// Assets in the db-build directory copied to .dbimageBuild so .dbimageBuild can be "context"
-	err = copy2.Copy(app.GetConfigPath("db-build/"), app.GetConfigPath(".dbimageBuild/"))
 	if err != nil {
 		return "", err
 	}
@@ -953,6 +942,14 @@ RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update 
 		}
 	}
 
+	// Assets in the web-build directory copied to .webimageBuild so .webimageBuild can be "context"
+	// This actually copies the Dockerfile, but it is then immediately overwritten by WriteImageDockerfile()
+	if userDockerfilePath != "" {
+		err = copy2.Copy(userDockerfilePath, filepath.Dir(fullpath))
+		if err != nil {
+			return err
+		}
+	}
 	return WriteImageDockerfile(fullpath, []byte(contents))
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -864,8 +864,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg:
 // docker-compose 'build'
 // It may include the contents of .ddev/<container>-build
 func WriteBuildDockerfile(fullpath string, userDockerfilePath string, extraPackages []string, composerVersion string, extraContent string) error {
+
+	// We must start with a clean base directory
+	err := os.RemoveAll(filepath.Dir(fullpath))
+	if err != nil {
+		return fmt.Errorf("unable to clean up directory %s, you may want to delete it manually: %v", filepath.Dir(fullpath), err)
+	}
 	// Start with user-built dockerfile if there is one.
-	err := os.MkdirAll(filepath.Dir(fullpath), 0755)
+	err = os.MkdirAll(filepath.Dir(fullpath), 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noticed in studying some "-built" containers that everything I'd ever done was ending up in then. It turns out that in the recent addition of `Dockerfile.*` we didn't clear out the .ddev/.webimageBuild or .ddev/.dbimageBuild before starting over with them, so we end up with lots of crap in there. Lots in my case. 

## How this PR Solves The Problem:

Clear those directories before using them.

## Manual Testing Instructions:

- [x] Create a Dockerfile.something
- [x] `ddev start`
- [x] Look in .ddev/webimageBuild and you should see both Dockerfile and Dockerfile.something.
- [ ] Remove .ddev/Dockerfile.something
- [ ] `ddev restart`. 
- [ ] Look again in .ddev/webimageBuild. It should have only the Dockerfile.

## Automated Testing Overview:

I think this does need a test.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3906"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

