### PR TITLE
Use HTTP_PROXY and friends to provide direct proxy support

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -872,11 +872,17 @@ func WriteBuildDockerfile(fullpath string, userDockerfilePath string, extraPacka
 	}
 
 	// Normal starting content is just the arg and base image
+	// The proxy stuff may be removable when https://github.com/docker/compose/issues/9034 is resolved
 	contents := `
 ### DDEV-injected base Dockerfile contents
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
-`
+` + fmt.Sprintf(`
+ENV http_proxy "%s"
+ENV HTTP_PROXY "%s"
+ENV NO_PROXY "%s"
+`, os.Getenv("http_proxy"), os.Getenv("HTTP_PROXY"), os.Getenv("NO_PROXY"))
+
 	contents = contents + `
 ARG username
 ARG uid


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/drud/ddev/issues/3960

Since Dockerfile.* was introduced in DDEV v1.19.3, you can't manually introduce proxy behavior in the build

## How this PR Solves The Problem:

If $HTTP_PROXY, $http_proxy, or $NO_PROXY is set in the environment (it normally is if configured on the system) then introduce those automatically into the build. 

For example, although these are normally set by the system, we'll set manually:
```bash
export NO_PROXY=127.0.0.1
export HTTP_PROXY=http://proxy:8888
```

After a `ddev start` we see in `.ddev/.webimageBuild/Dockerfile`:

```Dockerfile
### DDEV-injected base Dockerfile contents
ARG BASE_IMAGE
FROM $BASE_IMAGE

ENV http_proxy ""
ENV HTTP_PROXY "http://proxy:8888"
ENV NO_PROXY "127.0.0.1"

ARG username
ARG uid
ARG gid
RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username")

RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests autojump

RUN export XDEBUG_MODE=off && ( composer self-update --2 || composer self-update --2 || true )

RUN chmod 600 ~rfay/.pgpass ~rfay/.my.cnf
ENV NVM_DIR=/home/rfay/.nvm
```

## Manual Testing Instructions:

- [ ] Try this out in a real proxy environment
- [ ] Try it out in a non-proxy environment

## Automated Testing Overview:

I don't expect to add proxy testing



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3976"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

