### PR TITLE
wp command needs #ddev-generated [skip ci]

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#ddev-generated
 ## Description: Run WordPress CLI inside the web container
 ## Usage: wp [flags] [args]
 ## Example: "ddev wp core version" or "ddev wp plugin install user-switching --activate"


### PR DESCRIPTION
## The Problem/Issue/Bug:

The wp command didn't have #ddev-generated in it. 



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3918"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

