### PR TITLE
No environment replacement in install.yaml actions

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -243,8 +243,6 @@ func processAction(action string, dict map[string]interface{}, bashPath string) 
 		return fmt.Errorf("could not parse/execute action '%s': %v", action, err)
 	}
 	action = doc.String()
-	// Expand any remaining environment variables.
-	action = os.ExpandEnv(action)
 
 	out, err := exec.RunHostCommand(bashPath, "-c", action)
 	if err != nil {

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -72,7 +72,7 @@ You can see a simple install.yaml in [ddev-addon-template's install.yaml](https:
 
 ### Environment variable replacements
 
-Simple environment variables will be replaced in the `install.yaml` both as part of filenames and as used in the various actions. This can include environment variables in the context of where ddev is being run, as well as the standard [environment variables](custom-commands.md#environment-variables-provided) provided to custom host commands, like `DDEV_APPROOT`, `DDEV_DOCROOT`, etc. For example, if a file in `project_files` is listed as `somefile.${DDEV_PROJECT}.txt` with a project named `d10`, the file named `somefile.d10.txt` will be copied from the add-on into the project.
+Simple environment variables will be replaced in `install.yaml` as part of filenames. This can include environment variables in the context of where ddev is being run, as well as the standard [environment variables](custom-commands.md#environment-variables-provided) provided to custom host commands, like `DDEV_APPROOT`, `DDEV_DOCROOT`, etc. For example, if a file in `project_files` is listed as `somefile.${DDEV_PROJECT}.txt` with a project named `d10`, the file named `somefile.d10.txt` will be copied from the add-on into the project.
 
 ### Template action replacements (advanced)
 

--- a/pkg/util/yamltools.go
+++ b/pkg/util/yamltools.go
@@ -13,8 +13,6 @@ func YamlFileToMap(fname string) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file %s (%v)", fname, err)
 	}
-	c := os.ExpandEnv(string(contents))
-	contents = []byte(c)
 
 	itemMap := make(map[string]interface{})
 	err = yaml.Unmarshal(contents, &itemMap)


### PR DESCRIPTION
## The Problem/Issue/Bug:

Environment variable replacement in install.yaml actions made it impossible to use environment variables. 

## How this PR Solves The Problem:

Stop doing that.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3922"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

