### PR TITLE
Bump default php to 8.0, MariaDB to 10.4, add Maria 10.8

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -5,7 +5,8 @@ export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
 
 echo "buildkite building ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) as USER=${USER} for OS=${OSTYPE} in ${PWD} with golang=$(go version | awk '{print $3}') docker-desktop=$(scripts/docker-desktop-version.sh) docker=$(docker --version | awk '{print $3}') ddev version=$(ddev --version | awk '{print $3}'))"
 
-export GOTEST_SHORT=1
+# GOTEST_SHORT=8 means drupal9
+export GOTEST_SHORT=8
 export DDEV_NONINTERACTIVE=true
 export DDEV_DEBUG=true
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v29
+        - linux-homebrew-v30
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v29
+        key: linux-homebrew-v30
         paths:
           - /home/linuxbrew
     - run:
@@ -64,16 +64,16 @@ jobs:
     - run: 'mkdir -p ~/.ngrok2 && echo "authtoken: ${NGROK_TOKEN}" >~/.ngrok2/ngrok.yml'
     - restore_cache:
         keys:
-        - linux-homebrew-v29
+        - linux-homebrew-v30
     - restore_cache:
         keys:
-          - linux-testcache-v26
+          - linux-testcache-v27
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v29
+        key: linux-homebrew-v30
         paths:
           - /home/linuxbrew
     - run: echo "$(docker --version) $(docker-compose --version)"
@@ -84,7 +84,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-testcache-v26
+        key: linux-testcache-v27
         paths:
         - /home/circleci/.ddev/testcache
 
@@ -135,7 +135,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - macos-v25
+        - macos-v26
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -146,7 +146,7 @@ jobs:
         name: ddev tests
         no_output_timeout: "40m"
     - save_cache:
-        key: macos-v25
+        key: macos-v26
         paths:
         - /home/circleci/.ddev/testcache
     - store_test_results:
@@ -165,7 +165,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - macos-v25
+        - macos-v26
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -178,7 +178,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: macos-v25
+        key: macos-v26
         paths:
         - /home/circleci/.ddev/testcache
 
@@ -195,7 +195,7 @@ jobs:
         at: ~/
     - restore_cache:
         keys:
-        - macos-v25
+        - macos-v26
     # Run the built-in ddev tests with the executables just built.
     - run:
         command: ./.circleci/macos_circle_vm_setup.sh
@@ -207,7 +207,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: macos-v25
+        key: macos-v26
         paths:
         - /home/circleci/.ddev/testcache
 
@@ -224,7 +224,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v26
+        - linux-homebrew-v30
     - attach_workspace:
         at: ~/
     - run:
@@ -241,7 +241,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-linux-v26
+        key: linux-homebrew-v30
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -259,7 +259,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v26
+        - linux-homebrew-v30
     - attach_workspace:
         at: ~/
     - run:
@@ -278,7 +278,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: homebrew-linux-v26
+        key: linux-homebrew-v30
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -293,7 +293,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v26
+        - linux-homebrew-v30
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
@@ -315,7 +315,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v26
+        - linux-homebrew-v30
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
@@ -339,7 +339,7 @@ jobs:
         name: linux container test
 
     - save_cache:
-        key: homebrew-linux-v26
+        key: linux-homebrew-v30
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -406,7 +406,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - homebrew-linux-v26
+        - linux-homebrew-v30
     - attach_workspace:
         at: ~/
     - run:
@@ -414,7 +414,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: homebrew-linux-v26
+        key: linux-homebrew-v30
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         webserver: [apache-fpm, nginx-fpm]
-        tests: [test]
+        tests: ['test TESTARGS="-failfast"']
         os: [ ubuntu-20.04 ]
         mutagen: ['false', 'true']
         no-bind-mounts: ['true', 'false']
@@ -65,7 +65,6 @@ jobs:
 
       - name: DDEV tests
         run: |
-          echo "$(docker --version) $(docker-compose --version)"
           echo "DDEV_TEST_USE_MUTAGEN=${DDEV_TEST_USE_MUTAGEN}"
           make ${{ matrix.tests }}
 

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,11 +10,11 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.26
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.26
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
-	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
+	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \
-	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mysql_5.7_test mysql_8.0_test"; \
+	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mysql_5.7_test mysql_8.0_test"; \
   	fi )
 
 container: build
@@ -29,6 +29,7 @@ mariadb_10.4: mariadb_10.4_both
 mariadb_10.5: mariadb_10.5_both
 mariadb_10.6: mariadb_10.6_both
 mariadb_10.7: mariadb_10.7_both
+mariadb_10.8: mariadb_10.8_both
 
 mysql_5.5: mysql_5.5_amd64
 mysql_5.6: mysql_5.6_amd64

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -76,7 +76,7 @@ func init() {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
 		nodeps.AppTypeDrupal9: {
-			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: drupal9ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
+			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
 		nodeps.AppTypeDrupal10: {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal10App, postImportDBAction: nil, configOverrideAction: drupal10ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
@@ -96,7 +96,7 @@ func init() {
 		nodeps.AppTypeMagento2: {
 			settingsCreator: createMagento2SettingsFile, uploadDir: getMagento2UploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagento2SiteSettingsPaths, appTypeDetect: isMagento2App, postImportDBAction: nil, configOverrideAction: magento2ConfigOverrideAction, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction,
 		},
-		nodeps.AppTypeLaravel:   {appTypeDetect: isLaravelApp, postStartAction: laravelPostStartAction, configOverrideAction: laravelConfigOverrideAction},
+		nodeps.AppTypeLaravel:   {appTypeDetect: isLaravelApp, postStartAction: laravelPostStartAction, configOverrideAction: nil},
 		nodeps.AppTypeShopware6: {appTypeDetect: isShopware6App, apptypeSettingsPaths: setShopware6SiteSettingsPaths, uploadDir: getShopwareUploadDir, configOverrideAction: nil, postStartAction: shopware6PostStartAction, importFilesAction: shopware6ImportFilesAction},
 	}
 }

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -70,10 +70,10 @@ func init() {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal6Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal6App, postImportDBAction: nil, configOverrideAction: drupal6ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal6PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal7: {
-			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
+			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: drupal7ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal8: {
-			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
+			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: drupal8ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
 		},
 		nodeps.AppTypeDrupal9: {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal9App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,
@@ -91,7 +91,7 @@ func init() {
 			settingsCreator: createBackdropSettingsFile, uploadDir: getBackdropUploadDir, hookDefaultComments: getBackdropHooks, apptypeSettingsPaths: setBackdropSiteSettingsPaths, appTypeDetect: isBackdropApp, postImportDBAction: backdropPostImportDBAction, configOverrideAction: nil, postConfigAction: nil, postStartAction: backdropPostStartAction, importFilesAction: backdropImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeMagento: {
-			settingsCreator: createMagentoSettingsFile, uploadDir: getMagentoUploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagentoSiteSettingsPaths, appTypeDetect: isMagentoApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction,
+			settingsCreator: createMagentoSettingsFile, uploadDir: getMagentoUploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagentoSiteSettingsPaths, appTypeDetect: isMagentoApp, postImportDBAction: nil, configOverrideAction: magentoConfigOverrideAction, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction,
 		},
 		nodeps.AppTypeMagento2: {
 			settingsCreator: createMagento2SettingsFile, uploadDir: getMagento2UploadDir, hookDefaultComments: nil, apptypeSettingsPaths: setMagento2SiteSettingsPaths, appTypeDetect: isMagento2App, postImportDBAction: nil, configOverrideAction: magento2ConfigOverrideAction, postConfigAction: nil, postStartAction: nil, importFilesAction: magentoImportFilesAction,

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -70,7 +70,7 @@ func init() {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal6Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal6App, postImportDBAction: nil, configOverrideAction: drupal6ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal6PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal7: {
-			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: drupal7ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
+			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal7Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal7App, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: drupal7PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeDrupal8: {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal8Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal8App, postImportDBAction: nil, configOverrideAction: drupal8ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal8PostStartAction, importFilesAction: drupalImportFilesAction,

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -65,13 +65,13 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeDrupal6:   nodeps.PHP56,
 		nodeps.AppTypeDrupal7:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal8:   nodeps.PHPDefault,
-		nodeps.AppTypeDrupal9:   nodeps.PHP80,
+		nodeps.AppTypeDrupal9:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal10:  nodeps.PHP81,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:  nodeps.PHPDefault,
 		nodeps.AppTypeMagento:   nodeps.PHPDefault,
 		nodeps.AppTypeMagento2:  nodeps.PHP81,
-		nodeps.AppTypeLaravel:   nodeps.PHP80,
+		nodeps.AppTypeLaravel:   nodeps.PHPDefault,
 	}
 
 	for appType, expectedPHPVersion := range appTypes {

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -64,12 +64,12 @@ func TestPostConfigAction(t *testing.T) {
 	appTypes := map[string]string{
 		nodeps.AppTypeDrupal6:   nodeps.PHP56,
 		nodeps.AppTypeDrupal7:   nodeps.PHPDefault,
-		nodeps.AppTypeDrupal8:   nodeps.PHPDefault,
+		nodeps.AppTypeDrupal8:   nodeps.PHP74,
 		nodeps.AppTypeDrupal9:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal10:  nodeps.PHP81,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:  nodeps.PHPDefault,
-		nodeps.AppTypeMagento:   nodeps.PHPDefault,
+		nodeps.AppTypeMagento:   nodeps.PHP74,
 		nodeps.AppTypeMagento2:  nodeps.PHP81,
 		nodeps.AppTypeLaravel:   nodeps.PHPDefault,
 	}
@@ -102,7 +102,7 @@ func TestPostConfigAction(t *testing.T) {
 		assert.NoError(err)
 
 		// With a basic new app, the expectedPHPVersion should be the default
-		assert.EqualValues(app.PHPVersion, expectedPHPVersion)
+		assert.EqualValues(expectedPHPVersion, app.PHPVersion, "expected PHP version %s but got %s for apptype=%s", expectedPHPVersion, app.PHPVersion, appType)
 
 		newVersion := "19.0-" + appType
 		app.PHPVersion = newVersion

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -362,9 +362,9 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 	const apptypePos = 0
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
-		"drupal6phpversion": {nodeps.AppTypeDrupal6, nodeps.PHP56},
-		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHPDefault},
-		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHPDefault},
+		"drupal6phpversion":  {nodeps.AppTypeDrupal6, nodeps.PHP56},
+		"drupal7phpversion":  {nodeps.AppTypeDrupal7, nodeps.PHPDefault},
+		"drupal10phpversion": {nodeps.AppTypeDrupal10, nodeps.PHP81},
 	}
 
 	for testName, testValues := range testMatrix {
@@ -410,7 +410,7 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 		assert.Equal(name, app.Name)
 		assert.Equal(testValues[apptypePos], app.Type)
 		assert.Equal(nonexistentDocroot, app.Docroot)
-		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion)
+		assert.Equal(testValues[phpVersionPos], app.PHPVersion, "expected php%v for apptype %s", testValues[phpVersionPos], app.Type)
 
 		err = PrepDdevDirectory(tmpDir)
 		assert.NoError(err)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -223,9 +223,10 @@ func TestConfigCommand(t *testing.T) {
 	const apptypePos = 0
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
-		"drupal6phpversion": {nodeps.AppTypeDrupal6, nodeps.PHP56},
-		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHPDefault},
-		"drupal8phpversion": {nodeps.AppTypeDrupal8, nodeps.PHPDefault},
+		"magentophpversion":  {nodeps.AppTypeMagento, nodeps.PHP74},
+		"drupal7phpversion":  {nodeps.AppTypeDrupal7, nodeps.PHPDefault},
+		"drupal9phpversion":  {nodeps.AppTypeDrupal9, nodeps.PHPDefault},
+		"drupal10phpversion": {nodeps.AppTypeDrupal10, nodeps.PHP81},
 	}
 
 	for testName, testValues := range testMatrix {
@@ -288,7 +289,7 @@ func TestConfigCommand(t *testing.T) {
 		assert.Equal(name, app.Name)
 		assert.Equal(testValues[apptypePos], app.Type)
 		assert.Equal("docroot", app.Docroot)
-		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion, "PHP value incorrect for app %v", app)
+		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion, "PHP value incorrect for apptype %v (expected %s got %s) (%v)", app.Type, testValues[phpVersionPos], app.PHPVersion, app)
 		err = PrepDdevDirectory(testDir)
 		assert.NoError(err)
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -195,18 +195,19 @@ var (
 		},
 		// 10: shopware6
 		{
-			Name:                          "testpkgshopware6",
+			Name: "testpkgshopware6",
+			// tar -czf .tarballs/shopware6_code.tgz --exclude=public/media .
 			SourceURL:                     "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_code.tgz",
 			ArchiveInternalExtractionPath: "",
-			// cd public/fileadmin && tar -czf ../../.tarballs/shopware
+			// cd public/media && tar -czf ../../.tarballs/shopware6_files.tgz
 			FilesTarballURL:           "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_files.tgz",
-			DBTarURL:                  "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_db.tgz",
+			DBTarURL:                  "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_db.sql.tar.gz",
 			FullSiteTarballURL:        "",
 			Type:                      nodeps.AppTypeShopware6,
 			Docroot:                   "public",
 			Safe200URIWithExpectation: testcommon.URIWithExpect{URI: "/maintenance.html", Expect: "Our website is currently undergoing maintenance"},
-			DynamicURI:                testcommon.URIWithExpect{URI: "/Main-product-with-properties/SWDEMO10007.1", Expect: "Main product with properties"},
-			FilesImageURI:             "/media/2f/b0/e2/1603218072/hemd_600x600.jpg",
+			DynamicURI:                testcommon.URIWithExpect{URI: "/", Expect: "0180 - 000000"},
+			FilesImageURI:             "/media//05/23/ee/1658172194/shirt_red_600x600.jpg",
 		},
 		// 11: php
 		{

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -41,7 +41,7 @@ var (
 		// 0: wordpress
 		{
 			Name:                          "TestPkgWordpress",
-			SourceURL:                     "https://wordpress.org/wordpress-5.8.2.tar.gz",
+			SourceURL:                     "https://wordpress.org/wordpress-6.0.1.tar.gz",
 			ArchiveInternalExtractionPath: "wordpress/",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/wordpress5.8.2_files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/wordpress5.8.2_db.sql.tar.gz",
@@ -54,8 +54,8 @@ var (
 		// 1: drupal8
 		{
 			Name:                          "TestPkgDrupal8",
-			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.9.13.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-8.9.13/",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.9.20.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-8.9.20/",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d8_umami.files.tar.gz",
 			FilesZipballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d8_umami.files.zip",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d8_umami.sql.tar.gz",
@@ -70,8 +70,8 @@ var (
 		// 2: drupal7
 		{
 			Name:                          "TestPkgDrupal7", // Drupal D7
-			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-7.87.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-7.87/",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-7.90.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-7.90/",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d7test-7.59.files.tar.gz",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d7test-7.87-db.tar.gz",
 			FullSiteTarballURL:            "",
@@ -99,8 +99,8 @@ var (
 		// 4: backdrop
 		{
 			Name:                          "TestPkgBackdrop",
-			SourceURL:                     "https://github.com/backdrop/backdrop/archive/1.11.0.tar.gz",
-			ArchiveInternalExtractionPath: "backdrop-1.11.0/",
+			SourceURL:                     "https://github.com/backdrop/backdrop/archive/1.22.0.tar.gz",
+			ArchiveInternalExtractionPath: "backdrop-1.22.0/",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/backdrop_db.11.0.tar.gz",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/backdrop_files.11.0.tar.gz",
 			FullSiteTarballURL:            "",
@@ -163,8 +163,8 @@ var (
 		// 8: drupal9
 		{
 			Name:                          "TestPkgDrupal9",
-			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-9.4.1.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-9.4.1/",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-9.4.2.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-9.4.2/",
 			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d9_umami_files.tgz",
 			FilesZipballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d9_umami_files.zip",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d9_umami_sql.tar.gz",
@@ -221,15 +221,16 @@ var (
 		// 12: drupal10
 		{
 			Name:                          "TestPkgDrupal10",
-			SourceURL:                     "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d10_code.tgz",
-			ArchiveInternalExtractionPath: "",
-			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d10_files.tgz",
-			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/d10.sql.tar.gz",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-10.0.0-alpha6.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-10.0.0-alpha6",
+			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/drupal10-files.tgz",
+			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/drupal10-alpha6.sql.tar.gz",
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeDrupal10,
 			Docroot:                       "",
 			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.md", Expect: "Drupal is an open source content management platform"},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "Welcome to d10"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "This is a test page"},
+			FilesImageURI:                 "/sites/default/files/2022-07/Logo.png",
 		},
 	}
 
@@ -1799,9 +1800,9 @@ func readLastLine(fileName string) (string, error) {
 // TestDdevFullSiteSetup tests a full import-db and import-files and then looks to see if
 // we have a spot-test success hit on a URL
 func TestDdevFullSiteSetup(t *testing.T) {
-	if nodeps.IsMacM1() {
-		t.Skip("Skipping on Mac M1, it just has too many connection failed problems")
-	}
+	//if nodeps.IsMacM1() {
+	//	t.Skip("Skipping on Mac M1, it just has too many connection failed problems")
+	//}
 
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -113,16 +113,16 @@ var (
 		// 5: typo3
 		{
 			Name:                          "TestPkgTypo3",
-			SourceURL:                     "https://github.com/drud/typo3-v9-test/archive/v0.2.2.tar.gz",
-			ArchiveInternalExtractionPath: "typo3-v9-test-0.2.2/",
-			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3_v9.5_introduction_db.tar.gz",
-			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3_v9.5_introduction_files.tar.gz",
+			SourceURL:                     "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3v11_source.tgz",
+			ArchiveInternalExtractionPath: "",
+			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3v11_db.sql.tar.gz",
+			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3v11_fileadmin.tgz",
 			FullSiteTarballURL:            "",
 			Docroot:                       "public",
 			Type:                          nodeps.AppTypeTYPO3,
 			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "junk readme simply for reading"},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/index.php?id=65", Expect: "Boxed Content"},
-			FilesImageURI:                 "/fileadmin/introduction/images/streets/nikita-maru-70928.jpg",
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "This is test text for TestDdevFullSiteSetup"},
+			FilesImageURI:                 "/fileadmin/user_upload/Logo.png",
 		},
 		// 6: magento1
 		{

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -112,7 +112,8 @@ var (
 		},
 		// 5: typo3
 		{
-			Name:                          "TestPkgTypo3",
+			Name: "TestPkgTypo3",
+			// tar -czf .tarballs/typo3v11_source.tgz --exclude=var --exclude=public/fileadmin .
 			SourceURL:                     "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3v11_source.tgz",
 			ArchiveInternalExtractionPath: "",
 			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/typo3v11_db.sql.tar.gz",
@@ -197,14 +198,15 @@ var (
 			Name:                          "testpkgshopware6",
 			SourceURL:                     "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_code.tgz",
 			ArchiveInternalExtractionPath: "",
-			FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_files.tgz",
-			DBTarURL:                      "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_db.tgz",
-			FullSiteTarballURL:            "",
-			Type:                          nodeps.AppTypeShopware6,
-			Docroot:                       "public",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/maintenance.html", Expect: "Our website is currently undergoing maintenance"},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/Main-product-with-properties/SWDEMO10007.1", Expect: "Main product with properties"},
-			FilesImageURI:                 "/media/2f/b0/e2/1603218072/hemd_600x600.jpg",
+			// cd public/fileadmin && tar -czf ../../.tarballs/shopware
+			FilesTarballURL:           "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_files.tgz",
+			DBTarURL:                  "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/shopware6_db.tgz",
+			FullSiteTarballURL:        "",
+			Type:                      nodeps.AppTypeShopware6,
+			Docroot:                   "public",
+			Safe200URIWithExpectation: testcommon.URIWithExpect{URI: "/maintenance.html", Expect: "Our website is currently undergoing maintenance"},
+			DynamicURI:                testcommon.URIWithExpect{URI: "/Main-product-with-properties/SWDEMO10007.1", Expect: "Main product with properties"},
+			FilesImageURI:             "/media/2f/b0/e2/1603218072/hemd_600x600.jpg",
 		},
 		// 11: php
 		{

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -347,10 +347,10 @@ func drupal6ConfigOverrideAction(app *DdevApp) error {
 }
 
 // drupal0ConfigOverrideAction overrides php_version for D10, requires PHP8.0
-func drupal9ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP80
-	return nil
-}
+//func drupal9ConfigOverrideAction(app *DdevApp) error {
+//	app.PHPVersion = nodeps.PHP80
+//	return nil
+//}
 
 // drupal10ConfigOverrideAction overrides php_version for D10, requires PHP8.0
 func drupal10ConfigOverrideAction(app *DdevApp) error {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -346,6 +346,16 @@ func drupal6ConfigOverrideAction(app *DdevApp) error {
 	return nil
 }
 
+func drupal7ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP74
+	return nil
+}
+
+func drupal8ConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP74
+	return nil
+}
+
 // drupal0ConfigOverrideAction overrides php_version for D10, requires PHP8.0
 //func drupal9ConfigOverrideAction(app *DdevApp) error {
 //	app.PHPVersion = nodeps.PHP80

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -346,11 +346,6 @@ func drupal6ConfigOverrideAction(app *DdevApp) error {
 	return nil
 }
 
-func drupal7ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP74
-	return nil
-}
-
 func drupal8ConfigOverrideAction(app *DdevApp) error {
 	app.PHPVersion = nodeps.PHP74
 	return nil

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -2,7 +2,6 @@ package ddevapp
 
 import (
 	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
 	"path/filepath"
 )
@@ -47,7 +46,7 @@ func laravelPostStartAction(app *DdevApp) error {
 	return nil
 }
 
-func laravelConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP80
-	return nil
-}
+//func laravelConfigOverrideAction(app *DdevApp) error {
+//	app.PHPVersion = nodeps.PHP80
+//	return nil
+//}

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -167,6 +167,11 @@ func setMagento2SiteSettingsPaths(app *DdevApp) {
 	app.SiteSettingsPath = filepath.Join(app.AppRoot, app.Docroot, "..", "app", "etc", "env.php")
 }
 
+func magentoConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP74
+	return nil
+}
+
 // Latest magento2 requires php8.1
 func magento2ConfigOverrideAction(app *DdevApp) error {
 	app.PHPVersion = nodeps.PHP81

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -3,7 +3,7 @@
 package nodeps
 
 // MariaDBDefaultVersion is the default MariaDB version
-const MariaDBDefaultVersion = MariaDB103
+const MariaDBDefaultVersion = MariaDB104
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
@@ -16,6 +16,7 @@ var ValidMariaDBVersions = map[string]bool{
 	MariaDB105: true,
 	MariaDB106: true,
 	MariaDB107: true,
+	MariaDB108: true,
 }
 
 // MariaDB Versions
@@ -29,4 +30,5 @@ const (
 	MariaDB105 = "10.5"
 	MariaDB106 = "10.6"
 	MariaDB107 = "10.7"
+	MariaDB108 = "10.8"
 )

--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -12,6 +12,7 @@ var ValidMariaDBVersions = map[string]bool{
 	MariaDB105: true,
 	MariaDB106: true,
 	MariaDB107: true,
+	MariaDB108: true,
 }
 
 // MariaDB Versions
@@ -25,4 +26,5 @@ const (
 	MariaDB105 = "10.5"
 	MariaDB106 = "10.6"
 	MariaDB107 = "10.7"
+	MariaDB108 = "18.0"
 )

--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -1,7 +1,7 @@
 package nodeps
 
 // MariaDBDefaultVersion is the default MariaDB version
-const MariaDBDefaultVersion = MariaDB103
+const MariaDBDefaultVersion = MariaDB104
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -12,6 +12,7 @@ var ValidMariaDBVersions = map[string]bool{
 	MariaDB105: true,
 	MariaDB106: true,
 	MariaDB107: true,
+	MariaDB108: true,
 }
 
 // MariaDB Versions
@@ -25,4 +26,5 @@ const (
 	MariaDB105 = "10.5"
 	MariaDB106 = "10.6"
 	MariaDB107 = "10.7"
+	MariaDB108 = "10.8"
 )

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -1,7 +1,7 @@
 package nodeps
 
 // MariaDBDefaultVersion is the default MariaDB version
-const MariaDBDefaultVersion = MariaDB103
+const MariaDBDefaultVersion = MariaDB104
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{

--- a/pkg/nodeps/php_values.go
+++ b/pkg/nodeps/php_values.go
@@ -13,7 +13,7 @@ const (
 )
 
 // PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
-const PHPDefault = PHP74
+const PHPDefault = PHP80
 
 // ValidPHPVersions should be updated whenever PHP versions are added or removed, and should
 // be used to ensure user-supplied values are valid.

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -23,7 +23,7 @@ var WebTag = "v1.19.5" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "2022071_bump_php_maria"
+var BaseDBTag = "20220717_bump_php_maria"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -23,7 +23,7 @@ var WebTag = "v1.19.5" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.19.5"
+var BaseDBTag = "2022071_bump_php_maria"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Bump default PHP/MariaDB versions, add Maria 10.8

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4012"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

