### PR TITLE
[docs] Directly run installer script

### DIFF
--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -57,8 +57,6 @@ It's easiest to do this using gitpod (see above) because gitpod already has `doc
 
 When preparing your pull request, please use a branch name like "2020_<your_username>_short_description" so that it's easy to track to you.
 
-If you're doing a docs-only PR that does not require full testing, please add "[skip ci][ci skip]" to your commit messages; it saves a lot of testing resources.
-
 ## Docker Image changes
 
 If you make changes to a docker image (like ddev-webserver), it won't have any effect unless you:
@@ -76,8 +74,8 @@ To use `buildx` successfully you have to have the [`buildx` docker plugin](https
 To build multi-platform images you must `docker buildx create --use` as a one-time initialization.
 
 * If you just want to work locally and do a quick build for your own architecture, you can:
-    * `make VERSION=<version>`
-    * for `ddev-dbserver`: `make mariadb_10.3 VERSION=<version>` etc.
+  * `make VERSION=<version>`
+  * for `ddev-dbserver`: `make mariadb_10.3 VERSION=<version>` etc.
 
 * To push manually:
 

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -74,8 +74,8 @@ To use `buildx` successfully you have to have the [`buildx` docker plugin](https
 To build multi-platform images you must `docker buildx create --use` as a one-time initialization.
 
 * If you just want to work locally and do a quick build for your own architecture, you can:
-  * `make VERSION=<version>`
-  * for `ddev-dbserver`: `make mariadb_10.3 VERSION=<version>` etc.
+    * `make VERSION=<version>`
+    * for `ddev-dbserver`: `make mariadb_10.3 VERSION=<version>` etc.
 
 * To push manually:
 

--- a/docs/content/users/basics/faq.md
+++ b/docs/content/users/basics/faq.md
@@ -102,7 +102,7 @@ How can I install a specific version of DDEV?
 : If you want to use a different version of DDEV, you easily get a different version. If you're using homebrew, `brew unlink ddev` first, to get rid of the version you have there. Then use one of these options:
 
     1. Download the version you want from the [releases page](https://github.com/drud/ddev/releases) and place it somewhere in your `$PATH`.
-    2. Use the [install_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, use `curl -LsS https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.18.3-alpha1`
+    2. Use the [install_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, use `curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.18.3-alpha1`
     3. If you want the very latest, unreleased version of ddev, use `brew unlink ddev && brew install drud/ddev/ddev --HEAD`.
 
 How can I back up or restore all databases of all projects?

--- a/docs/content/users/basics/faq.md
+++ b/docs/content/users/basics/faq.md
@@ -102,7 +102,7 @@ How can I install a specific version of DDEV?
 : If you want to use a different version of DDEV, you easily get a different version. If you're using homebrew, `brew unlink ddev` first, to get rid of the version you have there. Then use one of these options:
 
     1. Download the version you want from the [releases page](https://github.com/drud/ddev/releases) and place it somewhere in your `$PATH`.
-    2. Use the [install_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, use `curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v1.18.3-alpha1`
+    2. Use the [install_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, use `curl -LsS https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.18.3-alpha1`
     3. If you want the very latest, unreleased version of ddev, use `brew unlink ddev && brew install drud/ddev/ddev --HEAD`.
 
 How can I back up or restore all databases of all projects?

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -98,7 +98,7 @@ Docker or an alternative is required before anything will work with DDEV. This i
     10. Check that docker is working inside Ubuntu (or your distro): `docker ps`
     11. Optional: If you prefer to use the *traditional Windows* ddev instead of working inside WSL2, install it with `choco install -y ddev`. The Windows ddev works fine with the WSL2-based Docker engine. However, the WSL2 ddev setup is vastly preferable and at least 10 times as fast. Support for the traditional Windows approach will eventually be dropped.
     12. Open the WSL2 terminal, for example `Ubuntu` from the Windows start menu.
-    13. Install `ddev` with `curl -LsS https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | sudo bash`
+    13. Install `ddev` with `curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | sudo bash`
     14. `sudo apt-get update && sudo apt-get install -y certutil xdg-utils` to install the `xdg-utils` package that allows `ddev launch` to work.
     15. In WSL2 run `mkcert -install`.
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -98,7 +98,7 @@ Docker or an alternative is required before anything will work with DDEV. This i
     10. Check that docker is working inside Ubuntu (or your distro): `docker ps`
     11. Optional: If you prefer to use the *traditional Windows* ddev instead of working inside WSL2, install it with `choco install -y ddev`. The Windows ddev works fine with the WSL2-based Docker engine. However, the WSL2 ddev setup is vastly preferable and at least 10 times as fast. Support for the traditional Windows approach will eventually be dropped.
     12. Open the WSL2 terminal, for example `Ubuntu` from the Windows start menu.
-    13. Install `ddev` with `curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | sudo bash`
+    13. Install `ddev` with `curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash`
     14. `sudo apt-get update && sudo apt-get install -y certutil xdg-utils` to install the `xdg-utils` package that allows `ddev launch` to work.
     15. In WSL2 run `mkcert -install`.
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -19,7 +19,7 @@ Docker or an alternative is required before anything will work with DDEV. This i
     Use this line on your terminal to download, verify, and install (or upgrade) ddev using the [install_ddev.sh script](https://github.com/drud/ddev/blob/master/scripts/install_ddev.sh). Note that this works with both amd64 and arm64 architectures, including Surface Pro X with WSL2 and 64-bit Raspberry Pi OS. It also works with macOS Apple Silicon M1 machines.
 
     ```
-    curl -LsS https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash
     ```
 
     The installation script can also take a version argument in order to install a specific version or a prerelease version. For example,

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -25,7 +25,7 @@ Docker or an alternative is required before anything will work with DDEV. This i
     The installation script can also take a version argument in order to install a specific version or a prerelease version. For example,
 
     ```
-    curl -LsS https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.19.2
+    curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.19.2
     ```
 
     To upgrade DDEV to the latest stable version, just run the script again.

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -19,13 +19,13 @@ Docker or an alternative is required before anything will work with DDEV. This i
     Use this line on your terminal to download, verify, and install (or upgrade) ddev using the [install_ddev.sh script](https://github.com/drud/ddev/blob/master/scripts/install_ddev.sh). Note that this works with both amd64 and arm64 architectures, including Surface Pro X with WSL2 and 64-bit Raspberry Pi OS. It also works with macOS Apple Silicon M1 machines.
 
     ```
-    curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh
+    curl -LsS https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash
     ```
 
     The installation script can also take a version argument in order to install a specific version or a prerelease version. For example,
 
     ```
-    curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v1.19.2
+    curl -LsS https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.19.2
     ```
 
     To upgrade DDEV to the latest stable version, just run the script again.
@@ -98,7 +98,7 @@ Docker or an alternative is required before anything will work with DDEV. This i
     10. Check that docker is working inside Ubuntu (or your distro): `docker ps`
     11. Optional: If you prefer to use the *traditional Windows* ddev instead of working inside WSL2, install it with `choco install -y ddev`. The Windows ddev works fine with the WSL2-based Docker engine. However, the WSL2 ddev setup is vastly preferable and at least 10 times as fast. Support for the traditional Windows approach will eventually be dropped.
     12. Open the WSL2 terminal, for example `Ubuntu` from the Windows start menu.
-    13. Install `ddev` with `curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh`
+    13. Install `ddev` with `curl -LsS https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | sudo bash`
     14. `sudo apt-get update && sudo apt-get install -y certutil xdg-utils` to install the `xdg-utils` package that allows `ddev launch` to work.
     15. In WSL2 run `mkcert -install`.
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

The current instructions on how to use the installer script all relay on downloading the script which can make troubles in case of changes in the master which then are ignored locally.

## How this PR Solves The Problem:

The new instruction directly passes the script to bash via pipe and avoids issues with deprecated and incompatible locally saved scripts.

## Manual Testing Instructions:

Follow the instructions changed by this PR to check if it works.

## Automated Testing Overview:

None

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4023"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

