### PR TITLE
Gitpod image needs explicit tag, and it needs to be bumped, fixes ddev-gitpod-launcher#22 [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drud/ddev-gitpod-base:latest
+image: drud/ddev-gitpod-base:20220715
 tasks:
   - name: build-run
     init: |

--- a/.gitpod/images/push.sh
+++ b/.gitpod/images/push.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_REPO=drud/ddev-gitpod-base:latest
+# Try `DOCKER_TAG="YYYYMMDD" ./push.sh`
+
+DOCKER_TAG=${DOCKER_TAG:-$(git describe --tags --always --dirty)}
+
+DOCKER_REPO=${DOCKER_REPO:-drud/ddev-gitpod-base:${DOCKER_TAG}}
 
 echo "Pushing ${DOCKER_REPO}"
 set -x
 # Build only current architecture and load into docker
 docker buildx build -t ${DOCKER_REPO} --push --platform=linux/amd64 .
+
+echo "This was pushed with ${DOCKER_REPO}. For it to take effect, it must be changed here in .gitpod.yaml and also in https://github.com/drud/ddev-gitpod-launcher/blob/main/.gitpod.yml"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/drud/ddev-gitpod-launcher/issues/22

## How this PR Solves The Problem:

Push a new image. 

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4002"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

