### PR TITLE
[tests] Use new workflow_id in cancel-previous-workflow [skip ci]

### DIFF
--- a/.github/workflows/cancel-previous-workflow.yml
+++ b/.github/workflows/cancel-previous-workflow.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: styfle/cancel-workflow-action@0.10.0
       with:
-        workflow_id: ${{ github.event.workflow.id }}
+        workflow_id: all


### PR DESCRIPTION
The latest version of the cancel-workflow github action allows workflow_id: all

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3943"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

