### PR TITLE
Fix typo in mariadb values for 10.8 arm64

### DIFF
--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -26,5 +26,5 @@ const (
 	MariaDB105 = "10.5"
 	MariaDB106 = "10.6"
 	MariaDB107 = "10.7"
-	MariaDB108 = "18.0"
+	MariaDB108 = "10.8"
 )


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/drud/ddev/pull/4012 introduced a bug/typo, for arm64 macOS only, that didn't use mariadb 10.8, but instead 18.0. This didn't get caught because on arm64 we don't have a complete set of GOTEST_SHORT tests.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4031"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

