### PR TITLE
Remove nodejs 12 and 17 from allowed values as out of support

### DIFF
--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -72,7 +72,7 @@ var ValidWebserverTypes = map[string]bool{
 	WebserverApacheFPM: true,
 }
 
-var ValidNodeJSVersions = []string{"12", "14", "16", "17", "18"}
+var ValidNodeJSVersions = []string{"14", "16", "18"}
 
 // App types
 const (


### PR DESCRIPTION
## The Problem/Issue/Bug:

Remove from nodejs_versions "12" and "17" as both are out of support.

Both can still be used via `ddev nvm`



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4073"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

