### PR TITLE
Persist yarn and npm caches, clean up ddev-global-config on delete, add $USER  to web env, fixes #3666

### DIFF
--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -11,7 +11,7 @@ var DebugCapabilitiesCmd = &cobra.Command{
 	Use:   "capabilities",
 	Short: "Show capabilities of this version of ddev",
 	Run: func(cmd *cobra.Command, args []string) {
-		capabilities := []string{"multiple-dockerfiles", "interactive-project-selection", "ddev-get-yaml-interpolation", "config-star-yaml-merging", "pre-dockerfile-insertion"}
+		capabilities := []string{"multiple-dockerfiles", "interactive-project-selection", "ddev-get-yaml-interpolation", "config-star-yaml-merging", "pre-dockerfile-insertion", "user-env-var", "npm-yarn-caching"}
 		output.UserOut.WithField("raw", capabilities).Print(strings.Join(capabilities, "\n"))
 	},
 }

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -58,7 +58,7 @@ a2enmod access_compat alias auth_basic authn_core authn_file authz_core authz_ho
 a2enconf charset localized-error-pages other-vhosts-access-log security serve-cgi-bin
 
 if [ "$DDEV_WEBSERVER_TYPE" = "apache-fpm" ] ; then
-    a2enmod proxy_fcgi 
+    a2enmod proxy_fcgi
     a2enconf php${DDEV_PHP_VERSION}-fpm
     a2dissite 000-default
 fi
@@ -78,11 +78,14 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
+set -x
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory,nvm_dir,npm/${HOSTNAME},yarn/${HOSTNAME}}
-yarn config set cache-folder/m nt/ddev-global-config/yarn/${HOSTNAME}
-npm config set cache /mnt/ddev-global-config/npm/${HOSTNAME}
-
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
+yarn config set cache-folder /mnt/ddev-global-cache/yarn/${HOSTNAME}
+npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME}
+
+set +x
+
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -78,7 +78,10 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
-sudo mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory,nvm_dir}/${HOSTNAME}
+sudo mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory,nvm_dir,npm/${HOSTNAME},yarn/${HOSTNAME}}
+yarn config set cache-folder/m nt/ddev-global-config/yarn/${HOSTNAME}
+npm config set cache /mnt/ddev-global-config/npm/${HOSTNAME}
+
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -78,7 +78,7 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
-sudo mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory,nvm_dir,npm/${HOSTNAME},yarn/${HOSTNAME}}
+sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm/${HOSTNAME},yarn/${HOSTNAME}}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 yarn config set cache-folder /mnt/ddev-global-cache/yarn/${HOSTNAME}
 npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME}

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -78,13 +78,10 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
-set -x
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory,nvm_dir,npm/${HOSTNAME},yarn/${HOSTNAME}}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 yarn config set cache-folder /mnt/ddev-global-cache/yarn/${HOSTNAME}
 npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME}
-
-set +x
 
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -58,7 +58,7 @@ a2enmod access_compat alias auth_basic authn_core authn_file authz_core authz_ho
 a2enconf charset localized-error-pages other-vhosts-access-log security serve-cgi-bin
 
 if [ "$DDEV_WEBSERVER_TYPE" = "apache-fpm" ] ; then
-    a2enmod proxy_fcgi 
+    a2enmod proxy_fcgi
     a2enconf php${DDEV_PHP_VERSION}-fpm
     a2dissite 000-default
 fi
@@ -75,9 +75,12 @@ disable_xhprof
 
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
-mkdir -p /mnt/ddev-global-cache/{bashhistory,mysqlhistory,nvm_dir}/${HOSTNAME}
+mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm/${HOSTNAME} yarn/${HOSTNAME}}
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
+
+yarn config set cache-folder /mnt/ddev-global-cache/yarn/${HOSTNAME}
+npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME}
 
 # chown of ddev-global-cache must be done with privileged container in app.Start()
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -68,6 +68,7 @@ services:
       - POSTGRES_USER=db
       - POSTGRES_DB=db
       - TZ={{ .Timezone }}
+      - USER={{ .Username }}
     command: ${DDEV_DB_CONTAINER_COMMAND}
     healthcheck:
       {{ if eq .DBType "postgres" }}
@@ -201,6 +202,7 @@ services:
     - PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}
     - SSH_AUTH_SOCK=/home/.ssh-agent/socket
     - TZ={{ .Timezone }}
+    - USER={{ .Username }}
     - VIRTUAL_HOST=${DDEV_HOSTNAME}
     {{ range $env := .WebEnvironment }}- "{{ $env }}"
     {{ end }}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2141,14 +2141,14 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	// If project is running, clean up ddev-global-cache
 	if status == SiteRunning && removeData {
 		_, _, err = app.Exec(&ExecOpts{
-			Cmd: "rm -rf /mnt/ddev-global-cache/{bashhistory,npm,nvm_dir,yarn}/${HOSTNAME}",
+			Cmd: "rm -rf /mnt/ddev-global-cache/*/${HOSTNAME}",
 		})
 		if err != nil {
 			util.Warning("Unable to clean up ddev-global-cache: %v", err)
 		}
 		if nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 			_, _, err = app.Exec(&ExecOpts{
-				Cmd:     "rm -rf /mnt/ddev-global-cache/mysqlhistory/${HOSTNAME}",
+				Cmd:     "rm -rf /mnt/ddev-global-cache/*/${HOSTNAME}",
 				Service: "db",
 			})
 			if err != nil {

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -1,7 +1,6 @@
 package ddevapp_test
 
 import (
-	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
@@ -42,12 +41,6 @@ func TestNodeJSVersions(t *testing.T) {
 
 	err = app.Start()
 	require.NoError(t, err)
-	// As of v1.19.0, the nvm_dir doesn't get cleaned up on delete,
-	//so on a machine where this test has run before this will fail, as nvm has been set up
-	_, _, err = app.Exec(&ddevapp.ExecOpts{
-		Cmd: fmt.Sprintf("rm -rf /mnt/ddev-global-cache/nvm_dir/%s-web", site.Name),
-	})
-	assert.NoError(err)
 
 	for _, v := range nodeps.GetValidNodeVersions() {
 		app.NodeJSVersion = v

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220722_yq_bump" // Note that this can be overridden by make
+var WebTag = "20220728_npm_yarn_cache" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Although we've been caching composer forever, yarn and npm caches were not persisted.
* $USER environment variable wasn't in containers
* #3666 ddev delete needs to clean up ddev-global-config when it runs

## How this PR Solves The Problem:

Do those things

## Manual Testing Instructions:

- [x] `ddev exec 'echo $USER'` should show user
- [x] `ddev npm install` should result in cached stuff in `/mnt/ddev-global-cache/npm/<hostname>`
- [x] `ddev yarn install` should result in cached stuff in `/mnt/ddev-global-cache/yarn/<hostname>`
- [x] `ddev delete -Oy` should clean up all host things in /mnt/ddev-global-cache, including bash history, yarn, npm, etc.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4051"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

