### PR TITLE
[tests only] Try to sort out colima test failures in startup

### DIFF
--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -10,7 +10,7 @@ brew uninstall go@1.15 || true
 brew unlink go || true
 brew uninstall go@1.17 || true
 brew uninstall postgresql || true
-brew install colima docker docker-compose go libpq mkcert mysql-client
+brew install colima docker docker-compose go jq libpq mkcert mysql-client
 brew link --force go libpq mysql-client
 
 # This command allows adding CA (in mkcert, etc) without the popup trust prompt

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -5,14 +5,14 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/versionconstants"
+	logOutput "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"log"
 	"os"
 	"path"
 	"runtime"
 	"strings"
 	"testing"
-
-	logOutput "github.com/sirupsen/logrus"
 
 	"path/filepath"
 
@@ -99,11 +99,11 @@ func testMain(m *testing.M) int {
 			logOutput.Errorf("-- FAIL: dockerutils_test failed to remove test container: %v", err)
 		}
 	}()
-	_, err = ContainerWait(30, map[string]string{"com.ddev.site-name": testContainerName})
+	_, err = ContainerWait(60, map[string]string{"com.ddev.site-name": testContainerName})
 	if err != nil {
-		logout, _ := exec.RunCommand("docker", []string{"logs", container.Name})
-		inspectOut, _ := exec.RunCommandPipe("sh", []string{"-c", fmt.Sprintf("docker inspect %s|jq -r '.[0].State.Health.Log'", container.Name)})
-		_ = fmt.Errorf("FAIL: dockerutils_test failed to ContainerWait for container: %v, logs\n========= container logs ======\n%s\n======= end logs =======\n==== health log =====\ninspectOut\n%s\n========", err, logout, inspectOut)
+		logout, _ := exec.RunHostCommand("docker", "logs", container.Name)
+		inspectOut, _ := exec.RunHostCommand("sh", "-c", fmt.Sprintf("docker inspect %s|jq -r '.[0].State.Health.Log'", container.Name))
+		log.Printf("FAIL: dockerutils_test failed to ContainerWait for container: %v, logs\n========= container logs ======\n%s\n======= end logs =======\n==== health log =====\ninspectOut\n%s\n========", err, logout, inspectOut)
 		return 4
 	}
 	exitStatus := m.Run()


### PR DESCRIPTION
## The Problem/Issue/Bug:

Colima tests fail oh-so-often on github actions test runner, macOS.

## How this PR Solves The Problem:

* Make sure jq is in the test runner
* Give better output if containerwait fails
* Wait 60 seconds instead of 30.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4111"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

