### PR TITLE
Bump docker-compose again to 2.9.0 since they released that (#4056)

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -562,7 +562,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.8.0"
+var RequiredDockerComposeVersion = "v2.9.0"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Problem/Issue/Bug:

Bump docker-compose again to 2.9.0 since they released that (#4056)

Use automated tests to verify. They say they introduced a breaking change in 2.8.0.
https://github.com/docker/compose/releases/tag/v2.9.0



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4062"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

