### PR TITLE
CircleCI should ignore gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -514,7 +514,13 @@ workflows:
 #    - lx_amd64_container_test
 #    - staticrequired
     - lx_amd64_fpm_test
+      branches:
+        ignore:
+          - gh-pages
     - lx_arm64_fpm_test
+      branches:
+        ignore:
+          - gh-pages
 #    - lx_arm64_container_test
 #        requires:
 #        - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -513,11 +513,11 @@ workflows:
 #    - mac_container_test
 #    - lx_amd64_container_test
 #    - staticrequired
-    - lx_amd64_fpm_test
+    - lx_amd64_fpm_test:
       branches:
         ignore:
           - gh-pages
-    - lx_arm64_fpm_test
+    - lx_arm64_fpm_test:
       branches:
         ignore:
           - gh-pages


### PR DESCRIPTION
## The Problem/Issue/Bug:

CircleCI keeps trying to test the gh-pages branch

## How this PR Solves The Problem:

Turn that off



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3993"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

