### PR TITLE
Use bullseye-slim for ssh agent container, fixes #3250

### DIFF
--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y bash expect file openssh-client socat psmisc && apt autoclean
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -39,11 +39,11 @@ var RouterTag = "v1.19.3" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 //var SSHAuthImage = "drud/ddev-ssh-agent"
-var SSHAuthImage = "mikebarkas/ddev-ssh-agent"
+var SSHAuthImage = "drud/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
 //var SSHAuthTag = "v1.19.0"
-var SSHAuthTag = "3250-test"
+var SSHAuthTag = "20220628_mikebarkas_sshagent"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -38,10 +38,12 @@ var RouterImage = "drud/ddev-router"
 var RouterTag = "v1.19.3" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
-var SSHAuthImage = "drud/ddev-ssh-agent"
+//var SSHAuthImage = "drud/ddev-ssh-agent"
+var SSHAuthImage = "mikebarkas/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.19.0"
+//var SSHAuthTag = "v1.19.0"
+var SSHAuthTag = "3250-test"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Problem/Issue/Bug:
To update to bullseye-slim

## How this PR Solves The Problem:
Changes the version for ddev-ssh-agent container

## Manual Testing Instructions:
Poweroff ddev and removed ssh agent images
Start a ddev project and should see pulling the new image

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
n/a

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3931"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

