### PR TITLE
Mutagen rework to use volume label and session label

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -76,6 +76,7 @@ Mailgun
 Manage
 MariaDB
 Misconfigured
+MUTAGEN_DATA_DIRECTORY
 MyDevSite
 MySQL
 MySite

--- a/cmd/ddev/cmd/a.go
+++ b/cmd/ddev/cmd/a.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/util"
+	"os"
 )
 
 // This file is a.go because global config must be loaded before anybody else
@@ -16,6 +17,7 @@ func init() {
 		util.Failed("unable to read global config: %v", err)
 	}
 	globalconfig.GetCAROOT()
+	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
 	// GetDockerClient should be called early to get DOCKER_HOST set
 	_ = dockerutil.GetDockerClient()
 }

--- a/cmd/ddev/cmd/clean.go
+++ b/cmd/ddev/cmd/clean.go
@@ -73,6 +73,7 @@ Additional commands that can help clean up resources:
 		globalDdevDir := globalconfig.GetGlobalDdevDir()
 		_ = os.RemoveAll(filepath.Join(globalDdevDir, "testcache"))
 		_ = os.RemoveAll(filepath.Join(globalDdevDir, "bin"))
+		_ = os.RemoveAll(globalconfig.GetMutagenDataDirectory())
 
 		output.UserOut.Print("Deleting snapshots and downloads for selected projects...")
 		for _, project := range projects {

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -99,10 +99,10 @@ func TestCustomCommands(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 
-	_, err = exec.RunHostCommand(DdevBin, "debug", "fix-commands")
-	require.NoError(t, err)
-	out, err := exec.RunHostCommand(DdevBin)
-	assert.NoError(err)
+	out, err := exec.RunHostCommand(DdevBin, "debug", "fix-commands")
+	require.NoError(t, err, "failed to run ddev debug fix-commands, out='%s', err=%v", out, err)
+	out, err = exec.RunHostCommand(DdevBin)
+	require.NoError(t, err, "failed to run ddev command, output='%s', err=%v", out, err)
 	assert.Contains(out, "mysql client in db container")
 
 	// Test the `ddev mysql` command with stdin

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -62,7 +62,9 @@ func TestCustomCommands(t *testing.T) {
 
 	origType := app.Type
 	t.Cleanup(func() {
-		// Stop the mutagen daemon runnning in the bogus homedir
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		// Stop the mutagen daemon running in the bogus homedir
 		ddevapp.StopMutagenDaemon()
 		err = os.Chdir(origDir)
 		assert.NoError(err)

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -31,6 +31,15 @@ func TestCustomCommands(t *testing.T) {
 	origHome, err := os.UserHomeDir()
 	require.NoError(t, err)
 
+	// Before changing HOME, make sure that mutagen is already running if we're using it,
+	// so we don't accidentally start it in the wrong directory
+	err = globalconfig.ReadGlobalConfig()
+	require.NoError(t, err)
+	if globalconfig.DdevGlobalConfig.MutagenEnabledGlobal {
+		out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "start")
+		require.NoError(t, err, "unable to run mutagen daemon start, out='%s', err=%v", out, err)
+	}
+
 	if runtime.GOOS == "windows" {
 		origHome = os.Getenv("USERPROFILE")
 	}

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -71,12 +71,12 @@ func TestCustomCommands(t *testing.T) {
 
 	origType := app.Type
 	t.Cleanup(func() {
+		err = os.Chdir(origDir)
+		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
 		// Stop the mutagen daemon running in the bogus homedir
 		ddevapp.StopMutagenDaemon()
-		err = os.Chdir(origDir)
-		assert.NoError(err)
 		runTime()
 		app.Type = origType
 		err = app.WriteConfig()
@@ -295,12 +295,7 @@ func TestLaunchCommand(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		// On windows, give it a moment to give up all resources and avoid failure on RemoveAll()
-		if runtime.GOOS == "windows" {
-			time.Sleep(time.Second * 2)
-		}
-		err = os.RemoveAll(testDir)
-		assert.NoError(err)
+		_ = os.RemoveAll(testDir)
 	})
 
 	// This only tests the https port changes, but that might be enough

--- a/cmd/ddev/cmd/debug-fixcommands.go
+++ b/cmd/ddev/cmd/debug-fixcommands.go
@@ -20,11 +20,11 @@ var DebugFixCommandsCmd = &cobra.Command{
 		if err != nil {
 			util.Warning("Failed to populate custom command files: %v", err)
 		}
-		// If no-bind-mounts we have to do a start to push it back in there again.
+		// If no-bind-mounts we have to do a start to push the commands back in there again.
 		if globalconfig.DdevGlobalConfig.NoBindMounts {
 			err = app.Start()
 			if err != nil {
-				util.Failed("Failed to restart: %v")
+				util.Failed("Failed to restart with NoBindMounts set: %v", err)
 			}
 		}
 	},

--- a/cmd/ddev/cmd/debug-mutagen.go
+++ b/cmd/ddev/cmd/debug-mutagen.go
@@ -17,6 +17,7 @@ var DebugMutagenCmd = &cobra.Command{
 	Example: `ddev debug mutagen sync list
 ddev debug mutagen daemon stop
 ddev debug mutagen
+ddev d mutagen sync list
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		mutagenPath := globalconfig.GetMutagenPath()

--- a/cmd/ddev/cmd/debug-nfsmount.go
+++ b/cmd/ddev/cmd/debug-nfsmount.go
@@ -53,7 +53,7 @@ var DebugNFSMountCmd = &cobra.Command{
 		if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", app.AppRoot)) {
 			shareDir = filepath.Join("/System/Volumes/Data", app.AppRoot)
 		}
-		volume, err := dockerutil.CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": fmt.Sprintf("addr=%s,hard,nolock,rw", hostDockerInternal), "device": ":" + dockerutil.MassageWindowsNFSMount(shareDir)})
+		volume, err := dockerutil.CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": fmt.Sprintf("addr=%s,hard,nolock,rw", hostDockerInternal), "device": ":" + dockerutil.MassageWindowsNFSMount(shareDir)}, nil)
 		//nolint: errcheck
 		defer dockerutil.RemoveVolume(testVolume)
 		if err != nil {

--- a/cmd/ddev/cmd/debug.go
+++ b/cmd/ddev/cmd/debug.go
@@ -7,8 +7,13 @@ import (
 
 // DebugCmd is the top-level "ddev debug" command
 var DebugCmd = &cobra.Command{
-	Use:   "debug [command]",
-	Short: "A collection of debugging commands",
+	Use:     "debug [command]",
+	Short:   "A collection of debugging commands",
+	Aliases: []string{"d", "dbg"},
+	Example: `ddev debug
+ddev debug mutagen sync list
+ddev d mutagen sync list
+ddev d capabilities`,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := cmd.Usage()
 		util.CheckErr(err)

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -19,9 +19,10 @@ var wrapListTableText bool
 
 // ListCmd represents the list command
 var ListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List projects",
-	Long:  `List projects. Shows all projects by default, shows active projects only with --active-only`,
+	Use:     "list",
+	Short:   "List projects",
+	Long:    `List projects. Shows all projects by default, shows active projects only with --active-only`,
+	Aliases: []string{"l", "ls"},
 	Example: `ddev list
 ddev list --active-only
 ddev list -A`,

--- a/cmd/ddev/cmd/mutagen-reset.go
+++ b/cmd/ddev/cmd/mutagen-reset.go
@@ -36,7 +36,7 @@ var MutagenResetCmd = &cobra.Command{
 		if err != nil {
 			// if the mutagen session just did not exist, continue on
 			if !strings.Contains(err.Error(), "does not exist") {
-				util.Failed("Failed to flush mutagen: %v", err)
+				util.Warning("Could not flush mutagen: %v", err)
 			}
 		}
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -330,9 +330,8 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		assert.NoError(err)
 
 		_, err = os.Stat(globalconfig.GetMutagenPath())
-		if err == nil {
-			out, err := exec.RunHostCommand(DdevBin, "debug", "mutagen", "daemon", "stop")
-			assert.NoError(err, "mutagen daemon stop returned %s", string(out))
+		if err == nil && (app.MutagenEnabled || app.MutagenEnabledGlobal) {
+			ddevapp.StopMutagenDaemon()
 		}
 	})
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -77,6 +77,7 @@ func TestMain(m *testing.M) {
 
 	// We don't want the tests reporting to Segment.
 	_ = os.Setenv("DDEV_NO_INSTRUMENTATION", "true")
+	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
 
 	// If GOTEST_SHORT is an integer, then use it as index for a single usage
 	// in the array. Any value can be used, it will default to just using the

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -323,7 +323,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	err = fileutil.AppendStringToFile(filepath.Join(globalconfig.GetGlobalDdevDir(), "global_config.yaml"), "last_started_version: v0.1")
 	require.NoError(t, err)
 	out, err = exec.RunHostCommand(DdevBin, "start")
-	assert.NoError(err)
+	require.NoError(t, err, "start failed, out='%s', err=%v", out, err)
 	assert.Contains(out, "ddev-ssh-agent container has been removed")
 	assert.Contains(out, "ssh-agent container is running")
 	t.Cleanup(func() {

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -331,7 +331,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		assert.NoError(err)
 
 		_, err = os.Stat(globalconfig.GetMutagenPath())
-		if err == nil && (app.MutagenEnabled || app.MutagenEnabledGlobal) {
+		if err == nil && app.IsMutagenEnabled() {
 			ddevapp.StopMutagenDaemon()
 		}
 	})

--- a/docs/content/users/basics/cli-usage.md
+++ b/docs/content/users/basics/cli-usage.md
@@ -10,7 +10,7 @@ Type `ddev` or `ddev -h`in a terminal window to see the available ddev commands.
 * `ddev ssh` takes you into the web container.
 * `ddev exec <command>` lets you execute any command inside the web container.
 * `ddev stop` stops a project and removes its memory usage (but does not throw away any data).
-* `ddev poweroff` stops all resources that DDEV is using.
+* `ddev poweroff` stops all resources that DDEV is using, including mutagen session if mutagen is enabled.
 * `ddev delete` will destroy the database and DDEV's knowledge of the project, but does nothing to your code.
 
 ## Lots of other commands

--- a/docs/content/users/basics/cli-usage.md
+++ b/docs/content/users/basics/cli-usage.md
@@ -10,7 +10,7 @@ Type `ddev` or `ddev -h`in a terminal window to see the available ddev commands.
 * `ddev ssh` takes you into the web container.
 * `ddev exec <command>` lets you execute any command inside the web container.
 * `ddev stop` stops a project and removes its memory usage (but does not throw away any data).
-* `ddev poweroff` stops all resources that DDEV is using, including mutagen session if mutagen is enabled.
+* `ddev poweroff` stops all resources that DDEV is using, including mutagen session if mutagen is enabled. (On start, mutagen will have to resync files for each project.)
 * `ddev delete` will destroy the database and DDEV's knowledge of the project, but does nothing to your code.
 
 ## Lots of other commands

--- a/docs/content/users/basics/cli-usage.md
+++ b/docs/content/users/basics/cli-usage.md
@@ -10,7 +10,7 @@ Type `ddev` or `ddev -h`in a terminal window to see the available ddev commands.
 * `ddev ssh` takes you into the web container.
 * `ddev exec <command>` lets you execute any command inside the web container.
 * `ddev stop` stops a project and removes its memory usage (but does not throw away any data).
-* `ddev poweroff` stops all resources that DDEV is using, including mutagen session if mutagen is enabled. (On start, mutagen will have to resync files for each project.)
+* `ddev poweroff` stops all resources that DDEV is using, including mutagen session if mutagen is enabled. (On start, mutagen will have to re-sync files for each project.)
 * `ddev delete` will destroy the database and DDEV's knowledge of the project, but does nothing to your code.
 
 ## Lots of other commands

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -176,7 +176,6 @@ Docker or an alternative is required before anything will work with DDEV. This i
 
     You can also easily perform the installation or upgrade manually if preferred. DDEV is just a single executable, no special installation is actually required, so for all operating systems, the installation is just copying DDEV into place where it's in the system path.
 
-    * `ddev poweroff` if upgrading
     * Download and extract the latest [ddev release](https://github.com/drud/ddev/releases) for your architecture.
     * Move ddev to /usr/local/bin: `mv ddev /usr/local/bin/` (may require sudo), or another directory in your `$PATH` as preferred.
     * Run `ddev` to test your installation. You should see DDEV's command usage output.

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -154,7 +154,7 @@ Instructions for Mutagen and NFS are below.
     Most people get all the information they need about mutagen by running `ddev mutagen monitor` to see the results. However, Mutagen has full logging. Here's how to run it:
 
     * `killall mutagen`
-    * `export MUTAGEN_DATA_DIRECTORY=~/.mutagen_data_directory`
+    * `export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory`
     * `export MUTAGEN_LOG_LEVEL=debug` or `export MUTAGEN_LOG_LEVEL=trace`
     * `~/.ddev/bin/mutagen daemon run`
     * Work with your project various actions and watch the output.

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -154,6 +154,7 @@ Instructions for Mutagen and NFS are below.
     Most people get all the information they need about mutagen by running `ddev mutagen monitor` to see the results. However, Mutagen has full logging. Here's how to run it:
 
     * `killall mutagen`
+    * `export MUTAGEN_DATA_DIRECTORY=~/.mutagen_data_directory`
     * `export MUTAGEN_LOG_LEVEL=debug` or `export MUTAGEN_LOG_LEVEL=trace`
     * `~/.ddev/bin/mutagen daemon run`
     * Work with your project various actions and watch the output.

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -136,8 +136,8 @@ Instructions for Mutagen and NFS are below.
     ### Troubleshooting Mutagen Sync Issues
 
     * Please make sure that DDEV projects work *without* mutagen before troubleshooting mutagen. `ddev config --mutagen-enabled=false && ddev restart`.
-    * `ddev poweroff` stops all registered mutagen sessions. You can also kill the mutagen daemon with `MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory ~/.ddev/bin/mutagen daemon stop`. After doing that you should not see any mutagen processes running when you use `ps -ef |grep mutagen`.
-    * DDEV's mutagen daemon keeps its data in a DDEV-only MUTAGEN_DATA_DIRECTORY, `~/.ddev_mutagen_data_directory`.
+    * As of DDEV v1.21.2, `ddev poweroff` stops all registered mutagen sessions. You can also kill the mutagen daemon with `MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory ~/.ddev/bin/mutagen daemon stop`. After doing that you should not see any mutagen processes running when you use `ps -ef |grep mutagen`.
+    * As of DDEV v1.21.2, DDEV's mutagen daemon keeps its data in a DDEV-only MUTAGEN_DATA_DIRECTORY, `~/.ddev_mutagen_data_directory`.
     * DDEV's mutagen is installed in `~/.ddev/bin/mutagen`. You can use all the features of mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory` and you can use all features of mutagen, including `~/.ddev/bin/mutagen sync list` and `~/.ddev/bin/mutagen daemon stop`.
         You can run the script [diagnose_mutagen.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/diagnose_mutagen.sh) to gather some information about the setup of mutagen. Please report its output when creating an issue or otherwise seeking support.
     * Try `ddev poweroff` or `~/.ddev/bin/mutagen daemon stop && ~/.ddev/bin/mutagen daemon start` to restart the mutagen daemon if you suspect it's hanging.

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -68,7 +68,6 @@ Instructions for Mutagen and NFS are below.
 
     * **Not for every project**: Mutagen is not the right choice for every project. If filesystem consistency is your highest priority (as opposed to performance) then there are reasons to be cautious, although people have had excellent experiences: there haven't been major issues reported, but two-way sync is a very difficult computational problem, and problems may surface.
     * **Don't change or remove files when DDEV is stopped**: If you change files (checking out a different branch, or removing a file) while DDEV is stopped, mutagen has no way to know you meant to do that. So when you start again, it will get the files that are stored and bring them back to the host.
-    * **Only one mutagen version on machine please**: DDEV installs its own mutagen. **You do not need to install mutagen.** Multiple mutagen versions can't coexist on one machine, so please stop any running mutagen. On macOS, `killall mutagen`. If you absolutely have to have mutagen installed via homebrew or another technique (for another project) make sure it's the same version as you get with `ddev version`.
     * **Works everywhere, most useful on macOS and traditional Windows**: This is mostly for macOS and traditional Windows users. WSL2 is already the preferred environment for Windows users, but if you're still using traditional Windows this makes a huge difference. Although DDEV with mutagen is fully supported and tested on traditional Windows and Linux/WSL2, enabling mutagen on Linux/WSL2 may not be your first choice, since it adds some complexity and very little performance.
     * **Increased disk usage**: Mutagen integration increases the size of your project code disk usage, because the code exists both on your computer and also inside a docker volume. (As of v1.19+, this does *not* include your file upload directory, so normally it's not too intrusive.) So take care that you have enough overall disk space, and also (on macOS) that you have enough file space set up in Docker Desktop. For projects before v1.19, if you have a large amount of data like user-generated content that does not need syncing (i.e. `fileadmin` for TYPO3 or `sites/default/files` for Drupal), you can exclude specific directories from getting synced and use regular docker mount for them instead. See [below for Advanced Mutagen configuration options](#advanced-mutagen-configuration-options). As of v1.19, this is handled automatically and these files are not mutagen-synced.
     * If your project is likely to change the same file on both the host and inside the container, you may be at risk for conflicts.
@@ -137,17 +136,18 @@ Instructions for Mutagen and NFS are below.
     ### Troubleshooting Mutagen Sync Issues
 
     * Please make sure that DDEV projects work *without* mutagen before troubleshooting mutagen. `ddev config --mutagen-enabled=false && ddev restart`.
-    * DDEV's mutagen may not be compatible with an existing mutagen on your system. Please make sure that any mutagen installs you have are not running, or stop them. You may want to `brew uninstall mutagen-io/mutagen/mutagen mutagen-io/mutagen/mutagen-beta` to get rid of brew-installed versions.
-    * DDEV's mutagen is installed in `~/.ddev/bin/mutagen`. You can use all the features of mutagen by running that, including `~/.ddev/bin/mutagen sync list` and `~/.ddev/bin/mutagen daemon stop`.
+    * `ddev poweroff` stops all registered mutagen sessions. You can also kill the mutagen daemon with `MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory ~/.ddev/bin/mutagen daemon stop`. After doing that you should not see any mutagen processes running when you use `ps -ef |grep mutagen`.
+    * DDEV's mutagen daemon keeps its data in a DDEV-only MUTAGEN_DATA_DIRECTORY, `~/.ddev_mutagen_data_directory`.
+    * DDEV's mutagen is installed in `~/.ddev/bin/mutagen`. You can use all the features of mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory` and you can use all features of mutagen, including `~/.ddev/bin/mutagen sync list` and `~/.ddev/bin/mutagen daemon stop`.
         You can run the script [diagnose_mutagen.sh](https://raw.githubusercontent.com/drud/ddev/master/scripts/diagnose_mutagen.sh) to gather some information about the setup of mutagen. Please report its output when creating an issue or otherwise seeking support.
-    * Try `~/.ddev/bin/mutagen daemon stop && ~/.ddev/bin/mutagen daemon start` to restart the mutagen daemon if you suspect it's hanging.
-    * Use `ddev mutagen reset` if you suspect trouble (and always after changing the `.ddev/mutagen/mutagen.yml`. This restarts everything from scratch, including the docker volume that's used to store your project inside the container.)
+    * Try `ddev poweroff` or `~/.ddev/bin/mutagen daemon stop && ~/.ddev/bin/mutagen daemon start` to restart the mutagen daemon if you suspect it's hanging.
+    * Use `ddev mutagen reset` if you suspect trouble (and always after changing the `.ddev/mutagen/mutagen.yml`. This restarts the project mutagen data (docker volume and mutagen session) from scratch.
     * `ddev mutagen monitor` can help watch mutagen behavior. It's the same as `~/.ddev/bin/mutagen sync monitor <syncname>`
     * `ddev debug mutagen` will let you run any mutagen command using the binary in `~/.ddev/bin/mutagen`.
     * If you're working on the host and expecting things to show up immediately inside the container, you can learn a lot by running `ddev mutagen monitor` in a separate window as you work. You'll see when mutagen responds to your changes and get an idea about how much delay there is.
     * Consider `ddev stop` before massive file change operations (like moving a directory, etc.)
     * If you get in real trouble, `ddev stop`, reset your files with git, and then `ddev mutagen reset` to throw away the docker volume (which may already have incorrect files on it.)
-    * If you're having trouble, we really want to hear from you to learn and try to sort it out. See the [Support channels](../support.md).
+    * If you're having trouble, we'd love to hear from you to learn and try to sort it out. See the [Support channels](../support.md).
 
     #### Advanced Mutagen Troubleshooting
 

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -107,7 +107,7 @@ Instructions for Mutagen and NFS are below.
     Remember if you edit the `.ddev/mutagen/mutagen.yml` file:
 
     * Remove the `#ddev-generated` line
-    * Execute a `ddev mutagen reset` to avoid the situation where the docker volume still has files from an older configuration.
+    * Execute a `ddev mutagen reset` to avoid the situation where the docker volume and mutagen session still have files from an older configuration.
 
     The most likely thing you'll want to do is to exclude a path from mutagen syncing, which you can do in the `paths:` section of the `ignore:` stanza in the `.ddev/mutagen/mutagen.yml`.
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -306,4 +306,6 @@ volumes:
   {{ if and .MutagenEnabled (not .NoProjectMount) }}
   project_mutagen:
     name: {{ .MutagenVolumeName }}
+    external: true
+
   {{ end }}{{/* end if and .MutagenEnabled (not .NoProjectMount) */}}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -974,6 +974,14 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 
+	if app.IsMutagenEnabled() && !CheckMutagenVolumeSyncCompatibility(app) {
+		util.Debug("Attempting to remove docker volume %s", GetMutagenVolumeName(app))
+		err = dockerutil.RemoveVolume(GetMutagenVolumeName(app))
+		if err != nil {
+			util.Failed("Mutagen docker volume is from another docker context, please `ddev mutagen reset`")
+		}
+	}
+
 	volumesNeeded := []string{"ddev-global-cache", "ddev-" + app.Name + "-snapshots"}
 	if app.IsMutagenEnabled() {
 		volumesNeeded = append(volumesNeeded, GetMutagenVolumeName(app))

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1890,7 +1890,6 @@ func (app *DdevApp) DockerEnv() {
 		"IS_DDEV_PROJECT":            "true",
 		"IS_GITPOD":                  isGitpod,
 		"IS_WSL2":                    isWSL2,
-		"MUTAGEN_DATA_DIRECTORY":     globalconfig.GetMutagenDataDirectory(),
 	}
 
 	// Set the DDEV_DB_CONTAINER_COMMAND command to empty to prevent docker-compose from complaining normally.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -978,7 +978,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		util.Debug("Attempting to remove docker volume %s", GetMutagenVolumeName(app))
 		err = dockerutil.RemoveVolume(GetMutagenVolumeName(app))
 		if err != nil {
-			util.Failed("Mutagen docker volume is from another docker context, please `ddev mutagen reset`")
+			return fmt.Errorf("Mutagen docker volume is from another docker context, please `ddev mutagen reset`")
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -979,7 +979,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		volumesNeeded = append(volumesNeeded, GetMutagenVolumeName(app))
 	}
 	for _, v := range volumesNeeded {
-		_, err = dockerutil.CreateVolume(v, "local", nil, map[string]string{"com.ddev.volume-signature": GetVolumeSignature(app)})
+		_, err = dockerutil.CreateVolume(v, "local", nil, map[string]string{"com.ddev.volume-signature": GetDefaultVolumeSignature(app)})
 		if err != nil {
 			return fmt.Errorf("unable to create docker volume %s: %v", v, err)
 		}
@@ -2810,8 +2810,8 @@ func (app *DdevApp) CreateUploadDirIfNecessary() {
 	}
 }
 
-// Get a volume signature to be applied especially to mutagen volume
-func GetVolumeSignature(app *DdevApp) string {
+// GetDefaultVolumeSignature gets a new volume signature to be applied especially to mutagen volume
+func GetDefaultVolumeSignature(app *DdevApp) string {
 	now := time.Now()
 	return fmt.Sprintf("%s-%d", dockerutil.DockerContext, now.Unix())
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2225,6 +2225,10 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 
 	// Remove data/database/projectInfo/hostname if we need to.
 	if removeData {
+		err = TerminateMutagenSync(app)
+		if err != nil {
+			util.Warning("unable to terminate mutagen session %s: %v", MutagenSyncName(app.Name), err)
+		}
 		if err = app.RemoveHostsEntries(); err != nil {
 			return fmt.Errorf("failed to remove hosts entries: %v", err)
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1890,6 +1890,7 @@ func (app *DdevApp) DockerEnv() {
 		"IS_DDEV_PROJECT":            "true",
 		"IS_GITPOD":                  isGitpod,
 		"IS_WSL2":                    isWSL2,
+		"MUTAGEN_DATA_DIRECTORY":     globalconfig.GetMutagenDataDirectory(),
 	}
 
 	// Set the DDEV_DB_CONTAINER_COMMAND command to empty to prevent docker-compose from complaining normally.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -987,7 +987,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		volumesNeeded = append(volumesNeeded, GetMutagenVolumeName(app))
 	}
 	for _, v := range volumesNeeded {
-		_, err = dockerutil.CreateVolume(v, "local", nil, map[string]string{"com.ddev.volume-signature": GetDefaultVolumeSignature(app)})
+		_, err = dockerutil.CreateVolume(v, "local", nil, map[string]string{mutagenSignatureLabelName: GetDefaultVolumeSignature(app)})
 		if err != nil {
 			return fmt.Errorf("unable to create docker volume %s: %v", v, err)
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -257,6 +257,7 @@ func TestMain(m *testing.M) {
 	// Avoid having sudo try to add to /etc/hosts.
 	// This is normally done by Testsite.Prepare()
 	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")
+	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
 
 	// If GOTEST_SHORT is an integer, then use it as index for a single usage
 	// in the array. Any value can be used, it will default to just using the

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -393,7 +393,7 @@ func (app *DdevApp) MutagenSyncFlush() error {
 			return errors.Errorf("Mutagen sync session '%s' does not exist", syncName)
 		}
 		status, _, _, _ := app.MutagenStatus()
-		if status != "paused" {
+		if status != "paused" && status != "failing" {
 			out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "flush", syncName)
 			if err != nil {
 				return fmt.Errorf("mutagen sync flush %s failed, output=%s, err=%v", syncName, out, err)
@@ -401,7 +401,7 @@ func (app *DdevApp) MutagenSyncFlush() error {
 		}
 
 		status, _, _, err := app.MutagenStatus()
-		if (status != "ok" && status != "problems" && status != "paused") || err != nil {
+		if (status != "ok" && status != "problems" && status != "paused" && status != "failing") || err != nil {
 			return err
 		}
 		util.Debug("Flushed mutagen sync session '%s'", syncName)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -327,6 +327,9 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, longResu
 		}
 		return "failing", shortResult, longResult, err
 	}
+	if shortResult == "[Paused]" {
+		return "paused", shortResult, longResult, nil
+	}
 
 	// We're going to assume that if it's applying changes things are still OK,
 	// even though there may be a whole list of problems.

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -328,7 +328,7 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 	if err != nil {
 		return "nosession", fullJSONResult, nil, err
 	}
-	if len(sessionMap) != 1 {
+	if len(sessionMap) < 1 {
 		return "", "", nil, fmt.Errorf("mutagen sessions may be in invalid state, please `ddev mutagen reset`")
 	}
 	mapRes := sessionMap[0]

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -27,6 +27,8 @@ import (
 	"unicode"
 )
 
+const mutagenSignatureLabelName = `com.ddev.volume-signature`
+
 // SetMutagenVolumeOwnership chowns the volume in use to the current user.
 // The mutagen volume is mounted both in /var/www (where it gets used) and
 // also on /tmp/project_mutagen (where it can be chowned without accidentally hitting
@@ -172,7 +174,7 @@ func CreateOrResumeMutagenSync(app *DdevApp) error {
 		}
 	} else { //
 		//TODO: Consider using a function to specify the docker beta
-		args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker:/%s/var/www/html", container.Names[0]), "--no-global-configuration", "--name", syncName, "--label", "com.ddev.volume-signature=" + GetMutagenVolumeLabel(app)}
+		args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker:/%s/var/www/html", container.Names[0]), "--no-global-configuration", "--name", syncName, "--label", mutagenSignatureLabelName + "=" + GetMutagenVolumeLabel(app)}
 		if configFile != "" {
 			args = append(args, fmt.Sprintf(`--configuration-file=%s`, configFile))
 		}
@@ -620,7 +622,7 @@ func (app *DdevApp) IsMutagenEnabled() bool {
 func GetMutagenVolumeLabel(app *DdevApp) string {
 	labels := dockerutil.VolumeLabels(GetMutagenVolumeName(app))
 	if labels != nil {
-		if l, ok := labels["com.ddev.volume-signature"]; ok {
+		if l, ok := labels[mutagenSignatureLabelName]; ok {
 			return l
 		}
 	}
@@ -661,7 +663,7 @@ func GetMutagenSyncLabel(app *DdevApp) string {
 	if status == "nosession" || err != nil {
 		return ""
 	}
-	if label, ok := mapResult["labels"].(map[string]interface{})["com.ddev.volume-signature"].(string); ok {
+	if label, ok := mapResult["labels"].(map[string]interface{})[mutagenSignatureLabelName].(string); ok {
 		return label
 	}
 	return ""

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -109,7 +109,7 @@ func SyncAndPauseMutagenSession(app *DdevApp) error {
 
 	// We don't want to flush if the web container isn't running
 	// because mutagen flush will hang forever - disconnected
-	if projStatus == SiteRunning && !strings.Contains(shortResult, "[Paused]") /* && !strings.Contains(longResult, "Connection state: Disconnected") */ {
+	if projStatus == SiteRunning && (mutagenStatus == "ok" || mutagenStatus == "problems") {
 		err := app.MutagenSyncFlush()
 		if err != nil {
 			util.Error("Error on 'mutagen sync flush %s': %v", syncName, err)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -352,11 +352,15 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 	}
 
 	problems := false
-	if _, ok := mapRes["alpha"].(map[string]interface{})["scanProblems"]; ok {
-		problems = true
+	if alpha, ok := mapRes["alpha"].(map[string]interface{}); ok {
+		if _, ok = alpha["scanProblems"]; ok {
+			problems = true
+		}
 	}
-	if _, ok := mapRes["beta"].(map[string]interface{})["scanProblems"]; ok {
-		problems = true
+	if beta, ok := mapRes["beta"].(map[string]interface{}); ok {
+		if _, ok = beta["scanProblems"]; ok {
+			problems = true
+		}
 	}
 	if _, ok := mapRes["conflicts"]; ok {
 		problems = true

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -679,3 +679,11 @@ func GetMutagenSyncLabel(app *DdevApp) (string, error) {
 	}
 	return "", fmt.Errorf("sync session label not found for sync session %s", MutagenSyncName(app.Name))
 }
+
+// TerminateAllMutagenSync terminates all sessions that match our signature label
+func TerminateAllMutagenSync() {
+	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "terminate", "--label-selector="+mutagenSignatureLabelName)
+	if err != nil {
+		util.Warning("could not terminate all mutagen sessions, output=%s, err=%v", out, err)
+	}
+}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -352,10 +352,13 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 	}
 
 	problems := false
-	if _, ok := mapRes["alpha"].(map[string]interface{})["scanProblems"].([]interface{}); ok {
+	if _, ok := mapRes["alpha"].(map[string]interface{})["scanProblems"]; ok {
 		problems = true
 	}
-	if _, ok := mapRes["beta"].(map[string]interface{})["scanProblems"].([]interface{}); ok {
+	if _, ok := mapRes["beta"].(map[string]interface{})["scanProblems"]; ok {
+		problems = true
+	}
+	if _, ok := mapRes["conflicts"]; ok {
 		problems = true
 	}
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -331,6 +331,9 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 	}
 	mapRes := sessionMap[0]
 
+	if paused, ok := mapRes["paused"].(bool); ok && paused == true {
+		return "paused", "paused", mapRes, nil
+	}
 	var ok bool
 	mutagenStatus := ""
 	if mutagenStatus, ok = mapRes["status"].(string); !ok {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -347,6 +347,9 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 	if !mounted {
 		return "not enabled", "", mapRes, nil
 	}
+	if err != nil {
+		return "", "", nil, err
+	}
 
 	problems := false
 	if _, ok := mapRes["alpha"].(map[string]interface{})["scanProblems"].([]interface{}); ok {
@@ -383,22 +386,6 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 		return status, shortResult, mapRes, nil
 	}
 	return "failing", shortResult, mapRes, nil
-}
-
-// parseMutagenStatusLine takes the full mutagen sync list output and
-// return just the right of the Status: line
-func parseMutagenStatusLine(fullStatus string) string {
-	statusLineLoc := strings.LastIndex(fullStatus, "\nStatus:")
-	statusLine := fullStatus[statusLineLoc+1:]
-	statusLineEnd := strings.Index(statusLine, "\n")
-	if statusLineEnd != -1 {
-		statusLine = statusLine[:statusLineEnd]
-	}
-	pieces := strings.Split(statusLine, ":")
-	if len(pieces) < 2 {
-		return ""
-	}
-	return strings.Trim(pieces[1], " \n\r")
 }
 
 // MutagenSyncFlush performs a mutagen sync flush, waits for result, and checks for errors

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -149,7 +149,7 @@ func CreateMutagenSync(app *DdevApp) error {
 		return fmt.Errorf("Cannot start mutagen sync because web container is not running: %v", container)
 	}
 
-	args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker://%s/var/www/html", container.ID), "--no-global-configuration", "--name", syncName}
+	args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker:/%s/var/www/html", container.Names[0]), "--no-global-configuration", "--name", syncName}
 	if configFile != "" {
 		args = append(args, fmt.Sprintf(`--configuration-file=%s`, configFile))
 	}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -466,9 +466,10 @@ func DownloadMutagen() error {
 // But no problem if there wasn't one
 func StopMutagenDaemon() {
 	if fileutil.FileExists(globalconfig.GetMutagenPath()) {
+		mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 		out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "stop")
 		if err != nil && !strings.Contains(out, "unable to connect to daemon") {
-			util.Warning("Unable to stop mutagen daemon: %v", err)
+			util.Warning("Unable to stop mutagen daemon: %v; MUTAGEN_DATA_DIRECTORY=%s", err, mutagenDataDirectory)
 		}
 		util.Success("Stopped mutagen daemon")
 	}

--- a/pkg/ddevapp/mutagen_config_assets/mutagen.yml
+++ b/pkg/ddevapp/mutagen_config_assets/mutagen.yml
@@ -2,6 +2,7 @@
 # To override this file remove the line above
 # and add your own configuration. If you override it you will
 # probably want to check it in.
+# Please do `ddev mutagen reset` after changing the file.
 # See ddev mutagen docs at
 # https://ddev.readthedocs.io/en/latest/users/install/performance/
 # For detailed information about mutagen configuration options, see

--- a/pkg/ddevapp/mutagen_config_assets/mutagen.yml
+++ b/pkg/ddevapp/mutagen_config_assets/mutagen.yml
@@ -20,7 +20,7 @@ sync:
       - "/.tarballs"
       - "/.ddev/db_snapshots"
       - "/.ddev/.importdb*"
-        "/.ddev/.*downloads"
+      - "/.ddev/.*downloads"
       - ".DS_Store"
       - ".idea"
       {{ if .UploadDir }}

--- a/pkg/ddevapp/mutagen_config_assets/mutagen.yml
+++ b/pkg/ddevapp/mutagen_config_assets/mutagen.yml
@@ -20,6 +20,7 @@ sync:
       - "/.tarballs"
       - "/.ddev/db_snapshots"
       - "/.ddev/.importdb*"
+        "/.ddev/.*downloads"
       - ".DS_Store"
       - ".idea"
       {{ if .UploadDir }}

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -24,6 +24,9 @@ func TestMutagenSimple(t *testing.T) {
 	}
 	assert := asrt.New(t)
 
+	// Make sure there's not an existing mutagen running, perhaps in wrong directory
+	_, _ = exec.RunHostCommand("pkill", "mutagen")
+
 	// Make sure this leaves us in the original test directory
 	origDir, _ := os.Getwd()
 

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -115,7 +115,7 @@ func TestMutagenSimple(t *testing.T) {
 
 	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list")
-	assert.NoError(err, "MUTAGEN_DATA_DIRECTORY=%s", mutagenDataDirectory)
+	assert.NoError(err, "mutagen sync list failed with MUTAGEN_DATA_DIRECTORY=%s: out=%s: %v", mutagenDataDirectory, out, err)
 	assert.Contains(out, "Started Mutagen daemon in background")
 	if !strings.Contains(out, "Started Mutagen daemon in background") && (runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
 		out, err := exec.RunHostCommand("bash", "-c", "ps -ef | grep mutagen")

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -110,8 +110,9 @@ func TestMutagenSimple(t *testing.T) {
 		assert.Error(err)
 	}
 
+	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list")
-	assert.NoError(err)
+	assert.NoError(err, "MUTAGEN_DATA_DIRECTORY=%s", mutagenDataDirectory)
 	assert.Contains(out, "Started Mutagen daemon in background")
 	if !strings.Contains(out, "Started Mutagen daemon in background") && (runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
 		out, err := exec.RunHostCommand("bash", "-c", "ps -ef | grep mutagen")

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -20,11 +20,9 @@ import (
 // TestMutagenSimple tests basic mutagen functionality
 func TestMutagenSimple(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("TestMutagenSimple one takes way too long on Windows, skipping")
+		t.Skip("TestMutagenSimple takes way too long on Windows, skipping")
 	}
 	assert := asrt.New(t)
-
-	mutagenPath := globalconfig.GetMutagenPath()
 
 	// Make sure this leaves us in the original test directory
 	origDir, _ := os.Getwd()
@@ -51,6 +49,8 @@ func TestMutagenSimple(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
+		err = ddevapp.TerminateMutagenSync(app)
+		assert.NoError(err)
 		assert.False(dockerutil.VolumeExists(ddevapp.GetMutagenVolumeName(app)))
 	})
 	err = app.Start()
@@ -62,8 +62,9 @@ func TestMutagenSimple(t *testing.T) {
 	assert.True(desc["mutagen_enabled"].(bool))
 
 	// Make sure the sync is there
-	out, err := exec.RunHostCommand(mutagenPath, "sync", "list", ddevapp.MutagenSyncName(app.Name))
-	assert.NoError(err, "output=%s", out)
+	status, short, long, err := app.MutagenStatus()
+	assert.NoError(err, "could not run mutagen sync list: status=%s short=%s, long=%s, err=%v", status, short, long, err)
+	assert.Equal("ok", status, "wrong status: status=%s short=%s, long=%s", status, short, long)
 
 	// Remove the vendor directory and sync
 	err = os.RemoveAll(filepath.Join(app.AppRoot, "vendor"))
@@ -90,10 +91,11 @@ func TestMutagenSimple(t *testing.T) {
 	assert.NoError(err)
 	assert.FileExists(filepath.Join(app.AppRoot, "vendor/bin/var-dump-server"))
 
-	// Stop app, should result in no more mutagen sync
+	// Stop app, should result in paused sync
 	err = app.Stop(false, false)
-	out, err = exec.RunHostCommand(mutagenPath, "sync", "list", ddevapp.MutagenSyncName(app.Name))
-	assert.Error(err, "output=%s", out)
+	status, short, long, err = app.MutagenStatus()
+	assert.NoError(err, "could not run mutagen sync list: status=%s short=%s, long=%s, err=%v", status, short, long, err)
+	assert.Equal("paused", status, "wrong status: status=%s short=%s, long=%s", status, short, long)
 
 	// Make sure we can stop the daemon
 	ddevapp.StopMutagenDaemon()
@@ -108,7 +110,7 @@ func TestMutagenSimple(t *testing.T) {
 		assert.Error(err)
 	}
 
-	out, err = exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list")
+	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list")
 	assert.NoError(err)
 	assert.Contains(out, "Started Mutagen daemon in background")
 	if !strings.Contains(out, "Started Mutagen daemon in background") && (runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
@@ -122,13 +124,15 @@ func TestMutagenSimple(t *testing.T) {
 
 	// Make sure sync is down on pause also
 	err = app.Pause()
-	out, err = exec.RunHostCommand(mutagenPath, "sync", "list", ddevapp.MutagenSyncName(app.Name))
-	assert.Error(err, "output=%s", out)
+	status, short, long, err = app.MutagenStatus()
+	assert.NoError(err, "could not run mutagen sync list: status=%s short=%s, long=%s, err=%v", status, short, long, err)
+	assert.Equal("paused", status, "wrong status: status=%s short=%s, long=%s", status, short, long)
 
 	// And that it's re-established when we start again
 	err = app.Start()
-	out, err = exec.RunHostCommand(mutagenPath, "sync", "list", ddevapp.MutagenSyncName(app.Name))
-	assert.NoError(err, "could not run mutagen sync list: output=%s", out)
+	status, short, long, err = app.MutagenStatus()
+	assert.NoError(err, "could not run mutagen sync list: status=%s short=%s, long=%s, err=%v", status, short, long, err)
+	assert.Equal("ok", status, "wrong status: status=%s short=%s, long=%s", status, short, long)
 
 	runTime()
 }

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -27,6 +27,8 @@ func PowerOff() {
 		util.Success("Project %s has been stopped.", app.GetName())
 	}
 
+	TerminateAllMutagenSync()
+
 	if err := RemoveSSHAgentContainer(); err != nil {
 		util.Error("Failed to remove ddev-ssh-agent: %v", err)
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -134,6 +134,22 @@ func GetDockerContext() (string, string, error) {
 	return context, dockerHost, nil
 }
 
+// GetDockerHostID returns DOCKER_HOST but with all special characters removed
+// It stands in for docker context, but docker context name is not a reliable indicator
+func GetDockerHostID() string {
+	_, host, err := GetDockerContext()
+	if err != nil {
+		util.Warning("Unable to GetDockerContext: %v", err)
+	}
+	// Convert DOCKER_HOST to alphanumeric
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		log.Fatal(err)
+	}
+	alphaOnly := reg.ReplaceAllString(host, "-")
+	return alphaOnly
+}
+
 // InspectContainer returns the full result of inspection
 func InspectContainer(name string) (*docker.Container, error) {
 	client, err := docker.NewClientFromEnv()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -978,10 +978,20 @@ func VolumeExists(volumeName string) bool {
 	return true
 }
 
-// CreateVolume creates a docker volume
-func CreateVolume(volumeName string, driver string, driverOpts map[string]string) (volume *docker.Volume, err error) {
+// VolumeLabels returns map of labels found on volume.
+func VolumeLabels(volumeName string) map[string]string {
 	client := GetDockerClient()
-	volume, err = client.CreateVolume(docker.CreateVolumeOptions{Name: volumeName, Driver: driver, DriverOpts: driverOpts})
+	v, err := client.InspectVolume(volumeName)
+	if err != nil {
+		return nil
+	}
+	return v.Labels
+}
+
+// CreateVolume creates a docker volume
+func CreateVolume(volumeName string, driver string, driverOpts map[string]string, labels map[string]string) (volume *docker.Volume, err error) {
+	client := GetDockerClient()
+	volume, err = client.CreateVolume(docker.CreateVolumeOptions{Name: volumeName, Labels: labels, Driver: driver, DriverOpts: driverOpts})
 	return volume, err
 }
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -983,7 +983,7 @@ func VolumeLabels(volumeName string) (map[string]string, error) {
 	client := GetDockerClient()
 	v, err := client.InspectVolume(volumeName)
 	if err != nil {
-		return nil, fmt.Errorf("volume %s not found", volumeName)
+		return nil, err
 	}
 	return v.Labels, nil
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -979,13 +979,13 @@ func VolumeExists(volumeName string) bool {
 }
 
 // VolumeLabels returns map of labels found on volume.
-func VolumeLabels(volumeName string) map[string]string {
+func VolumeLabels(volumeName string) (map[string]string, error) {
 	client := GetDockerClient()
 	v, err := client.InspectVolume(volumeName)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("volume %s not found", volumeName)
 	}
-	return v.Labels
+	return v.Labels, nil
 }
 
 // CreateVolume creates a docker volume

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1208,11 +1208,7 @@ func DownloadDockerCompose() error {
 	}
 	output.UserOut.Printf("Downloading %s ...", composeURL)
 
-	path, err := globalconfig.GetDockerComposePath()
-	if err != nil {
-		return err
-	}
-	_ = os.Remove(path)
+	_ = os.Remove(destFile)
 
 	_ = os.MkdirAll(globalBinDir, 0777)
 	err = util.DownloadFile(destFile, composeURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"))

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -483,7 +483,7 @@ func TestCreateVolume(t *testing.T) {
 	// Make sure there's no existing volume.
 	//nolint: errcheck
 	RemoveVolume("junker99")
-	volume, err := CreateVolume("junker99", "local", map[string]string{})
+	volume, err := CreateVolume("junker99", "local", map[string]string{}, nil)
 	require.NoError(t, err)
 
 	//nolint: errcheck
@@ -508,12 +508,8 @@ func TestRemoveVolume(t *testing.T) {
 	if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", source)) {
 		source = filepath.Join("/System/Volumes/Data", source)
 	}
-	volume, err := CreateVolume(
-		testVolume,
-		"local",
-		map[string]string{"type": "nfs", "o": "addr=host.docker.internal,hard,nolock,rw",
-			"device": ":" + MassageWindowsNFSMount(source)},
-	)
+	volume, err := CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": "addr=host.docker.internal,hard,nolock,rw",
+		"device": ":" + MassageWindowsNFSMount(source)}, nil)
 	assert.NoError(err)
 
 	volumes, err := client.ListVolumes(docker.ListVolumesOptions{Filters: map[string][]string{"name": {testVolume}}})

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -35,6 +35,7 @@ func testMain(m *testing.M) int {
 	EnsureDdevNetwork()
 
 	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")
+	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
 
 	// prep docker container for docker util tests
 	client := GetDockerClient()

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -80,6 +80,11 @@ func GetMutagenPath() string {
 	return filepath.Join(GetDDEVBinDir(), mutagenBinary)
 }
 
+// GetMutagenDataDirectory gets the full path to the MUTAGEN_DATA_DIRECTORY
+func GetMutagenDataDirectory() string {
+	return filepath.Join(GetGlobalDdevDir(), "mutagen_data_directory")
+}
+
 // GetDockerComposePath gets the full path to the docker-compose binary
 // Normally this is the one that has been downloaded to ~/.ddev/bin, but if
 // UseDockerComposeFromPath, then it will be whatever if found in $PATH

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -82,6 +82,12 @@ func GetMutagenPath() string {
 
 // GetMutagenDataDirectory gets the full path to the MUTAGEN_DATA_DIRECTORY
 func GetMutagenDataDirectory() string {
+	currentMutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
+	if currentMutagenDataDirectory != "" {
+		return currentMutagenDataDirectory
+	}
+	// If it's not already set, return ~/.ddev_mutagen_data_directory
+	// This may be affected by tests that change $HOME
 	return GetGlobalDdevDir() + "_" + "mutagen_data_directory"
 }
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -82,7 +82,7 @@ func GetMutagenPath() string {
 
 // GetMutagenDataDirectory gets the full path to the MUTAGEN_DATA_DIRECTORY
 func GetMutagenDataDirectory() string {
-	return filepath.Join(GetGlobalDdevDir(), "mutagen_data_directory")
+	return GetGlobalDdevDir() + "_" + "mutagen_data_directory"
 }
 
 // GetDockerComposePath gets the full path to the docker-compose binary

--- a/scripts/diagnose_mutagen.sh
+++ b/scripts/diagnose_mutagen.sh
@@ -4,13 +4,7 @@
 # directory where you're having trouble and provide its
 # output in a gist at gist.github.com with any issue you open about mutagen.
 
-if command -v mutagen >/dev/null ; then
-  echo "mutagen additionally installed in PATH at $(command -v mutagen), version $(mutagen version)"
-fi
-if killall -0 mutagen 2>/dev/null; then
-  echo "mutagen is running on this system:"
-  ps -ef | grep mutagen
-fi
+export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory
 
 ddev list
 ddev describe


### PR DESCRIPTION
## The Problem/Issue/Bug:

@xenoscopic, maintainer of mutagen, suggests that we can have a more successful mutagen lifecycle by using the container name for beta identifier instead of using the container id. This is a first test of that. I originally did it that way, but switched to ID for some reason. 

When the container name is used, we can *pause* the mutagen session instead of terminating it, and it will do better with a number of things. That's not here yet, but if things work out in automated tests it has potential.

## How this PR Solves The Problem:

* Use new json output of `mutagen` commands, especially `mutagen sync list`
* Use labels on sync sessions and docker volumes and verify that they match
* Use pause and resume instead of creating sync sessions from scratch

## TODO

- [x] Use a more specific `mutagen sync list` filter so we don't have to get all sessions
- [x] Should `ddev poweroff` stop all mutagen sessions? Probably.
- [x] On upgrade, clear terminate all sync sessions.
- [x] Update docs, especially debugging and using mutagen directly, and explain MUTAGEN_DATA_DIRECTORY
- [x] Improve the name of the dockerhost ID to be more readable. Dashes? Or use it explicitly?
- [x] `ddev poweroff` means that mutagen will have to be re-synced because mutagen session is killed off. `ddev stop` doesn't do that.
- [x] `ddev clean` should clear MUTAGEN_DATA_DIRECTORY.

## Manual Testing Instructions:

- [x] Try to confuse system by
  - [x] Moving context from default to colima
  - [x] Reverse that
- [x] Remove a file from .ddev/docker-compose.*.yaml, then `ddev restart`. Does it reappear?

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

- [ ] Mutagen no longer conflicts with other mutagen instances that may be running on the machine. It maintains its own `MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory`


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4109"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

