### PR TITLE
Updating the link to the logos, fixes #4034

### DIFF
--- a/docs/content/developers/styleguide.md
+++ b/docs/content/developers/styleguide.md
@@ -8,12 +8,10 @@
 
 You can find a set of DDEV logos [here](https://github.com/drud/ddev/tree/master/docs/content/developers/logos).
 
-If possible, use the SVG version of the logo, as a vector graphic is independent of the resolution and gives the best
-results regardless of the pixel density of the display.
+If possible, use the [SVG version](https://github.com/drud/ddev/tree/master/docs/content/developers/logos/SVG) of the logo, as a vector graphic is independent of the resolution and gives the best results regardless of the pixel density of the display.
 
-If the SVG format is not supported, you can use the exported PNG versions of the logo. Use @2x, @3x, and @4x for high
-pixel density displays. Many applications support @2x annotations in the image path and automatically choose the correct
-image for the display in use.
+If the SVG format is not supported, you can use the exported PNG versions of the logo. Use [@2x](https://github.com/drud/ddev/tree/master/docs/content/developers/logos/2x), [@3x](https://github.com/drud/ddev/tree/master/docs/content/developers/logos/3x), and [@4x](https://github.com/drud/ddev/tree/master/docs/content/developers/logos/4x) for high
+pixel density displays. Many applications support [@2x](https://github.com/drud/ddev/tree/master/docs/content/developers/logos/2x) annotations in the image path and automatically choose the correct image for the display in use.
 
 Currently there is no prepared version for dark backgrounds of the word/figurative mark.
 

--- a/docs/content/developers/styleguide.md
+++ b/docs/content/developers/styleguide.md
@@ -6,7 +6,7 @@
 |-----------------------------------------|------------------------------------------------|
 | ![Figurative Mark](logos/1x/Logo.png) | ![Figurative Mark](logos/1x/Logo_w_text.png) |
 
-You can find a set of DDEV logos [here](logos).
+You can find a set of DDEV logos [here](https://github.com/drud/ddev/tree/master/docs/content/developers/logos).
 
 If possible, use the SVG version of the logo, as a vector graphic is independent of the resolution and gives the best
 results regardless of the pixel density of the display.


### PR DESCRIPTION
## The Problem/Issue/Bug: Broken logo link

## How this PR Solves The Problem: 
Update the link to https://github.com/drud/ddev/tree/master/docs/content/developers/logos

## Manual Testing Instructions: Check the link works!

## Automated Testing Overview:
N/A
## Related Issue Link(s):
Fixes #4034 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4048"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

