### PR TITLE
Bump mutagen to 0.15.1

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -54,7 +54,7 @@ var BUILDINFO = "BUILDINFO should have new info"
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.15.0"
+const RequiredMutagenVersion = "0.15.1"
 
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Mutagen has 0.15.1



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4121"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

