### PR TITLE
[Tests only] Fix TestComposer for new composer requirement

### DIFF
--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -66,6 +66,7 @@ func TestComposer(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 
+	_, _, err = app.Composer([]string{"config", "--no-plugins", "allow-plugins", "true"})
 	_, _, err = app.Composer([]string{"install", "--no-progress", "--no-interaction"})
 	assert.NoError(err)
 	err = app.MutagenSyncFlush()

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -67,10 +67,11 @@ func TestComposer(t *testing.T) {
 	assert.NoError(err)
 
 	_, _, err = app.Composer([]string{"config", "--no-plugins", "allow-plugins", "true"})
+	require.NoError(t, err)
 	_, _, err = app.Composer([]string{"install", "--no-progress", "--no-interaction"})
-	assert.NoError(err)
+	require.NoError(t, err)
 	err = app.MutagenSyncFlush()
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	out, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd: "ls -l vendor/bin/var-dump-server | awk '{print $1}'",

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -75,6 +75,9 @@ func TestMutagenSimple(t *testing.T) {
 	})
 	assert.Contains(stderr, "cannot access '/var/www/html/vendor'")
 
+	_, _, err = app.Composer([]string{"config", "--no-plugins", "allow-plugins", "true"})
+	require.NoError(t, err)
+
 	// Now composer install again and make sure all the stuff comes back
 	stdout, stderr, err := app.Composer([]string{"install", "--no-progress", "--no-interaction"})
 	assert.NoError(err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

The composer plugin requirement broke TestComposer

Allow plugins.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3964"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

