### PR TITLE
Don't ask people to ddev poweroff if first use of ddev

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -202,17 +202,23 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 			}
 		}
 	}
-	if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" && globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
+	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
+
+		// If they have a new version (but not first-timer) then prompt to poweroff
+		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {
+			okPoweroff := util.Confirm("It looks like you have a new DDEV version. During an upgrade it's important to `ddev poweroff`. May I do `ddev poweroff` before continuing? This does no harm and loses no data.")
+			if okPoweroff {
+				ddevapp.PowerOff()
+			}
+		}
+
+		// If they have a new version write the new version into last-started
 		globalconfig.DdevGlobalConfig.LastStartedVersion = versionconstants.DdevVersion
 		err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 		if err != nil {
 			return err
 		}
 
-		okPoweroff := util.Confirm("It looks like you have a new DDEV version. During an upgrade it's important to `ddev poweroff`. May I do `ddev poweroff` before continuing? This does no harm and loses no data.")
-		if okPoweroff {
-			ddevapp.PowerOff()
-		}
 		return nil
 	}
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -202,7 +202,7 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 			}
 		}
 	}
-	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
+	if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" && globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
 		globalconfig.DdevGlobalConfig.LastStartedVersion = versionconstants.DdevVersion
 		err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 		if err != nil {

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -321,6 +321,9 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	oldTimeInt, err := strconv.ParseInt(oldTime, 10, 64)
 	require.NoError(t, err)
 
+	// Make sure we have starting version that is not v0.0
+	err = fileutil.AppendStringToFile(filepath.Join(globalconfig.GetGlobalDdevDir(), "global_config.yaml"), "last_started_version: v0.1")
+	require.NoError(t, err)
 	out, err := exec.RunHostCommand(DdevBin, "start")
 	assert.NoError(err)
 	assert.Contains(out, "ddev-ssh-agent container has been removed")


### PR DESCRIPTION
## The Problem/Issue/Bug:

Brand new users get asked if we can do a `ddev poweroff`, but it doesn't make sense.

## How this PR Solves The Problem:

Don't ask them if they're brand new (last_used_version == v0.0)

## Manual Testing Instructions:

- [x] Move ~/.ddev/global_config.yaml out of the way, `mv ~/.ddev/global_config.yaml ~/.ddev/global_config.yaml.bak`
- [x] `ddev start` - You should only be asked to opt into instrumentation, not poweroff
- [x] Change ddev version to higher version. You should be asked to poweroff
- [x] Other permutations.
- [x] Don't forget to put your global_config.yaml back

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3965"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

