### PR TITLE
Bump gitpod usage of ddev to use apt and apt-get upgrade it [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drud/ddev-gitpod-base:20220715
+image: drud/ddev-gitpod-base:20220718
 tasks:
   - name: build-run
     init: |
@@ -8,6 +8,7 @@ tasks:
       ddev debug download-images
       ddev delete -Oy tmp
       mkcert -install
+      apt-get update >/dev/null && apt-get upgrade -y >/dev/null
     command: |
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,6 @@ tasks:
       ddev debug download-images
       ddev delete -Oy tmp
       mkcert -install
-      apt-get update >/dev/null && apt-get upgrade -y >/dev/null
     command: |
       export DDEV_NONINTERACTIVE=true
       DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,7 +28,7 @@ tasks:
         ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
         ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
       fi
-      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+      gp ports await 8080 && sleep 1 && gp preview $(gp url 8080)
 
 vscode:
   extensions:

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -5,17 +5,18 @@ USER root
 
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 
-RUN apt-get update >/dev/null && sudo apt-get install -y aspell autojump file mysql-client netcat nodejs python3-pip telnet xdg-utils >/dev/null
+RUN curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
+RUN echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
+
+RUN apt-get update >/dev/null && sudo apt-get install -y aspell autojump ddev file mysql-client netcat nodejs python3-pip telnet xdg-utils >/dev/null
 
 RUN pip3 install mkdocs pyspelling pymdown-extensions
 RUN npm install -g markdownlint-cli
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.46.2
 
-RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.17.8.linux-amd64.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz && ln -s /usr/local/go/bin/go /usr/local/bin/go
+RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.18.4.linux-amd64.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 USER gitpod
-
-RUN curl -sL -o /tmp/install_ddev.sh https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash /tmp/install_ddev.sh
 
 RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" ]; then . "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh"; fi' >>~/.bashrc
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

DDEV v1.19.5 is out, need to bump gitpod image

## How this PR Solves The Problem:

Bumps it.

Also switches to using apt-get to install ddev instead of using install_ddev.sh

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4018"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

