### PR TITLE
Bump docker-compose to 2.7.0

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -562,7 +562,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.5.1"
+var RequiredDockerComposeVersion = "v2.7.0"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Problem/Issue/Bug:

Current version of docker-compose is 2.7.0

## How this PR Solves The Problem:

Bump it and see if it works.

## Manual Testing Instructions:

If it passes automated tests it's probably fine.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4052"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

