### PR TITLE
Add `/opt/phpstorm-coverage` directory to web-container

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -101,6 +101,9 @@ RUN phpdismod xdebug && curl -sSL --fail --output /usr/local/bin/phive "https://
 RUN set -o pipefail && curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus
 RUN set -o pipefail && curl -sSL https://github.com/platformsh/platformsh-cli/releases/download/$(curl --silent "https://api.github.com/repos/platformsh/platformsh-cli/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/platform.phar --output /usr/local/bin/platform && chmod 777 /usr/local/bin/platform
 
+RUN mkdir -p "/opt/phpstorm-coverage" && \
+    chmod a+rw "/opt/phpstorm-coverage"
+
 # TODO: v1.18.0 had numerous problems, see https://github.com/acquia/cli/issues/508#issuecomment-967185296
 # and https://github.com/acquia/cli/issues/721 and https://github.com/acquia/cli/issues/722
 # When things sort out, additional work will be required in acquia.yaml.example to make it work

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -14,7 +14,7 @@ var DdevVersion = "v0.0.0-overridden-by-make" // Note that this is overridden by
 var SegmentKey = ""
 
 // WebImg defines the default web image used for applications.
-var WebImg = "niconator/ddev-webserver"
+var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
 var WebTag = "20220619_add_phpstorm_coverage_directory" // Note that this can be overridden by make

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -14,10 +14,10 @@ var DdevVersion = "v0.0.0-overridden-by-make" // Note that this is overridden by
 var SegmentKey = ""
 
 // WebImg defines the default web image used for applications.
-var WebImg = "drud/ddev-webserver"
+var WebImg = "niconator/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.19.3-1" // Note that this can be overridden by make
+var WebTag = "20220619_add_phpstorm_coverage_directory" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

https://github.com/drud/ddev/issues/3920

## How this PR Solves The Problem:

This PR adds the PHPStorm required directory `/opt/phpstorm-coverage`  to the web-container with read/write premissions for the cli user.

As discussed in #3920, a Docker volume would allow persistence of the coverage reports, but I don't think this is necessary. Therefore, adding the directory was the easiest solution.
PHPStorm does allow loading coverage data from previous runs, but it does not load it automatically at startup. This is a pretty hidden feature and I don't think anyone would use it.

## Manual Testing Instructions:
The directory `/opt/phpstorm-coverage` should exist right after `ddev start`. 
Your default user (not root) should be able to read / write files in this directory.

## Automated Testing Overview:
I don't think tests for this are needed.

## Related Issue Link(s):

* https://github.com/drud/ddev/issues/3920

## Release/Deployment notes:

Please don't forget to remove the reference to my tagged container in versionconstants.go.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3924"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

