### PR TITLE
Add NODE_EXTRA_CA_CERTS to web container, fixes #4032

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -193,6 +193,7 @@ services:
     - LINES
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history
     - MYSQL_PWD=db
+    - NODE_EXTRA_CA_CERTS=/mnt/ddev-global-cache/mkcert/rootCA.pem
     - PGDATABASE=db
     - PGHOST=db
     - PGPASSWORD=db


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4032

## How this PR Solves The Problem:

Add the suggested env var inside container

## Manual Testing Instructions:

- [x] `ddev exec 'echo $NODE_EXTRA_CA_CERTS'`
- [x] Try this script inside container, call it try.js; change the target URL. From https://stackoverflow.com/a/48729712/215713. it should work with `ddev exec node try.js`, but if you `ddev ssh` and `unset NODE_EXTRA_CA_CERTS` it should fail when running it there with `node try.js`
```js
const getScript = (url) => {
    return new Promise((resolve, reject) => {
        const http      = require('http'),
              https     = require('https');

        let client = http;

        if (url.toString().indexOf("https") === 0) {
            client = https;
        }

        client.get(url, (resp) => {
            let data = '';

            // A chunk of data has been recieved.
            resp.on('data', (chunk) => {
                data += chunk;
            });

            // The whole response has been received. Print out the result.
            resp.on('end', () => {
                resolve(data);
            });

        }).on("error", (err) => {
            reject(err);
        });
    });
};

(async (url) => {
    console.log(await getScript(url));
})('https://d9.ddev.site/');
```

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4049"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

