### PR TITLE
[docs] Fix code highlighting in docs performance page

### DIFF
--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -50,7 +50,7 @@ Instructions for Mutagen and NFS are below.
 
     When mutagen is enabled, DDEV attempts to exclude from syncing the `upload_dir` (user-generated files) in project types that a default `upload_dir` or where `upload_dir` is explicitly set in `.ddev/config.yaml`. It does this by using a bind-mount in the generated `docker-compose` configuration and excluding the directory from syncing in the `.ddev/mutagen/mutagen.yml`. In most cases you need not take any action to get this behavior.
 
-    If you have a nonstandard location for user-generated files, like `private/fileadmin` with the deprecated typo3-secure-web` approach, you should override the project defaults by setting `upload_dir` in `.ddev/config.yaml` to point to the correct directory so mutagen can be set up to sync correctly.
+    If you have a nonstandard location for user-generated files, like `private/fileadmin` with the deprecated `typo3-secure-web` approach, you should override the project defaults by setting `upload_dir` in `.ddev/config.yaml` to point to the correct directory so mutagen can be set up to sync correctly.
 
     ### Caveats about Mutagen Integration
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
There was a typo in the code highlighting on the performance page within the docs


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4097"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

