### PR TITLE
[DOCS] Fix tabs for drupal section on the quickstart page

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -159,7 +159,7 @@ Here's a quickstart instructions for a number of different environments:
         ddev launch
         ```
 
-        === "Drupal 10"
+    === "Drupal 10"
 
         ### Drupal 10 composer build
     
@@ -180,7 +180,7 @@ Here's a quickstart instructions for a number of different environments:
         
         Note that as Drupal 10 moves from alpha to beta and then release, you'll want to change the tag from `^10@alpha` to `^10@beta` and then `^10`.
 
-        === "Drupal 6/7"
+    === "Drupal 6/7"
 
         ### Drupal 6/7 install
     
@@ -198,7 +198,7 @@ Here's a quickstart instructions for a number of different environments:
         
         Quickstart instructions for database imports can be found under [Importing a database](#importing-a-database).
 
-        === "Git clone"
+    === "Git clone"
 
         ### Git clone build
     


### PR DESCRIPTION
## The Problem/Issue/Bug:
Tab indentation was wrong.

## Manual testing
Please click [here](https://ddev--4084.org.readthedocs.build/en/4084/users/quickstart/#drupal)

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4084"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

