### PR TITLE
Colima name may only be a prefix - fix IsColima()

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1282,7 +1282,7 @@ func IsColima() bool {
 		util.Warning("IsColima(): Unable to get docker info, err=%v", err)
 		return false
 	}
-	if info.Name == "colima" {
+	if strings.HasPrefix(info.Name, "colima") {
 		return true
 	}
 	return false


### PR DESCRIPTION
## The Problem/Issue/Bug:

IsColima() detects whether we're on colima; among other things this lets us generate host.docker.internal

But it may not just be "colima", it may be "colima-9p", more generally "colima-<profile>". 

## How this PR Solves The Problem:

Change to look at the docker name profile.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3935"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

