### PR TITLE
Provide DDEV_VERSION env variable in container

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -178,6 +178,7 @@ services:
     - DDEV_FILES_DIR
     - DDEV_WEBSERVER_TYPE
     - DDEV_XDEBUG_ENABLED
+    - DDEV_VERSION
     - DEPLOY_NAME=local
     {{ if not .DisableSettingsManagement }}
     - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1852,6 +1852,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_ROUTER_HTTPS_PORT":     app.RouterHTTPSPort,
 		"DDEV_XDEBUG_ENABLED":        strconv.FormatBool(app.XdebugEnabled),
 		"DDEV_PRIMARY_URL":           app.GetPrimaryURL(),
+		"DDEV_VERSION":               versionconstants.DdevVersion,
 		"DOCKER_SCAN_SUGGEST":        "false",
 		"GOOS":                       runtime.GOOS,
 		"GOARCH":                     runtime.GOARCH,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3763,6 +3763,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		"DDEV_ROUTER_HTTPS_PORT": app.RouterHTTPSPort,
 		"DDEV_SITENAME":          app.Name,
 		"DDEV_TLD":               app.ProjectTLD,
+		"DDEV_VERSION":           versionconstants.DdevVersion,
 		"DDEV_WEBSERVER_TYPE":    app.WebserverType,
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

As a developer I want to execute scripts in the container. Sometimes it's good to know which ddev version is currently used to have a different logic or to warn that some features require an ddev update.

## How this PR Solves The Problem:

Register a new DDEV_VERSION variable in the container.

## Manual Testing Instructions:

Start a new project and run `echo $DDEV_VERSION`. It should print the currently used ddev version as string.
For stable versions it's a tag like `v1.20.0`.

## Automated Testing Overview:

Test was added to `pkg/ddevapp/ddevapp_test.go`.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4080"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

