### PR TITLE
Skip option validation for composer create-project

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -154,6 +154,9 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 // when they try ddev composer create-project
 var ComposerCreateProjectCmd = &cobra.Command{
 	Use: "create-project",
+	FParseErrWhitelist: cobra.FParseErrWhitelist{
+		UnknownFlags: true,
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		util.Failed(`'ddev composer create-project' is unsupported. Please use 'ddev composer create'
 for basic project creation or 'ddev ssh' into the web container and execute


### PR DESCRIPTION
## The Problem/Issue/Bug:

If `ddev composer create-project` is called with an option the message about the usage of `ddev composer create` instead is not shown but an error about an unknown option.

The issue poped up in this DDEV Discord thread https://discord.com/channels/664580571770388500/999382823033118801.

## How this PR Solves The Problem:

This PR enforces to skip the option validation and shows the correct message in any case.

## Manual Testing Instructions:

Run e.g. `ddev composer create-project -s centarro/commerce-kickstart-project kickstart` which will show the correct message about the correct usage with `ddev composer create` now.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4033"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

