### PR TITLE
Make sure that the temp global commands dir is created, fixes #3955

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -31,7 +31,10 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	projectCommandPath := app.GetConfigPath("commands")
 	// Make sure our target global command directory is empty
 	copiedGlobalCommandPath := app.GetConfigPath(".global_commands")
-
+	err = os.MkdirAll(copiedGlobalCommandPath, 0755)
+	if err != nil {
+		return err
+	}
 	commandsAdded := map[string]int{}
 	for _, commandSet := range []string{projectCommandPath, copiedGlobalCommandPath} {
 		commandDirs, err := fileutil.ListFilesInDirFullPath(commandSet)

--- a/pkg/ddevapp/commands.go
+++ b/pkg/ddevapp/commands.go
@@ -4,11 +4,13 @@ import (
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/util"
+	copy2 "github.com/otiai10/copy"
 	"os"
 	"path/filepath"
 )
 
-// PopulateCustomCommandFiles sets up the needed directories and files
+// PopulateCustomCommandFiles sets up the custom command files in the project
+// directories where they need to go.
 func PopulateCustomCommandFiles(app *DdevApp) error {
 
 	sourceGlobalCommandPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands")
@@ -20,13 +22,20 @@ func PopulateCustomCommandFiles(app *DdevApp) error {
 	projectCommandPath := app.GetConfigPath("commands")
 	// Make sure our target global command directory is empty
 	copiedGlobalCommandPath := app.GetConfigPath(".global_commands")
-	err = os.RemoveAll(copiedGlobalCommandPath)
+	err = os.MkdirAll(copiedGlobalCommandPath, 0755)
+	if err != nil {
+		util.Error("Unable to create directory %s: %v", copiedGlobalCommandPath, err)
+		return nil
+	}
+
+	// Make sure it's empty
+	err = fileutil.PurgeDirectory(copiedGlobalCommandPath)
 	if err != nil {
 		util.Error("Unable to remove %s: %v", copiedGlobalCommandPath, err)
 		return nil
 	}
 
-	err = fileutil.CopyDir(sourceGlobalCommandPath, copiedGlobalCommandPath)
+	err = copy2.Copy(sourceGlobalCommandPath, copiedGlobalCommandPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3955 

Ugly output in a project that hasn't gotten its .global_commands directory created yet

## How this PR Solves The Problem:

Make sure it's created

## Manual Testing Instructions:

```
mkdir junk && cd junk
ddev config --auto
ddev get drud/ddev-cron
```

You shouldn't see any ugly output, but all shell-based commands should work as well.




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3987"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

