### PR TITLE
Try to fix golangci-lint crash with update

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,7 +35,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.47
+        version: v1.48
 
         # Optional: working directory, useful for monorepos
         # working-directory: somedir


### PR DESCRIPTION
## The Problem/Issue/Bug:

Trying to fix crashes of golangci-lint, https://github.com/drud/ddev/runs/7755098131?check_suite_focus=true

It seems to be the fault of gocritic, 

A variety of issues including 

* https://github.com/golangci/golangci-lint-action/issues/545

May be affected by using go 1.19, so that's probably the fix, lock to 1.18


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4101"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

