### PR TITLE
GetComposerRoot uses relative path to working_dir, should be approot

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -398,7 +398,7 @@ func (app *DdevApp) GetComposerRoot(inContainer, showWarning bool) string {
 	basePath := ""
 
 	if inContainer {
-		basePath = app.DefaultWorkingDirMap()["web"]
+		basePath = "/var/www/html"
 	} else {
 		basePath = app.AppRoot
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* @joelpittet discovered in https://discord.com/channels/664580571770388500/999439336267333743 that `composer_root` was ending up relative to the `working_dir` instead of relative to the project root, as described in the docs.
* Only Drupal6 and Drupal7 have a default `working_dir` that is not the project root, so this hadn't seemed to affect anybody, and composer is not commonly used on Drupal7.
* The work to add composer_root was done in https://github.com/drud/ddev/pull/3654

## How this PR Solves The Problem:

Make the composer_root relative to project root, not to working_dir

## Manual Testing Instructions:

- [ ] Create a Drupal 7 project with `composer.json` not in the root.  (Can be another type of project with working_dir set)
- [ ] `ddev composer install` should work.

## Automated Testing Overview:

No changes



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4038"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

