### PR TITLE
Use goreleaser for most release actions, add apt and yum repositories, fixes #3723, fixes #1678

### DIFF
--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -65,7 +65,7 @@ popd >/dev/null
 
 # Generate macOS-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64 && chmod +x mkcert
+curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64 && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
 popd >/dev/null
 

--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -48,40 +48,37 @@ fi
 # Generate macOS-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_amd64 >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64 && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
+tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate macOS-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64 && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
+tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate linux-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_amd64 >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64 && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
+tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate linux-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_arm64 >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm64 && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
+tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate linux-arm tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_arm >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_linux-arm.$VERSION.tar.gz ddev *completion*.sh
+tar -czf $ARTIFACTS/ddev_linux-arm.$VERSION.tar.gz ddev 
 popd >/dev/null
 
 # generate windows-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
 curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe
-tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe *completion*.sh mkcert.exe
-if [ -d chocolatey ]; then
-  tar -czf $ARTIFACTS/ddev_chocolatey_amd64-.$VERSION.tar.gz chocolatey
-fi
+tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe  mkcert.exe
 popd >/dev/null
 
 

--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -45,41 +45,41 @@ if [ "${BUILD_IMAGE_TARBALLS}" = "true" ]; then
 fi
 
 # Generate and place extra items like autocomplete
-$BUILTPATH/ddev_gen_autocomplete
+#$BUILTPATH/ddev_gen_autocomplete
 
 # The completion scripts get placed into the linux build dir (.gotmp/bin)
 # So now copy them into the real build directory
-for dir in .gotmp/bin/linux_amd64 .gotmp/bin/linux_arm64 .gotmp/bin/darwin_amd64 .gotmp/bin/darwin_arm64 .gotmp/bin/windows_amd64; do
-  cp .gotmp/bin/ddev_*completion* $dir
-done
+#for dir in .gotmp/bin/linux_amd64 .gotmp/bin/linux_arm64 .gotmp/bin/darwin_amd64 .gotmp/bin/darwin_arm64 .gotmp/bin/windows_amd64; do
+#  cp .gotmp/bin/ddev_*completion* $dir
+#done
 
 # Create tarball of completion scripts
-pushd .gotmp/bin >/dev/null && tar -czf $ARTIFACTS/ddev_shell_completion_scripts.$VERSION.tar.gz *completion*.sh && popd >/dev/null
-cp $BASE_DIR/.gotmp/bin/windows_amd64/ddev_windows_installer*.exe $ARTIFACTS
+#pushd .gotmp/bin >/dev/null && tar -czf $ARTIFACTS/ddev_shell_completion_scripts.$VERSION.tar.gz *completion*.sh && popd >/dev/null
+#cp $BASE_DIR/.gotmp/bin/windows_amd64/ddev_windows_installer*.exe $ARTIFACTS
 
 # Generate macOS-amd64 tarball/zipball
-pushd $BASE_DIR/.gotmp/bin/darwin_amd64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64 && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
-popd >/dev/null
+#pushd $BASE_DIR/.gotmp/bin/darwin_amd64 >/dev/null
+#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64 && chmod +x mkcert
+#tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
+#popd >/dev/null
 
 # Generate macOS-arm64 tarball/zipball
-pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64 && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
-popd >/dev/null
+#pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
+#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64 && chmod +x mkcert
+#tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
+#popd >/dev/null
 
 # Generate linux-amd64 tarball/zipball
-pushd $BASE_DIR/.gotmp/bin/linux_amd64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64 && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
-popd >/dev/null
+#pushd $BASE_DIR/.gotmp/bin/linux_amd64 >/dev/null
+#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64 && chmod +x mkcert
+#tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
+#popd >/dev/null
 
 # Generate linux-arm64 tarball/zipball
-pushd $BASE_DIR/.gotmp/bin/linux_arm64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm64 && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
-popd >/dev/null
+#pushd $BASE_DIR/.gotmp/bin/linux_arm64 >/dev/null
+#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm64 && chmod +x mkcert
+#tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
+#popd >/dev/null
 
 # Generate linux-arm tarball/zipball
 #pushd $BASE_DIR/.gotmp/bin/linux_arm >/dev/null
@@ -88,30 +88,30 @@ popd >/dev/null
 #popd >/dev/null
 
 # generate windows-amd64 tarball/zipball
-pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
-curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe
-tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe *completion*.sh mkcert.exe
-if [ -d chocolatey ]; then
-  tar -czf $ARTIFACTS/ddev_chocolatey_amd64-.$VERSION.tar.gz chocolatey
-fi
-popd >/dev/null
+#pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
+#curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe
+#tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe *completion*.sh mkcert.exe
+#if [ -d chocolatey ]; then
+#  tar -czf $ARTIFACTS/ddev_chocolatey_amd64-.$VERSION.tar.gz chocolatey
+#fi
+#popd >/dev/null
 
 # Create macOS and Linux homebrew bottles
-for os in high_sierra arm64_big_sur x86_64_linux; do
-  NO_V_VERSION=${VERSION#v}
-  rm -rf /tmp/bottle
-  BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
-  mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh/site-functions,share/fish/vendor_completions.d}
-  cp $BASE_DIR/.gotmp/bin/ddev_bash_completion.sh $BOTTLE_BASE/etc/bash_completion.d/ddev
-  cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh/site-functions/_ddev
-  cp $BASE_DIR/.gotmp/bin/ddev_fish_completion.sh $BOTTLE_BASE/share/fish/vendor_completions.d/ddev.fish
-
-  if [ "${os}" = "high_sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin; fi
-  if [ "${os}" = "arm64_big_sur" ]; then cp $BASE_DIR/.gotmp/bin/darwin_arm64/ddev $BOTTLE_BASE/bin; fi
-  if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/linux_amd64/ddev $BOTTLE_BASE/bin; fi
-  cp $BASE_DIR/{README.md,LICENSE} $BOTTLE_BASE
-  tar -czf $ARTIFACTS/ddev-$NO_V_VERSION.$os.bottle.tar.gz -C /tmp/bottle .
-done
+#for os in high_sierra arm64_big_sur x86_64_linux; do
+#  NO_V_VERSION=${VERSION#v}
+#  rm -rf /tmp/bottle
+#  BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
+#  mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh/site-functions,share/fish/vendor_completions.d}
+#  cp $BASE_DIR/.gotmp/bin/ddev_bash_completion.sh $BOTTLE_BASE/etc/bash_completion.d/ddev
+#  cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh/site-functions/_ddev
+#  cp $BASE_DIR/.gotmp/bin/ddev_fish_completion.sh $BOTTLE_BASE/share/fish/vendor_completions.d/ddev.fish
+#
+#  if [ "${os}" = "high_sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin; fi
+#  if [ "${os}" = "arm64_big_sur" ]; then cp $BASE_DIR/.gotmp/bin/darwin_arm64/ddev $BOTTLE_BASE/bin; fi
+#  if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/linux_amd64/ddev $BOTTLE_BASE/bin; fi
+#  cp $BASE_DIR/{README.md,LICENSE} $BOTTLE_BASE
+#  tar -czf $ARTIFACTS/ddev-$NO_V_VERSION.$os.bottle.tar.gz -C /tmp/bottle .
+#done
 
 # Create the sha256 files
 cd $ARTIFACTS

--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -69,12 +69,6 @@ curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VE
 tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
-# Generate linux-arm tarball/zipball
-pushd $BASE_DIR/.gotmp/bin/linux_arm >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm && chmod +x mkcert
-tar -czf $ARTIFACTS/ddev_linux-arm.$VERSION.tar.gz ddev 
-popd >/dev/null
-
 # generate windows-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
 curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe

--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -44,50 +44,38 @@ if [ "${BUILD_IMAGE_TARBALLS}" = "true" ]; then
   done
 fi
 
-# Generate and place extra items like autocomplete
-$BUILTPATH/ddev_gen_autocomplete
 
-# The completion scripts get placed into the linux build dir (.gotmp/bin)
-# So now copy them into the real build directory
-for dir in .gotmp/bin/linux_amd64 .gotmp/bin/linux_arm64 .gotmp/bin/darwin_amd64 .gotmp/bin/darwin_arm64 .gotmp/bin/windows_amd64; do
-  cp .gotmp/bin/ddev_*completion* $dir
-done
-
- Create tarball of completion scripts
-pushd .gotmp/bin >/dev/null && tar -czf $ARTIFACTS/ddev_shell_completion_scripts.$VERSION.tar.gz *completion*.sh && popd >/dev/null
-cp $BASE_DIR/.gotmp/bin/windows_amd64/ddev_windows_installer*.exe $ARTIFACTS
-
- Generate macOS-amd64 tarball/zipball
+# Generate macOS-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_amd64 >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64 && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
 popd >/dev/null
 
- Generate macOS-arm64 tarball/zipball
+# Generate macOS-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64 && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
 popd >/dev/null
 
- Generate linux-amd64 tarball/zipball
+# Generate linux-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_amd64 >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64 && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
 popd >/dev/null
 
- Generate linux-arm64 tarball/zipball
+# Generate linux-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_arm64 >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm64 && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
 popd >/dev/null
 
- Generate linux-arm tarball/zipball
+# Generate linux-arm tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_arm >/dev/null
 curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_linux-arm.$VERSION.tar.gz ddev *completion*.sh
 popd >/dev/null
 
- generate windows-amd64 tarball/zipball
+# generate windows-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
 curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe
 tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe *completion*.sh mkcert.exe
@@ -96,25 +84,4 @@ if [ -d chocolatey ]; then
 fi
 popd >/dev/null
 
-# Create macOS and Linux homebrew bottles
-#for os in high_sierra arm64_big_sur x86_64_linux; do
-#  NO_V_VERSION=${VERSION#v}
-#  rm -rf /tmp/bottle
-#  BOTTLE_BASE=/tmp/bottle/ddev/$NO_V_VERSION
-#  mkdir -p $BOTTLE_BASE/{bin,etc/bash_completion.d,share/zsh/site-functions,share/fish/vendor_completions.d}
-#  cp $BASE_DIR/.gotmp/bin/ddev_bash_completion.sh $BOTTLE_BASE/etc/bash_completion.d/ddev
-#  cp $BASE_DIR/.gotmp/bin/ddev_zsh_completion.sh $BOTTLE_BASE/share/zsh/site-functions/_ddev
-#  cp $BASE_DIR/.gotmp/bin/ddev_fish_completion.sh $BOTTLE_BASE/share/fish/vendor_completions.d/ddev.fish
-#
-#  if [ "${os}" = "high_sierra" ]; then cp $BASE_DIR/.gotmp/bin/darwin_amd64/ddev $BOTTLE_BASE/bin; fi
-#  if [ "${os}" = "arm64_big_sur" ]; then cp $BASE_DIR/.gotmp/bin/darwin_arm64/ddev $BOTTLE_BASE/bin; fi
-#  if [ "${os}" = "x86_64_linux" ]; then cp $BASE_DIR/.gotmp/bin/linux_amd64/ddev $BOTTLE_BASE/bin; fi
-#  cp $BASE_DIR/{README.md,LICENSE} $BOTTLE_BASE
-#  tar -czf $ARTIFACTS/ddev-$NO_V_VERSION.$os.bottle.tar.gz -C /tmp/bottle .
-#done
 
-# Create the sha256 files
-cd $ARTIFACTS
-#for item in *.*; do
-#  sha256sum $item >$item.sha256.txt
-#done

--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -45,56 +45,56 @@ if [ "${BUILD_IMAGE_TARBALLS}" = "true" ]; then
 fi
 
 # Generate and place extra items like autocomplete
-#$BUILTPATH/ddev_gen_autocomplete
+$BUILTPATH/ddev_gen_autocomplete
 
 # The completion scripts get placed into the linux build dir (.gotmp/bin)
 # So now copy them into the real build directory
-#for dir in .gotmp/bin/linux_amd64 .gotmp/bin/linux_arm64 .gotmp/bin/darwin_amd64 .gotmp/bin/darwin_arm64 .gotmp/bin/windows_amd64; do
-#  cp .gotmp/bin/ddev_*completion* $dir
-#done
+for dir in .gotmp/bin/linux_amd64 .gotmp/bin/linux_arm64 .gotmp/bin/darwin_amd64 .gotmp/bin/darwin_arm64 .gotmp/bin/windows_amd64; do
+  cp .gotmp/bin/ddev_*completion* $dir
+done
 
-# Create tarball of completion scripts
-#pushd .gotmp/bin >/dev/null && tar -czf $ARTIFACTS/ddev_shell_completion_scripts.$VERSION.tar.gz *completion*.sh && popd >/dev/null
-#cp $BASE_DIR/.gotmp/bin/windows_amd64/ddev_windows_installer*.exe $ARTIFACTS
+ Create tarball of completion scripts
+pushd .gotmp/bin >/dev/null && tar -czf $ARTIFACTS/ddev_shell_completion_scripts.$VERSION.tar.gz *completion*.sh && popd >/dev/null
+cp $BASE_DIR/.gotmp/bin/windows_amd64/ddev_windows_installer*.exe $ARTIFACTS
 
-# Generate macOS-amd64 tarball/zipball
-#pushd $BASE_DIR/.gotmp/bin/darwin_amd64 >/dev/null
-#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64 && chmod +x mkcert
-#tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
-#popd >/dev/null
+ Generate macOS-amd64 tarball/zipball
+pushd $BASE_DIR/.gotmp/bin/darwin_amd64 >/dev/null
+curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64 && chmod +x mkcert
+tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
+popd >/dev/null
 
-# Generate macOS-arm64 tarball/zipball
-#pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
-#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64 && chmod +x mkcert
-#tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
-#popd >/dev/null
+ Generate macOS-arm64 tarball/zipball
+pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
+curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64 && chmod +x mkcert
+tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
+popd >/dev/null
 
-# Generate linux-amd64 tarball/zipball
-#pushd $BASE_DIR/.gotmp/bin/linux_amd64 >/dev/null
-#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64 && chmod +x mkcert
-#tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
-#popd >/dev/null
+ Generate linux-amd64 tarball/zipball
+pushd $BASE_DIR/.gotmp/bin/linux_amd64 >/dev/null
+curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64 && chmod +x mkcert
+tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev *completion*.sh mkcert
+popd >/dev/null
 
-# Generate linux-arm64 tarball/zipball
-#pushd $BASE_DIR/.gotmp/bin/linux_arm64 >/dev/null
-#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm64 && chmod +x mkcert
-#tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
-#popd >/dev/null
+ Generate linux-arm64 tarball/zipball
+pushd $BASE_DIR/.gotmp/bin/linux_arm64 >/dev/null
+curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm64 && chmod +x mkcert
+tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev *completion*.sh mkcert
+popd >/dev/null
 
-# Generate linux-arm tarball/zipball
-#pushd $BASE_DIR/.gotmp/bin/linux_arm >/dev/null
-#curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm && chmod +x mkcert
-#tar -czf $ARTIFACTS/ddev_linux-arm.$VERSION.tar.gz ddev *completion*.sh
-#popd >/dev/null
+ Generate linux-arm tarball/zipball
+pushd $BASE_DIR/.gotmp/bin/linux_arm >/dev/null
+curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm && chmod +x mkcert
+tar -czf $ARTIFACTS/ddev_linux-arm.$VERSION.tar.gz ddev *completion*.sh
+popd >/dev/null
 
-# generate windows-amd64 tarball/zipball
-#pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
-#curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe
-#tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe *completion*.sh mkcert.exe
-#if [ -d chocolatey ]; then
-#  tar -czf $ARTIFACTS/ddev_chocolatey_amd64-.$VERSION.tar.gz chocolatey
-#fi
-#popd >/dev/null
+ generate windows-amd64 tarball/zipball
+pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
+curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe
+tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe *completion*.sh mkcert.exe
+if [ -d chocolatey ]; then
+  tar -czf $ARTIFACTS/ddev_chocolatey_amd64-.$VERSION.tar.gz chocolatey
+fi
+popd >/dev/null
 
 # Create macOS and Linux homebrew bottles
 #for os in high_sierra arm64_big_sur x86_64_linux; do
@@ -115,6 +115,6 @@ fi
 
 # Create the sha256 files
 cd $ARTIFACTS
-for item in *.*; do
-  sha256sum $item >$item.sha256.txt
-done
+#for item in *.*; do
+#  sha256sum $item >$item.sha256.txt
+#done

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -13,6 +13,7 @@ env:
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
+  DDEV_AUR_REPO: ddev
 
 jobs:
   build-most:
@@ -206,7 +207,13 @@ jobs:
 #      - name: Generate artifacts
 #        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
-      # Goreleaser does GitHub release artifacts, homebrew, AUR
+      - name: set conditional environments
+        # Use ddev-bin (default) unless not running with repo owner = drud
+        run: |
+          echo "DDEV_AUR_REPO=ddev-edge >$GITHUB_ENV
+        if: github.repository_owner != "drud"
+
+    # Goreleaser does GitHub release artifacts, homebrew, AUR
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v3
         if: startsWith( github.ref, 'refs/tags/v1')

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -226,6 +226,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ secrets.GITHUB_REPOSITORY_OWNER }}
 
 #      - name: Upload all artifacts
 #        uses: actions/upload-artifact@v3

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -13,7 +13,7 @@ env:
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
-  DDEV_AUR_REPO: ddev-edge
+  GITHUB_REPOSITORY_OWNER: ${{ secrets.GITHUB_REPOSITORY_OWNER }}
 
 jobs:
   build-most:
@@ -70,7 +70,6 @@ jobs:
     name: Build and Sign Windows binaries
     runs-on: [ self-hosted, windows-signer ]
     env:
-      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
       SegmentKey: ${{ secrets.SEGMENTKEY }}
     steps:
       - uses: actions/checkout@v3
@@ -204,16 +203,7 @@ jobs:
         if: steps.notarizedmac.outputs.cache-hit != 'true'
         run: exit 1
 
-#      - name: Generate artifacts
-#        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
-
-      - name: set conditional environments
-        # Use ddev-edge (default) unless running with repo owner = drud
-        run: |
-          echo "DDEV_AUR_REPO=ddev" >$GITHUB_ENV
-        if: env.GITHUB_REPOSITORY_OWNER == 'drud'
-
-    # Goreleaser does GitHub release artifacts, homebrew, AUR
+      # Goreleaser does GitHub release artifacts, homebrew, AUR, deb/rpm
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v3
         if: startsWith( github.ref, 'refs/tags/v1')
@@ -226,69 +216,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
-          GITHUB_REPOSITORY_OWNER: ${{ secrets.GITHUB_REPOSITORY_OWNER }}
 
-#      - name: Upload all artifacts
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: all-ddev-executables
-#          path: ${{ github.workspace }}/artifacts/*
-#      - name: Upload macos-amd64 binary
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: ddev-macos-amd64
-#          path: .gotmp/bin/darwin_amd64/ddev
-#      - name: Upload macos-arm64 binary
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: ddev-macos-arm64
-#          path: .gotmp/bin/darwin_arm64/ddev
-#      - name: Upload linux-arm64 binary
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: ddev-linux-arm64
-#          path: .gotmp/bin/linux_arm64/ddev
-#      - name: Upload inux_amd644 binary
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: ddev-linux-amd64
-#          path: .gotmp/bin/linux_amd64/ddev
-#      - name: Upload windows_amd64 installer
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: ddev-windows-amd64-installer
-#          path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe
+
       - name: Show github.ref
         run: echo ${{ github.ref }}
-#      - name: "Upload release artifacts to github release"
-#        if: startsWith( github.ref, 'refs/tags/v1')
-#        uses: skx/github-action-publish-binaries@master
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          args: ${{ github.workspace }}/artifacts/*
-
-#      - name: "Bump homebrew edge release"
-#        if: env.DDEV_GITHUB_TOKEN != '' && startsWith( github.ref, 'refs/tags/v1')
-#        run: |
-#          bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_EDGE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
-#
-#      - name: "Bump homebrew main release if necessary"
-#        if: env.DDEV_GITHUB_TOKEN != '' && startsWith( github.ref, 'refs/tags/v1') && !contains( github.ref, '-')
-#        run: |
-#          bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_STABLE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
-
-#      - name: "Push AUR ddev-edge-bin"
-#        if: env.AUR_SSH_PRIVATE_KEY != '' && startsWith( github.ref, 'refs/tags/v1')
-#        run: |
-#          echo GITHUB_REF=${GITHUB_REF}
-#          .ci-scripts/bump_aur.sh ddev-edge-bin ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts
-#
-#      - name: "Push AUR ddev-bin if necessary"
-#        if: env.AUR_SSH_PRIVATE_KEY != '' &&  startsWith( github.ref, 'refs/tags/v1') && !contains( github.ref, '-')
-#        run: |
-#          echo GITHUB_REF=${GITHUB_REF}
-#          .ci-scripts/bump_aur.sh ddev-bin "${GITHUB_REF##*/}" ${{ github.workspace }}/artifacts
 
       - name: Chocolatey windows release
         if: env.CHOCOLATEY_API_KEY != '' && startsWith( github.ref, 'refs/tags/v1')

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -225,6 +225,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
 
 #      - name: Upload all artifacts
 #        uses: actions/upload-artifact@v3

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -203,8 +203,8 @@ jobs:
         if: steps.notarizedmac.outputs.cache-hit != 'true'
         run: exit 1
 
-      - name: Generate artifacts
-        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
+#      - name: Generate artifacts
+#        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -20,7 +20,6 @@ jobs:
     name: Build DDEV executables except Windows
     runs-on: ubuntu-20.04
     env:
-      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
       SegmentKey: ${{ secrets.SEGMENTKEY }}
 
     steps:

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -206,6 +206,7 @@ jobs:
 #      - name: Generate artifacts
 #        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
+      # Goreleaser does GitHub release artifacts, homebrew, AUR
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v3
         if: startsWith( github.ref, 'refs/tags/v1')
@@ -268,17 +269,17 @@ jobs:
 #        run: |
 #          bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_STABLE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
 
-      - name: "Push AUR ddev-edge-bin"
-        if: env.AUR_SSH_PRIVATE_KEY != '' && startsWith( github.ref, 'refs/tags/v1')
-        run: |
-          echo GITHUB_REF=${GITHUB_REF}
-          .ci-scripts/bump_aur.sh ddev-edge-bin ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts
-
-      - name: "Push AUR ddev-bin if necessary"
-        if: env.AUR_SSH_PRIVATE_KEY != '' &&  startsWith( github.ref, 'refs/tags/v1') && !contains( github.ref, '-')
-        run: |
-          echo GITHUB_REF=${GITHUB_REF}
-          .ci-scripts/bump_aur.sh ddev-bin "${GITHUB_REF##*/}" ${{ github.workspace }}/artifacts
+#      - name: "Push AUR ddev-edge-bin"
+#        if: env.AUR_SSH_PRIVATE_KEY != '' && startsWith( github.ref, 'refs/tags/v1')
+#        run: |
+#          echo GITHUB_REF=${GITHUB_REF}
+#          .ci-scripts/bump_aur.sh ddev-edge-bin ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts
+#
+#      - name: "Push AUR ddev-bin if necessary"
+#        if: env.AUR_SSH_PRIVATE_KEY != '' &&  startsWith( github.ref, 'refs/tags/v1') && !contains( github.ref, '-')
+#        run: |
+#          echo GITHUB_REF=${GITHUB_REF}
+#          .ci-scripts/bump_aur.sh ddev-bin "${GITHUB_REF##*/}" ${{ github.workspace }}/artifacts
 
       - name: Chocolatey windows release
         if: env.CHOCOLATEY_API_KEY != '' && startsWith( github.ref, 'refs/tags/v1')

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -39,7 +39,7 @@ jobs:
           go-version: 1.*
       
       - name: Build DDEV executables
-        run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64
+        run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 completions mkcert
 
       - name: "Verify that SegmentKey is working (Linux amd64)"
         run: |
@@ -199,55 +199,67 @@ jobs:
       - name: Generate artifacts
         run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
-      - name: Upload all artifacts
-        uses: actions/upload-artifact@v3
+      - name: goreleaser
+        uses: goreleaser/goreleaser-action@v3
+        if: startsWith( github.ref, 'refs/tags/v1')
         with:
-          name: all-ddev-executables
-          path: ${{ github.workspace }}/artifacts/*
-      - name: Upload macos-amd64 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-macos-amd64
-          path: .gotmp/bin/darwin_amd64/ddev
-      - name: Upload macos-arm64 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-macos-arm64
-          path: .gotmp/bin/darwin_arm64/ddev
-      - name: Upload linux-arm64 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-linux-arm64
-          path: .gotmp/bin/linux_arm64/ddev
-      - name: Upload inux_amd644 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-linux-amd64
-          path: .gotmp/bin/linux_amd64/ddev
-      - name: Upload windows_amd64 installer
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-windows-amd64-installer
-          path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser-pro
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+#      - name: Upload all artifacts
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: all-ddev-executables
+#          path: ${{ github.workspace }}/artifacts/*
+#      - name: Upload macos-amd64 binary
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: ddev-macos-amd64
+#          path: .gotmp/bin/darwin_amd64/ddev
+#      - name: Upload macos-arm64 binary
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: ddev-macos-arm64
+#          path: .gotmp/bin/darwin_arm64/ddev
+#      - name: Upload linux-arm64 binary
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: ddev-linux-arm64
+#          path: .gotmp/bin/linux_arm64/ddev
+#      - name: Upload inux_amd644 binary
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: ddev-linux-amd64
+#          path: .gotmp/bin/linux_amd64/ddev
+#      - name: Upload windows_amd64 installer
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: ddev-windows-amd64-installer
+#          path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe
       - name: Show github.ref
         run: echo ${{ github.ref }}
-      - name: "Upload release artifacts to github release"
-        if: startsWith( github.ref, 'refs/tags/v1')
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: ${{ github.workspace }}/artifacts/*
+#      - name: "Upload release artifacts to github release"
+#        if: startsWith( github.ref, 'refs/tags/v1')
+#        uses: skx/github-action-publish-binaries@master
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          args: ${{ github.workspace }}/artifacts/*
 
-      - name: "Bump homebrew edge release"
-        if: env.DDEV_GITHUB_TOKEN != '' && startsWith( github.ref, 'refs/tags/v1')
-        run: |
-          bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_EDGE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
-
-      - name: "Bump homebrew main release if necessary"
-        if: env.DDEV_GITHUB_TOKEN != '' && startsWith( github.ref, 'refs/tags/v1') && !contains( github.ref, '-')
-        run: |
-          bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_STABLE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
+#      - name: "Bump homebrew edge release"
+#        if: env.DDEV_GITHUB_TOKEN != '' && startsWith( github.ref, 'refs/tags/v1')
+#        run: |
+#          bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_EDGE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
+#
+#      - name: "Bump homebrew main release if necessary"
+#        if: env.DDEV_GITHUB_TOKEN != '' && startsWith( github.ref, 'refs/tags/v1') && !contains( github.ref, '-')
+#        run: |
+#          bash -x .ci-scripts/bump_homebrew.sh ${HOMEBREW_STABLE_REPOSITORY} ddev ${GITHUB_REF##*/} ${{ github.workspace }}/artifacts ${DDEV_MAIN_REPO_ORGNAME}
 
       - name: "Push AUR ddev-edge-bin"
         if: env.AUR_SSH_PRIVATE_KEY != '' && startsWith( github.ref, 'refs/tags/v1')

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -13,7 +13,7 @@ env:
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
-  DDEV_AUR_REPO: ddev
+  DDEV_AUR_REPO: ddev-edge
 
 jobs:
   build-most:
@@ -208,10 +208,10 @@ jobs:
 #        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
       - name: set conditional environments
-        # Use ddev-bin (default) unless not running with repo owner = drud
+        # Use ddev-edge (default) unless running with repo owner = drud
         run: |
-          echo "DDEV_AUR_REPO=ddev-edge >$GITHUB_ENV
-        if: github.repository_owner != "drud"
+          echo "DDEV_AUR_REPO=ddev" >$GITHUB_ENV
+        if: env.GITHUB_REPOSITORY_OWNER == 'drud'
 
     # Goreleaser does GitHub release artifacts, homebrew, AUR
       - name: goreleaser

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -58,6 +58,13 @@ jobs:
           path: .gotmp/bin
           key: ${{ github.sha }}-${{ github.ref }}-build-most
 
+  # This Windows self-hosted runner has to be set up with gnu tar and zstd.exe, or
+  # this step will fail to properly create the cache.
+  # Make sure gnu tar is the tar used here. System PATH should have C:\program files\gnu\usr\bin near top
+  # Get zstd.exe from https://github.com/facebook/zstd/releases - I put it into C:\program files\gnu\usr\bin
+  # so it would be in PATH
+  # See https://github.com/actions/cache/issues/580
+  # Run the Windows action with debug enabled to be able to see which tar is in use, etc.
   sign-windows:
     name: Build and Sign Windows binaries
     runs-on: [ self-hosted, windows-signer ]

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build and sign windows binaries and installer
         shell: bash
         run: |
-          if [ "${DDEV_WINDOWS_SIGN}" != "true" ]; then echo "DDEV_WINDOWS_SIGN is not true, exiting" && exit 1; fi
+          if [ "${DDEV_WINDOWS_SIGN}" != "true" ]; then echo "Warning: DDEV_WINDOWS_SIGN is not true"; fi
           make windows_install
       - name: Show github.ref
         run: echo ${{ github.ref }}

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -14,6 +14,7 @@ env:
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
   GITHUB_REPOSITORY_OWNER: ${{ secrets.GITHUB_REPOSITORY_OWNER }}
+  DDEV_WINDOWS_SIGN: ${{ secrets.DDEV_WINDOWS_SIGN }}
 
 jobs:
   build-most:
@@ -37,7 +38,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.*
-      
+
       - name: Build DDEV executables
         run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 completions mkcert
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -225,7 +225,7 @@ aurs:
 
   license: "Apache 2"
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
-  git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}-bin.git'
+  git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}.git'
 
   # Custom package instructions.
   #

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
   goamd64:
   - v1
   prebuilt:
-    path: .gotmp/bin/{{.Os}}_{{.Arch}}/ddev_windows_installer.v1.19.3-32-gc0ec496a{{.Ext}}
+    path: .gotmp/bin/windows_amd64/ddev_windows_installer.exe
   binary: ddev-windows-installer
 
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -225,7 +225,7 @@ aurs:
 
   license: "Apache 2"
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
-  git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}.git'
+  git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}-bin.git'
 
   # Custom package instructions.
   #

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -176,6 +176,11 @@ brews:
     head "https://github.com/drud/ddev.git", branch: "master"
     depends_on "go" => :build
     depends_on "make" => :build
+  install: |
+    bin.install "ddev"
+    bash_completion.install "ddev_bash_completion.sh" => "ddev"
+    zsh_completion.install "ddev_zsh_completion.sh" => "ddev"
+    fish_completion.install "ddev_fish_completion.sh" => "ddev"
 
 #  install: |
 #    system "make", "VERSION=v#{version}", "COMMIT=v#{version}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,7 +151,7 @@ checksum:
 release:
   prerelease: auto
   github:
-    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
+    owner: rfay
     name: ddev
 
 brews:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -218,7 +218,7 @@ aurs:
 
   homepage: "https://ddev.com/"
 
-  description: "Local docker-based development environment."
+  description: "DDEV-Local: a local web development environment"
 
   maintainers:
   - 'Randy Fay <randy@randyfay.com>'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,38 @@ builds:
     path: .gotmp/bin/windows_amd64/ddev_windows_installer.exe
   binary: ddev-windows-installer.exe
 
+
+archives:
+- id: ddev
+  builds:
+  - ddev
+  format: tar.gz
+  name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}.v{{ .Version }}"
+  replacements:
+    darwin: macos
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - LICENSE
+
+- id: completions
+  builds:
+  - completions
+  format: binary
+#  files:
+#    - .gotmp/bin/completions.tar.gz
+
+- id: ddev-windows-installer
+  builds:
+  - ddev-windows-installer
+  format: binary
+#  files:
+#  - none*
+#  files:
+#  - LICENSE
+
+
 checksum:
   name_template: "checksums.txt"
 
@@ -82,35 +114,5 @@ nfpms:
   - rpm
 
 
-archives:
-- id: ddev
-  builds:
-  - ddev
-  format: tar.gz
-  name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}.v{{ .Version }}"
-  replacements:
-    darwin: macos
-  format_overrides:
-  - goos: windows
-    format: zip
-  files:
-  - LICENSE
-
-- id: completions
-  builds:
-  - completions
-  format: tar.gz
-#  files:
-#    - .gotmp/bin/completions.tar.gz
-
-
-- id: ddev_windows_installer
-  builds:
-  - ddev_windows_installer
-  format: tar.gz
-#  files:
-#  - none*
-#  files:
-#  - LICENSE
 
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,13 @@ brews:
   - name: mkcert
   custom_block: |
     head "https://github.com/drud/ddev.git", branch: "master"
+    depends_on "go" => :build
+    depends_on "make" => :build
+
+  install: |
+    system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
+    bin.install "ddev"
+    
   test: |
     system "#{bin}/ddev --version"
 
@@ -61,7 +68,6 @@ nfpms:
   formats:
   - deb
   - rpm
-  - apk
 
 archives:
 - id: ddev
@@ -70,7 +76,6 @@ archives:
   # Default is empty, which includes all builds.
   builds:
   - ddev
-#  - default
 
   # Archive format. Valid options are `tar.gz`, `tar.xz`, `tar`, `gz`, `zip` and `binary`.
   # If format is `binary`, no archives are created and the binaries are instead

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -225,7 +225,7 @@ aurs:
 
   license: "Apache 2"
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
-  git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}.git'
+  git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}-bin.git'
 
   package: |-
     # bin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -236,9 +236,9 @@ aurs:
     mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
     mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
     mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
-    install -Dm644 "./src/ddev_bash_completions.sh" "${pkgdir}/usr/share/bash-completion/completions/ddev"
-    install -Dm644 "./src/ddev_zsh_completions.sh" "${pkgdir}/usr/share/zsh/site-functions/_ddev"
-    install -Dm644 "./src/ddev_fish_completions.sh" "${pkgdir}/usr/share/fish/vendor_completions.d/ddev.fish"
+    install -Dm644 "./src/ddev_bash_completion.sh" "${pkgdir}/usr/share/bash-completion/completions/ddev"
+    install -Dm644 "./src/ddev_zsh_completion.sh" "${pkgdir}/usr/share/zsh/site-functions/_ddev"
+    install -Dm644 "./src/ddev_fish_completion.sh" "${pkgdir}/usr/share/fish/vendor_completions.d/ddev.fish"
 
   # Git author used to commit to the repository.
   # Defaults are shown below.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -210,7 +210,7 @@ snapshot:
 
 
 aurs:
-- name: ${{ Env.DDEV_AUR_REPO }}
+- name: ${{ .Env.DDEV_AUR_REPO }}
 
   # artifact ids.
   ids:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,7 +151,7 @@ checksum:
 release:
   prerelease: auto
   github:
-    owner: {{ Env.GITHUB_REPOSITORY_OWNER }}
+    owner: "{{ Env.GITHUB_REPOSITORY_OWNER }}"
     name: ddev
 
 brews:
@@ -159,11 +159,11 @@ brews:
   ids:
   - ddev
   tap:
-    owner: rfay
+    owner: "{{  Env.GITHUB_REPOSITORY_OWNER }}"
     name: homebrew-ddev
   description: DDEV
   folder: Formula
-  homepage: https://ddev.com
+  homepage: https://github.com/drud/ddev
   license: "Apache 2"
   # ddev brew will only be uploaded on non-prerelease
   skip_upload: auto
@@ -194,11 +194,11 @@ brews:
   ids:
   - ddev
   tap:
-    owner: rfay
+    owner: "{{  Env.GITHUB_REPOSITORY_OWNER }}"
     name: homebrew-ddev-edge
   description: DDEV
   folder: Formula
-  homepage: https://ddev.com
+  homepage: https://github.com/drud/ddev
   license: "Apache 2"
   # ddev-edge brew will always be uploaded
   skip_upload: "false"
@@ -248,7 +248,7 @@ aurs:
 - name: "ddev"
   ids:
   - ddev
-  homepage: "https://ddev.com/"
+  homepage: "https://github.com/drud/ddev"
   description: "DDEV-Local: a local web development environment"
   maintainers:
   - 'Randy Fay <randy at randyfay.com>'
@@ -280,13 +280,13 @@ aurs:
 - name: "ddev-edge"
   ids:
   - ddev
-  homepage: "https://ddev.com/"
+  homepage: "https://github.com/drud/ddev"
   description: "DDEV-Local: a local web development environment (edge)"
   maintainers:
   - 'Randy Fay <randy at randyfay.com>'
   license: "Apache 2"
   # Always upload, even on prerelease
-  skip_upload: false
+  skip_upload: "false"
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
   git_url: 'ssh://aur@aur.archlinux.org/ddev-edge-bin.git'
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -210,7 +210,7 @@ snapshot:
 
 
 aurs:
-- name: {{ .Env.DDEV_AUR_REPO }}
+- name: "{{ .Env.DDEV_AUR_REPO }}"
 
   # artifact ids.
   ids:
@@ -225,7 +225,7 @@ aurs:
 
   license: "Apache 2"
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
-  git_url: 'ssh://aur@aur.archlinux.org/ddev-bin.git'
+  git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}.git'
 
   # Custom package instructions.
   #

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,10 +54,10 @@ brews:
     depends_on "go" => :build
     depends_on "make" => :build
 
-  install: |
-    system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
-    bin.install "ddev"
-    
+#  install: |
+#    system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
+#    system "cp", ".gotmp/bin/darwin_arm64/ddev", "#{bin}/ddev"
+
   test: |
     system "#{bin}/ddev --version"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,9 @@ brews:
   - name: mkcert
   custom_block: |
     head "https://github.com/drud/ddev.git", branch: "master"
+  test: |
+    system "#{bin}/ddev --version"
+
 
 nfpms:
 - maintainer: Randy Fay

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -227,13 +227,6 @@ aurs:
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
   git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}.git'
 
-  # Custom package instructions.
-  #
-  # Defaults to `install -Dm755 "./PROJECT_NAME" "${pkgdir}/usr/bin/PROJECT_NAME",
-  # which is not always correct.
-  #
-  # We recommend you override this, installing the binary, license and
-  # everything else your package needs.
   package: |-
     # bin
     install -Dm755 "./ddev" "${pkgdir}/usr/bin/ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,8 +95,8 @@ archives:
   # Keys should be valid GOOSs or GOARCHs.
   # Values are the respective replacements.
   # Default is empty.
-  #  replacements:
-  #    amd64: 64-bit
+  replacements:
+    darwin: macos
   #    386: 32-bit
   #    darwin: macOS
   #    linux: Tux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -177,10 +177,18 @@ brews:
     depends_on "go" => :build
     depends_on "make" => :build
   install: |
-    bin.install "ddev"
-    bash_completion.install "ddev_bash_completion.sh" => "ddev"
-    zsh_completion.install "ddev_zsh_completion.sh" => "ddev"
-    fish_completion.install "ddev_fish_completion.sh" => "ddev"
+    if build.head?
+        os = OS.mac? ? "darwin" : "linux"
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        system "mkdir", "-p", "#{bin}"
+        system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
+        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
+    else
+        bin.install "ddev"
+        bash_completion.install "ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install "ddev_zsh_completion.sh" => "ddev"
+        fish_completion.install "ddev_fish_completion.sh" => "ddev"
+    end
 
 #  install: |
 #    system "make", "VERSION=v#{version}", "COMMIT=v#{version}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,7 +151,7 @@ checksum:
 release:
   prerelease: auto
   github:
-    owner: "{{ Env.GITHUB_REPOSITORY_OWNER }}"
+    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
     name: ddev
 
 brews:
@@ -159,7 +159,7 @@ brews:
   ids:
   - ddev
   tap:
-    owner: "{{  Env.GITHUB_REPOSITORY_OWNER }}"
+    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
     name: homebrew-ddev
   description: DDEV
   folder: Formula
@@ -194,7 +194,7 @@ brews:
   ids:
   - ddev
   tap:
-    owner: "{{  Env.GITHUB_REPOSITORY_OWNER }}"
+    owner: "{{  .Env.GITHUB_REPOSITORY_OWNER }}"
     name: homebrew-ddev-edge
   description: DDEV
   folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -210,7 +210,7 @@ snapshot:
 
 
 aurs:
-- name: ${{ .Env.DDEV_AUR_REPO }}
+- name: {{ .Env.DDEV_AUR_REPO }}
 
   # artifact ids.
   ids:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,9 +17,18 @@ builds:
     path: .gotmp/bin/{{.Os}}_{{.Arch}}/ddev{{.Ext}}
   binary: ddev
 
+- id: completions
+  builder: prebuilt
+  goos:
+  - linux
+  goarch:
+  - arm64
+  prebuilt:
+    path: .gotmp/bin/completions.tar.gz
+  binary: completions.tar.gz
+
 - id: ddev-windows-installer
   builder: prebuilt
-
   goos:
   - windows
   goarch:
@@ -28,7 +37,7 @@ builds:
   - v1
   prebuilt:
     path: .gotmp/bin/windows_amd64/ddev_windows_installer.exe
-  binary: ddev-windows-installer
+  binary: ddev-windows-installer.exe
 
 checksum:
   name_template: "checksums.txt"
@@ -40,7 +49,10 @@ release:
     name: ddev
 
 brews:
-- tap:
+- name: ddev
+  ids:
+  - ddev
+  tap:
     owner: rfay
     name: homebrew-ddev-edge
   description: DDEV
@@ -69,159 +81,36 @@ nfpms:
   - deb
   - rpm
 
+
 archives:
 - id: ddev
-
-  # Builds reference which build instances should be archived in this archive.
-  # Default is empty, which includes all builds.
   builds:
   - ddev
-
-  # Archive format. Valid options are `tar.gz`, `tar.xz`, `tar`, `gz`, `zip` and `binary`.
-  # If format is `binary`, no archives are created and the binaries are instead
-  # uploaded directly.
-  # Default is `tar.gz`.
   format: tar.gz
-
-  # Archive name template.
-  # Defaults:
-  # - if format is `tar.gz`, `tar.xz`, `gz` or `zip`:
-  #   - `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
-  # - if format is `binary`:
-  #   - `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
   name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}.v{{ .Version }}"
-
-  # Replacements for GOOS and GOARCH in the archive name.
-  # Keys should be valid GOOSs or GOARCHs.
-  # Values are the respective replacements.
-  # Default is empty.
   replacements:
     darwin: macos
-  #    386: 32-bit
-  #    darwin: macOS
-  #    linux: Tux
-
-  # Set to true, if you want all files in the archive to be in a single directory.
-  # If set to true and you extract the archive 'goreleaser_Linux_arm64.tar.gz',
-  # you get a folder 'goreleaser_Linux_arm64'.
-  # If set to false, all files are extracted separately.
-  # You can also set it to a custom folder name (templating is supported).
-  # Default is false.
-  #  wrap_in_directory: true
-
-  # Can be used to change the archive formats for specific GOOSs.
-  # Most common use case is to archive as zip on Windows.
-  # Default is empty.
   format_overrides:
   - goos: windows
     format: zip
-
-  # Additional files/template/globs you want to add to the archive.
-  # Defaults are any files matching `LICENSE*`, `README*`, `CHANGELOG*`,
-  #  `license*`, `readme*` and `changelog*`.
   files:
   - LICENSE
-#  - README_{{.Os}}.md
-#  - CHANGELOG.md
-#  - docs/*
-#  - design/*.png
-#  - templates/**/*
-  # a more complete example, check the globbing deep dive below
-#  - src: '*.md'
-#    dst: docs
-    # Strip parent folders when adding files to the archive.
-    # Default: false
-#    strip_parent: true
-    # File info.
-    # Not all fields are supported by all formats available formats.
-    # Defaults to the file info of the actual file if not provided.
-#    info:
-#      owner: root
-#      group: root
-#      mode: 0644
-#      # format is `time.RFC3339Nano`
-#      mtime: 2008-01-02T15:04:05Z
 
-  # Disables the binary count check.
-  # Default: false
-  allow_different_binary_count: false
+- id: completions
+  builds:
+  - completions
+  format: tar.gz
+#  files:
+#    - .gotmp/bin/completions.tar.gz
+
 
 - id: ddev_windows_installer
-
-  # Builds reference which build instances should be archived in this archive.
-  # Default is empty, which includes all builds.
   builds:
   - ddev_windows_installer
-  #  - default
-
-  # Archive format. Valid options are `tar.gz`, `tar.xz`, `tar`, `gz`, `zip` and `binary`.
-  # If format is `binary`, no archives are created and the binaries are instead
-  # uploaded directly.
-  # Default is `tar.gz`.
-  format: binary
-
-  # Archive name template.
-  # Defaults:
-  # - if format is `tar.gz`, `tar.xz`, `gz` or `zip`:
-  #   - `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
-  # - if format is `binary`:
-  #   - `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
-#  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-
-  # Replacements for GOOS and GOARCH in the archive name.
-  # Keys should be valid GOOSs or GOARCHs.
-  # Values are the respective replacements.
-  # Default is empty.
-  #  replacements:
-  #    amd64: 64-bit
-  #    386: 32-bit
-  #    darwin: macOS
-  #    linux: Tux
-
-  # Set to true, if you want all files in the archive to be in a single directory.
-  # If set to true and you extract the archive 'goreleaser_Linux_arm64.tar.gz',
-  # you get a folder 'goreleaser_Linux_arm64'.
-  # If set to false, all files are extracted separately.
-  # You can also set it to a custom folder name (templating is supported).
-  # Default is false.
-  #  wrap_in_directory: true
-
-  # Can be used to change the archive formats for specific GOOSs.
-  # Most common use case is to archive as zip on Windows.
-  # Default is empty.
-#  format_overrides:
-#  - goos: windows
-#    format: zip
-
-  # Additional files/template/globs you want to add to the archive.
-  # Defaults are any files matching `LICENSE*`, `README*`, `CHANGELOG*`,
-  #  `license*`, `readme*` and `changelog*`.
-  files:
-  - none*
+  format: tar.gz
+#  files:
+#  - none*
 #  files:
 #  - LICENSE
-    #  - README_{{.Os}}.md
-    #  - CHANGELOG.md
-    #  - docs/*
-    #  - design/*.png
-    #  - templates/**/*
-    # a more complete example, check the globbing deep dive below
-    #  - src: '*.md'
-    #    dst: docs
-    # Strip parent folders when adding files to the archive.
-    # Default: false
-    #    strip_parent: true
-    # File info.
-    # Not all fields are supported by all formats available formats.
-  # Defaults to the file info of the actual file if not provided.
-  #    info:
-  #      owner: root
-  #      group: root
-  #      mode: 0644
-  #      # format is `time.RFC3339Nano`
-  #      mtime: 2008-01-02T15:04:05Z
 
-  # Disables the binary count check.
-  # Default: false
-  allow_different_binary_count: false
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,7 +89,7 @@ archives:
   #   - `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
   # - if format is `binary`:
   #   - `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}.v{{ .Version }}"
 
   # Replacements for GOOS and GOARCH in the archive name.
   # Keys should be valid GOOSs or GOARCHs.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -248,4 +248,4 @@ aurs:
 
 
 furies:
-- account: rfay
+- account: drud

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 builds:
 - id: ddev
+  # Requires make  darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64 mkcert
   builder: prebuilt
   goos:
   - linux
@@ -17,7 +18,27 @@ builds:
     path: .gotmp/bin/{{.Os}}_{{.Arch}}/ddev{{.Ext}}
   binary: ddev
 
-- id: completions
+- id: mkcert
+  # requires make completions
+  builder: prebuilt
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - arm64
+  - amd64
+  goamd64:
+  - v1
+  ignore:
+  - goos: windows
+    goarch: arm64
+  prebuilt:
+    path: .gotmp/bin/{{.Os}}_{{.Arch}}/mkcert{{.Ext}}
+  binary: mkcert
+
+- id: completions-tarball
+  # requires make completions
   builder: prebuilt
   goos:
   - linux
@@ -26,6 +47,54 @@ builds:
   prebuilt:
     path: .gotmp/bin/completions.tar.gz
   binary: completions.tar.gz
+
+- id: ddev_bash_completion.sh
+  # requires make completions
+  builder: prebuilt
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - arm64
+  - amd64
+  goamd64:
+  - v1
+  prebuilt:
+    path: .gotmp/bin/completions/ddev_bash_completion.sh
+  binary: ddev_bash_completion.sh
+
+- id: ddev_zsh_completion.sh
+  # requires make completions
+  builder: prebuilt
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - arm64
+  - amd64
+  goamd64:
+  - v1
+  prebuilt:
+    path: .gotmp/bin/completions/ddev_zsh_completion.sh
+  binary: ddev_zsh_completion.sh
+
+- id: ddev_fish_completion.sh
+  # requires make completions
+  builder: prebuilt
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - arm64
+  - amd64
+  goamd64:
+  - v1
+  prebuilt:
+    path: .gotmp/bin/completions/ddev_fish_completion.sh
+  binary: ddev_fish_completion.sh
 
 - id: ddev-windows-installer
   builder: prebuilt
@@ -44,6 +113,10 @@ archives:
 - id: ddev
   builds:
   - ddev
+  - mkcert
+  - ddev_bash_completion.sh
+  - ddev_zsh_completion.sh
+  - ddev_fish_completion.sh
   format: tar.gz
   name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}.v{{ .Version }}"
   replacements:
@@ -51,10 +124,13 @@ archives:
   format_overrides:
   - goos: windows
     format: zip
+  wrap_in_directory: false
   files:
   - LICENSE
+  - .gotmp/bin/{{.Os}}_{{.Arch}}/mkcert*
+  allow_different_binary_count: true
 
-- id: completions
+- id: completions-tarball
   builds:
   - completions
   format: binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -221,7 +221,7 @@ aurs:
   description: "DDEV-Local: a local web development environment"
 
   maintainers:
-  - 'Randy Fay <randy@randyfay.com>'
+  - 'Randy Fay <randy at randyfay.com>'
 
   license: "Apache 2"
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
@@ -236,7 +236,7 @@ aurs:
   # everything else your package needs.
   package: |-
     # bin
-    install -Dm755 "./mybin" "${pkgdir}/usr/bin/ddev"
+    install -Dm755 "./ddev" "${pkgdir}/usr/bin/ddev"
     install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/ddev/LICENSE"
     
     # completions

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -207,3 +207,51 @@ nfpms:
 
 snapshot:
   name_template: '{{ .Version }}-{{.ShortCommit}}'
+
+
+aurs:
+- name: ${{ Env.DDEV_AUR_REPO }}
+
+  # artifact ids.
+  ids:
+  - ddev
+
+  homepage: "https://ddev.com/"
+
+  description: "Local docker-based development environment."
+
+  maintainers:
+  - 'Randy Fay <randy@randyfay.com>'
+
+  license: "Apache 2"
+  private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
+  git_url: 'ssh://aur@aur.archlinux.org/ddev-bin.git'
+
+  # Custom package instructions.
+  #
+  # Defaults to `install -Dm755 "./PROJECT_NAME" "${pkgdir}/usr/bin/PROJECT_NAME",
+  # which is not always correct.
+  #
+  # We recommend you override this, installing the binary, license and
+  # everything else your package needs.
+  package: |-
+    # bin
+    install -Dm755 "./mybin" "${pkgdir}/usr/bin/ddev"
+    install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/ddev/LICENSE"
+    
+    # completions
+    mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
+    mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
+    mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
+    install -Dm644 "./completions/ddev_bash_completions.sh" "${pkgdir}/usr/share/bash-completion/completions/ddev"
+    install -Dm644 "./completions/ddev_zsh_completions.sh" "${pkgdir}/usr/share/zsh/site-functions/_ddev"
+    install -Dm644 "./completions/ddev_fish_completions.sh" "${pkgdir}/usr/share/fish/vendor_completions.d/ddev.fish"
+
+  # Git author used to commit to the repository.
+  # Defaults are shown below.
+  commit_author:
+    name: Randy Fay
+    email: randy@randyfay.com
+
+#  # Default depends on the client.
+#  url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -246,5 +246,6 @@ aurs:
     name: Randy Fay
     email: randy@randyfay.com
 
-#  # Default depends on the client.
-#  url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
+
+furies:
+- account: rfay

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -243,9 +243,9 @@ aurs:
     mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
     mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
     mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
-    install -Dm644 "./completions/ddev_bash_completions.sh" "${pkgdir}/usr/share/bash-completion/completions/ddev"
-    install -Dm644 "./completions/ddev_zsh_completions.sh" "${pkgdir}/usr/share/zsh/site-functions/_ddev"
-    install -Dm644 "./completions/ddev_fish_completions.sh" "${pkgdir}/usr/share/fish/vendor_completions.d/ddev.fish"
+    install -Dm644 "./src/ddev_bash_completions.sh" "${pkgdir}/usr/share/bash-completion/completions/ddev"
+    install -Dm644 "./src/ddev_zsh_completions.sh" "${pkgdir}/usr/share/zsh/site-functions/_ddev"
+    install -Dm644 "./src/ddev_fish_completions.sh" "${pkgdir}/usr/share/fish/vendor_completions.d/ddev.fish"
 
   # Git author used to commit to the repository.
   # Defaults are shown below.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -204,6 +204,13 @@ nfpms:
   formats:
   - deb
   - rpm
+  overrides:
+    deb:
+      dependencies:
+      - libnss3-tools
+    rpm:
+      dependencies:
+      - nss-tools
 
 snapshot:
   name_template: '{{ .Version }}-{{.ShortCommit}}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,7 +58,7 @@ archives:
   builds:
   - completions
   format: binary
-  name_template: completions.tar.gz
+  name_template: ddev_shell_completion_scripts.v{{.Version}}.tar.gz
 #  files:
 #    - .gotmp/bin/completions.tar.gz
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,6 +58,7 @@ archives:
   builds:
   - completions
   format: binary
+  name_template: completions.tar.gz
 #  files:
 #    - .gotmp/bin/completions.tar.gz
 
@@ -65,6 +66,8 @@ archives:
   builds:
   - ddev-windows-installer
   format: binary
+  name_template: "ddev_windows_installer.v{{.Version}}"
+
 #  files:
 #  - none*
 #  files:
@@ -113,6 +116,5 @@ nfpms:
   - deb
   - rpm
 
-
-
-
+snapshot:
+  name_template: '{{ .Version }}-{{.ShortCommit}}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -245,22 +245,18 @@ snapshot:
 
 
 aurs:
-- name: "{{ .Env.DDEV_AUR_REPO }}"
-
-  # artifact ids.
+- name: "ddev"
   ids:
   - ddev
-
   homepage: "https://ddev.com/"
-
   description: "DDEV-Local: a local web development environment"
-
   maintainers:
   - 'Randy Fay <randy at randyfay.com>'
-
   license: "Apache 2"
+  # main ddev repo will only be uploaded on non-prerelease
+  skip_upload: auto
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
-  git_url: 'ssh://aur@aur.archlinux.org/{{.Env.DDEV_AUR_REPO}}-bin.git'
+  git_url: 'ssh://aur@aur.archlinux.org/ddev-bin.git'
 
   package: |-
     # bin
@@ -281,6 +277,37 @@ aurs:
     name: Randy Fay
     email: randy@randyfay.com
 
+- name: "ddev-edge"
+  ids:
+  - ddev
+  homepage: "https://ddev.com/"
+  description: "DDEV-Local: a local web development environment (edge)"
+  maintainers:
+  - 'Randy Fay <randy at randyfay.com>'
+  license: "Apache 2"
+  # Always upload, even on prerelease
+  skip_upload: false
+  private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
+  git_url: 'ssh://aur@aur.archlinux.org/ddev-edge-bin.git'
+
+  package: |-
+    # bin
+    install -Dm755 "./ddev" "${pkgdir}/usr/bin/ddev"
+    install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/ddev/LICENSE"
+    
+    # completions
+    mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
+    mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
+    mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
+    install -Dm644 "./ddev_bash_completion.sh" "${pkgdir}/usr/share/bash-completion/completions/ddev"
+    install -Dm644 "./ddev_zsh_completion.sh" "${pkgdir}/usr/share/zsh/site-functions/_ddev"
+    install -Dm644 "./ddev_fish_completion.sh" "${pkgdir}/usr/share/fish/vendor_completions.d/ddev.fish"
+
+  # Git author used to commit to the repository.
+  # Defaults are shown below.
+  commit_author:
+    name: Randy Fay
+    email: randy@randyfay.com
 
 furies:
 - account: drud

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -194,7 +194,7 @@ brews:
   ids:
   - ddev
   tap:
-    owner: "{{  .Env.GITHUB_REPOSITORY_OWNER }}"
+    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
     name: homebrew-ddev-edge
   description: DDEV
   folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -236,9 +236,9 @@ aurs:
     mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
     mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
     mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
-    install -Dm644 "./src/ddev_bash_completion.sh" "${pkgdir}/usr/share/bash-completion/completions/ddev"
-    install -Dm644 "./src/ddev_zsh_completion.sh" "${pkgdir}/usr/share/zsh/site-functions/_ddev"
-    install -Dm644 "./src/ddev_fish_completion.sh" "${pkgdir}/usr/share/fish/vendor_completions.d/ddev.fish"
+    install -Dm644 "./ddev_bash_completion.sh" "${pkgdir}/usr/share/bash-completion/completions/ddev"
+    install -Dm644 "./ddev_zsh_completion.sh" "${pkgdir}/usr/share/zsh/site-functions/_ddev"
+    install -Dm644 "./ddev_fish_completion.sh" "${pkgdir}/usr/share/fish/vendor_completions.d/ddev.fish"
 
   # Git author used to commit to the repository.
   # Defaults are shown below.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+##### BUILDS ######
 builds:
 - id: ddev
   # Requires make  darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64 mkcert
@@ -108,7 +109,7 @@ builds:
     path: .gotmp/bin/windows_amd64/ddev_windows_installer.exe
   binary: ddev-windows-installer.exe
 
-
+###### Archives ######
 archives:
 - id: ddev
   builds:
@@ -135,8 +136,6 @@ archives:
   - completions
   format: binary
   name_template: ddev_shell_completion_scripts.v{{.Version}}.tar.gz
-#  files:
-#    - .gotmp/bin/completions.tar.gz
 
 - id: ddev-windows-installer
   builds:
@@ -144,19 +143,15 @@ archives:
   format: binary
   name_template: "ddev_windows_installer.v{{.Version}}"
 
-#  files:
-#  - none*
-#  files:
-#  - LICENSE
-
-
 checksum:
   name_template: "checksums.txt"
 
+
+#### RELEASE ####
 release:
   prerelease: auto
   github:
-    owner: rfay
+    owner: {{ Env.GITHUB_REPOSITORY_OWNER }}
     name: ddev
 
 brews:
@@ -165,11 +160,13 @@ brews:
   - ddev
   tap:
     owner: rfay
-    name: homebrew-ddev-edge
+    name: homebrew-ddev
   description: DDEV
   folder: Formula
   homepage: https://ddev.com
   license: "Apache 2"
+  # ddev brew will only be uploaded on non-prerelease
+  skip_upload: auto
   dependencies:
   - name: mkcert
   custom_block: |
@@ -190,13 +187,44 @@ brews:
         fish_completion.install "ddev_fish_completion.sh" => "ddev"
     end
 
-#  install: |
-#    system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
-#    system "cp", ".gotmp/bin/darwin_arm64/ddev", "#{bin}/ddev"
-
   test: |
     system "#{bin}/ddev --version"
 
+- name: ddev-edge
+  ids:
+  - ddev
+  tap:
+    owner: rfay
+    name: homebrew-ddev-edge
+  description: DDEV
+  folder: Formula
+  homepage: https://ddev.com
+  license: "Apache 2"
+  # ddev-edge brew will always be uploaded
+  skip_upload: "false"
+  dependencies:
+  - name: mkcert
+  custom_block: |
+    head "https://github.com/drud/ddev.git", branch: "master"
+    depends_on "go" => :build
+    depends_on "make" => :build
+  install: |
+    if build.head?
+        os = OS.mac? ? "darwin" : "linux"
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        system "mkdir", "-p", "#{bin}"
+        system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
+        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
+    else
+        bin.install "ddev"
+        bash_completion.install "ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install "ddev_zsh_completion.sh" => "ddev"
+        fish_completion.install "ddev_fish_completion.sh" => "ddev"
+    end
+
+  test: |
+    system "#{bin}/ddev --version"
+    
 
 nfpms:
 - maintainer: Randy Fay

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,7 +151,7 @@ checksum:
 release:
   prerelease: auto
   github:
-    owner: rfay
+    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
     name: ddev
 
 brews:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -236,9 +236,11 @@ nfpms:
     deb:
       dependencies:
       - libnss3-tools
+      - xdg-utils
     rpm:
       dependencies:
       - nss-tools
+      - xdg-utils
 
 snapshot:
   name_template: '{{ .Version }}-{{.ShortCommit}}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -190,7 +190,7 @@ brews:
   test: |
     system "#{bin}/ddev --version"
 
-- name: ddev-edge
+- name: ddev
   ids:
   - ddev
   tap:

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -451,6 +451,7 @@ rabbitmq
 rc
 readme
 readthedocs
+redhat
 redis
 relatime
 remotepath

--- a/Makefile
+++ b/Makefile
@@ -202,9 +202,9 @@ darwin_arm64_notarized: darwin_arm64_signed
 		curl -sSL -f https://raw.githubusercontent.com/drud/signing_tools/master/macos_notarize.sh | bash -s - --app-specific-password=$(DDEV_MACOS_APP_PASSWORD) --apple-id=notarizer@localdev.foundation --primary-bundle-id=com.ddev.ddev --target-binary="$(GOTMP)/bin/darwin_arm64/ddev" ; \
 	fi
 
-windows_install: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe
+windows_install: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe
 
-$(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe: $(GOTMP)/bin/windows_amd64/ddev.exe $(GOTMP)/bin/windows_amd64/sudo_license.txt $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.txt winpkg/ddev.nsi
+$(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe: $(GOTMP)/bin/windows_amd64/ddev.exe $(GOTMP)/bin/windows_amd64/sudo_license.txt $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.txt winpkg/ddev.nsi
 	ls -l .gotmp/bin/windows_amd64
 	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing ddev.exe, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows binaries..." && signtool sign ".gotmp/bin/windows_amd64/ddev.exe" ".gotmp/bin/windows_amd64/mkcert.exe" ".gotmp/bin/windows_amd64/ddev_gen_autocomplete.exe"; fi
 	@makensis -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows
@@ -214,12 +214,12 @@ $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe: $(GOTMP)/bin/w
 no_v_version:
 	@echo $(NO_V_VERSION)
 
-chocolatey: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe
+chocolatey: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe
 	rm -rf $(GOTMP)/bin/windows_amd64/chocolatey && cp -r winpkg/chocolatey $(GOTMP)/bin/windows_amd64/chocolatey
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(NO_V_VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1
 	perl -pi -e 's/REPLACE_GITHUB_ORG/$(GITHUB_ORG)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1 #GITHUB_ORG is for testing, for example when the binaries are on rfay acct
-	perl -pi -e "s/REPLACE_INSTALLER_CHECKSUM/$$(cat $(GOTMP)/bin/windows_amd64/ddev_windows_installer.$(VERSION).exe.sha256.txt | awk '{ print $$1; }')/g" $(GOTMP)/bin/windows_amd64/chocolatey/tools/*
+	perl -pi -e "s/REPLACE_INSTALLER_CHECKSUM/$$(cat $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe.sha256.txt | awk '{ print $$1; }')/g" $(GOTMP)/bin/windows_amd64/chocolatey/tools/*
 	if [[ "$(NO_V_VERSION)" =~ -g[0-9a-f]+ ]]; then \
 		echo "Skipping chocolatey build on interim version"; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ darwin_amd64: $(GOTMP)/bin/darwin_amd64/ddev
 darwin_arm64: $(GOTMP)/bin/darwin_arm64/ddev
 windows_amd64: windows_install
 windows_arm64: $(GOTMP)/bin/windows_arm64/ddev.exe
+completions: $(GOTMP)/bin/completions.tar.gz
 
 TARGETS=$(GOTMP)/bin/linux_amd64/ddev $(GOTMP)/bin/linux_arm64/ddev $(GOTMP)/bin/linux_arm/ddev $(GOTMP)/bin/darwin_amd64/ddev $(GOTMP)/bin/darwin_arm64/ddev $(GOTMP)/bin/windows_amd64/ddev.exe
 $(TARGETS): $(GOFILES)
@@ -85,6 +86,9 @@ $(TARGETS): $(GOFILES)
 	$( shell if [ -d $(GOTMP) ]; then chmod -R u+w $(GOTMP); fi )
 	@echo $(VERSION) >VERSION.txt
 
+$(GOTMP)/bin/completions.tar.gz: build
+	$(GOTMP)/bin/$(BUILD_OS)_$(BUILD_ARCH)/ddev_gen_autocomplete
+	tar -C $(GOTMP)/bin/completions -cf $(GOTMP)/bin/completions.tar.gz .
 
 TEST_TIMEOUT=4h
 BUILD_ARCH = $(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,11 @@ $(GOTMP)/bin/completions.tar.gz: build
 
 mkcert: $(GOTMP)/bin/darwin_arm64/mkcert $(GOTMP)/bin/darwin_amd64/mkcert $(GOTMP)/bin/linux_arm64/mkcert $(GOTMP)/bin/linux_amd64/mkcert
 
+# Download mkcert to it can be added to tarball installations
 $(GOTMP)/bin/darwin_arm64/mkcert $(GOTMP)/bin/darwin_amd64/mkcert $(GOTMP)/bin/linux_arm64/mkcert $(GOTMP)/bin/linux_amd64/mkcert:
 	@export TARGET=$(word 3, $(subst /, ,$@)) && \
 	export GOOS="$${TARGET%_*}" GOARCH="$${TARGET#*_}" && \
+	mkdir -p $(GOTMP)/bin/$${GOOS}_$${GOARCH} && \
 	curl -sL --fail -o $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert https://github.com/drud/mkcert/releases/download/$(MKCERT_VERSION)/mkcert-$(MKCERT_VERSION)-$${GOOS}-$${GOARCH} && chmod +x $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert
 
 TEST_TIMEOUT=4h

--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,9 @@ windows_install: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe
 
 $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe: $(GOTMP)/bin/windows_amd64/ddev.exe $(GOTMP)/bin/windows_amd64/sudo_license.txt $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.txt winpkg/ddev.nsi
 	ls -l .gotmp/bin/windows_amd64
-	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing ddev.exe, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows binaries..." && signtool sign ".gotmp/bin/windows_amd64/ddev.exe" ".gotmp/bin/windows_amd64/mkcert.exe" ".gotmp/bin/windows_amd64/ddev_gen_autocomplete.exe"; fi
+	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing ddev.exe, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows binaries..." && signtool sign -fd SHA256 ".gotmp/bin/windows_amd64/ddev.exe" ".gotmp/bin/windows_amd64/mkcert.exe" ".gotmp/bin/windows_amd64/ddev_gen_autocomplete.exe"; fi
 	@makensis -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows
-	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing ddev_windows_installer, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows installer binary..." && signtool sign "$@"; fi
+	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing ddev_windows_installer, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows installer binary..." && signtool sign -fd SHA256 "$@"; fi
 	$(SHASUM) $@ >$@.sha256.txt
 
 no_v_version:

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ chocolatey: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe
 	rm -rf $(GOTMP)/bin/windows_amd64/chocolatey && cp -r winpkg/chocolatey $(GOTMP)/bin/windows_amd64/chocolatey
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(NO_V_VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1
-	perl -pi -e 's/REPLACE_GITHUB_ORG/$(GITHUB_ORG)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1 #GITHUB_ORG is for testing, for example when the binaries are on rfay acct
+	perl -pi -e 's/REPLACE_GITHUB_ORG/$(GITHUB_REPOSITORY_OWNER)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1 #GITHUB_ORG is for testing, for example when the binaries are on rfay acct
 	perl -pi -e "s/REPLACE_INSTALLER_CHECKSUM/$$(cat $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe.sha256.txt | awk '{ print $$1; }')/g" $(GOTMP)/bin/windows_amd64/chocolatey/tools/*
 	if [[ "$(NO_V_VERSION)" =~ -g[0-9a-f]+ ]]; then \
 		echo "Skipping chocolatey build on interim version"; \

--- a/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
+++ b/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/drud/ddev/pkg/util"
 )
 
-var targetDir = ".gotmp/bin"
+var targetDir = ".gotmp/bin/completions"
 
 func main() {
 	if _, err := os.Stat(targetDir); os.IsNotExist(err) {

--- a/docs/developers/release-management.md
+++ b/docs/developers/release-management.md
@@ -137,7 +137,7 @@ Note that this is done automatically by the release build, on a dedicated Window
 
 ### Basic instructions
 
-1. Install the suggested [Windows SDK 10](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
+1. Install the suggested [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
 2. Install [Visual Studio Community 2015](https://msdn.microsoft.com/en-us/library/mt613162.aspx)
 3. Run the [Developer Command Prompt](https://docs.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2019)
 4. The keyfob and Safenet Authentication Client must be installed. The best documentation for the Safenet software is at <https://support.globalsign.com/ssl/ssl-certificates-installation/safenet-drivers>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,24 +48,28 @@ As a one-time initialization, run `mkcert -install`, which may require your sudo
 DDEV has Debian and RPM packages.
 
 * Debian/Ubuntu and derivative distros - Install the ddev apt repositories with:
-```bash
-echo "deb https://drud.fury.site/apt/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
-curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
-sudo apt update && sudo apt install ddev
- ```
-In the future you can update as usual, with `sudo apt update && sudo apt upgrade`.__
+
+  ```bash
+  echo "deb https://drud.fury.site/apt/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
+  curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
+  sudo apt update && sudo apt install ddev
+   ```
+  
+  In the future you can update as usual, with `sudo apt update && sudo apt upgrade`.
 
 * Yum/RPM (Fedora, RedHat, etc.):
-```bash
-echo '[ddev]
-name=DDEV Repo
-baseurl=https://yum.fury.io/drud/
-enabled=1
-gpgcheck=0' | tee -a /etc/yum.repos.d/ddev.repo
 
-dnf install --refresh ddev
-```
-In the future you can update as usual, with `sudo dnf upgrade ddev`
+  ```bash
+  echo '[ddev]
+  name=DDEV Repo
+  baseurl=https://yum.fury.io/drud/
+  enabled=1
+  gpgcheck=0' | sudo tee -a /etc/yum.repos.d/ddev.repo
+  
+  sudo dnf install --refresh ddev
+  ```
+  
+  In the future you can update as usual, with `sudo dnf upgrade ddev`
 
 ### Linux, macOS and Windows WSL2 (using install_ddev.sh)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,9 +43,33 @@ We maintain a package on [Arch Linux (`AUR`)](https://aur.archlinux.org/packages
 
 As a one-time initialization, run `mkcert -install`, which may require your sudo password. See below for additional information.
 
-### Linux, macOS and Windows WSL2 (install script)
+### Linux with apt or yum
 
-**NOTE: macOS users that have installed via Homebrew or Arch Linux users that have installed via the package manager above do not need the install script.**
+DDEV has Debian and RPM packages.
+
+* Debian/Ubuntu and derivative distros - Install the ddev apt repositories with:
+```bash
+echo "deb https://drud.fury.site/apt/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
+curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
+sudo apt update && sudo apt install ddev
+ ```
+In the future you can update as usual, with `sudo apt update && sudo apt upgrade`.__
+
+* Yum/RPM (Fedora, RedHat, etc.):
+```bash
+echo '[ddev]
+name=DDEV Repo
+baseurl=https://yum.fury.io/drud/
+enabled=1
+gpgcheck=0' | tee -a /etc/yum.repos.d/ddev.repo
+
+dnf install --refresh ddev
+```
+In the future you can update as usual, with `sudo dnf upgrade ddev`
+
+### Linux, macOS and Windows WSL2 (using install_ddev.sh)
+
+**NOTE: macOS users that have installed via Homebrew and Linux users that have installed via the package manager above do not need the install script.**
 
 Linux, macOS and Windows WSL2 (see below) users can use this line of code to your terminal to download, verify, and install (or upgrade) ddev using the [install_ddev.sh script](https://github.com/drud/ddev/blob/master/scripts/install_ddev.sh). Note that this works with both amd64 and arm64 architectures, including Surface Pro X with WSL2 and 64-bit Raspberry Pi OS. It also works with macOS Apple Silicon M1 machines.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 * Colima (macOS), `docker-ce` (Linux/WSL2) or [Docker Desktop](https://www.docker.com/products/docker-desktop) or a related docker back-end are required. Installing or upgrading docker-compose is not required as DDEV uses its own private docker-compose version. See [Docker Installation](users/docker_installation.md).
 * OS Support
-    * macOS Catalina and higher (macOS 10.15 and higher); it should run anywhere docker runs (Current Docker Desktop has deprecated macOS 10.14 and below, but Docker Desktop versions prior to  can still work with DDEV-Local on High Sierra. You can look through the [Docker Desktop for Mac Release Notes](https://docs.docker.com/desktop/mac/release-notes/) for older versions.)
+    * macOS Catalina and higher (macOS 10.15 and higher); it should run anywhere docker runs (Current Docker Desktop has deprecated macOS 10.14 and below, but Docker Desktop versions prior to  can still work with DDEV-Local on High Sierra. You can look through the [Docker Desktop for Mac Release Notes](https://docs.docker.com/desktop/mac/release-notes/) for older versions. In addition, Colima supports older versions.)
     * Linux: Most Linux distributions which can run Docker-ce are fine. This includes at least Ubuntu 18.04+ (20.04 is recommended), Debian Jessie+, Fedora 25+. Make sure to follow the docker-ce [post-install steps](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
     * Windows 10/11 (all editions) with WSL2 (version [1903.1049, 1909.1049](https://devblogs.microsoft.com/commandline/wsl-2-support-is-coming-to-windows-10-versions-1903-and-1909/), 2004 or later)
     * (Non-WSL2) Windows 10/11 Home, Pro, or Enterprise with [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop)

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,12 +50,11 @@ DDEV has Debian and RPM packages.
 * Debian/Ubuntu and derivative distros - Install the ddev apt repositories with:
 
   ```bash
-  echo "deb https://drud.fury.site/apt/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
-  curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
+  echo "deb [trusted=yes] https://apt.fury.io/drud/ /" | sudo tee -a /etc/apt/sources.list.d/ddev.list
   sudo apt update && sudo apt install ddev
    ```
   
-  In the future you can update as usual, with `sudo apt update && sudo apt upgrade`.
+  In the future you can update as usual, with `sudo apt update && sudo apt upgrade`. (Signed repo support will be added in the near future.)
 
 * Yum/RPM (Fedora, RedHat, etc.):
 
@@ -69,7 +68,7 @@ DDEV has Debian and RPM packages.
   sudo dnf install --refresh ddev
   ```
   
-  In the future you can update as usual, with `sudo dnf upgrade ddev`
+  In the future you can update as usual, with `sudo dnf upgrade ddev`. (Signed repo support will be added in the near future.)
 
 ### Linux, macOS and Windows WSL2 (using install_ddev.sh)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ We maintain a package on [Arch Linux (`AUR`)](https://aur.archlinux.org/packages
 
 As a one-time initialization, run `mkcert -install`, which may require your sudo password. See below for additional information.
 
-### Linux with apt or yum
+### Linux (including WSL2) with apt or yum
 
 DDEV has Debian and RPM packages.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,23 +49,23 @@ DDEV has Debian and RPM packages.
 
 * Debian/Ubuntu and derivative distros - Install the ddev apt repositories with:
 
-  ```bash
-  echo "deb [trusted=yes] https://apt.fury.io/drud/ /" | sudo tee -a /etc/apt/sources.list.d/ddev.list
-  sudo apt update && sudo apt install ddev
-   ```
+```bash
+echo "deb [trusted=yes] https://apt.fury.io/drud/ /" | sudo tee -a /etc/apt/sources.list.d/ddev.list
+sudo apt update && sudo apt install ddev
+```
   
   In the future you can update as usual, with `sudo apt update && sudo apt upgrade`. (Signed repo support will be added in the near future.)
 
 * Yum/RPM (Fedora, RedHat, etc.):
 
-  ```bash
-  echo '[ddev]
-  name=DDEV Repo
-  baseurl=https://yum.fury.io/drud/
-  enabled=1
-  gpgcheck=0' | sudo tee -a /etc/yum.repos.d/ddev.repo
+```bash
+echo '[ddev]
+name=DDEV Repo
+baseurl=https://yum.fury.io/drud/
+enabled=1
+gpgcheck=0' | sudo tee -a /etc/yum.repos.d/ddev.repo
   
-  sudo dnf install --refresh ddev
+sudo dnf install --refresh ddev
   ```
   
   In the future you can update as usual, with `sudo dnf upgrade ddev`. (Signed repo support will be added in the near future.)

--- a/docs/users/docker_installation.md
+++ b/docs/users/docker_installation.md
@@ -65,6 +65,8 @@ sudo groupadd docker && sudo usermod -aG docker $USER
 
 ### Linux Installation: Docker
 
+* **Although Docker Desktop for Linux has been released in 2022, it does not seem to be as robust or reliable as the traditional docker-ce installation described below.**
+
 * **Please don't forget that Linux installation absolutely requires post-install steps (below).**
 
 * **Please don't use `sudo` with docker. If you're needing it, you haven't finished the installation. Don't use `sudo` with ddev, except the rare case where you need the `ddev hostname` command.**

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -147,10 +147,13 @@ tar -xzf $TARBALL
 
 printf "${GREEN}Download verified. Ready to place ddev and mkcert in your /usr/local/bin.${RESET}\n"
 
+if command -v brew >/dev/null ; then
+  echo "Attempting to unlink any homebrew-installed ddev with 'brew unlink ddev'"
+  brew unlink ddev >/dev/null
+fi
 if [ -L /usr/local/bin/ddev ] ; then
-    printf "${RED}ddev already exists as a link in /usr/local/bin. Was it installed with homebrew?${RESET}\n"
+    printf "${RED}ddev already exists as a link in /usr/local/bin/ddev. Was it installed with homebrew?${RESET}\n"
     printf "${RED}Cowardly refusing to install over existing symlink${RESET}\n"
-    printf "${RED}Use 'brew unlink ddev' to remove the symlink. Or use 'brew upgrade drud/ddev/ddev' to upgrade.${RESET}\n"
     exit 101
 fi
 

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -108,10 +108,10 @@ if [[ ${rv} -lt 0 ]]; then
 fi
 
 if [[ "$OS" == "Darwin" ]]; then
-    SHACMD="shasum -a 256"
+    SHACMD="shasum -a 256 --ignore-missing"
     FILEBASE="ddev_macos"
 elif [[ "$OS" == "Linux" ]]; then
-    SHACMD="sha256sum"
+    SHACMD="sha256sum --ignore-missing"
     FILEBASE="ddev_linux"
 else
     printf "${RED}Sorry, this installer does not support your platform at this time.${RESET}\n"
@@ -130,7 +130,11 @@ if ! docker --version >/dev/null 2>&1; then
 fi
 
 TARBALL="$FILEBASE.$VERSION.tar.gz"
-SHAFILE="$TARBALL.sha256.txt"
+OLD_CHECKSUM=$(semver_compare "${VERSION}" "v1.19.3")
+SHAFILE=checksums.txt
+if [ ${OLD_CHECKSUM} != 1 ]; then
+  SHAFILE="$TARBALL.sha256.txt"
+fi
 
 curl -fsSL "$RELEASE_BASE_URL/$TARBALL" -o "${TMPDIR}/${TARBALL}" || (printf "${RED}Failed downloading $RELEASE_BASE_URL/$TARBALL${RESET}\n" && exit 108)
 curl -fsSL "$RELEASE_BASE_URL/$SHAFILE" -o "${TMPDIR}/${SHAFILE}" || (printf "${RED}Failed downloading $RELEASE_BASE_URL/$SHAFILE${RESET}\n" && exit 109)

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-GITHUB_USERNAME=drud
+GITHUB_OWNER=${GITHUB_OWNER:-drud}
 ARTIFACTS="ddev mkcert macos_ddev_nfs_setup.sh"
 TMPDIR=/tmp
 
@@ -91,7 +91,7 @@ case ${unamearch} in
   ;;
 esac
 
-LATEST_RELEASE=$(curl -fsSL -H 'Accept: application/json' https://github.com/${GITHUB_USERNAME}/ddev/releases/latest || (printf "${RED}Failed to get find latest release${RESET}\n" >/dev/stderr && exit 107))
+LATEST_RELEASE=$(curl -fsSL -H 'Accept: application/json' https://github.com/${GITHUB_OWNER}/ddev/releases/latest || (printf "${RED}Failed to get find latest release${RESET}\n" >/dev/stderr && exit 107))
 # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
 LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 
@@ -99,7 +99,7 @@ VERSION=$LATEST_VERSION
 if [ $# -ge 1 ]; then
   VERSION=$1
 fi
-RELEASE_BASE_URL="https://github.com/${GITHUB_USERNAME}/ddev/releases/download/$VERSION"
+RELEASE_BASE_URL="https://github.com/${GITHUB_OWNER}/ddev/releases/download/$VERSION"
 
 rv=$(semver_compare "${VERSION}" "v1.10.0")
 if [[ ${rv} -lt 0 ]]; then
@@ -138,7 +138,7 @@ fi
 
 curl -fsSL "$RELEASE_BASE_URL/$TARBALL" -o "${TMPDIR}/${TARBALL}" || (printf "${RED}Failed downloading $RELEASE_BASE_URL/$TARBALL${RESET}\n" && exit 108)
 curl -fsSL "$RELEASE_BASE_URL/$SHAFILE" -o "${TMPDIR}/${SHAFILE}" || (printf "${RED}Failed downloading $RELEASE_BASE_URL/$SHAFILE${RESET}\n" && exit 109)
-curl -fsSL "https://raw.githubusercontent.com/${GITHUB_USERNAME}/ddev/master/scripts/macos_ddev_nfs_setup.sh" -o "${TMPDIR}/macos_ddev_nfs_setup.sh" || (printf "${RED}Failed downloading "https://raw.githubusercontent.com/${GITHUB_USERNAME}/ddev/master/scripts/macos_ddev_nfs_setup.sh"${RESET}\n" && exit 110)
+curl -fsSL "https://raw.githubusercontent.com/${GITHUB_OWNER}/ddev/master/scripts/macos_ddev_nfs_setup.sh" -o "${TMPDIR}/macos_ddev_nfs_setup.sh" || (printf "${RED}Failed downloading "https://raw.githubusercontent.com/${GITHUB_OWNER}/ddev/master/scripts/macos_ddev_nfs_setup.sh"${RESET}\n" && exit 110)
 
 cd $TMPDIR
 $SHACMD -c "$SHAFILE"
@@ -147,9 +147,9 @@ tar -xzf $TARBALL
 
 printf "${GREEN}Download verified. Ready to place ddev and mkcert in your /usr/local/bin.${RESET}\n"
 
-if command -v brew >/dev/null ; then
+if command -v brew >/dev/null && brew info ddev >/dev/null ; then
   echo "Attempting to unlink any homebrew-installed ddev with 'brew unlink ddev'"
-  brew unlink ddev >/dev/null
+  brew unlink ddev >/dev/null 2>&1 || true
 fi
 if [ -L /usr/local/bin/ddev ] ; then
     printf "${RED}ddev already exists as a link in /usr/local/bin/ddev. Was it installed with homebrew?${RESET}\n"

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -147,7 +147,7 @@ tar -xzf $TARBALL
 
 printf "${GREEN}Download verified. Ready to place ddev and mkcert in your /usr/local/bin.${RESET}\n"
 
-if command -v brew >/dev/null && brew info ddev >/dev/null ; then
+if command -v brew >/dev/null && brew info ddev >/dev/null 2>/dev/null ; then
   echo "Attempting to unlink any homebrew-installed ddev with 'brew unlink ddev'"
   brew unlink ddev >/dev/null 2>&1 || true
 fi

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -118,7 +118,7 @@
  *
  * Has to be done before including headers
  */
-OutFile "..\.gotmp\bin\windows_amd64\ddev_windows_installer.${PRODUCT_VERSION}.exe"
+OutFile "..\.gotmp\bin\windows_amd64\ddev_windows_installer.exe"
 Unicode true
 SetCompressor /SOLID lzma
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/drud/ddev/issues/3723
* https://github.com/drud/ddev/issues/1678

## How this PR Solves The Problem:

Uses goreleaser for almost all of the post-build release process

## TODO
- [x] Use environment variable to specify target repo for release, blocked by https://github.com/goreleaser/goreleaser/issues/3202
- [ ] Gemfury/Fury instructions need to include use of key for access (both deb and yum). Config at https://manage.fury.io/manage/drud/settings/gpg, info at https://gemfury.com/guide/apt/configure-apt/

## Manual Testing Instructions:

There are a thousand things to test once we make a release using this.

- [x]  Make a ddev-edge install
- [x]  Homebrew install
    - [x]  Mac arm64
    - [x]  Mac amd64
    - [x]  Linux amd64
    - [x]  Verify that completions get installed
- [x]  install_ddev.sh install
    - [x]  Mac arm64
    - [x]  Mac amd64
    - [x]  Linux amd64
    - [x]  With old releases
    - [x]  Consider making install_ddev.sh do a brew unlink
- [x]  AUR
    - [x]  Verify installation
    - [x]  Verify that completions get installed
- [x]  Download from release
    - [x]  Windows installer
    - [x]  Windows binary
    - [x]  All other options linux/mac/amd64/arm64
- [x]  apt install, arm64 and amd64
- [x]  yum install, amd64
- [x] chocolatey
- [x]  Verify that mac and windows artifacts are properly signed



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3939"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

