### PR TITLE
20220815 fix remove image

### DIFF
--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -29,7 +29,7 @@ func TestCmdVersion(t *testing.T) {
 
 	assert.Equal(versionconstants.DdevVersion, raw["DDEV version"])
 	assert.Equal(versionconstants.WebImg+":"+versionconstants.WebTag, raw["web"])
-	assert.Equal(versionconstants.GetDBImage(nodeps.MariaDB), raw["db"])
+	assert.Equal(versionconstants.GetDBImage(nodeps.MariaDB, ""), raw["db"])
 	assert.Equal(versionconstants.GetDBAImage(), raw["dba"])
 	dockerVersion, _ := dockerutil.GetDockerVersion()
 	assert.Equal(dockerVersion, raw["docker"])

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -98,7 +98,7 @@ func deleteDdevImages(deleteAll bool) error {
 	routerimage := versionconstants.RouterImage + ":" + versionconstants.RouterTag
 	sshimage := versionconstants.SSHAuthImage + ":" + versionconstants.SSHAuthTag
 
-	nameAry := strings.Split(versionconstants.GetDBImage(nodeps.MariaDB), ":")
+	nameAry := strings.Split(versionconstants.GetDBImage(nodeps.MariaDB, ""), ":")
 	keepDBImageTag := "notagfound"
 	if len(nameAry) > 1 {
 		keepDBImageTag = nameAry[1]

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -57,7 +57,7 @@ func TestNewConfig(t *testing.T) {
 	})
 
 	// Ensure the config uses specified defaults.
-	assert.Equal(app.GetDBImage(), versionconstants.GetDBImage(nodeps.MariaDB))
+	assert.Equal(app.GetDBImage(), versionconstants.GetDBImage(nodeps.MariaDB, ""))
 	assert.Equal(app.WebImage, versionconstants.GetWebImage())
 	app.Name = util.RandString(32)
 	app.Type = nodeps.AppTypeDrupal8

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -79,7 +79,7 @@ func TestMutagenSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now composer install again and make sure all the stuff comes back
-	stdout, stderr, err := app.Composer([]string{"install", "--no-progress", "--no-interaction"})
+	stdout, _, err := app.Composer([]string{"install", "--no-progress", "--no-interaction"})
 	require.NoError(t, err, "stderr=%s, err=%v", stdout, err)
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd: "ls -l vendor/bin/var-dump-server >/dev/null",

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -953,9 +953,11 @@ func MassageWindowsNFSMount(mountPoint string) string {
 // RemoveVolume removes named volume. Does not throw error if the volume did not exist.
 func RemoveVolume(volumeName string) error {
 	client := GetDockerClient()
-	err := client.RemoveVolumeWithOptions(docker.RemoveVolumeOptions{Name: volumeName})
-	if err != nil && err.Error() != "" && err.Error() != "no such volume" {
-		return err
+	if _, err := client.InspectVolume(volumeName); err == nil {
+		err := client.RemoveVolumeWithOptions(docker.RemoveVolumeOptions{Name: volumeName})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1015,10 +1017,10 @@ func RemoveImage(tag string) error {
 	client := GetDockerClient()
 	_, err := client.InspectImage(tag)
 	if err == nil {
-		err := client.RemoveImageExtended(tag, docker.RemoveImageOptions{Force: true})
+		err = client.RemoveImageExtended(tag, docker.RemoveImageOptions{Force: true})
 
 		if err == nil {
-			util.Success("Deleted docker image %s", tag)
+			util.Debug("Deleted docker image %s", tag)
 		} else {
 			util.Warning("Unable to delete %s: %v", tag, err)
 		}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1013,12 +1013,15 @@ func GetHostDockerInternalIP() (string, error) {
 // RemoveImage removes an image with force
 func RemoveImage(tag string) error {
 	client := GetDockerClient()
-	err := client.RemoveImageExtended(tag, docker.RemoveImageOptions{Force: true})
-
+	_, err := client.InspectImage(tag)
 	if err == nil {
-		util.Success("Deleted docker image %s", tag)
-	} else {
-		util.Warning("Unable to delete %s: %v", tag, err)
+		err := client.RemoveImageExtended(tag, docker.RemoveImageOptions{Force: true})
+
+		if err == nil {
+			util.Success("Deleted docker image %s", tag)
+		} else {
+			util.Warning("Unable to delete %s: %v", tag, err)
+		}
 	}
 	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,7 +22,7 @@ func GetVersionInfo() map[string]string {
 
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
 	versionInfo["web"] = versionconstants.GetWebImage()
-	versionInfo["db"] = versionconstants.GetDBImage(nodeps.MariaDB)
+	versionInfo["db"] = versionconstants.GetDBImage(nodeps.MariaDB, "")
 	versionInfo["dba"] = versionconstants.GetDBAImage()
 	versionInfo["router"] = versionconstants.RouterImage + ":" + versionconstants.RouterTag
 	versionInfo["ddev-ssh-agent"] = versionconstants.SSHAuthImage + ":" + versionconstants.SSHAuthTag

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -66,10 +66,13 @@ func GetWebImage() string {
 }
 
 // GetDBImage returns the correctly formatted db image:tag reference
-func GetDBImage(dbType string, dbVersion ...string) string {
+func GetDBImage(dbType string, dbVersion string) string {
 	v := nodeps.MariaDBDefaultVersion
-	if len(dbVersion) > 0 {
-		v = dbVersion[0]
+	if dbVersion != "" {
+		v = dbVersion
+	}
+	if dbType == "" {
+		dbType = nodeps.MariaDB
 	}
 	switch dbType {
 	case nodeps.Postgres:


### PR DESCRIPTION
## The Problem/Issue/Bug:

* I discovered while working on #4109 that GetDBImage() was completely broken. Fix it
* Minor improvements to TestMutagenSimple()
* RemoveVolume() and RemoveImage() now check for existence before trying to delete

## Manual Testing Instructions:

- [ ] Verify that the dbimage-built is gone after `ddev delete`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

