### PR TITLE
Action processing/yaml parsing improvements for pre/post ddev-get actions

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -163,6 +163,12 @@ ddev get --list --all
 				util.Failed("unable to import yaml file %s: %v", fullpath, err)
 			}
 		}
+		for k, v := range map[string]string{"DdevGlobalConfig": globalconfig.GetGlobalConfigPath(), "DdevProjectConfig": app.GetConfigPath("config.yaml")} {
+			yamlMap[k], err = util.YamlFileToMap(v)
+			if err != nil {
+				util.Failed("unable to read file %s", v)
+			}
+		}
 
 		dict, err := util.YamlToDict(yamlMap)
 		if err != nil {
@@ -233,7 +239,7 @@ ddev get --list --all
 // processAction takes a stanza from yaml exec section and executes it.
 func processAction(action string, dict map[string]interface{}, bashPath string) error {
 	action = "set -eu -o pipefail\n" + action
-	t, err := template.New("preInstall").Funcs(sprig.TxtFuncMap()).Parse(action)
+	t, err := template.New("processAction").Funcs(sprig.TxtFuncMap()).Parse(action)
 	if err != nil {
 		return fmt.Errorf("could not parse action '%s': %v", action, err)
 	}
@@ -253,7 +259,7 @@ func processAction(action string, dict map[string]interface{}, bashPath string) 
 		output.UserOut.Print(out)
 	}
 	if !strings.Contains(action, `#ddev-nodisplay`) {
-		output.UserOut.Printf("Executed pre-install action %v, output=%s.", action, out)
+		output.UserOut.Printf("Executed action '%v', output='%s'", action, out)
 	}
 	return nil
 }

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -249,6 +249,9 @@ func processAction(action string, dict map[string]interface{}, bashPath string) 
 	if err != nil {
 		return fmt.Errorf("Unable to run action %v: %v, output=%s", action, err, out)
 	}
+	if len(out) > 0 {
+		output.UserOut.Print(out)
+	}
 	if !strings.Contains(action, `#ddev-nodisplay`) {
 		output.UserOut.Printf("Executed pre-install action %v, output=%s.", action, out)
 	}

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -230,8 +230,9 @@ ddev get --list --all
 	},
 }
 
-// processAction takes a line from yaml exec section and executes it.
+// processAction takes a stanza from yaml exec section and executes it.
 func processAction(action string, dict map[string]interface{}, bashPath string) error {
+	action = "set -eu -o pipefail\n" + action
 	t, err := template.New("preInstall").Funcs(sprig.TxtFuncMap()).Parse(action)
 	if err != nil {
 		return fmt.Errorf("could not parse action '%s': %v", action, err)

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -57,7 +57,9 @@ func RunHostCommand(command string, args ...string) (string, error) {
 	if globalconfig.DdevVerbose {
 		output.UserOut.Printf("RunHostCommand: " + command + " " + strings.Join(args, " "))
 	}
-	o, err := exec.Command(command, args...).CombinedOutput()
+	c := exec.Command(command, args...)
+	c.Stdin = os.Stdin
+	o, err := c.CombinedOutput()
 	if globalconfig.DdevVerbose {
 		output.UserOut.Printf("RunHostCommand returned. output=%v err=%v", string(o), err)
 	}

--- a/pkg/util/yamltools.go
+++ b/pkg/util/yamltools.go
@@ -38,6 +38,8 @@ func YamlToDict(topm interface{}) (map[string]interface{}, error) {
 				res[ys], err = YamlToDict(v)
 			case map[string]interface{}:
 				res[ys], err = YamlToDict(v)
+			case []interface{}:
+				res[ys] = v
 			case interface{}:
 				res[ys] = v
 			default:


### PR DESCRIPTION
* Use os.Stdin with ddev-get actions (and everything else that does RunHostCommand()
* Automatically add `set -eu -o pipefail` to ddev-get actions
* If #ddev-nodisplay, still display any output, just not the explanatory output
* Add ~/.ddev/global_config.yaml and project .ddev/config.yaml to the yaml maps for use in go templating
* Add []interface case for parsing yaml