### PR TITLE
Don't use docker-compose to wait for db container to become healthy

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -149,12 +149,6 @@ services:
     user: '$DDEV_UID:$DDEV_GID'
     hostname: {{ .Name }}-web
 
-    {{ if not .OmitDB }}
-    depends_on:
-      db:
-        condition: service_healthy
-    {{ end }}
-
     ports:
       - "{{ .DockerIP }}:$DDEV_HOST_WEBSERVER_PORT:80"
       - "{{ .DockerIP }}:$DDEV_HOST_HTTPS_PORT:443"

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1211,13 +1211,19 @@ func (app *DdevApp) Start() error {
 		}
 	}
 
+	// Wait for web/db containers to become healthy
+	dependers := []string{"web"}
+	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+		dependers = append(dependers, "db")
+	}
+	err = app.Wait(dependers)
+	if err != nil {
+		util.Warning("Failed waiting for web/db containers to become ready: %v", err)
+	}
+
 	// WebExtraDaemons have to be started after mutagen sync is done, because so often
 	// they depend on code being synced into the container/volume
 	if len(app.WebExtraDaemons) > 0 {
-		err = app.Wait([]string{"web"})
-		if err != nil {
-			util.Warning("Failed waiting for web container to become ready: %v", err)
-		}
 		util.Debug("Starting web_extra_daaemons")
 		stdout, stderr, err := app.Exec(&ExecOpts{
 			Cmd: `supervisorctl start webextradaemons:*`,
@@ -1961,7 +1967,7 @@ func (app *DdevApp) WaitByLabels(labels map[string]string) error {
 	waitTime := app.FindMaxTimeout()
 	err := dockerutil.ContainersWait(waitTime, labels)
 	if err != nil {
-		return fmt.Errorf("container(s) failed to become healthy after %d seconds. This may be just a problem with the healthcheck and not a functional problem. %v", waitTime, err)
+		return fmt.Errorf("container(s) failed to become healthy before their configured timeout or in %d seconds. This may be just a problem with the healthcheck and not a functional problem. (%v)", waitTime, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

* https://github.com/docker/compose/issues/9732

If the db container exits, for example because the db type has been changed and the existing database is incompatible with the new one, the `docker-compose up` hangs forever without any information. Unfortunately we can't let docker-compose do the work for us as we had anticipated in #3858.

## How this PR Solves The Problem:

* Remove the docker-compose depends_on
* Add inline code to check db container

Note that DDEV v1.20 web_extra_daemons already waits for these things (now), so the original problem described in #3702 should be resolved *if* it uses web_extra_daemons, which would be great.

## Manual Testing Instructions:

- [x] Make db container fail by changing its type. `ddev restart`. You should get clear feedback, not a hang.

## Related Issue Link(s):

* https://github.com/drud/ddev/issues/3702
* https://github.com/drud/ddev/pull/3858

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4095"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

