### PR TITLE
Regresssion: Handle single port in HTTP_EXPOSE or HTTPS_EXPOSE in determineRouterPorts()

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -256,9 +257,18 @@ func determineRouterPorts() []string {
 				// should be hostPort:hostPort so router can determine what port a request came from
 				// and route the request to the correct upstream
 				exposePort := ""
-				ports := []string{""}
+				var ports []string
+
+				// Make sure that we are fully numeric in the port pair, and not empty, or ignore
+				_, err = strconv.Atoi(strings.ReplaceAll(exposePortPair, ":", ""))
+				if err != nil {
+					continue
+				}
 				if strings.Contains(exposePortPair, ":") {
 					ports = strings.Split(exposePortPair, ":")
+				} else {
+					// HTTP_EXPOSE and HTTPS_EXPOSE can be a single port, meaning port:port
+					ports = []string{exposePortPair, exposePortPair}
 				}
 				exposePort = ports[0]
 


### PR DESCRIPTION

## The Problem/Issue/Bug:

HTTP_EXPOSE with a single value is legitimate, and is used in ddev-redis-commander.

Regression was introduced in https://github.com/drud/ddev/pull/4057 where that situation was not properly handled and thus an empty string was added into the array of ports to expose.

As a result, HEAD was failing on the ddev-redis-commander tests

## How this PR Solves The Problem:

* Handle the single-value properly
* Check for empty and otherwise non-numeric values in HTTP*_EXPOSE

## Manual Testing Instructions:

Try ddev-redis with ddev-redis-commander

## Followup

- [ ] Re-run the ddev-redis-commander tests after this is pulled



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4065"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

