### PR TITLE
Add PHPUnit command with path remapping

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -190,7 +190,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err)
 
 	// Make sure that all the official ddev-provided custom commands are usable by just checking help
-	for _, c := range []string{"launch", "mysql", "npm", "php", "xdebug", "yarn"} {
+	for _, c := range []string{"launch", "mysql", "npm", "php", "phpunit", "xdebug", "yarn"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.NoError(err, "Failed to run ddev %s -h", c)
 	}

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpunit
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpunit
@@ -1,0 +1,9 @@
+#!/bin/bash
+#ddev-generated
+
+## Description: Run Symphony phpunit tests
+## Usage: phpunit <test>
+## Example: "ddev phpunit" or "ddev phpunit tests/Util"
+CWD=$(pwd)
+
+ddev . ./vendor/bin/phpunit "$@" | sed "2,\$s|/var/www/html|$CWD|"


### PR DESCRIPTION
Fixes #4077

## The Problem/Issue/Bug:
I run different projects with different PHP requirements.
I generally use an alias to switch my host PHP version but sometimes forget when I switch projects. This causes my tests to fail.

I been using the command on ddev-contrib but it has a problem:
- file paths are displayed relative to the container and not the host

This means I can not click on the filename in VScode to open them


## How this PR Solves The Problem:
This PR adds a command to run PHPUnit tests inside the container.
It attempts to rewrite the path which allows me to click through.

It does have some issues though:
- it only works on linux
- it does not display out put in color

I am unsure how to correct this issues so this PR is "draft". 
I feel like there might be a "better" solution but I do not know this area well enough.
Perhaps the community can help.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4078"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

