### PR TITLE
Allow proxying arbitrary ports and starting daemons, more explicit nodejs support, fixes #3456

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -173,6 +173,7 @@ blackfire
 bool
 breakpoint
 browser
+browsersync
 bugfix
 bugfixes
 buildkite

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -538,6 +538,7 @@ subdirectory
 subdirectories
 subfield
 sudo
+supervisord
 sur
 susi
 svg

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -214,6 +214,7 @@ cron
 cson
 current
 customizations
+daemonize
 data
 database
 db

--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -11,7 +11,7 @@ var DebugCapabilitiesCmd = &cobra.Command{
 	Use:   "capabilities",
 	Short: "Show capabilities of this version of ddev",
 	Run: func(cmd *cobra.Command, args []string) {
-		capabilities := []string{"multiple-dockerfiles", "interactive-project-selection", "ddev-get-yaml-interpolation", "config-star-yaml-merging", "pre-dockerfile-insertion", "user-env-var", "npm-yarn-caching"}
+		capabilities := []string{"multiple-dockerfiles", "interactive-project-selection", "ddev-get-yaml-interpolation", "config-star-yaml-merging", "pre-dockerfile-insertion", "user-env-var", "npm-yarn-caching", "exposed-ports-configuration", "daemon-run-configuration"}
 		output.UserOut.WithField("raw", capabilities).Print(strings.Join(capabilities, "\n"))
 	},
 }

--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -11,7 +11,16 @@ var DebugCapabilitiesCmd = &cobra.Command{
 	Use:   "capabilities",
 	Short: "Show capabilities of this version of ddev",
 	Run: func(cmd *cobra.Command, args []string) {
-		capabilities := []string{"multiple-dockerfiles", "interactive-project-selection", "ddev-get-yaml-interpolation", "config-star-yaml-merging", "pre-dockerfile-insertion", "user-env-var", "npm-yarn-caching", "exposed-ports-configuration", "daemon-run-configuration"}
+		capabilities := []string{
+			"multiple-dockerfiles",
+			"interactive-project-selection",
+			"ddev-get-yaml-interpolation",
+			"config-star-yaml-merging",
+			"pre-dockerfile-insertion",
+			"user-env-var",
+			"npm-yarn-caching",
+			"exposed-ports-configuration",
+			"daemon-run-configuration"}
 		output.UserOut.WithField("raw", capabilities).Print(strings.Join(capabilities, "\n"))
 	},
 }

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -185,6 +185,11 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			}
 			t.AppendRow(table.Row{"Mailhog", "", fmt.Sprintf("MailHog: %s\n`ddev launch -m`", mailhogURL)})
 
+			//WebExtraExposedPorts stanza
+			for _, extraPort := range app.WebExtraExposedPorts {
+				t.AppendRow(table.Row{extraPort.Name, "", fmt.Sprintf("InDocker: localhost:%d https://%s:%d http://%s:%d", extraPort.WebContainerPort, app.GetHostname(), extraPort.HTTPSPort, app.GetHostname(), extraPort.HTTPPort)})
+			}
+
 			// All URLs stanza
 			_, _, urls := app.GetAllURLs()
 			s := strings.Join(urls, ", ")

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -175,6 +175,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 		}
 
 		if !ddevapp.IsRouterDisabled(app) {
+			// MailHog stanza
 			mailhogURL := ""
 			if _, ok := desc["mailhog_url"]; ok {
 				mailhogURL = desc["mailhog_url"].(string)
@@ -182,8 +183,9 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			if _, ok := desc["mailhog_https_url"]; ok {
 				mailhogURL = desc["mailhog_https_url"].(string)
 			}
-
 			t.AppendRow(table.Row{"Mailhog", "", fmt.Sprintf("MailHog: %s\n`ddev launch -m`", mailhogURL)})
+
+			// All URLs stanza
 			_, _, urls := app.GetAllURLs()
 			s := strings.Join(urls, ", ")
 			urlString := text.WrapSoft(s, int(urlPortWidth))

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/conf.d/supervisor.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/conf.d/supervisor.conf
@@ -8,3 +8,10 @@ nodaemon=false               ; (start in foreground if true;default false)
 command=/usr/local/bin/kill_supervisor.py
 process_name=child_exit_monitor
 events=PROCESS_STATE_FATAL,PROCESS_STATE_EXITED
+
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/conf.d/supervisor.conf
+++ b/containers/ddev-webserver/ddev-webserver-prod-files/etc/supervisor/conf.d/supervisor.conf
@@ -8,3 +8,10 @@ nodaemon=false               ; (start in foreground if true;default false)
 command=/usr/local/bin/kill_supervisor.py
 process_name=child_exit_monitor
 events=PROCESS_STATE_FATAL,PROCESS_STATE_EXITED
+
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -1,3 +1,4 @@
+
 # Additional Service Configurations and Add-ons for ddev
 
 DDEV-Local projects can be extended to provide additional add-ons, including services. This is achieved by adding docker-compose files to a project's `.ddev` directory that defines the added add-on(s).
@@ -98,9 +99,7 @@ More exotic template-based replacements can be seen in advanced test [example](h
 Commonly used services will be migrated from the ddev-contrib repository to individual, tested, supported repositories, but
  [ddev-contrib](https://github.com/drud/ddev-contrib) repository has a wealth of additional examples and instructions:
 
-* **ElasticHQ**:See [ElasticHQ](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/elastichq).
 * **Headless Chrome**: See [Headless Chrome for Behat Testing](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/headless-chrome)
-* **MongoDB**: See [MongoDB](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/mongodb).
 * **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/old_php)
 * **RabbitMQ**: See [RabbitMQ](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
 * **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/typo3-solr)

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -22,6 +22,25 @@ A collection of vetted service configurations is available in the [Additional Se
 
 If you need to create a service configuration for your project, see [Defining an additional service with Docker Compose](custom-compose-files.md)
 
+## Running extra daemons in the web container
+
+If you need extra daemons to start up automatically inside the web container, you can easily add them using `web_extra_daemons` in `.ddev/config.yaml`. 
+
+You might be running node daemons that serve a particular purpose (like browsersync) or daemons like a cron daemon, etc.
+
+For example, you could use this configuration to run two instances of the nodejs http-server serving different directories:
+
+```yaml
+web_extra_daemons:
+  - name: "http-1"
+    command: "node_modules/.bin/http-server -p 3000"
+    directory: /var/www/html
+  - name: "http-2"
+    command: "node_modules/.bin/http-server /var/www/html/sub -p 3000"
+    directory: /var/www/html
+```
+
+
 ## Exposing extra ports via ddev-router
 
 If your web container has additional HTTP servers running inside it on different ports, those can be exposed using `web_extra_exposed_ports` in `.ddev/config.yaml`. For example, this configuration would expose a `node-vite` HTTP server running on port 3000 inside the web container via ddev-router to ports 9998 (http) and 9999 (https), so it could be accessed via `https://<project>.ddev.site:9999`:

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -24,7 +24,7 @@ If you need to create a service configuration for your project, see [Defining an
 
 ## Running extra daemons in the web container
 
-If you need extra daemons to start up automatically inside the web container, you can easily add them using `web_extra_daemons` in `.ddev/config.yaml`. 
+If you need extra daemons to start up automatically inside the web container, you can easily add them using `web_extra_daemons` in `.ddev/config.yaml`.
 
 You might be running node daemons that serve a particular purpose (like browsersync) or daemons like a cron daemon, etc.
 
@@ -39,7 +39,6 @@ web_extra_daemons:
     command: "node_modules/.bin/http-server /var/www/html/sub -p 3000"
     directory: /var/www/html
 ```
-
 
 ## Exposing extra ports via ddev-router
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -35,6 +35,7 @@ web_extra_exposed_ports:
 ```
 
 The configuration below would expose a nodejs server running in the web container on port 3000 as `https://<project>.ddev.site:4000` and a "something" server running in the web container on port 4000 as `https://<project>.ddev.site:4000`:
+
 ```yaml
 web_extra_exposed_ports:
   - name: nodejs
@@ -46,6 +47,7 @@ web_extra_exposed_ports:
     https_port: 4000
     http_port: 3999
 ```
+
 ## Providing custom environment variables to a container
 
 Custom environment variables may be set in the project config.yaml or the ~/.ddev/global_config.yaml with the `web_environment` key, for example

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -267,4 +267,4 @@ And create a `.ddev/web-build/Dockerfile.<daemonname>` to install the config fil
 ADD daemonname.conf /etc/supervisor/conf.d
 ```
 
-Full details for advanced configuration possibilities are in [supervisor docs](http://supervisord.org/configuration.html).
+Full details for advanced configuration possibilities are in [supervisor docs](http://supervisord.org/configuration.html#program-x-section-settings).

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -24,7 +24,7 @@ If you need to create a service configuration for your project, see [Defining an
 
 ## Using nodejs with DDEV
 
-There are many, many ways to deploy nodejs in any project, so DDEV tries to let you set up any possiblity you can come up with.
+There are many, many ways to deploy nodejs in any project, so DDEV tries to let you set up any possibility you can come up with.
 
 * You can choose the nodejs version you want to use in `.ddev/config.yaml` with `nodejs_version`
 * `ddev nvm` gives you the full capabilities of nvm.
@@ -39,7 +39,7 @@ Please share your techniques using the many ways to share. Best are [ddev-get ad
 
 If you need extra daemons to start up automatically inside the web container, you can easily add them using `web_extra_daemons` in `.ddev/config.yaml`.
 
-You might be running node daemons that serve a particular purpose (like browsersync) or daemons like a cron daemon, etc.
+You might be running node daemons that serve a particular purpose (like `browsersync`) or daemons like a `cron` daemon, etc.
 
 For example, you could use this configuration to run two instances of the nodejs http-server serving different directories:
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -22,6 +22,30 @@ A collection of vetted service configurations is available in the [Additional Se
 
 If you need to create a service configuration for your project, see [Defining an additional service with Docker Compose](custom-compose-files.md)
 
+## Exposing extra ports via ddev-router
+
+If your web container has additional HTTP servers running inside it on different ports, those can be exposed using `web_extra_exposed_ports` in `.ddev/config.yaml`. For example, this configuration would expose a `node-vite` HTTP server running on port 3000 inside the web container via ddev-router to ports 9998 (http) and 9999 (https), so it could be accessed via `https://<project>.ddev.site:9999`:
+
+```yaml
+web_extra_exposed_ports:
+  - name: node-vite
+    container_port: 3000
+    http_port: 9998
+    https_port: 9999
+```
+
+The configuration below would expose a nodejs server running in the web container on port 3000 as `https://<project>.ddev.site:4000` and a "something" server running in the web container on port 4000 as `https://<project>.ddev.site:4000`:
+```yaml
+web_extra_exposed_ports:
+  - name: nodejs
+    container_port: 3000
+    http_port: 2999
+    https_port: 3000
+  - name: something
+    container_port: 4000
+    https_port: 4000
+    http_port: 3999
+```
 ## Providing custom environment variables to a container
 
 Custom environment variables may be set in the project config.yaml or the ~/.ddev/global_config.yaml with the `web_environment` key, for example

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -46,12 +46,18 @@ For example, you could use this configuration to run two instances of the nodejs
 ```yaml
 web_extra_daemons:
   - name: "http-1"
-    command: "node_modules/.bin/http-server -p 3000"
+    command: "/var/www/html/node_modules/.bin/http-server -p 3000"
     directory: /var/www/html
   - name: "http-2"
-    command: "node_modules/.bin/http-server /var/www/html/sub -p 3000"
+    command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
     directory: /var/www/html
 ```
+
+* `directory` should be the absolute path inside the container to the directory where the daemon should run.
+* `command` must be a simple binary with its arguments. `bash` features like `cd` or `&&` don't work; bash isn't used in evaluating the command. If the program to be run is not in the `ddev-webserver` `$PATH` then it should have the absolute in-container path to the program to be run, like `/var/www/html/node_modules/.bin/http-server`.
+* `web_extra_daemons` is a shortcut for adding a configuration to `supervisord`, which organizes daemons inside the web container. If the default settings are inadequate for your use, you can write a [complete config file for your daemon](#explicit-supervisord-configuration-for-additional-daemons).
+* Your daemon is expected to run in the foreground, not to daemonize itself, `supervisord` will take care of that.
+* To see the results of the attempt to start your daemon, see `ddev logs` or `docker logs ddev-<project>-web`.
 
 ## Exposing extra ports via ddev-router
 
@@ -112,6 +118,11 @@ The globals from the env file would be available on the next ddev start. It is i
 
 ### Altering the in-container $PATH
 
+Sometimes it's easiest to just put the command you need into the existing `$PATH` using a symbolic link rather than changing the in-container PATH. For example, the project `bin` directory is already in the PATH. So if you have a command you want to run that is not already in the $PATH, you can just add a symlink. A couple of examples:
+
+* On Craft CMS, the `craft` script is often in the project root, which is not in the PATH. But if you `mkdir bin && ln -s craft bin/craft` you should be able to use `ddev exec craft` just fine. (Note however that `ddev craft` takes care of this for you.)
+* On projects where the `vendor` directory is not in the project root (Acquia projects, for example, have `composer.json` and `vendor` in the `docroot` directory), you can `mkdir bin && ln -s docroot/vendor/bin/drush bin/drush` to put `drush` in your PATH. (With projects like this make sure to set `composer_root: docroot` so that `ddev composer` works properly.)
+
 Because many things touch the `$PATH` environment variable, it's slightly harder to change it, but it's easy: Add a script to `<project>/.ddev/homeadditions/.bashrc.d/` or (global) `~/.ddev/homeadditions/.bashrc.d/` that adds to the `$PATH` variable. For example, if your project vendor directory is not in the expected place (`/var/www/html/vendor/bin`) you can add a `<project>/.ddev/homeadditions/.bashrc.d/path.sh` with contents:
 
 ```bash
@@ -154,7 +165,7 @@ If you're using `webserver_type: apache-fpm` in your .ddev/config.yaml, you can 
 * Any errors in your configuration may cause the web container to fail, so if you see that behavior, use `ddev logs` to diagnose.
 * **IMPORTANT**: Changes to .ddev/apache/apache-site.conf take place on a `ddev start`. You can also `ddev exec apachectl -k graceful` to reload the apache configuration.
 
-### Providing custom PHP configuration (php.ini)
+## Providing custom PHP configuration (php.ini)
 
 You can provide additional PHP configuration for a project by creating a directory called `.ddev/php/` and adding any number of php configuration ini files (they must be \*.ini files). Normally, you should just override the specific option that you need to override. Note that any file that exists in `.ddev/php/` will be copied into `/etc/php/[version]/(cli|fpm)/conf.d`, so it's possible to replace files that already exist in the container. Common usage is to put custom overrides in a file called `my-php.ini`. Make sure you include the section header that goes with each item (like `[PHP]`)
 
@@ -169,7 +180,7 @@ An example file in .ddev/php/my-php.ini might look like this:
 max_execution_time = 240;
 ```
 
-### Custom mysql/MariaDB configuration (`my.cnf`)
+## Custom mysql/MariaDB configuration (`my.cnf`)
 
 You can provide additional MySQL configuration for a project by creating a directory called `.ddev/mysql/` and adding any number of MySQL configuration files (these must have the suffix `.cnf`). These files will be automatically included when MySQL is started. Make sure that the section header is included in the file
 
@@ -199,7 +210,7 @@ For example, many teams commit their config.yaml and share it throughout the tea
 router_http_port: 8080
 ```
 
-config.\*.yaml is by default omitted from git by the .ddev/.gitignore file.
+config.\*.yaml is by default omitted from git by the .ddev/.gitignore file. You can commit it by using `git add -f .ddev/config.<something>.yaml`.
 
 Extra config.\*.yaml files are loaded in lexicographic order, so "config.a.yaml" will be overridden by "config.b.yaml".
 
@@ -212,3 +223,28 @@ these rules:
 2. Lists of strings like `additional_hostnames` or `additional_fqdns` are merged.
 3. The list of environment variables in `web_environment` are "smart merged": if you add the same environment variable with a different value, the value in the override file will replace the value from config.yaml.
 4. Hook specifications in the `hooks` variable are also merged.
+
+## Explicit supervisord configuration for additional daemons
+
+Although most extra daemons (like nodejs daemons, etc) can be configured easily using [web_extra_daemons](#running-extra-daemons-in-the-web-container), there may be situations where you want complete control of the `supervisord` configuration.
+
+In these case you can create a `.ddev/web-build/<daemonname>.conf` with configuration like 
+
+```
+[program:daemonname]
+command=/var/www/html/path/to/daemon
+directory=/var/www/html/
+autorestart=true
+startretries=10
+stdout_logfile=/proc/self/fd/2
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+```
+
+And create a `.ddev/web-build/Dockerfile.<daemonname>` to install the config file:
+
+```dockerfile
+ADD daemonname.conf /etc/supervisor/conf.d
+```
+
+Full details for advanced configuration possibilities are in [supervisor docs](http://supervisord.org/configuration.html).

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -22,6 +22,19 @@ A collection of vetted service configurations is available in the [Additional Se
 
 If you need to create a service configuration for your project, see [Defining an additional service with Docker Compose](custom-compose-files.md)
 
+## Using nodejs with DDEV
+
+There are many, many ways to deploy nodejs in any project, so DDEV tries to let you set up any possiblity you can come up with.
+
+* You can choose the nodejs version you want to use in `.ddev/config.yaml` with `nodejs_version`
+* `ddev nvm` gives you the full capabilities of nvm.
+* `ddev npm` and `ddev yarn` provide shortcuts to the npm and yarn commands inside the container, and their caches are persistent.
+* You can run nodejs daemons using [Running extra daemons](#running-extra-daemons-in-the-web-container).
+* You can expose nodejs ports via ddev-router by using [Exposing extra ports](#exposing-extra-ports-via-ddev-router).
+* You can just manually run particular nodejs scripts as needed using `ddev exec <script>` or `ddev exec nodejs <script>`.
+
+Please share your techniques using the many ways to share. Best are [ddev-get add-ons](additional-services.md#additional-service-configurations-and-add-ons-for-ddev), but [Stack Overflow](https://stackoverflow.com/tags/ddev) and [ddev-contrib](https://github.com/drud/ddev-contrib) are others.
+
 ## Running extra daemons in the web container
 
 If you need extra daemons to start up automatically inside the web container, you can easily add them using `web_extra_daemons` in `.ddev/config.yaml`.

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -74,7 +74,7 @@ web_extra_daemons:
 ```
 
 * `directory` should be the absolute path inside the container to the directory where the daemon should run.
-* `command` must be a simple binary with its arguments. `bash` features like `cd` or `&&` don't work; bash isn't used in evaluating the command. If the program to be run is not in the `ddev-webserver` `$PATH` then it should have the absolute in-container path to the program to be run, like `/var/www/html/node_modules/.bin/http-server`.
+* `command` is best as a simple binary with its arguments, but `bash` features like `cd` or `&&` do work. If the program to be run is not in the `ddev-webserver` `$PATH` then it should have the absolute in-container path to the program to be run, like `/var/www/html/node_modules/.bin/http-server`.
 * `web_extra_daemons` is a shortcut for adding a configuration to `supervisord`, which organizes daemons inside the web container. If the default settings are inadequate for your use, you can write a [complete config file for your daemon](#explicit-supervisord-configuration-for-additional-daemons).
 * Your daemon is expected to run in the foreground, not to daemonize itself, `supervisord` will take care of that.
 * To see the results of the attempt to start your daemon, see `ddev logs` or `docker logs ddev-<project>-web`.

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -37,6 +37,26 @@ Please share your techniques using the many ways to share. Best are [ddev-get ad
 
 ## Running extra daemons in the web container
 
+You can run processes inside the web container a number of ways. 
+
+1. You can manually execute them when you need them, with `ddev exec`, for example.
+2. You can run them with a post-start hook.
+3. You can run them automatically using `web_extra_daemons`.
+
+### Running extra daemons with post-start hook
+
+Needed daemons can be run either with a `post-start` `exec` hook or they can be automatically started using supervisord.
+
+A simple `post-start` exec hook in `.ddev/config.yaml` might look like:
+
+```yaml
+hooks:
+  post-start:
+    - exec: "nohup /var/www/html/frontend/node_modules/.bin/vite &"
+```
+
+### Running extra daemons using `web_extra_daemons`
+
 If you need extra daemons to start up automatically inside the web container, you can easily add them using `web_extra_daemons` in `.ddev/config.yaml`.
 
 You might be running node daemons that serve a particular purpose (like `browsersync`) or daemons like a `cron` daemon, etc.

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -52,7 +52,7 @@ A simple `post-start` exec hook in `.ddev/config.yaml` might look like:
 ```yaml
 hooks:
   post-start:
-    - exec: "nohup /var/www/html/frontend/node_modules/.bin/vite &"
+    - exec: "nohup php --docroot=/var/www/html/something -S 0.0.0.0:6666 &"
 ```
 
 ### Running extra daemons using `web_extra_daemons`

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -37,7 +37,7 @@ Please share your techniques using the many ways to share. Best are [ddev-get ad
 
 ## Running extra daemons in the web container
 
-You can run processes inside the web container a number of ways. 
+You can run processes inside the web container a number of ways.
 
 1. You can manually execute them when you need them, with `ddev exec`, for example.
 2. You can run them with a post-start hook.
@@ -248,7 +248,7 @@ these rules:
 
 Although most extra daemons (like nodejs daemons, etc) can be configured easily using [web_extra_daemons](#running-extra-daemons-in-the-web-container), there may be situations where you want complete control of the `supervisord` configuration.
 
-In these case you can create a `.ddev/web-build/<daemonname>.conf` with configuration like 
+In these case you can create a `.ddev/web-build/<daemonname>.conf` with configuration like
 
 ```
 [program:daemonname]

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -94,6 +94,9 @@ services:
     cap_add:
       - SYS_PTRACE
     working_dir: "{{ .WebWorkingDir }}"
+
+    {{ .WebExtraExposedPorts }}
+
     volumes:
       {{ if and (not .MutagenEnabled) (not .NoProjectMount) }}
       - type: {{ .MountType }}
@@ -186,10 +189,10 @@ services:
     - HOST_DOCKER_INTERNAL_IP={{ .HostDockerInternalIP }}
     # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
     # To expose a container port to a different host port, define the port as hostPort:containerPort
-    - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:{{ .MailhogPort }}
+    - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:{{ .MailhogPort }},{{ .WebExtraHTTPPorts }}
     # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
     # To expose an HTTPS port, define the port as securePort:containerPort.
-    - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:{{ .MailhogPort }}
+    - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:{{ .MailhogPort }},{{ .WebExtraHTTPSPorts }}
     - IS_DDEV_PROJECT=true
     - LINES
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -189,10 +189,10 @@ services:
     - HOST_DOCKER_INTERNAL_IP={{ .HostDockerInternalIP }}
     # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
     # To expose a container port to a different host port, define the port as hostPort:containerPort
-    - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:{{ .MailhogPort }},{{ .WebExtraHTTPPorts }}
+    - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:{{ .MailhogPort }}{{ .WebExtraHTTPPorts }}
     # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
     # To expose an HTTPS port, define the port as securePort:containerPort.
-    - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:{{ .MailhogPort }},{{ .WebExtraHTTPSPorts }}
+    - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:{{ .MailhogPort }}{{ .WebExtraHTTPSPorts }}
     - IS_DDEV_PROJECT=true
     - LINES
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -766,7 +766,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	if len(exposedPorts) != 0 {
 		templateVars.WebExtraHTTPPorts = "," + strings.Join(webimageExtraHTTPPorts, ",")
 		templateVars.WebExtraHTTPSPorts = "," + strings.Join(webimageExtraHTTPSPorts, ",")
-		
+
 		templateVars.WebExtraExposedPorts = "expose:\n    - "
 		// Odd way to join ints into a string from https://stackoverflow.com/a/37533144/215713
 		templateVars.WebExtraExposedPorts = templateVars.WebExtraExposedPorts + strings.Trim(strings.Join(strings.Fields(fmt.Sprint(exposedPorts)), "\n    - "), "[]")

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -836,10 +836,10 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	for _, appStart := range app.WebExtraDaemons {
 		supervisorConf := fmt.Sprintf(`
 [program:%s]
-command=%s
+command=bash -c "%s || sleep 2"
 directory=%s
 autorestart=true
-startretries=10
+startretries=15
 stdout_logfile=/proc/self/fd/2
 stdout_logfile_maxbytes=0
 redirect_stderr=true

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -763,12 +763,13 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		webimageExtraHTTPSPorts = append(webimageExtraHTTPSPorts, fmt.Sprintf("%d:%d", a.HTTPSPort, a.WebContainerPort))
 		exposedPorts = append(exposedPorts, a.WebContainerPort)
 	}
-	templateVars.WebExtraHTTPPorts = strings.Join(webimageExtraHTTPPorts, ",")
-	templateVars.WebExtraHTTPSPorts = strings.Join(webimageExtraHTTPSPorts, ",")
 	if len(exposedPorts) != 0 {
+		templateVars.WebExtraHTTPPorts = "," + strings.Join(webimageExtraHTTPPorts, ",")
+		templateVars.WebExtraHTTPSPorts = "," + strings.Join(webimageExtraHTTPSPorts, ",")
+		
 		templateVars.WebExtraExposedPorts = "expose:\n    - "
 		// Odd way to join ints into a string from https://stackoverflow.com/a/37533144/215713
-		templateVars.WebExtraExposedPorts = templateVars.WebExtraExposedPorts + strings.Trim(strings.Join(strings.Fields(fmt.Sprint(exposedPorts)), "    - "), "[]")
+		templateVars.WebExtraExposedPorts = templateVars.WebExtraExposedPorts + strings.Trim(strings.Join(strings.Fields(fmt.Sprint(exposedPorts)), "\n    - "), "[]")
 	}
 
 	if app.Database.Type == nodeps.Postgres {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -19,7 +19,6 @@ import (
 	"github.com/lextoumbourou/goodhosts"
 	"github.com/mattn/go-isatty"
 	"github.com/otiai10/copy"
-	"github.com/pkg/errors"
 	osexec "os/exec"
 
 	"path"
@@ -1197,7 +1196,7 @@ func (app *DdevApp) Start() error {
 		}
 		err = CreateMutagenSync(app)
 		if err != nil {
-			return errors.Errorf("Failed to create mutagen sync session %s. You may be able to resolve this problem 'ddev mutagen reset' (err=%v)", MutagenSyncName(app.Name), err)
+			return fmt.Errorf("Failed to create mutagen sync session '%s'. You may be able to resolve this problem 'ddev mutagen reset' (err=%v)", MutagenSyncName(app.Name), err)
 		}
 		mStatus, _, _, err := app.MutagenStatus()
 		if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1214,6 +1214,10 @@ func (app *DdevApp) Start() error {
 	// WebExtraDaemons have to be started after mutagen sync is done, because so often
 	// they depend on code being synced into the container/volume
 	if len(app.WebExtraDaemons) > 0 {
+		err = app.Wait([]string{"web"})
+		if err != nil {
+			util.Warning("Failed waiting for web container to become ready: %v", err)
+		}
 		util.Debug("Starting web_extra_daaemons")
 		stdout, stderr, err := app.Exec(&ExecOpts{
 			Cmd: `supervisorctl start webextradaemons:*`,

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1211,6 +1211,18 @@ func (app *DdevApp) Start() error {
 		}
 	}
 
+	// WebExtraDaemons have to be started after mutagen sync is done, because so often
+	// they depend on code being synced into the container/volume
+	if len(app.WebExtraDaemons) > 0 {
+		util.Debug("Starting web_extra_daaemons")
+		stdout, stderr, err := app.Exec(&ExecOpts{
+			Cmd: `supervisorctl start webextradaemons:*`,
+		})
+		if err != nil {
+			util.Warning("Unable to start web_extra_daemons using supervisorctl, stdout=%s, stderr=%s: %v", stdout, stderr, err)
+		}
+	}
+
 	if !IsRouterDisabled(app) {
 		err = StartDdevRouter()
 		if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -65,6 +65,17 @@ type DatabaseDesc struct {
 	Version string `yaml:"version"`
 }
 
+type WebExposedPort struct {
+	WebContainerPort int `yaml:"container_port"`
+	HTTPPort         int `yaml:"http_port"`
+	HTTPSPort        int `yaml:"https_port"`
+}
+
+type WebExtraDaemon struct {
+	Command   string `yaml:"command"`
+	Directory string `yaml:"directory"`
+}
+
 // DdevApp is the struct that represents a ddev app, mostly its config
 // from config.yaml.
 type DdevApp struct {
@@ -126,6 +137,8 @@ type DdevApp struct {
 	WebEnvironment            []string               `yaml:"web_environment"`
 	NodeJSVersion             string                 `yaml:"nodejs_version"`
 	DefaultContainerTimeout   string                 `yaml:"default_container_timeout,omitempty"`
+	WebExtraExposedPorts      []WebExposedPort       `yaml:"web_extra_exposed_ports,omitempty"`
+	WebExtraDaemons           []WebExtraDaemon       `yaml:"web_extra_daemons,omitempty"`
 	ComposeYaml               map[string]interface{} `yaml:"-"`
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -66,9 +66,10 @@ type DatabaseDesc struct {
 }
 
 type WebExposedPort struct {
-	WebContainerPort int `yaml:"container_port"`
-	HTTPPort         int `yaml:"http_port"`
-	HTTPSPort        int `yaml:"https_port"`
+	Name             string `yaml:"name"`
+	WebContainerPort int    `yaml:"container_port"`
+	HTTPPort         int    `yaml:"http_port"`
+	HTTPSPort        int    `yaml:"https_port"`
 }
 
 type WebExtraDaemon struct {
@@ -2307,6 +2308,11 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 
 		httpsURLs = append(httpsURLs, "https://"+name+httpsPort)
 		httpURLs = append(httpURLs, "http://"+name+httpPort)
+
+		for _, extraPort := range app.WebExtraExposedPorts {
+			httpsURLs = append(httpsURLs, fmt.Sprintf("https://%s:%d", name, extraPort.HTTPSPort))
+			httpURLs = append(httpURLs, fmt.Sprintf("http://%s:%d", name, extraPort.HTTPPort))
+		}
 	}
 
 	if !IsRouterDisabled(app) {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -73,6 +73,7 @@ type WebExposedPort struct {
 }
 
 type WebExtraDaemon struct {
+	Name      string `yaml:"name"`
 	Command   string `yaml:"command"`
 	Directory string `yaml:"directory"`
 }
@@ -2308,11 +2309,6 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 
 		httpsURLs = append(httpsURLs, "https://"+name+httpsPort)
 		httpURLs = append(httpURLs, "http://"+name+httpPort)
-
-		for _, extraPort := range app.WebExtraExposedPorts {
-			httpsURLs = append(httpsURLs, fmt.Sprintf("https://%s:%d", name, extraPort.HTTPSPort))
-			httpURLs = append(httpURLs, fmt.Sprintf("http://%s:%d", name, extraPort.HTTPPort))
-		}
 	}
 
 	if !IsRouterDisabled(app) {

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -18,8 +18,11 @@ import (
 func TestExtraPortExpose(t *testing.T) {
 	assert := asrt.New(t)
 
-	testDir := TestSites[0].Dir
-	app, err := NewApp(testDir, true)
+	site := TestSites[0]
+
+	testcommon.ClearDockerEnv()
+	app := new(DdevApp)
+	err := app.Init(site.Dir)
 	assert.NoError(err)
 
 	t.Cleanup(func() {
@@ -43,7 +46,7 @@ func TestExtraPortExpose(t *testing.T) {
 		{Name: "FirstDaemon", Command: "php -S 0.0.0.0:3000", Directory: "/var/www/html"},
 		{Name: "SecondDaemon", Command: "php -S 0.0.0.0:4000", Directory: "/var/www/html/sub"},
 	}
-	err = app.Start()
+	err = app.Restart()
 	require.NoError(t, err)
 
 	// Careful with portsToTest because https ports won't work on github actions Colima tests (although they work fine on normal mac)

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"fmt"
 	. "github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
@@ -46,8 +47,11 @@ func TestExtraPortExpose(t *testing.T) {
 		{Name: "FirstDaemon", Command: "php -S 0.0.0.0:3000", Directory: "/var/www/html"},
 		{Name: "SecondDaemon", Command: "php -S 0.0.0.0:4000", Directory: "/var/www/html/sub"},
 	}
-	err = app.Restart()
-	require.NoError(t, err)
+	err = app.Start()
+	if err != nil {
+		logs, logErr := exec.RunCommand("docker", []string{"logs", "ddev-" + app.Name + "-web"})
+		t.Fatalf("app failed to start: %v, logErr=%v logs=%v", err, logErr, logs)
+	}
 
 	// Careful with portsToTest because https ports won't work on github actions Colima tests (although they work fine on normal mac)
 	portsToTest := []string{"3000", "4000"}

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestExtraPortExpose tests exposing additional ports with web_extra_exposed_ports.
@@ -36,6 +37,7 @@ func TestExtraPortExpose(t *testing.T) {
 	err = os.WriteFile(filepath.Join(app.AppRoot, "testfile.html"), []byte(`this is test1 in root`), 0755)
 	require.NoError(t, err)
 	err = os.MkdirAll(filepath.Join(app.AppRoot, "sub"), 0777)
+	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(app.AppRoot, "sub", "testfile.html"), []byte(`this is test2 in root/sub`), 0755)
 	require.NoError(t, err)
 
@@ -57,6 +59,12 @@ func TestExtraPortExpose(t *testing.T) {
 	portsToTest := []string{"3000", "4000"}
 	if !nodeps.IsGitpod() && (globalconfig.GetCAROOT() == "" || IsRouterDisabled(app)) {
 		portsToTest = []string{"2999", "3999"}
+	}
+
+	// If mutagen is enabled, it may take some time for the "sub" directory to exist inside
+	// the container. Wait a bit.
+	if app.IsMutagenEnabled() {
+		time.Sleep(time.Second * 5)
 	}
 	for i, p := range portsToTest {
 		url := fmt.Sprintf("%s:%s/testfile.html", app.GetPrimaryURL(), p)

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -1,0 +1,50 @@
+package ddevapp_test
+
+import (
+	"fmt"
+	. "github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExtraPortExpose tests exposing additional ports with web_extra_exposed_ports.
+func TestExtraPortExpose(t *testing.T) {
+	assert := asrt.New(t)
+
+	testDir := TestSites[0].Dir
+	app, err := NewApp(testDir, true)
+	assert.NoError(err)
+
+	t.Cleanup(func() {
+		err = app.Stop(true, false)
+		assert.NoError(err)
+	})
+
+	err = os.WriteFile(filepath.Join(app.AppRoot, "testfile.html"), []byte(`this is a test`), 0755)
+	require.NoError(t, err)
+
+	app.WebExtraExposedPorts = []WebExposedPort{
+		{Name: "first", WebContainerPort: 3000, HTTPPort: 2999, HTTPSPort: 3000},
+		{Name: "second", WebContainerPort: 4000, HTTPPort: 3999, HTTPSPort: 4000},
+	}
+	err = app.Start()
+	require.NoError(t, err)
+
+	// Run php built-in webserver on 3000 and 4000
+	_, _, err = app.Exec(&ExecOpts{
+		Cmd: "nohup php -S 0.0.0.0:3000 &",
+	})
+	_, _, err = app.Exec(&ExecOpts{
+		Cmd: "nohup php -S 0.0.0.0:4000 &",
+	})
+
+	for _, p := range []string{"3000", "4000"} {
+		out, resp, err := testcommon.GetLocalHTTPResponse(t, fmt.Sprintf("%s:%s/testfile.html", app.GetPrimaryURL(), p))
+		require.NoError(t, err, "failed to get hit port %s, out=%s, resp=%v err=%v", p, out, resp, err)
+		assert.Contains(out, "this is a test")
+	}
+}

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 // TestExtraPortExpose tests exposing additional ports with web_extra_exposed_ports.
@@ -61,11 +60,6 @@ func TestExtraPortExpose(t *testing.T) {
 		portsToTest = []string{"2999", "3999"}
 	}
 
-	// If mutagen is enabled, it may take some time for the "sub" directory to exist inside
-	// the container. Wait a bit.
-	if app.IsMutagenEnabled() {
-		time.Sleep(time.Second * 5)
-	}
 	for i, p := range portsToTest {
 		url := fmt.Sprintf("%s:%s/testfile.html", app.GetPrimaryURL(), p)
 		out, resp, err := testcommon.GetLocalHTTPResponse(t, url)

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -3,6 +3,8 @@ package ddevapp_test
 import (
 	"fmt"
 	. "github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +14,7 @@ import (
 )
 
 // TestExtraPortExpose tests exposing additional ports with web_extra_exposed_ports.
+// It also tests web_extra_daemons
 func TestExtraPortExpose(t *testing.T) {
 	assert := asrt.New(t)
 
@@ -22,29 +25,36 @@ func TestExtraPortExpose(t *testing.T) {
 	t.Cleanup(func() {
 		err = app.Stop(true, false)
 		assert.NoError(err)
+		err = os.RemoveAll(filepath.Join(app.AppRoot, "testfile1.html"))
+		assert.NoError(err)
 	})
 
-	err = os.WriteFile(filepath.Join(app.AppRoot, "testfile.html"), []byte(`this is a test`), 0755)
+	err = os.WriteFile(filepath.Join(app.AppRoot, "testfile.html"), []byte(`this is test1 in root`), 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(app.AppRoot, "sub"), 0777)
+	err = os.WriteFile(filepath.Join(app.AppRoot, "sub", "testfile.html"), []byte(`this is test2 in root/sub`), 0755)
 	require.NoError(t, err)
 
 	app.WebExtraExposedPorts = []WebExposedPort{
 		{Name: "first", WebContainerPort: 3000, HTTPPort: 2999, HTTPSPort: 3000},
 		{Name: "second", WebContainerPort: 4000, HTTPPort: 3999, HTTPSPort: 4000},
 	}
+	app.WebExtraDaemons = []WebExtraDaemon{
+		{Name: "FirstDaemon", Command: "php -S 0.0.0.0:3000", Directory: "/var/www/html"},
+		{Name: "SecondDaemon", Command: "php -S 0.0.0.0:4000", Directory: "/var/www/html/sub"},
+	}
 	err = app.Start()
 	require.NoError(t, err)
 
-	// Run php built-in webserver on 3000 and 4000
-	_, _, err = app.Exec(&ExecOpts{
-		Cmd: "nohup php -S 0.0.0.0:3000 &",
-	})
-	_, _, err = app.Exec(&ExecOpts{
-		Cmd: "nohup php -S 0.0.0.0:4000 &",
-	})
-
-	for _, p := range []string{"3000", "4000"} {
-		out, resp, err := testcommon.GetLocalHTTPResponse(t, fmt.Sprintf("%s:%s/testfile.html", app.GetPrimaryURL(), p))
-		require.NoError(t, err, "failed to get hit port %s, out=%s, resp=%v err=%v", p, out, resp, err)
-		assert.Contains(out, "this is a test")
+	// Careful with portsToTest because https ports won't work on github actions Colima tests (although they work fine on normal mac)
+	portsToTest := []string{"3000", "4000"}
+	if !nodeps.IsGitpod() && (globalconfig.GetCAROOT() == "" || IsRouterDisabled(app)) {
+		portsToTest = []string{"2999", "3999"}
+	}
+	for i, p := range portsToTest {
+		url := fmt.Sprintf("%s:%s/testfile.html", app.GetPrimaryURL(), p)
+		out, resp, err := testcommon.GetLocalHTTPResponse(t, url)
+		assert.NoError(err, "failed to get hit url %s, out=%s, resp=%v err=%v", url, out, resp, err)
+		assert.Contains(out, fmt.Sprintf("this is test%d", i+1))
 	}
 }

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -137,7 +137,16 @@ func CreateMutagenSync(app *DdevApp) error {
 		return err
 	}
 	if container == nil {
-		return errors.Errorf("web container not found")
+		return fmt.Errorf("web container for %s not found", app.Name)
+	}
+	if container.State != "running" {
+		// TODO: Improve or debug this temporary debug usage
+		util.Warning("web container is not running, logs follow")
+		logsErr := app.Logs("web", false, false, "100")
+		if logsErr != nil {
+			util.Warning("error from getting logs: %v", logsErr)
+		}
+		return fmt.Errorf("Cannot start mutagen sync because web container is not running: %v", container)
 	}
 
 	args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker://%s/var/www/html", container.ID), "--no-global-configuration", "--name", syncName}

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -250,15 +250,17 @@ func determineRouterPorts() []string {
 				exposePorts = append(exposePorts, ports...)
 			}
 
-			for _, exposePort := range exposePorts {
+			for _, exposePortPair := range exposePorts {
 				// ports defined as hostPort:containerPort allow for router to configure upstreams
 				// for containerPort, with server listening on hostPort. exposed ports for router
 				// should be hostPort:hostPort so router can determine what port a request came from
 				// and route the request to the correct upstream
-				if strings.Contains(exposePort, ":") {
-					ports := strings.Split(exposePort, ":")
-					exposePort = ports[0]
+				exposePort := ""
+				ports := []string{""}
+				if strings.Contains(exposePortPair, ":") {
+					ports = strings.Split(exposePortPair, ":")
 				}
+				exposePort = ports[0]
 
 				var match bool
 				for _, routerPort := range routerPorts {

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -187,7 +187,7 @@ const ConfigInstructions = `
 # the default 120. This helps in importing huge databases, for example.
 
 # web_extra_exposed_ports:
-# - 
+# -
 #    container_port: 3000
 #    https_port: 3000
 #    http_port: 2999

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -186,6 +186,21 @@ const ConfigInstructions = `
 # The default time that ddev waits for all containers to become ready can be increased from
 # the default 120. This helps in importing huge databases, for example.
 
+# web_extra_exposed_ports:
+# - 
+#    container_port: 3000
+#    https_port: 3000
+#    http_port: 2999
+# Allows a set of extra ports to be exposed via ddev-router
+# The port behavior on the ddev-webserver must be arranged separately
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+
 # Many ddev commands can be extended to run tasks before or after the
 # ddev command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -131,7 +131,7 @@ func Cleanup(app *DdevApp) error {
 		}
 	}
 	// Always kill the temporary volumes on ddev remove
-	vols := []string{app.GetNFSMountVolumeName(), "ddev-" + app.Name + "-snapshots", app.Name + "-ddev-config", app.Name + "_project_" + "mutagen"}
+	vols := []string{app.GetNFSMountVolumeName(), "ddev-" + app.Name + "-snapshots", app.Name + "-ddev-config"}
 
 	for _, volName := range vols {
 		_ = dockerutil.RemoveVolume(volName)

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -131,7 +131,7 @@ func Cleanup(app *DdevApp) error {
 		}
 	}
 	// Always kill the temporary volumes on ddev remove
-	vols := []string{app.GetNFSMountVolumeName(), "ddev-" + app.Name + "-snapshots", app.Name + "-ddev-config"}
+	vols := []string{app.GetNFSMountVolumeName(), "ddev-" + app.Name + "-snapshots", app.Name + "-ddev-config", app.Name + "_project_" + "mutagen"}
 
 	for _, volName := range vols {
 		_ = dockerutil.RemoveVolume(volName)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220728_npm_yarn_cache" // Note that this can be overridden by make
+var WebTag = "20220728_proxy_arbitrary_ports" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3456 
* Fix difficulty of using docker-compose.*.yaml to start daemons
* Explicit proxying

## Manual Testing Instructions:

Try out all the things in the doc

## Automated Testing Overview:

Added TestExtraPortExpose



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4057"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

