### PR TITLE
Try to get logs even if site unhealthy

### DIFF
--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -31,11 +30,6 @@ ddev logs -s db [projectname]`,
 			util.Failed("GetRequestedProjects() failed:  %v", err)
 		}
 		project := projects[0]
-		status, _ := project.SiteStatus()
-
-		if status != ddevapp.SiteRunning {
-			util.Failed("Project is not currently running. Try 'ddev start'.")
-		}
 
 		err = project.Logs(serviceType, follow, timestamp, tail)
 		if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

I had a web container crash and ddev wouldn't give me the logs with `ddev logs`. 

## How this PR Solves The Problem:

Try to get the logs even if the project is unhealthy.

## Manual Testing Instructions:

Kill a container and do `ddev logs` against it.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3942"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

