### PR TITLE
Custom command for Craft CMS "craft" utility

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -4,7 +4,7 @@
 ## Description: Run Craft CMS command inside the web container
 ## Usage: craft [flags] [args]
 ## Example: "ddev craft db/backup" or "craft db/backup ./my-backups" (see https://craftcms.com/docs/4.x/console-commands.html)
-## ProjectTypes: craftcms
+## ProjectTypes: php
 ## ExecRaw: true
 
 php ./craft "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#ddev-generated
+## Description: Run Craft CMS commands inside the web container
+## Usage: craft [flags] [args]
+## Example: "ddev craft db/backup" or "craft db/backup ./my-backups" (see https://craftcms.com/docs/4.x/console-commands.html)
+## ProjectTypes: craftcms
+## ExecRaw: true
+
+php ./craft "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #ddev-generated
-## Description: Run Craft CMS commands inside the web container
+## Description: Run Craft CMS command inside the web container
 ## Usage: craft [flags] [args]
 ## Example: "ddev craft db/backup" or "craft db/backup ./my-backups" (see https://craftcms.com/docs/4.x/console-commands.html)
 ## ProjectTypes: craftcms


### PR DESCRIPTION
## The Problem/Issue/Bug:

Running Craft CMS commands requires one of the following syntaxes, which is fine but somewhat verbose.

```shell
ddev exec php craft

ddev exec ./craft
```

## How this PR Solves The Problem:

This PR adds a new `craft` convenience command so that running the command is less verbose.

```shell
ddev craft
```

## Manual Testing Instructions:

Running `ddev craft` should show the help text for `craft`.

## Release/Deployment notes:

This is a small step in getting better support for Craft CMS in DDEV. I have added it for the `php` project type, which may be too broad. It is my hope that @pixelandtonic team will consider submitting (or perhaps are already working on) a complete Craft CMS project type for DDEV in due course.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4040"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

