### PR TITLE
[Docs] Laravel Quickstart: Add command to automatically replace APP_URL with $DDEV_PRIMARY_URL

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -284,6 +284,7 @@ Here's a quickstart instructions for a number of different environments:
     ddev start
     ddev composer create --prefer-dist laravel/laravel
     ddev exec "cat .env.example | sed  -E 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' > .env"
+    ddev exec 'sed -i "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" .env'
     ddev exec "php artisan key:generate"
     ddev launch
     ```


### PR DESCRIPTION
## The Problem/Issue/Bug:

`APP_URL` should be set correctly in Laravels `.env`, this was missing in the [quickstart](https://ddev.readthedocs.io/en/stable/users/cli-usage/#laravel-quickstart).

## How this PR Solves The Problem:

I added and tested the following on OSX 11.6.5 and ddev version v1.19.1.

```bash
ddev exec 'sed -i "/APP_URL=/c APP_URL=$DDEV_PRIMARY_URL" .env'
```

A more readable version (as described [here](https://programarivm.medium.com/how-to-set-a-web-env-variable-from-the-command-line-on-linux-unix-a06016bb9b89)) would be the following. 

```bash
sed -i "s/APP_URL=.*/APP_URL=${DDEV_PRIMARY_URL}/g" .env
```

But I couldn't get it to work with quote escaping. 🤔

## Manual Testing Instructions:

## Automated Testing Overview:

No tests needed, just docs improvement

## Related Issue Link(s):

- https://github.com/drud/ddev/issues/3636

## Release/Deployment notes:


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3949"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

