### PR TITLE
Insert user Dockerfiles earlier, fixes #3988, fixes #3960

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -74,6 +74,10 @@ ENV COMPOSER_HOME=""
 
 **Remember that the Dockerfile is building a docker image that will be used later with ddev.** At the time the Dockerfile is executing, your code is not mounted and the container is not running, it's just being built. So for example, an `npm install` in /var/www/html will not do anything useful because the code is not there at image building time.
 
+## HTTP proxy support inside containers and during build
+
+DDEV will automatically recognize systems that have the environment variables HTTP_PROXY, HTTPS_PROXY, and NO_PROXY set to configure proxy behavior. It will then configure generated images to include those values and set them up to be able to use the proxy during build time and at run time.
+
 ### Debugging the Dockerfile build
 
 It can be complicated to figure out what's going on when building a Dockerfile, and even more complicated when you're seeing it go by as part of `ddev start`.

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -36,7 +36,7 @@ For more complex requirements, you can add:
 * `.ddev/db-build/Dockerfile`
 * `.ddev/db-build/Dockerfile.*`
 
-These files' content will be appended to ddev's own Dockerfile for each image.
+These files' content will be inserted into the constructed Dockerfile for each image. They are inserted *before* most of the rest of the things that are done to build the image, and are done in alpha order, so `Dockerfile` is inserted first, followed by `Dockerfile.*` in alpha order. You can examine the resultant Dockerfile (which should not be changed as it is generated) at `.ddev/.webimageBuild/Dockerfile` and you can force a rebuild with `ddev debug refresh`.
 
 Examples of possible Dockerfiles are given in `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example` (these examples are created in your project when you `ddev config` the project).
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -886,7 +886,7 @@ FROM $BASE_IMAGE
 		v := os.Getenv(proxyVar)
 		if v != "" {
 			useProxy = true
-			contents = contents + fmt.Sprintf("ENV %s %s", proxyVar, v)
+			contents = contents + fmt.Sprintf("\nENV %s %s\n", proxyVar, v)
 		}
 	}
 	if useProxy {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -873,6 +873,8 @@ func WriteBuildDockerfile(fullpath string, userDockerfilePath string, extraPacka
 
 	// Normal starting content is just the arg and base image
 	contents := `
+#ddev-generated - Do not modify this file; your modifications will be overwritten.
+
 ### DDEV-injected base Dockerfile contents
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
@@ -883,8 +885,39 @@ ARG uid
 ARG gid
 RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username")
 `
+	// If there are user dockerfiles, insert their contents
+	if userDockerfilePath != "" {
+		files, err := filepath.Glob(userDockerfilePath + "/Dockerfile*")
+		if err != nil {
+			return err
+		}
+
+		for _, file := range files {
+			// We'll skip the example file
+			if file == userDockerfilePath+"/Dockerfile.example" {
+				continue
+			}
+
+			userContents, err := fileutil.ReadFileIntoString(file)
+			if err != nil {
+				return err
+			}
+
+			// Backward compatible fix, remove unnecessary BASE_IMAGE references
+			re, err := regexp.Compile(`ARG BASE_IMAGE.*\n|FROM \$BASE_IMAGE.*\n`)
+			if err != nil {
+				return err
+			}
+
+			userContents = re.ReplaceAllString(userContents, "")
+			contents = contents + "\n\n### From user file " + file + ":\n" + userContents
+		}
+	}
+
 	if extraPackages != nil {
+
 		contents = contents + `
+### from webimage_extra_packages or dbimage_extra_packages
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 
@@ -914,35 +947,6 @@ RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update 
 	}
 
 	contents = contents + extraContent
-
-	// If there are user dockerfiles, appends their contents
-	if userDockerfilePath != "" {
-		files, err := filepath.Glob(userDockerfilePath + "/Dockerfile*")
-		if err != nil {
-			return err
-		}
-
-		for _, file := range files {
-			// We'll skip the example file
-			if file == userDockerfilePath+"/Dockerfile.example" {
-				continue
-			}
-
-			userContents, err := fileutil.ReadFileIntoString(file)
-			if err != nil {
-				return err
-			}
-
-			// Backward compatible fix, remove unnecessary BASE_IMAGE references
-			re, err := regexp.Compile(`ARG BASE_IMAGE.*\n|FROM \$BASE_IMAGE.*\n`)
-			if err != nil {
-				return err
-			}
-
-			userContents = re.ReplaceAllString(userContents, "")
-			contents = contents + "\n\n### From user file " + file + ":\n" + userContents
-		}
-	}
 
 	// Assets in the web-build directory copied to .webimageBuild so .webimageBuild can be "context"
 	// This actually copies the Dockerfile, but it is then immediately overwritten by WriteImageDockerfile()


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3988 
* #3960 

In DDEV v1.19.3, multiple user Dockerfiles were supported, and they were all added *after* the initial portions of generated Dockerfile content. This meant that things like HTTP_PROXY/HTTPS_PROXY could not be added before the `apt-get` things or related things. And it also meant that things like custom-cert installation couldn't be done before the other things happened. 


## How this PR Solves The Problem:

- [x] Move user-provided Dockerfile content to near the beginning of the generated .ddev/webimageBuild/Dockerfile, so user-generated Dockerfile content can take precedence.
- [x] Adds explicit support for proxy, using the HTTP_PROXY and HTTPS_PROXY and NO_PROXY environment variables. docker-compose should be doing this, and claims to, but it doesn't actually work out.

## Manual Testing Instructions:

- [x] Create a .ddev/web-build/Dockerfile and/or `Dockerfile.*`
- [x] `ddev start`
- [x] Inspect the .ddev/.webimageBuild/Dockerfile to review the actual order of inclusions
- [x] Verify that the actual build is done right by `ddev ssh` and inspect the build, or `docker image inspect` or review in Docker Desktop.
- [x] Verify that setting HTTP_PROXY in the traditional way works

## Automated Testing Overview:


## Release considerations

- [ ] Since ddev now directly supports proxies (via HTTP_PROXY and friends) the ddev-contrib recipe should be updated to point to the ddev docs.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3990"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

