### PR TITLE
[docs] Fix broken link, fixes #4044

### DIFF
--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -91,7 +91,7 @@ yaml_read_files:
 
 then `value1` can be used throughout the `install.yaml` as `{{ example.value1 }}` and it will be replaced with the value `xxx`.
 
-More exotic template-based replacements can be seen in advanced test [example](../../../../cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/install.yaml).
+More exotic template-based replacements can be seen in advanced test [example](https://github.com/drud/ddev/blob/master/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/install.yaml).
 
 ## Additional services in ddev-contrib (MongoDB, Elasticsearch, etc)
 


### PR DESCRIPTION
## The Problem/Issue/Bug: See #4044 

## How this PR Solves The Problem: 
Replaces the relative link with a direct link to https://github.com/drud/ddev/blob/master/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/install.yaml

## Manual Testing Instructions: 
Check the link works in the ["Additional Service Configurations and Add-ons for ddev"](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/) page,

Section ["Template action replacements (advanced)"](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/#template-action-replacements-advanced),

the link to "advanced test example".

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s): 
fixes #4044 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4050"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

