### PR TITLE
[tests only] Acquia/Pantheon fixes post-composer-no-plugins

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -163,8 +163,8 @@ var (
 		// 8: drupal9
 		{
 			Name:                          "TestPkgDrupal9",
-			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-9.1.4.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-9.1.4/",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-9.4.1.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-9.4.1/",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d9_umami_files.tgz",
 			FilesZipballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d9_umami_files.zip",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d9_umami_sql.tar.gz",

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -172,7 +172,7 @@ var (
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeDrupal9,
 			Docroot:                       "",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "Drupal is an open source content management platform"},
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.md", Expect: "Drupal is an open source content management platform"},
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/node/1", Expect: "Deep mediterranean quiche"},
 			FilesImageURI:                 "/sites/default/files/mediterranean-quiche-umami.jpg",
 		},

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -223,8 +224,16 @@ func TestAcquiaPush(t *testing.T) {
 
 	fName := tval + ".txt"
 	fContent := []byte(tval)
-	err = os.WriteFile(filepath.Join(d9code.Dir, "sites/default/files", fName), fContent, 0644)
+	err = os.WriteFile(filepath.Join(app.AppRoot, app.Docroot, "sites/default/files", fName), fContent, 0644)
 	assert.NoError(err)
+	err = app.MutagenSyncFlush()
+	require.NoError(t, err)
+
+	// Make sure that the file we created exists in the container
+	_, _, err = app.Exec(&ExecOpts{
+		Cmd: fmt.Sprintf("ls %s", path.Join("/var/www/html", app.Docroot, "sites/default/files", fName)),
+	})
+	require.NoError(t, err)
 
 	// Build our PUSH acquia.yaml from the example file
 	s, err := os.ReadFile(app.GetConfigPath("providers/acquia.yaml.example"))

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -196,9 +196,15 @@ func TestAcquiaPush(t *testing.T) {
 	err = app.Start()
 	require.NoError(t, err)
 
+	// Since allow-plugins isn't there and you can't even set it with composer...
+	// set it with jq.
+	_, _, err = app.Exec(&ExecOpts{
+		Cmd: `jq -r <composer.json '.config."allow-plugins"=true' >composer.json.plugins && mv composer.json.plugins composer.json`,
+	})
+	require.NoError(t, err)
 	// Make sure we have drush
 	_, _, err = app.Exec(&ExecOpts{
-		Cmd: "composer require --no-interaction drush/drush:* >/dev/null 2>/dev/null",
+		Cmd: "composer require --no-interaction drush/drush >/dev/null 2>/dev/null",
 	})
 	require.NoError(t, err)
 

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -194,6 +194,15 @@ func TestAcquiaPush(t *testing.T) {
 	err = PopulateExamplesCommandsHomeadditions(app.Name)
 	require.NoError(t, err)
 
+	// Create the uploaddir and a file; it won't have existed in our download
+	tval := nodeps.RandomString(10)
+	fName := tval + ".txt"
+	fContent := []byte(tval)
+	err = os.MkdirAll(filepath.Join(app.AppRoot, app.Docroot, "sites/default/files"), 0777)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(app.AppRoot, app.Docroot, "sites/default/files", fName), fContent, 0644)
+	require.NoError(t, err)
+
 	err = app.Start()
 	require.NoError(t, err)
 
@@ -215,18 +224,10 @@ func TestAcquiaPush(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create database and files entries that we can verify after push
-	tval := nodeps.RandomString(10)
 	writeQuery := fmt.Sprintf(`mysql -e 'CREATE TABLE IF NOT EXISTS %s ( title VARCHAR(255) NOT NULL ); INSERT INTO %s VALUES("%s");'`, t.Name(), t.Name(), tval)
 	_, _, err = app.Exec(&ExecOpts{
 		Cmd: writeQuery,
 	})
-	require.NoError(t, err)
-
-	fName := tval + ".txt"
-	fContent := []byte(tval)
-	err = os.WriteFile(filepath.Join(app.AppRoot, app.Docroot, "sites/default/files", fName), fContent, 0644)
-	assert.NoError(err)
-	err = app.MutagenSyncFlush()
 	require.NoError(t, err)
 
 	// Make sure that the file we created exists in the container

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -207,9 +207,8 @@ func TestAcquiaPush(t *testing.T) {
 	require.NoError(t, err)
 
 	// Since allow-plugins isn't there and you can't even set it with composer...
-	// set it with jq.
 	_, _, err = app.Exec(&ExecOpts{
-		Cmd: `jq -r <composer.json '.config."allow-plugins"=true' >composer.json.plugins && mv composer.json.plugins composer.json`,
+		Cmd: `composer config --no-plugins allow-plugins true`,
 	})
 	require.NoError(t, err)
 	// Make sure we have drush

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -204,6 +204,13 @@ func TestPantheonPush(t *testing.T) {
 	err = app.Start()
 	require.NoError(t, err)
 
+	// Since allow-plugins isn't there and you can't even set it with composer...
+	// set it with jq.
+	_, _, err = app.Exec(&ExecOpts{
+		Cmd: `jq -r <composer.json '.config."allow-plugins"=true' >composer.json.plugins && mv composer.json.plugins composer.json`,
+	})
+	require.NoError(t, err)
+
 	// Make sure we have drush
 	_, _, err = app.Exec(&ExecOpts{
 		Cmd: "composer require --no-interaction drush/drush:* >/dev/null 2>/dev/null",

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -213,9 +213,8 @@ func TestPantheonPush(t *testing.T) {
 	require.NoError(t, err)
 
 	// Since allow-plugins isn't there and you can't even set it with composer...
-	// set it with jq.
 	_, _, err = app.Exec(&ExecOpts{
-		Cmd: `jq -r <composer.json '.config."allow-plugins"=true' >composer.json.plugins && mv composer.json.plugins composer.json`,
+		Cmd: `composer config --no-plugins allow-plugins true`,
 	})
 	require.NoError(t, err)
 

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -190,6 +190,14 @@ func TestPantheonPush(t *testing.T) {
 	err = PopulateExamplesCommandsHomeadditions(app.Name)
 	require.NoError(t, err)
 
+	tval := nodeps.RandomString(10)
+	err = os.MkdirAll(filepath.Join(app.AppRoot, app.Docroot, "sites/default/files"), 0777)
+	require.NoError(t, err)
+	fName := tval + ".txt"
+	fContent := []byte(tval)
+	err = os.WriteFile(filepath.Join(app.AppRoot, app.Docroot, "sites/default/files", fName), fContent, 0644)
+	require.NoError(t, err)
+
 	// Build our pantheon.yaml from the example file
 	s, err := os.ReadFile(app.GetConfigPath("providers/pantheon.yaml.example"))
 	require.NoError(t, err)
@@ -226,15 +234,10 @@ func TestPantheonPush(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create database and files entries that we can verify after push
-	tval := nodeps.RandomString(10)
 	_, _, err = app.Exec(&ExecOpts{
 		Cmd: fmt.Sprintf(`mysql -e 'CREATE TABLE IF NOT EXISTS %s ( title VARCHAR(255) NOT NULL ); INSERT INTO %s VALUES("%s");'`, t.Name(), t.Name(), tval),
 	})
 	require.NoError(t, err)
-	fName := tval + ".txt"
-	fContent := []byte(tval)
-	err = os.WriteFile(filepath.Join(app.AppRoot, "sites/default/files", fName), fContent, 0644)
-	assert.NoError(err)
 
 	err = app.Push(provider, false, false)
 	require.NoError(t, err)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -299,7 +299,7 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 	}
 
 	output.UserOut.Printf("Downloaded %s into %s", sourceURL, archiveFullPath)
-	
+
 	err = os.RemoveAll(extractPath)
 	if err != nil {
 		return extractPath, "", fmt.Errorf("failed to remove %s: %v", extractPath, err)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -124,6 +124,11 @@ func (site *TestSite) Prepare() error {
 	err = app.ConfigFileOverrideAction()
 	util.CheckErr(err)
 
+	err = os.MkdirAll(filepath.Join(app.AppRoot, app.Docroot, app.GetUploadDir()), 0777)
+	if err != nil {
+		return fmt.Errorf("Failed to create upload dir for test site: %v", err)
+	}
+
 	err = app.WriteConfig()
 	if err != nil {
 		return errors.Errorf("Failed to write site config for site %s, dir %s, err: %v", app.Name, app.GetAppRoot(), err)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -299,7 +299,11 @@ func GetCachedArchive(siteName string, prefixString string, internalExtractionPa
 	}
 
 	output.UserOut.Printf("Downloaded %s into %s", sourceURL, archiveFullPath)
-
+	
+	err = os.RemoveAll(extractPath)
+	if err != nil {
+		return extractPath, "", fmt.Errorf("failed to remove %s: %v", extractPath, err)
+	}
 	if filepath.Ext(archiveFullPath) == ".zip" {
 		err = archive.Unzip(archiveFullPath, extractPath, internalExtractionPath)
 	} else {


### PR DESCRIPTION
## The Problem/Issue/Bug:

* The composer full restriction on no plugins went into effect, breaking TestAcquiaPush and TestPantheonPush

## How this PR Solves The Problem:

- [x] Make both use jq to allow plugins in composer.json

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3950"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

