### PR TITLE
[docs] Show how to use signed debian packages, for #3997

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -38,11 +38,12 @@ Docker or an alternative is required before anything will work with DDEV. This i
     * Debian/Ubuntu and derivative distros - Install the ddev apt repositories with:
 
     ```bash
-    echo "deb [trusted=yes] https://apt.fury.io/drud/ /" | sudo tee -a /etc/apt/sources.list.d/ddev.list
-    sudo apt update && sudo apt install ddev
+    curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
+    echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
+    sudo apt update && sudo apt install -y ddev
     ```
   
-    In the future you can update as usual, with `sudo apt update && sudo apt upgrade`. (Signed repo support will be added in the near future.)
+    In the future you can update as usual, with `sudo apt update && sudo apt upgrade`.
 
     * Yum/RPM (Fedora, RedHat, etc.):
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3997
Debian apt packages are now signed, fix doc to show that approach.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4008"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

