### PR TITLE
Fix issue where the script doesn't fire on page load or search.

### DIFF
--- a/docs/content/assets/temp-fix-header-links-in-tabs.js
+++ b/docs/content/assets/temp-fix-header-links-in-tabs.js
@@ -1,5 +1,4 @@
-// Fires whenever the hash changes
-window.addEventListener('hashchange', function () {
+const fixTabs = () => {
     // Get current hash
     let currentHash = window.location.href.split('#')[1];
     if (!currentHash) return
@@ -43,4 +42,10 @@ window.addEventListener('hashchange', function () {
 
     // scroll to hash
     hashElement.scrollIntoView();
-}, false);
+};
+
+// Fires after initial page load
+window.addEventListener('load', fixTabs, false);
+
+// Fires whenever the hash changes
+window.addEventListener('hashchange', fixTabs, false);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ theme:
 #  - content.tabs.link
   - navigation.expand
   - navigation.indexes
-  - navigation.instant
+#  - navigation.instant
   - navigation.sections
   - navigation.tabs
 #  - navigation.tabs.sticky


### PR DESCRIPTION
## The Problem/Issue/Bug:
This PR fixes part of [this issue](https://github.com/drud/ddev/issues/4059) by triggering the `fixTabs` function on page load and on hash change.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4069"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

## Manual testing
Use [this link](https://ddev--4069.org.readthedocs.build/en/latest/users/install/ddev-installation/#linux) to test, you'll notice the page automatically opening the Linux tab.