### PR TITLE
Improve release with goreleaser cleanups, fixes #4021

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -211,6 +211,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          FURY_ACCOUNT: ${{ secrets.FURY_ACCOUNT }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -320,4 +320,4 @@ aurs:
     email: randy@randyfay.com
 
 furies:
-- account: drud
+- account: "{{ .Env.FURY_ACCOUNT }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -245,6 +245,8 @@ nfpms:
       dependencies:
       - libnss3-tools
       - xdg-utils
+      replaces:
+      - mkcert
     rpm:
       dependencies:
       - nss-tools

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,10 +11,10 @@ builds:
   - amd64
   - arm64
   goamd64:
-    - v1
+  - v1
   ignore:
-    - goos: windows
-      goarch: arm64
+  - goos: windows
+    goarch: arm64
   prebuilt:
     path: .gotmp/bin/{{.Os}}_{{.Arch}}/ddev{{.Ext}}
   binary: ddev
@@ -61,6 +61,9 @@ builds:
   - amd64
   goamd64:
   - v1
+  ignore:
+  - goos: windows
+    goarch: arm64
   prebuilt:
     path: .gotmp/bin/completions/ddev_bash_completion.sh
   binary: ddev_bash_completion.sh
@@ -77,6 +80,9 @@ builds:
   - amd64
   goamd64:
   - v1
+  ignore:
+  - goos: windows
+    goarch: arm64
   prebuilt:
     path: .gotmp/bin/completions/ddev_zsh_completion.sh
   binary: ddev_zsh_completion.sh
@@ -93,6 +99,9 @@ builds:
   - amd64
   goamd64:
   - v1
+  ignore:
+  - goos: windows
+    goarch: arm64
   prebuilt:
     path: .gotmp/bin/completions/ddev_fish_completion.sh
   binary: ddev_fish_completion.sh
@@ -107,7 +116,7 @@ builds:
   - v1
   prebuilt:
     path: .gotmp/bin/windows_amd64/ddev_windows_installer.exe
-  binary: ddev-windows-installer.exe
+  binary: ddev-windows-installer
 
 ###### Archives ######
 archives:
@@ -128,12 +137,11 @@ archives:
   wrap_in_directory: false
   files:
   - LICENSE
-  - .gotmp/bin/{{.Os}}_{{.Arch}}/mkcert*
   allow_different_binary_count: true
 
 - id: completions-tarball
   builds:
-  - completions
+  - completions-tarball
   format: binary
   name_template: ddev_shell_completion_scripts.v{{.Version}}.tar.gz
 

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -17,7 +17,11 @@ The following "Repository secret" environment variables must be added to <https:
 
 * `DDEV_WINDOWS_SIGNING_PASSWORD`: The windows signing password.
 
-* `SegmentKey`: The key that enabled the Segment reporting
+* `SegmentKey`: The key that enabled the Segment reporting.
+
+* `FURY_ACCOUNT`: The account at fury.io to push the packages to.
+
+* `FURY_TOKEN`: The push token assigned to the fury account above.
 
 ## Creating a release (almost everything is now automated)
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

- `.gotmp` was accidentially added to the tarballs
- arm64 is not applicable for Windows
- Fury account is hardcoded
- completion scripts are missing in the release
- conflict with `mkcert` package on Debian 12 and Ubuntu 22 - #4021 

## How this PR Solves The Problem:

This patch addresses the above mentioned issues and solves them properly.

The replace of mkcert is a temporary solution and should be removed and replaced by a conflict once the mkcert package is available in stable releases.

## Manual Testing Instructions:

A test release can be found at https://github.com/gilbertsoft/ddev/releases/tag/v1.19.6-alpha.2.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4027"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

