### PR TITLE
Support for pre.Dockerfile.*

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -5,7 +5,7 @@ defaults:
     shell: bash
 on:
   push:
-    branches: [ master, main, 20220714_publish_binaries_on_master_workflow ]
+    branches: [ master, main ]
   release:
     types: [ created ]
 

--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -11,7 +11,7 @@ var DebugCapabilitiesCmd = &cobra.Command{
 	Use:   "capabilities",
 	Short: "Show capabilities of this version of ddev",
 	Run: func(cmd *cobra.Command, args []string) {
-		capabilities := []string{"multiple-dockerfiles", "interactive-project-selection", "ddev-get-yaml-interpolation"}
+		capabilities := []string{"multiple-dockerfiles", "interactive-project-selection", "ddev-get-yaml-interpolation", "pre-dockerfile-insertion"}
 		output.UserOut.WithField("raw", capabilities).Print(strings.Join(capabilities, "\n"))
 	},
 }

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -36,7 +36,7 @@ For more complex requirements, you can add:
 * `.ddev/db-build/Dockerfile`
 * `.ddev/db-build/Dockerfile.*`
 
-These files' content will be inserted into the constructed Dockerfile for each image. They are inserted *after* most of the rest of the things that are done to build the image, and are done in alpha order, so `Dockerfile` is inserted first, followed by `Dockerfile.*` in alpha order. 
+These files' content will be inserted into the constructed Dockerfile for each image. They are inserted *after* most of the rest of the things that are done to build the image, and are done in alpha order, so `Dockerfile` is inserted first, followed by `Dockerfile.*` in alpha order.
 
 For certain use cases, you might need to add stuff very early on the Dockerfile (i.e. proxy settings, SSL termination, etc.) you can also create:
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -36,7 +36,16 @@ For more complex requirements, you can add:
 * `.ddev/db-build/Dockerfile`
 * `.ddev/db-build/Dockerfile.*`
 
-These files' content will be inserted into the constructed Dockerfile for each image. They are inserted *before* most of the rest of the things that are done to build the image, and are done in alpha order, so `Dockerfile` is inserted first, followed by `Dockerfile.*` in alpha order. You can examine the resultant Dockerfile (which should not be changed as it is generated) at `.ddev/.webimageBuild/Dockerfile` and you can force a rebuild with `ddev debug refresh`.
+These files' content will be inserted into the constructed Dockerfile for each image. They are inserted *after* most of the rest of the things that are done to build the image, and are done in alpha order, so `Dockerfile` is inserted first, followed by `Dockerfile.*` in alpha order. 
+
+For certain use cases, you might need to add stuff very early on the Dockerfile (i.e. proxy settings, SSL termination, etc.) you can also create:
+
+* `.ddev/web-build/pre.Dockerfile.*`
+* `.ddev/db-build/pre.Dockerfile.*`
+
+These are inserted *before* everything else.
+
+You can examine the resultant Dockerfile (which should not be changed as it is generated) at `.ddev/.webimageBuild/Dockerfile` and you can force a rebuild with `ddev debug refresh`.
 
 Examples of possible Dockerfiles are given in `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example` (these examples are created in your project when you `ddev config` the project).
 
@@ -73,10 +82,6 @@ ENV COMPOSER_HOME=""
 ```
 
 **Remember that the Dockerfile is building a docker image that will be used later with ddev.** At the time the Dockerfile is executing, your code is not mounted and the container is not running, it's just being built. So for example, an `npm install` in /var/www/html will not do anything useful because the code is not there at image building time.
-
-## HTTP proxy support inside containers and during build
-
-DDEV will automatically recognize systems that have the environment variables HTTP_PROXY, HTTPS_PROXY, and NO_PROXY set to configure proxy behavior. It will then configure generated images to include those values and set them up to be able to use the proxy during build time and at run time.
 
 ### Debugging the Dockerfile build
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -885,7 +885,7 @@ ARG uid
 ARG gid
 RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username")
 `
-	// If there are user dockerfiles, insert their contents
+	// If there are user pre.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
 		files, err := filepath.Glob(userDockerfilePath + "/pre.Dockerfile*")
 		if err != nil {
@@ -898,14 +898,14 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 				return err
 			}
 
-			contents = contents + "\n\n### From user file " + file + ":\n" + userContents
+			contents = contents + "\n\n### From user Dockerfile " + file + ":\n" + userContents
 		}
 	}
 
 	if extraPackages != nil {
 		contents = contents + `
 ### DDEV-injected from webimage_extra_packages or dbimage_extra_packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 
 	// For webimage, update to latest composer.
@@ -949,7 +949,7 @@ RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update 
 		}
 
 		for _, file := range files {
-			// We'll skip the example file
+			// Skip the example file
 			if file == userDockerfilePath+"/Dockerfile.example" {
 				continue
 			}
@@ -966,7 +966,7 @@ RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update 
 			}
 
 			userContents = re.ReplaceAllString(userContents, "")
-			contents = contents + "\n\n### From user file " + file + ":\n" + userContents
+			contents = contents + "\n\n### From user Dockerfile " + file + ":\n" + userContents
 		}
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -904,7 +904,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 
 	if extraPackages != nil {
 		contents = contents + `
-### from webimage_extra_packages or dbimage_extra_packages
+### DDEV-injected from webimage_extra_packages or dbimage_extra_packages
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 
@@ -929,11 +929,17 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg:
 		// Try composer self-update twice because of troubles with composer downloads
 		// breaking testing.
 		contents = contents + fmt.Sprintf(`
+### DDEV-injected composer update
 RUN export XDEBUG_MODE=off && ( composer self-update %s || composer self-update %s || true )
 `, composerSelfUpdateArg, composerSelfUpdateArg)
 	}
 
-	contents = contents + extraContent
+	if extraContent != "" {
+		contents = contents + fmt.Sprintf(`
+### DDEV-injected extra content
+%s
+`, extraContent)
+	}
 
 	// If there are user dockerfiles, appends their contents
 	if userDockerfilePath != "" {


### PR DESCRIPTION
Partially reverts 
* #3990 
with a `pre.Dockerfile.*` approach and keeping regular `Dockerfile*` at the end of the insertions.

From Discord: https://discord.com/channels/664580571770388500/997163304822771842

# Release Consequences

- [ ] Update https://github.com/drud/ddev-contrib/tree/master/recipes/proxy to show the new technique

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3999"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

