### PR TITLE
ddev-generated was missing from Dockerfile.example, breaking some ddev get

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -220,6 +220,7 @@ func (app *DdevApp) WriteConfig() error {
 
 	// Write example Dockerfiles into build directories
 	contents := []byte(`
+#ddev-generated
 # You can copy this Dockerfile.example to Dockerfile to add configuration
 # or packages or anything else to your webimage
 # These additions will be appended last to ddev's own Dockerfile
@@ -232,6 +233,7 @@ RUN echo "Built on $(date)" > /build-date.txt
 		return err
 	}
 	contents = []byte(`
+#ddev-generated
 # You can copy this Dockerfile.example to Dockerfile to add configuration
 # or packages or anything else to your dbimage
 RUN echo "Built on $(date)" > /build-date.txt

--- a/pkg/ddevapp/dotddev_assets/providers/README.txt
+++ b/pkg/ddevapp/dotddev_assets/providers/README.txt
@@ -1,6 +1,8 @@
 Providers README
 ================
 
+#ddev-generated
+
 ## Introduction to Hosting Provider Integration
 
 As of DDEV-Local v1.17, the hosting provider integration has been completely rewritten and reorganized, and integrations for Platform.sh and Acquia hosting have been added to the previous integration for Pantheon.io.


### PR DESCRIPTION

## The Problem/Issue/Bug:

The #ddev-generated marker was missing from Dockerfile.example, causing `ddev get` to balk at overwriting the .ddev/web-build directory.

## How this PR Solves The Problem:

Add it in

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3916"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

