### PR TITLE
Minor release workflow cleanup [skip ci]

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -154,11 +154,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build-most, sign-windows, notarize-macos]
     env:
-      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
       DDEV_GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
-      HOMEBREW_EDGE_REPOSITORY: ${{ secrets.HOMEBREW_EDGE_REPOSITORY }}
-      HOMEBREW_STABLE_REPOSITORY: ${{ secrets.HOMEBREW_STABLE_REPOSITORY }}
-      DDEV_MAIN_REPO_ORGNAME: ${{ secrets.DDEV_MAIN_REPO_ORGNAME }}
       CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
     steps:
@@ -216,6 +212,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
 
 
       - name: Show github.ref

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -17,10 +17,6 @@ The following "Repository secret" environment variables must be added to <https:
 
 * `DDEV_WINDOWS_SIGNING_PASSWORD`: The windows signing password.
 
-* `HOMEBREW_EDGE_REPOSITORY`: The name of the GitHub repo used for the edge channel on homebrew, drud/homebrew-ddev-ege
-
-* `HOMEBREW_STABLE_REPOSITORY`: The name of the GitHub repo used for the stable channel on homebrew/ drud/homebrew-ddev
-
 * `SegmentKey`: The key that enabled the Segment reporting
 
 ## Creating a release (almost everything is now automated)


### PR DESCRIPTION
I noted some release flow obsoletes and tried to remove/reorg.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3970"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

