### PR TITLE
[tests only] Try out 1.0.14 of github-action-markdown-link-check

### DIFF
--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -33,7 +33,7 @@ jobs:
       #    - name: Debugging with tmate
       #      uses: mxschmitt/action-tmate@v3.1
       - name: "Check links in markdown"
-        uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
+        uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
         with:
           use-quiet-mode: 'yes'
           folder-path: 'docs/'


### PR DESCRIPTION
## The Problem/Issue/Bug:

See what happens with  1.0.14 of github-action-markdown-link-check

* https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/127#issuecomment-1203642587



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4071"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

