### PR TITLE
Use current acquia acli, fixes #3511 and use existing backup in integration, fixes #3333

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -14,7 +14,7 @@ ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
 ENV CAROOT /mnt/ddev-global-cache/mkcert
 
-# TARGETPLATFORM is Docker buildx's target platform (e.g. linux/arm64), while 
+# TARGETPLATFORM is Docker buildx's target platform (e.g. linux/arm64), while
 # BUILDPLATFORM is the platform of the build host (e.g. linux/amd64)
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -95,7 +95,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
 
 ADD ddev-webserver-dev-base-files /
 RUN phpdismod blackfire xhprof
-RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_${MAILHOG_ARCH} -o /usr/local/bin/mailhog; 
+RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_${MAILHOG_ARCH} -o /usr/local/bin/mailhog;
 
 RUN phpdismod xdebug && curl -sSL --fail --output /usr/local/bin/phive "https://phar.io/releases/phive.phar" && chmod 777 /usr/local/bin/phive && phpenmod xdebug
 RUN set -o pipefail && curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus
@@ -104,11 +104,8 @@ RUN set -o pipefail && curl -sSL https://github.com/platformsh/platformsh-cli/re
 RUN mkdir -p "/opt/phpstorm-coverage" && \
     chmod a+rw "/opt/phpstorm-coverage"
 
-# TODO: v1.18.0 had numerous problems, see https://github.com/acquia/cli/issues/508#issuecomment-967185296
-# and https://github.com/acquia/cli/issues/721 and https://github.com/acquia/cli/issues/722
-# When things sort out, additional work will be required in acquia.yaml.example to make it work
-# and then maybe we can use latest, but might be best to lock it to a version anyway.
-RUN curl -sSL --output /usr/local/bin/acli https://github.com/acquia/cli/releases/download/1.14.0/acli.phar && chmod 777 /usr/local/bin/acli
+RUN curl -sSL --output /usr/local/bin/acli https://github.com/acquia/cli/releases/latest/download/acli.phar && chmod 777 /usr/local/bin/acli
+
 RUN curl -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands && rm /tmp/backdrop-drush-extension.zip
 
 RUN mkdir -p /etc/nginx/sites-enabled /var/log/apache2 /var/run/apache2 /var/lib/apache2/module/enabled_by_admin /var/lib/apache2/module/disabled_by_admin && \

--- a/docs/content/users/providers/acquia.md
+++ b/docs/content/users/providers/acquia.md
@@ -18,7 +18,7 @@ ddev's Acquia integration pulls database and files from an existing project into
    ```
 
 5. Copy .ddev/providers/acquia.yaml.example to .ddev/providers/acquia.yaml.
-6. Update the project_id corresponding to the environment you want to work with.
+6. Update the project_id and database corresponding to the environment you want to work with.
    - If you have acli install, you can use the following command: `acli remote:aliases:list`
    - Or, on the Acquia Cloud Platform navigate to the environments page, click on the header and look for the "SSH URL" line. E.g. `project1.dev@cool-projects.acquia-sites.com` would have a project ID of `project1.dev`
 7. Your project must include drush; `ddev composer require drush/drush` if it isn't there already.

--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
@@ -33,15 +33,16 @@ auth_command:
     if [ -z "${ACQUIA_API_KEY:-}" ] || [ -z "${ACQUIA_API_SECRET:-}" ]; then echo "Please make sure you have set ACQUIA_API_KEY and ACQUIA_API_SECRET in ~/.ddev/global_config.yaml" && exit 1; fi
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
-    acli auth:login -n --key="${ACQUIA_API_KEY}" --secret="${ACQUIA_API_SECRET}"
-    acli remote:aliases:download -n >/dev/null
+
+    acli -n auth:login -n --key="${ACQUIA_API_KEY}" --secret="${ACQUIA_API_SECRET}"
+    acli -n remote:aliases:download --all --destination-dir $HOME/.drush -n >/dev/null
 
 db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    acli pull:db --on-demand --no-import -- @${project_id}
+    acli -n pull:db --on-demand --no-import -- @${project_id}
     mv /tmp/*.sql.gz /var/www/html/.ddev/.downloads/db.sql.gz
 
 files_pull_command:
@@ -61,10 +62,10 @@ db_push_command:
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     cd /var/www/html/.ddev/.downloads
     drush rsync -y --alias-path=~/.drush ./db.sql.gz @${project_id}:/tmp/db.${TIMESTAMP}.sql.gz
-    acli remote:ssh -n ${project_id} -- "cd /tmp && gunzip db.${TIMESTAMP}.sql.gz"
-    acli remote:drush -n ${project_id} -- "sql-cli </tmp/db.${TIMESTAMP}.sql"
-    acli remote:drush -n ${project_id} -- cr
-    acli remote:ssh -n ${project_id} -- "rm /tmp/db.${TIMESTAMP}.*"
+    acli -n remote:ssh -n ${project_id} -- "cd /tmp && gunzip db.${TIMESTAMP}.sql.gz"
+    acli -n remote:drush -n ${project_id} -- "sql-cli </tmp/db.${TIMESTAMP}.sql"
+    acli -n remote:drush -n ${project_id} -- cr
+    acli -n remote:ssh -n ${project_id} -- "rm /tmp/db.${TIMESTAMP}.*"
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 files_push_command:

--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
@@ -27,7 +27,7 @@
 environment_variables:
   project_id: yourproject.dev
   database_name: yourproject
-  
+
 auth_command:
   command: |
     set -eu -o pipefail
@@ -44,11 +44,11 @@ db_pull_command:
     set -eu -o pipefail
     # If no database_name is configured, infer it from project_id
     if [ -z "${database_name:-}" ]; then database_name=${project_id%%.*}; fi
-    acli api:environments:database-backup-list ${project_id} ${database_name} --limit=1
-    backup_id="$(acli api:environments:database-backup-list ${project_id} ${database_name} --limit=1 | jq -r .[].id)"
-    backup_url=$(acli api:environments:database-backup-download ${project_id} ${database_name} ${backup_id} | jq -r .url)
+    backup_time=$(acli -n api:environments:database-backup-list ${project_id} ${database_name} --limit=1 | jq -r .[].completed_at)
+    backup_id="$(acli -n api:environments:database-backup-list ${project_id} ${database_name} --limit=1 | jq -r .[].id)"
+    backup_url=$(acli -n api:environments:database-backup-download ${project_id} ${database_name} ${backup_id} | jq -r .url)
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    echo "Downloading backup $backup_id"
+    echo "Downloading backup $backup_id from $backup_time"
     curl -o /var/www/html/.ddev/.downloads/db.sql.gz ${backup_url}
 
 files_pull_command:

--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml.example
@@ -13,7 +13,7 @@
 #    - ACQUIA_API_SECRET=xxxxx
 #    ```
 # 5. Copy .ddev/providers/acquia.yaml.example to .ddev/providers/acquia.yaml.
-# 6. Update the project_id corresponding to the environment you want to work with.
+# 6. Update the project_id and database corresponding to the environment you want to work with.
 #   - If have acli install, you can use the following command: `acli remote:aliases:list`
 #   - Or, on the Acquia Cloud Platform navigate to the environments page, click on the header and look for the "SSH URL" line. Eg. `project1.dev@cool-projects.acquia-sites.com` would have a project ID of `project1.dev`
 # 7. Your project must include drush; `ddev composer require drush/drush` if it isn't there already.
@@ -26,7 +26,8 @@
 
 environment_variables:
   project_id: yourproject.dev
-
+  database_name: yourproject
+  
 auth_command:
   command: |
     set -eu -o pipefail
@@ -39,11 +40,16 @@ auth_command:
 
 db_pull_command:
   command: |
-    # set -x   # You can enable bash debugging output by uncommenting
+    #set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    # If no database_name is configured, infer it from project_id
+    if [ -z "${database_name:-}" ]; then database_name=${project_id%%.*}; fi
+    acli api:environments:database-backup-list ${project_id} ${database_name} --limit=1
+    backup_id="$(acli api:environments:database-backup-list ${project_id} ${database_name} --limit=1 | jq -r .[].id)"
+    backup_url=$(acli api:environments:database-backup-download ${project_id} ${database_name} ${backup_id} | jq -r .url)
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    acli -n pull:db --on-demand --no-import -- @${project_id}
-    mv /tmp/*.sql.gz /var/www/html/.ddev/.downloads/db.sql.gz
+    echo "Downloading backup $backup_id"
+    curl -o /var/www/html/.ddev/.downloads/db.sql.gz ${backup_url}
 
 files_pull_command:
   command: |

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -24,6 +24,7 @@ import (
  * defined in the constants below.
  */
 const acquiaPullTestSite = "ddevdemo.dev"
+const acquiaPullDatabase = "ddevdemo"
 const acquiaPushTestSite = "ddevdemo.test"
 
 const acquiaPullSiteURL = "http://ddevdemodev.prod.acquia-sites.com/"
@@ -106,7 +107,11 @@ func TestAcquiaPull(t *testing.T) {
 	// Build our acquia.yaml from the example file
 	s, err := os.ReadFile(app.GetConfigPath("providers/acquia.yaml.example"))
 	require.NoError(t, err)
+
+	// Replace the project_id and database_name
 	x := strings.Replace(string(s), "project_id:", fmt.Sprintf("project_id: %s\n#project_id:", acquiaPullTestSite), -1)
+	x = strings.Replace(x, "database_name: ", fmt.Sprintf("database_name: %s\n#database_name:", acquiaPullDatabase), -1)
+
 	err = os.WriteFile(app.GetConfigPath("providers/acquia.yaml"), []byte(x), 0666)
 	assert.NoError(err)
 	err = app.WriteConfig()

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -67,6 +67,7 @@ func TestAcquiaPull(t *testing.T) {
 
 	app, err := NewApp(siteDir, true)
 	assert.NoError(err)
+	app.PHPVersion = "8.0"
 
 	t.Cleanup(func() {
 		err = app.Stop(true, false)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220619_add_phpstorm_coverage_directory" // Note that this can be overridden by make
+var WebTag = "20220703_acli" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3511 : Use current versions of acli (Acquia cli tool)
* #3333: Use an existing backup on Acquia instead of dumping it ourselves

## Manual Testing Instructions:

- [x] Use this PR binary
- [x] Update acquia.yaml to use the body of the acquia.yaml.example from this PR
- [x] Verify download success

## Automated Testing Overview:

* Minor changes to TestAcquiaPull to accomodate.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3951"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

