### PR TITLE
Update platform integration documentation

### DIFF
--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -21,21 +21,25 @@ web_environment:
 ## Platform.sh per Project Configuration
 
 1. Check out the site from platform.sh and then configure it with `ddev config`. You'll want to use `ddev start` and make sure the basic functionality is working.
-2. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT variables to your project `.ddev/config.yaml` or a `.ddev/config.*.yaml`:
+2. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT variables to your project.
 
-```yaml
-web_environment:
-  - PLATFORM_PROJECT=nf4amudfn23biyourproject
-  - PLATFORM_ENVIRONMENT=main
-```
-or with
-```bash
-ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"
-```
+    * Either in `.ddev/config.yaml` or a `.ddev/config.*.yaml` file:
 
-4. `ddev restart`
-5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
-6. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+        ```yaml
+        web_environment:
+          - PLATFORM_PROJECT=nf4amudfn23biyourproject
+          - PLATFORM_ENVIRONMENT=main
+        ```
+
+    * Or with a command from your terminal:
+
+        ```bash
+        ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"
+         ```
+
+3. `ddev restart`
+4. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
+5. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
 ## Usage
 

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -35,7 +35,7 @@ web_environment:
 
         ```bash
         ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"
-         ```
+        ```
 
 3. `ddev restart`
 4. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -6,29 +6,32 @@ ddev provides integration with the [Platform.sh Website Management Platform](htt
 
 ddev's Platform.sh integration pulls database and files from an existing Platform.sh site/environment into your local system so you can develop locally.
 
-## Platform.sh Quickstart
+## Platform.sh Global Configuration
 
-1. Check out the site from platform.sh and then configure it with `ddev config`. You'll want to use `ddev start` and make sure the basic functionality is working.
-2. Obtain and configure an API token.
-   a. Login to the Platform.sh Dashboard and go to Account->API Tokens to create an API token for ddev to use.
-   b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml:
+You need to obtain and configure an API token first. This is only needed once.
 
-   ```yaml
-   web_environment:
-   - PLATFORMSH_CLI_TOKEN=abcdeyourtoken
-   ```
-
-3. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT variables to your project `.ddev/config.yaml` or a `.ddev/config.*.yaml`:
+1. Login to the Platform.sh Dashboard and go to Account->API Tokens to create an API token for ddev to use.
+2. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml:
 
 ```yaml
-   web_environment:
-   - PLATFORM_PROJECT=nf4amudfn23biyourproject
-   - PLATFORM_ENVIRONMENT=main
- ```
+web_environment:
+  - PLATFORMSH_CLI_TOKEN=abcdeyourtoken
+```
 
-You can also do this with `ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"`
-4. `ddev restart`
-5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
+## Platform.sh per Project Configuration
+
+1. Check out the site from platform.sh and then configure it with `ddev config`. You'll want to use `ddev start` and make sure the basic functionality is working.
+2. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT variables to your project `.ddev/config.yaml` or a `.ddev/config.*.yaml`:
+
+```yaml
+web_environment:
+  - PLATFORM_PROJECT=nf4amudfn23biyourproject
+  - PLATFORM_ENVIRONMENT=main
+```
+
+You can also do this with `ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"`  
+4. `ddev restart`  
+5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.  
 6. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
 ## Usage

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -28,10 +28,13 @@ web_environment:
   - PLATFORM_PROJECT=nf4amudfn23biyourproject
   - PLATFORM_ENVIRONMENT=main
 ```
+or with
+```bash
+ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"
+```
 
-You can also do this with `ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"`  
-4. `ddev restart`  
-5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.  
+4. `ddev restart`
+5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 6. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
 ## Usage


### PR DESCRIPTION
- Split one time config (cli_token) from per project config
- Improve formating (using double spaces) so that both mkdocs and github print new bullets on a new line

## The Problem/Issue/Bug:
https://ddev.readthedocs.io/en/latest/users/providers/platform/ is a bit hard to follow because of poorly rendered markdown list and the fact that global configuration is mixed with per-project config

![image](https://user-images.githubusercontent.com/520237/184089231-62593071-8eb3-4a2f-863b-0f9e6970f0f4.png)

This MR separates one time config and improves lists

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4106"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

