### PR TITLE
Bump the internet detection timeout to 3000=3s

### DIFF
--- a/.github/workflows/selfhosted-upgrades.sh
+++ b/.github/workflows/selfhosted-upgrades.sh
@@ -41,4 +41,4 @@ docker rmi -f $(docker images --filter "dangling=true" -q --no-trunc) >/dev/null
 docker rmi -f $(docker images | awk '/drud.*-built/ {print $3}' ) >/dev/null || true
 
 # Make sure the global internet detection timeout is not set to 0 (broken)
-perl -pi -e 's/^internet_detection_timeout_ms:.*$/internet_detection_timeout_ms: 750/g' ~/.ddev/global_config.yaml
+perl -pi -e 's/^internet_detection_timeout_ms:.*$/internet_detection_timeout_ms: 3000/g' ~/.ddev/global_config.yaml

--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -211,7 +211,7 @@ func init() {
 	configGlobalCommand.Flags().Bool("nfs-mount-enabled", false, "Enable NFS mounting on all projects globally")
 	configGlobalCommand.Flags().BoolVarP(&instrumentationOptIn, "instrumentation-opt-in", "", false, "instrumentation-opt-in=true")
 	configGlobalCommand.Flags().Bool("router-bind-all-interfaces", false, "router-bind-all-interfaces=true")
-	configGlobalCommand.Flags().Int("internet-detection-timeout-ms", 750, "Increase timeout when checking internet timeout, in milliseconds")
+	configGlobalCommand.Flags().Int("internet-detection-timeout-ms", 3000, "Increase timeout when checking internet timeout, in milliseconds")
 	configGlobalCommand.Flags().Bool("disable-http2", false, "Optionally disable http2 in ddev-router, 'ddev global --disable-http2' or `ddev global --disable-http2=false'")
 	configGlobalCommand.Flags().Bool("use-letsencrypt", false, "Enables experimental Let's Encrypt integration, 'ddev global --use-letsencrypt' or `ddev global --use-letsencrypt=false'")
 	configGlobalCommand.Flags().String("letsencrypt-email", "", "Email associated with Let's Encrypt, `ddev global --letsencrypt-email=me@example.com'")

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -50,7 +50,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	args := []string{"config", "global"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nweb-environment=[]\nmutagen-enabled=false\nnfs-mount-enabled=false\nrouter-bind-all-interfaces=false\ninternet-detection-timeout-ms=750\ndisable-http2=false\nuse-letsencrypt=false\nletsencrypt-email=\ntable-style=default\nsimple-formatting=false\nauto-restart-containers=false\nuse-hardened-images=false\nfail-on-hook-fail=false\nrequired-docker-compose-version=\nuse-docker-compose-from-path=false")
+	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nweb-environment=[]\nmutagen-enabled=false\nnfs-mount-enabled=false\nrouter-bind-all-interfaces=false\ninternet-detection-timeout-ms=3000\ndisable-http2=false\nuse-letsencrypt=false\nletsencrypt-email=\ntable-style=default\nsimple-formatting=false\nauto-restart-containers=false\nuse-hardened-images=false\nfail-on-hook-fail=false\nrequired-docker-compose-version=\nuse-docker-compose-from-path=false")
 
 	// Update a config
 	// Don't include no-bind-mounts because global testing

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -159,7 +159,7 @@ func TestIsInternetActiveTimeout(t *testing.T) {
 	internetActiveResetVariables()
 
 	globalconfig.IsInternetActiveNetResolver = internetActiveNetResolverStub{
-		sleepTime: 1000 * time.Millisecond,
+		sleepTime: 4000 * time.Millisecond,
 	}
 
 	asrt.False(t, globalconfig.IsInternetActive())

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -107,7 +107,7 @@ const (
 	// DdevDefaultTLD is the top-level-domain used by default, can be overridden
 	DdevDefaultTLD                  = "ddev.site"
 	DefaultDefaultContainerTimeout  = "120"
-	InternetDetectionTimeoutDefault = 750
+	InternetDetectionTimeoutDefault = 3000
 	MinimumDockerSpaceWarning       = 5000000 // 5GB in KB (to compare against df reporting in KB)
 )
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

I often find that the internet detection timeout is incorrect and it wants to add a hostname to /etc/hosts

## How this PR Solves The Problem:

Use longer timeout. It usually won't matter



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3921"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

