### PR TITLE
Give more error info on bin/magento failure

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/magento
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/magento
@@ -8,8 +8,8 @@
 ## ExecRaw: true
 
 if ! command -v bin/magento >/dev/null; then
-  echo 'bin/magento is not available in your installation.'
-  echo 'Please verify that you installed the shop in your working dir.'
+  echo 'bin/magento is not available in your installation or if it is maybe it is not executable, fix with chmod +x bin/magento.'
+  echo 'Please verify that you installed the shop in your project directory.'
   exit 1
 fi
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/magento
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/magento
@@ -7,10 +7,10 @@
 ## ProjectTypes: magento2
 ## ExecRaw: true
 
-if ! command -v bin/magento >/dev/null; then
-  echo 'bin/magento is not available in your installation or if it is maybe it is not executable, fix with chmod +x bin/magento.'
+if [ ! -f bin/magento ]; then
+  echo 'bin/magento does not exist in your project root directory.'
   echo 'Please verify that you installed the shop in your project directory.'
   exit 1
 fi
 
-bin/magento "$@"
+php bin/magento "$@"


### PR DESCRIPTION
## The Problem/Issue/Bug:

People sometimes have the magento command not executable and then they get an error from `ddev magento`

## How this PR Solves The Problem:

Prompt them about this possibility

## Manual Testing Instructions:

- [x] Make sure `ddev magento` works fine
- [x] `chmod -ugo-x bin/magento` and `ddev magento` - you should see the changed error prompt.

See discord conversation, https://discord.com/channels/664580571770388500/1001062475065724989

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4041"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

