### PR TITLE
Don't create upload_dir if not in mutagen, warn instead of failing, fixes #3688

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -127,6 +127,9 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	}
 
 	// Create the upload dir so that mounts will happen with mutagen.
+	// We only need to do this if mutagen is enabled,
+	// and we only need to do it if an upload_dir is configured either
+	// via project-type defaults or explicit settings of upload_dir
 	if app.IsMutagenEnabled() && app.GetHostUploadDirFullPath() != "" && !fileutil.FileExists(app.GetHostUploadDirFullPath()) {
 		err = os.MkdirAll(app.GetHostUploadDirFullPath(), 0755)
 		if err != nil {

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -2,7 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/drud/ddev/pkg/fileutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -113,28 +112,9 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 
 	app.SetApptypeSettingsPaths()
 
-	if app.DisableSettingsManagement {
+	if app.DisableSettingsManagement && app.Type != nodeps.AppTypePHP {
 		util.Warning("Not creating CMS settings files because disable_settings_management=true")
 		return "", nil
-	}
-
-	// If neither settings file options are set, then don't continue. Return
-	// a nil error because this should not halt execution if the apptype
-	// does not have a settings definition.
-	if app.SiteDdevSettingsFile == "" && app.SiteSettingsPath == "" {
-		util.Warning("Project type has no settings paths configured, so not creating settings file.")
-		return "", nil
-	}
-
-	// Create the upload dir so that mounts will happen with mutagen.
-	// We only need to do this if mutagen is enabled,
-	// and we only need to do it if an upload_dir is configured either
-	// via project-type defaults or explicit settings of upload_dir
-	if app.IsMutagenEnabled() && app.GetHostUploadDirFullPath() != "" && !fileutil.FileExists(app.GetHostUploadDirFullPath()) {
-		err = os.MkdirAll(app.GetHostUploadDirFullPath(), 0755)
-		if err != nil {
-			util.Warning("Unable to create upload directory %s: %v", app.GetHostUploadDirFullPath(), err)
-		}
 	}
 
 	// Drupal and WordPress love to change settings files to be unwriteable.

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/fileutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -126,10 +127,10 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	}
 
 	// Create the upload dir so that mounts will happen with mutagen.
-	if app.GetHostUploadDirFullPath() != "" {
+	if app.IsMutagenEnabled() && app.GetHostUploadDirFullPath() != "" && !fileutil.FileExists(app.GetHostUploadDirFullPath()) {
 		err = os.MkdirAll(app.GetHostUploadDirFullPath(), 0755)
 		if err != nil {
-			return "", fmt.Errorf("Unable to create upload directory: %v", err)
+			util.Warning("Unable to create upload directory %s: %v", app.GetHostUploadDirFullPath(), err)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1105,6 +1105,13 @@ func (app *DdevApp) Start() error {
 			}
 		}
 	}
+
+	// Settings files + upload_dir have to be created before WriteDockerComposeYaml()
+	// so we know if there is an upload_dir available to mount in the mutagen case.
+	if _, err = app.CreateSettingsFile(); err != nil {
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
+	}
+
 	// WriteConfig .ddev-docker-compose-*.yaml
 	err = app.WriteDockerComposeYAML()
 	if err != nil {
@@ -1204,10 +1211,6 @@ func (app *DdevApp) Start() error {
 	err = app.WaitByLabels(map[string]string{"com.ddev.site-name": app.GetName()})
 	if err != nil {
 		return err
-	}
-
-	if _, err = app.CreateSettingsFile(); err != nil {
-		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 
 	err = app.PostStartAction()
@@ -2713,8 +2716,8 @@ func (app *DdevApp) GetHostUploadDirFullPath() string {
 
 // GetContainerUploadDirFullPath returns the full path to the upload directory in container or "" if there is none
 func (app *DdevApp) GetContainerUploadDirFullPath() string {
-	if app.GetUploadDir() != "" {
-		return path.Join("/var/www/html", app.Docroot, app.GetUploadDir())
+	if d := app.GetUploadDir(); d != "" {
+		return path.Join("/var/www/html", app.Docroot, d)
 	}
 	return ""
 }


### PR DESCRIPTION


## The Problem/Issue/Bug:

* #3688 

## How this PR Solves The Problem:

* Don't create upload_dir except when using mutagen
* Warn if there's a problem, instead of failing

## Manual Testing Instructions:

- [x] Nonexistent sites/default/files or other upload_dir should get created, but only with mutagen_enabled
- [x] Symlink at sites/default/files should not result in an error (but check to make sure mutagen works!)
- [x] Existing sites/default/files - nothing different should happen.

## Automated Testing Overview:

No new tests

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3952"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

