### PR TITLE
[docs] Improve doc readability by changing the theme and style

### DIFF
--- a/docs/content/assets/extra.css
+++ b/docs/content/assets/extra.css
@@ -1,23 +1,70 @@
+/* variables */
+:root {
+    /* #4051b5 (indigo primary) in decimal RGB */
+    --custom-bg-color: rgba(64, 81, 181, .1);
+}
+
 /* table does not need a scrollbar, see https://github.com/drud/ddev/pull/3290#issuecomment-942888867
  */
 .md-typeset__table {
-  padding-right: 0;
+    padding-right: 0;
 }
 
 dt {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 .md-typeset :is(.admonition,details) {
-  font-size: .70rem;
-  background-color: inherit;
+    font-size: .70rem;
+    background-color: inherit;
 }
+
 .md-typeset .tabbed-content {
-  background-color: aliceblue;
-  padding: 10px;
+    background-color: var(--custom-bg-color);
+    padding: 10px;
 }
 
 /* only required if we have our svg logo out there */
 /*.md-logo {*/
 /*  filter:invert(40%)*/
 /*}*/
+
+/* typography */
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4,
+.md-typeset h5,
+.md-typeset h6 {
+    font-weight: 700;
+    margin-bottom: .5em;
+    color: var(--md-primary-fg-color);
+}
+
+.md-content {
+    max-width: 130ch;
+}
+
+/* blockquote */
+[dir=ltr] .md-typeset blockquote {
+    border-left-color: var(--md-primary-fg-color);
+    background: var(--custom-bg-color);
+    padding: .6rem 1rem;
+}
+
+[dir=ltr] .md-typeset blockquote strong {
+    color: var(--md-primary-fg-color);
+}
+
+[dir=ltr] .md-typeset blockquote p:first-child {
+    margin-top: 0;
+}
+
+[dir=ltr] .md-typeset blockquote p:last-child {
+    margin-bottom: 0;
+}
+
+/* tabs */
+.md-typeset .tabbed-labels label {
+    font-size: 16px;
+}

--- a/docs/content/assets/extra.css
+++ b/docs/content/assets/extra.css
@@ -103,3 +103,16 @@ dt {
 .md-typeset .tabbed-labels label {
     font-size: 0.75rem;
 }
+
+.md-typeset .tabbed-button {
+    width: 30px;
+    height: 100%;
+    border-radius: unset!important;
+}
+
+.md-typeset .tabbed-button:after {
+    -webkit-mask-size: cover;
+    mask-size: cover;
+    mask-position: center;
+    -webkit-mask-position: center;
+}

--- a/docs/content/assets/extra.css
+++ b/docs/content/assets/extra.css
@@ -66,5 +66,5 @@ dt {
 
 /* tabs */
 .md-typeset .tabbed-labels label {
-    font-size: 16px;
+    font-size: 0.75rem;
 }

--- a/docs/content/assets/extra.css
+++ b/docs/content/assets/extra.css
@@ -45,6 +45,41 @@ dt {
     max-width: 130ch;
 }
 
+/* main menu */
+.md-container > nav .md-tabs__item {
+    position: relative !important;
+    height: 2rem;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.md-container > nav .md-tabs__link {
+    margin-top: 0;
+}
+
+.md-container > nav .md-tabs__link:after {
+    content: '';
+    background: #fff;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    top: 0;
+}
+
+.md-container > nav .md-tabs__link:hover:after,
+.md-container > nav .md-tabs__link--active:after {
+    opacity: 0.1;
+}
+
+.md-tabs[hidden] .md-tabs__link,
+.md-container > nav .md-tabs[hidden] .md-tabs__link {
+    transform: unset;
+    transition: opacity .3s ease;
+}
+
 /* blockquote */
 [dir=ltr] .md-typeset blockquote {
     border-left-color: var(--md-primary-fg-color);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ theme:
   name: material
   palette:
   - scheme: default
-    primary: light-blue
+    primary: indigo
     accent: indigo
   features:
 #  - content.tabs.link


### PR DESCRIPTION
## The Problem/Issue/Bug:
The readability within the new docs should be improved;
1. The light-blue theme has a very low contrast ratio which results in poor accessibility
2. The line length within the docs is too long, which makes text harder to read and understand.
3. Heading margin feels off, the content related to the heading is too far away.
4. Heading styling should stand out more, this in terms helps with navigation throughout the page.
5. Blockquotes should stand out more, they usually contain important information the user has to read. Currently it can easily be overlooked,
 
## How this PR Solves The Problem:
1. The light-blue theme has been replaced with indigo, as the contrast between backgrounds and text is better.
2. The max width for `div.md-content` has been reduced by almost 300px.
3. All heading margins have been reduced and are now being set relative to the headings font-size
4. Headings are now bold and their color is set to the primary theme color so you distinguish between content and headings better.
5. Blockquotes styling has changed

## Manual Testing Instructions:
You can view this PR's results by using [this link](https://ddev--4009.org.readthedocs.build/en/4009/).

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4009"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

