### PR TITLE
Bump images to v1.19.5

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,13 +17,13 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.19.4" // Note that this can be overridden by make
+var WebTag = "v1.19.5" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.19.4"
+var BaseDBTag = "v1.19.5"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"
@@ -35,7 +35,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.19.4" // Note that this can be overridden by make
+var RouterTag = "v1.19.5" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 //var SSHAuthImage = "drud/ddev-ssh-agent"
@@ -43,7 +43,7 @@ var SSHAuthImage = "drud/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
 //var SSHAuthTag = "v1.19.0"
-var SSHAuthTag = "v1.19.4"
+var SSHAuthTag = "v1.19.5"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Bump images to v1.19.5

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4011"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

