### PR TITLE
Check database type, allow migration, fixes #4089, fixes #3923

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -709,6 +709,13 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 		return fmt.Errorf("failed to validate config: %v", err)
 	}
 
+	// If the database already exists in volume and is not of this type, then throw an error
+	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
+			return fmt.Errorf("Unable to configure project %s with database type %s because that database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', and you can try a migration with 'ddev debug migrate-database %s' see docs at %s", app.Name, dbType, dbType, dbType, app.Database.Type+":"+app.Database.Version, "https://ddev.readthedocs.io/en/latest/users/extend/database_types/")
+		}
+	}
+
 	if err := app.WriteConfig(); err != nil {
 		return fmt.Errorf("could not write ddev config file %s: %v", app.ConfigPath, err)
 	}

--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -20,7 +20,9 @@ var DebugCapabilitiesCmd = &cobra.Command{
 			"user-env-var",
 			"npm-yarn-caching",
 			"exposed-ports-configuration",
-			"daemon-run-configuration"}
+			"daemon-run-configuration",
+			"get-volume-db-version",
+		}
 		output.UserOut.WithField("raw", capabilities).Print(strings.Join(capabilities, "\n"))
 	},
 }

--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -22,6 +22,7 @@ var DebugCapabilitiesCmd = &cobra.Command{
 			"exposed-ports-configuration",
 			"daemon-run-configuration",
 			"get-volume-db-version",
+			"migrate-database",
 		}
 		output.UserOut.WithField("raw", capabilities).Print(strings.Join(capabilities, "\n"))
 	},

--- a/cmd/ddev/cmd/debug-check-db-match.go
+++ b/cmd/ddev/cmd/debug-check-db-match.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// DebugCheckDBMatch verified that the DB Type/Version in container matches configured
+var DebugCheckDBMatch = &cobra.Command{
+	Use:   "check-db-match",
+	Short: "Verify that the database in the ddev-db server matches the configured type/version",
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Can't find active project: %v", err)
+		}
+
+		dbType, err := app.GetExistingDBType()
+		if err != nil {
+			util.Failed("Failed to check existing DB type: %v", err)
+		}
+		expected := app.Database.Type + ":" + app.Database.Version
+		if expected != dbType {
+			util.Failed("configured database type=%s but database type in volume is %s", expected, dbType)
+		}
+		util.Success("database in volume matches configured database: %s", expected)
+	},
+}
+
+func init() {
+	DebugCmd.AddCommand(DebugCheckDBMatch)
+}

--- a/cmd/ddev/cmd/debug-get-volume-db-version.go
+++ b/cmd/ddev/cmd/debug-get-volume-db-version.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// DebugGetVolumeDBVersion gets the DB Type/Version in the ddev-dbserver
+var DebugGetVolumeDBVersion = &cobra.Command{
+	Use:   "get-volume-db-version",
+	Short: "Get the database type/version found in the ddev-dbserver's database volume, which may not be the same as the configured database type/version",
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Can't find active project: %v", err)
+		}
+
+		dbType, err := app.GetExistingDBType()
+		if err != nil {
+			util.Failed("Failed to get existing DB type/version: %v", err)
+		}
+		util.Success(dbType)
+	},
+}
+
+func init() {
+	DebugCmd.AddCommand(DebugGetVolumeDBVersion)
+}

--- a/cmd/ddev/cmd/debug-migrate-database.go
+++ b/cmd/ddev/cmd/debug-migrate-database.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+// DebugMigrateDatabase Migrates a database to a new type
+var DebugMigrateDatabase = &cobra.Command{
+	Use:   "migrate-database",
+	Short: "Migrate a mysql or mariadb database to a different dbtype:dbversion; works only with mysql and mariadb, not with postgres",
+	Example: `ddev debug migrate-database mysql:8.0
+ddev debug migrate-database mariadb:10.7`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Can't find active project: %v", err)
+		}
+
+		newDBVersionType := args[0]
+		existingDBType, err := app.GetExistingDBType()
+		if err != nil {
+			util.Failed("Failed to get existing DB type/version: %v", err)
+		}
+		if newDBVersionType == existingDBType {
+			util.Success("database type in the docker volume is already %s", newDBVersionType)
+			return
+		}
+		if !strings.HasPrefix(newDBVersionType, nodeps.MariaDB) && !strings.HasPrefix(newDBVersionType, nodeps.MySQL) {
+			util.Failed("this command can only convert between mariadb and mysql")
+		}
+		if !(nodeps.IsValidMariaDBVersion(newDBVersionType) || nodeps.IsValidMySQLVersion(newDBVersionType)) && !(nodeps.IsValidMariaDBVersion(existingDBType) || nodeps.IsValidMySQLVersion(existingDBType)) {
+			if !util.Confirm(fmt.Sprintf("Is it OK to attempt conversion from %s to %s?\nThis will export your database, create a snapshot,\nthen destroy your current database and import into the new database type.\nIt only migrates the 'db' database", existingDBType, newDBVersionType)) {
+				util.Failed("migrate-database cancelled")
+			}
+			err = os.MkdirAll(app.GetConfigPath(".downloads"), 0755)
+			if err != nil {
+				util.Failed("failed to create %s: %v", app.GetConfigPath(".downloads"), err)
+			}
+
+			status, _ := app.SiteStatus()
+			if status != ddevapp.SiteRunning {
+				err = app.Start()
+				if err != nil {
+					util.Failed("failed to start %s: %v", app.Name, err)
+				}
+			}
+
+			err = app.ExportDB(app.GetConfigPath(".downloads/db.sql.gz"), "gzip", "db")
+			if err != nil {
+				util.Failed("failed to export-db to %s: %v", app.GetConfigPath(".downloads/db.sql.gz"), err)
+			}
+			err = app.Stop(true, true)
+			if err != nil {
+				util.Failed("failed to stop and delete %s with snapshot: %v", app.Name, err)
+			}
+
+			typeVals := strings.Split(newDBVersionType, ":")
+			app.Database.Type = typeVals[0]
+			app.Database.Version = typeVals[1]
+			err = app.WriteConfig()
+			if err != nil {
+				util.Failed("failed to WriteConfig: %v", err)
+			}
+			err = app.Start()
+			if err != nil {
+				util.Failed("failed to start %s: %v", app.Name, err)
+			}
+			err = app.ImportDB(app.GetConfigPath(".downloads/db.sql.gz"), "", true, false, "")
+			if err != nil {
+				util.Failed("failed to import-db %s: %v", app.GetConfigPath(".downloads/db.sql.gz"), err)
+			}
+			util.Success("database was converted to %s", newDBVersionType)
+			return
+		} else {
+			util.Failed("Invalid target source database type (%s) or target database type (%s)", existingDBType, newDBVersionType)
+		}
+	},
+}
+
+func init() {
+	DebugCmd.AddCommand(DebugMigrateDatabase)
+}

--- a/cmd/ddev/cmd/debug-migrate-database.go
+++ b/cmd/ddev/cmd/debug-migrate-database.go
@@ -78,9 +78,8 @@ ddev debug migrate-database mariadb:10.7`,
 			}
 			util.Success("database was converted to %s", newDBVersionType)
 			return
-		} else {
-			util.Failed("Invalid target source database type (%s) or target database type (%s)", existingDBType, newDBVersionType)
 		}
+		util.Failed("Invalid target source database type (%s) or target database type (%s)", existingDBType, newDBVersionType)
 	},
 }
 

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/Masterminds/sprig/v3"
 	"github.com/drud/ddev/pkg/archive"
-	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
@@ -144,13 +143,15 @@ ddev get --list --all
 			defer cleanup()
 		}
 
+		// 20220811: Don't auto-start because it auto-creates the wrong database in some situations, leading to a
+		// chicken-egg problem in getting database configured. See https://github.com/platformsh/ddev-platformsh/issues/24
 		// Automatically start, as we don't want to be taking actions with mutagen off, for example.
-		if status, _ := app.SiteStatus(); status != ddevapp.SiteRunning {
-			err = app.Start()
-			if err != nil {
-				util.Failed("Failed to start app %s to ddev-get: %v", app.Name, err)
-			}
-		}
+		//if status, _ := app.SiteStatus(); status != ddevapp.SiteRunning {
+		//	err = app.Start()
+		//	if err != nil {
+		//		util.Failed("Failed to start app %s to ddev-get: %v", app.Name, err)
+		//	}
+		//}
 
 		yamlFile := filepath.Join(extractedDir, "install.yaml")
 		yamlContent, err := fileutil.ReadFileIntoString(yamlFile)

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -154,7 +154,7 @@ func init() {
 	// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
 	_, err := dockerutil.GetDockerVersion()
 	// ddev --version may be called without docker available.
-	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "config" {
+	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "config" || os.Args[1] != "debug" {
 		util.Failed("Could not connect to a docker provider. Please start or install a docker provider.\nFor install help go to: https://ddev.readthedocs.io/en/latest/users/install/")
 	}
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -154,7 +154,7 @@ func init() {
 	// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
 	_, err := dockerutil.GetDockerVersion()
 	// ddev --version may be called without docker available.
-	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" {
+	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "config" {
 		util.Failed("Could not connect to a docker provider. Please start or install a docker provider.\nFor install help go to: https://ddev.readthedocs.io/en/latest/users/install/")
 	}
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -154,7 +154,7 @@ func init() {
 	// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
 	_, err := dockerutil.GetDockerVersion()
 	// ddev --version may be called without docker available.
-	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "config" || os.Args[1] != "debug" {
+	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" {
 		util.Failed("Could not connect to a docker provider. Please start or install a docker provider.\nFor install help go to: https://ddev.readthedocs.io/en/latest/users/install/")
 	}
 

--- a/docs/content/users/extend/database_types.md
+++ b/docs/content/users/extend/database_types.md
@@ -19,9 +19,9 @@ Since the existing binary database may not be compatible with changes to your co
 * `ddev debug get-volume-db-version` will show the current binary database type.
 * `ddev debug check-db-match` will show if your configured project matches the binary database type.
 * `ddev debug migrate-database` allows an automated attempt at migrating your database to a different type/version.
-  * This only works with databases of type `mysql` or `mariadb`.
-  * It often can't work to migrate *from* databases of type `mysql:8.0` because dumps of that type most often can't be easily imported into all other database types.
-  * Examples: `ddev debug migrate-database mariadb:10.7`, `ddev debug migrate-database mysql:8.0`
+    * This only works with databases of type `mysql` or `mariadb`.
+    * It often can't work to migrate *from* databases of type `mysql:8.0` because dumps of that type most often can't be easily imported into all other database types.
+    * Examples: `ddev debug migrate-database mariadb:10.7`, `ddev debug migrate-database mysql:8.0`
 
 ## Caveats
 

--- a/docs/content/users/extend/database_types.md
+++ b/docs/content/users/extend/database_types.md
@@ -12,6 +12,17 @@ database:
   version: 10.6
 ```
 
+## Checking the existing database and/or migrating
+
+Since the existing binary database may not be compatible with changes to your configuration, you need to check and/or migrate your database.
+
+* `ddev debug get-volume-db-version` will show the current binary database type.
+* `ddev debug check-db-match` will show if your configured project matches the binary database type.
+* `ddev debug migrate-database` allows an automated attempt at migrating your database to a different type/version.
+  * This only works with databases of type `mysql` or `mariadb`.
+  * It often can't work to migrate *from* databases of type `mysql:8.0` because dumps of that type most often can't be easily imported into all other database types.
+  * Examples: `ddev debug migrate-database mariadb:10.7`, `ddev debug migrate-database mysql:8.0`
+
 ## Caveats
 
 * If you change the database type or version in an existing project, the existing database will not be compatible with your change, so you'll want to use `ddev export-db` to save a dump first.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -439,12 +439,13 @@ func (app *DdevApp) ValidateConfig() error {
 		return fmt.Errorf("unsupported database type/version: '%s:%s', ddev %s only supports the following database types and versions: mariadb: %v, mysql: %v, postgres: %v", app.Database.Type, app.Database.Version, runtime.GOARCH, nodeps.GetValidMariaDBVersions(), nodeps.GetValidMySQLVersions(), nodeps.GetValidPostgresVersions())
 	}
 
+	// This check is too intensive for app.Init() and ddevapp.GetActiveApp(), slows things down dramatically
 	// If the database already exists in volume and is not of this type, then throw an error
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
-		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
-			return fmt.Errorf("Unable to configure project %s with database type %s because that database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', see docs at %s", app.Name, dbType, dbType, dbType, "https://ddev.readthedocs.io/en/latest/users/extend/database_types/")
-		}
-	}
+	//if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+	//	if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
+	//		return fmt.Errorf("Unable to configure project %s with database type %s because that database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', see docs at %s", app.Name, dbType, dbType, dbType, "https://ddev.readthedocs.io/en/latest/users/extend/database_types/")
+	//	}
+	//}
 
 	// golang on windows is not able to time.LoadLocation unless
 	// go is installed... so skip validation on Windows

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -439,6 +439,13 @@ func (app *DdevApp) ValidateConfig() error {
 		return fmt.Errorf("unsupported database type/version: '%s:%s', ddev %s only supports the following database types and versions: mariadb: %v, mysql: %v, postgres: %v", app.Database.Type, app.Database.Version, runtime.GOARCH, nodeps.GetValidMariaDBVersions(), nodeps.GetValidMySQLVersions(), nodeps.GetValidPostgresVersions())
 	}
 
+	// If the database already exists in volume and is not of this type, then throw an error
+	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
+			return fmt.Errorf("Unable to configure project %s with database type %s because that database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', see docs at %s", app.Name, dbType, dbType, dbType, "https://ddev.readthedocs.io/en/latest/users/extend/database_types/")
+		}
+	}
+
 	// golang on windows is not able to time.LoadLocation unless
 	// go is installed... so skip validation on Windows
 	if runtime.GOOS != "windows" {

--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -1,0 +1,47 @@
+package ddevapp
+
+import (
+	"fmt"
+	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/versionconstants"
+	"strconv"
+	"strings"
+)
+
+// GetExistingDBType returns type/version like mariadb:10.4 or postgres:13 or "" if no existing volume
+// This has to make a docker container run so is fairly costly.
+func (app *DdevApp) GetExistingDBType() (string, error) {
+
+	volName := app.GetMariaDBVolumeName()
+	if !dockerutil.VolumeExists(volName) {
+		volName = app.GetPostgresVolumeName()
+		if !dockerutil.VolumeExists(volName) {
+			//output.UserOut.Printf("No database volume currently exists for project %s, one will be created when needed", app.Name)
+			return "", nil
+		}
+	}
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.GetWebImage(), "", []string{"sh", "-c", "cat /var/tmp/db_mariadb_version.txt || cat /var/tmp/PG_VERSION"}, []string{}, []string{}, []string{volName + ":/var/tmp"}, "", true, false, nil)
+
+	if err != nil {
+		util.Failed("failed to RunSimpleContainer to inspect database version/type: %v, output=%s", err, out)
+	}
+
+	dbType := ""
+	dbVersion := ""
+	out = strings.Trim(out, " \n\r\t")
+	if _, err := strconv.Atoi(out); err == nil {
+		dbType = nodeps.Postgres
+		dbVersion = out
+	} else {
+		res := strings.Split(out, "_")
+		if len(res) != 2 {
+			return "", fmt.Errorf("could not split version string %s", out)
+		}
+		dbType = res[0]
+		dbVersion = res[1]
+	}
+
+	return dbType + ":" + dbVersion, nil
+}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -959,6 +959,12 @@ func (app *DdevApp) Start() error {
 	app.DockerEnv()
 	dockerutil.EnsureDdevNetwork()
 
+	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+		if dbType, err := app.GetExistingDBType(); err != nil || dbType != app.Database.Type+":"+app.Database.Version {
+			return fmt.Errorf("Unable to start project %s because the configured database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', see docs at %s", app.Name, dbType, dbType, "https://ddev.readthedocs.io/en/latest/users/extend/database_types/")
+		}
+	}
+
 	volumesNeeded := []string{"ddev-global-cache", "ddev-" + app.Name + "-snapshots"}
 	for _, v := range volumesNeeded {
 		_, err = dockerutil.CreateVolume(v, "local", nil)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -963,7 +963,7 @@ func (app *DdevApp) Start() error {
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 		// OK to start if dbType is empty (nonexistent) or if it matches
 		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
-			return fmt.Errorf("Unable to start project %s because the configured database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', see docs at %s", app.Name, dbType, dbType, "https://ddev.readthedocs.io/en/latest/users/extend/database_types/")
+			return fmt.Errorf("Unable to start project %s because the configured database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s' and then you might want to try 'ddev debug migrate-database %s', see docs at %s", app.Name, dbType, dbType, app.Database.Type+":"+app.Database.Version, "https://ddev.readthedocs.io/en/latest/users/extend/database_types/")
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -756,6 +756,7 @@ func (app *DdevApp) ExportDB(outFile string, compressionType string, targetDB st
 }
 
 // SiteStatus returns the current status of an application determined from web and db service health.
+// returns status, statusDescription
 func (app *DdevApp) SiteStatus() (string, string) {
 	if !fileutil.FileExists(app.GetAppRoot()) {
 		return SiteDirMissing, fmt.Sprintf(`%s: %v; Please "ddev stop --unlist %s"`, SiteDirMissing, app.GetAppRoot(), app.Name)
@@ -960,7 +961,8 @@ func (app *DdevApp) Start() error {
 	dockerutil.EnsureDdevNetwork()
 
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
-		if dbType, err := app.GetExistingDBType(); err != nil || dbType != app.Database.Type+":"+app.Database.Version {
+		// OK to start if dbType is empty (nonexistent) or if it matches
+		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
 			return fmt.Errorf("Unable to start project %s because the configured database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', see docs at %s", app.Name, dbType, dbType, "https://ddev.readthedocs.io/en/latest/users/extend/database_types/")
 		}
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1430,6 +1430,11 @@ func TestDdevAllDatabases(t *testing.T) {
 	err = app.Stop(true, false)
 	require.NoError(t, err)
 
+	// Existing DB type in volume should be empty
+	dbType, err := app.GetExistingDBType()
+	assert.NoError(err)
+	assert.Equal("", strings.Trim(dbType, " \n\r\t"))
+
 	// Make sure there isn't an old db laying around
 	_ = dockerutil.RemoveVolume(app.Name + "-mariadb")
 	t.Cleanup(func() {
@@ -1469,6 +1474,10 @@ func TestDdevAllDatabases(t *testing.T) {
 			t.Errorf("Continuing/skippping %s due to app.Start() failure %v", dbVersion, startErr)
 			continue
 		}
+
+		inVolumeDBType, err := app.GetExistingDBType()
+		assert.NoError(err)
+		assert.Equal(dbTypeVersion, inVolumeDBType)
 
 		// The db_mariadb_version.txt file does not exist on postgres
 		if dbType != nodeps.Postgres {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1128,6 +1128,10 @@ func TestDdevImportDB(t *testing.T) {
 		assert.NoError(err)
 		_ = os.Remove(filepath.Join(app.AppRoot, "hello-pre-import-db-"+app.Name))
 		_ = os.Remove(filepath.Join(app.AppRoot, "hello-post-import-db-"+app.Name))
+		for _, dbType := range []string{nodeps.Postgres, nodeps.MariaDB} {
+			err = dockerutil.RemoveVolume(app.Name + "-" + dbType)
+			require.NoError(t, err)
+		}
 
 	})
 
@@ -1298,6 +1302,13 @@ func TestDdevImportDB(t *testing.T) {
 				assert.Len(lines, 2)
 			}
 		}
+	}
+
+	err = app.Stop(true, false)
+	require.NoError(t, err)
+	for _, dbType := range []string{nodeps.Postgres, nodeps.MariaDB} {
+		err = dockerutil.RemoveVolume(app.Name + "-" + dbType)
+		assert.NoError(err)
 	}
 	app.Database = ddevapp.DatabaseDesc{Type: nodeps.MariaDB, Version: nodeps.MariaDBDefaultVersion}
 	err = app.WriteConfig()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1413,7 +1413,7 @@ func TestDdevAllDatabases(t *testing.T) {
 	dbVersions = nodeps.RemoveItemFromSlice(dbVersions, "postgres:9")
 	//Use a smaller list if GOTEST_SHORT
 	if os.Getenv("GOTEST_SHORT") != "" {
-		dbVersions = []string{"postgres:14", "mariadb:10.2", "mariadb:10.3", "mysql:8.0", "mysql:5.7"}
+		dbVersions = []string{"postgres:14", "mariadb:10.3", "mariadb:10.4", "mysql:8.0", "mysql:5.7"}
 		t.Logf("Using limited set of database servers because GOTEST_SHORT is set (%v)", dbVersions)
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4089 
* #3923 

It's not a common occurrence, but people are really frustrated when they configure a database and then can't start it. 

## How this PR Solves The Problem:

* Check on start to see if the existing database matches the configuration
* Check on DB config change to see if the existing database matches the configuration
* `ddev debug check-db-match` checks to see if they match
* `ddev debug get-volume-db-version` gets the existing in-container in-volume value
* `ddev debug migrate-database` will attempt a database migration

## Manual Testing Instructions:

- [x] Test changing config in .ddev/config.yaml and then `ddev start`. It should fail and complain with a good message
- [x] Try changing with `ddev config --database-version` and it should complain with a good message.
- [x] Check performance. I think some of these commands may be feeling too sluggish. Check through.
- [x] Test `ddev debug check-db-match`
- [x] Test `ddev debug get-volume-db-version`

## Automated Testing Overview:

* TestDdevAllDatabases has additional coverage.


## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4105"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

