### PR TITLE
Make yarn cachedir setting dependent on version, fixes #4088

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -80,8 +80,8 @@ sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm/${HOSTNAME},yarn/${HOSTNAME}}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
-yarn config set cache-folder /mnt/ddev-global-cache/yarn/${HOSTNAME}
-npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME}
+yarn config set cache-folder /mnt/ddev-global-cache/yarn/${HOSTNAME} || yarn config set cacheFolder /mnt/ddev-global-cache/yarn/${HOSTNAME} || true
+npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME} || true
 
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.20.0" // Note that this can be overridden by make
+var WebTag = "20220808_yarn_crash" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4088 

## How this PR Solves The Problem:

Try both yarn cachedir setting techniques; just give up if they don't work

## Manual Testing Instructions:

- [x] Site-install yarn 2+ and `ddev restart` a project. See #4088 . Verify cache config and usage.
- [ ] Use a traditional yarn project, `ddev restart`, verify cache config.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4090"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

