### PR TITLE
[tests only] Attempt to chase Windows NFS homeadditions failure

### DIFF
--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -94,6 +94,10 @@ func TestHomeadditions(t *testing.T) {
 
 	app, err := ddevapp.GetActiveApp(site.Name)
 	require.NoError(t, err)
+
+	err = app.Start()
+	require.NoError(t, err)
+
 	// Make sure that even though there was a global and a project-level .myscript.sh
 	// the project-level one should win.
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -98,6 +98,13 @@ func TestHomeadditions(t *testing.T) {
 	// the project-level one should win.
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
+		Cmd:     "ls -al ~/",
+	})
+	assert.NoError(err)
+	t.Logf("Results of ls -al in homedir: %v", stdout)
+
+	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "web",
 		Cmd:     "~/.myscript.sh",
 	})
 	assert.NoError(err)

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -84,7 +84,7 @@ func TestHomeadditions(t *testing.T) {
 	err = os.Symlink(filepath.Join(origDir, "testdata", t.Name(), "global/realglobaltarget.txt"), filepath.Join(tmpHomeGlobalHomeadditionsDir, "realglobaltarget.txt"))
 	require.NoError(t, err)
 	// Run ddev start make sure homeadditions example files get populated
-	_, err = exec.RunHostCommand(DdevBin, "start")
+	_, err = exec.RunHostCommand(DdevBin, "restart")
 	assert.NoError(err)
 
 	for _, f := range []string{"bash_aliases.example", "README.txt"} {
@@ -95,19 +95,10 @@ func TestHomeadditions(t *testing.T) {
 	app, err := ddevapp.GetActiveApp(site.Name)
 	require.NoError(t, err)
 
-	err = app.Start()
-	require.NoError(t, err)
-
 	// Make sure that even though there was a global and a project-level .myscript.sh
 	// the project-level one should win.
-	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
-		Service: "web",
-		Cmd:     "ls -al ~/",
-	})
-	assert.NoError(err)
-	t.Logf("Results of ls -al in homedir: %v", stdout)
 
-	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
+	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Cmd:     "~/.myscript.sh",
 	})


### PR DESCRIPTION
## The Problem/Issue/Bug:

TestHomeadditions is failing on Windows NFS, see https://buildkite.com/drud/ddev-windows-dockerforwindows-nfs/builds/5765#018287cd-8a45-4bf9-a816-ef4b0aa0eb47

## How this PR Solves The Problem:

Try to get more information about why it's failing. I haven't been able to recreate on local Windows machine.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4104"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

