### PR TITLE
[docs] missing close to code block on d10 quick start

### DIFF
--- a/docs/users/cli-usage.md
+++ b/docs/users/cli-usage.md
@@ -213,6 +213,7 @@ ddev composer install
 ddev drush site:install -y
 ddev drush uli
 ddev launch
+```
 
 Note that as Drupal 10 moves from alpha to beta and then release, you'll want to change the tag from `^10@alpha` to `^10@beta` and then `^10`.
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

https://ddev.readthedocs.io/en/stable/users/cli-usage/#drupal-10-quickstart has missing code block ending, breaks D6/7 quickstart

## How this PR Solves The Problem:

Adds missing ticks

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3934"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

