### PR TITLE
ddev get <item> should run with project running, to avoid mutagen problems

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/Masterminds/sprig/v3"
 	"github.com/drud/ddev/pkg/archive"
+	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
@@ -142,6 +143,15 @@ ddev get --list --all
 			}
 			defer cleanup()
 		}
+
+		// Automatically start, as we don't want to be taking actions with mutagen off, for example.
+		if status, _ := app.SiteStatus(); status != ddevapp.SiteRunning {
+			err = app.Start()
+			if err != nil {
+				util.Failed("Failed to start app %s to ddev-get: %v", app.Name, err)
+			}
+		}
+
 		yamlFile := filepath.Join(extractedDir, "install.yaml")
 		yamlContent, err := fileutil.ReadFileIntoString(yamlFile)
 		if err != nil {


### PR DESCRIPTION

## The Problem/Issue/Bug:

If you use `ddev get <something>` with a stopped project, it can confuse mutagen by making changes when it's not running, and then reconciliation can do strange things when you start.

## How this PR Solves The Problem:

Start the project before getting/changing files.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4054"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

