### PR TITLE
[docs] Fix spellcheck configuration to inspect indented blocks, fixes #3981

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -11,6 +11,7 @@ matrix:
   - pyspelling.filters.markdown:
       markdown_extensions:
       - pymdownx.superfences:
+          disable_indented_code_blocks: true
   - pyspelling.filters.html:
       comments: false
       ignores:

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -16,7 +16,7 @@ Instructions for Mutagen and NFS are below.
 
     ## Mutagen
 
-    **;TLDR:** If you're on macOS or Windows just enable mutagen. `ddev config global --mutagen-enabled`. You'll be glad you did.
+    **TL;DR:** If you're on macOS or Windows just enable mutagen. `ddev config global --mutagen-enabled`. You'll be glad you did.
 
     The Mutagen asynchronous caching feature offers advanced performance experiences and is recommended for most projects. It's now the preferred way to get great webserving performance on macOS and Windows. Unlike the NFS feature, it requires no pre-configuration or installation. **You do not need to (and should not) install mutagen.** It can also be significantly faster than NFS and massively faster than plain vanilla Docker or Colima. In addition, it makes filesystem watchers (fsnotify/inotify) work correctly.
     


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3981 

## How this PR Solves The Problem:

Indented blocks were considered code by superfences, so were not inspected. 

I tested this without the spellcheck fixes from https://github.com/drud/ddev/pull/3979 (listed in #3981) and it now catches them.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3982"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

