### PR TITLE
Fix bash completion installation docs

### DIFF
--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -21,7 +21,7 @@ Shells like bash and zsh need help to do this though, they have to know what the
     If you're installing DDEV via homebrew, each new release will automatically get a refreshed completions script.
 
 === "Bash without Homebrew"
-    The completion script is exactly the same, it's just that you have to install it yourself. Each system may have a slightly different technique, and you'll need to figure it out. On Debian/Ubuntu, you would use [these instructions](https://www.cyberciti.biz/faq/add-bash-auto-completion-in-ubuntu-linux/) to enable bash-completion, and then `sudo mkdir -p /etc/bash_completion.d && sudo cp ddev_bash_completion.sh /etc/bash_completion.d`. This deploys the ddev_bash_completion.sh script where it needs to be. Again, every Linux distro has a different technique, and you may have to figure yours out.
+    The completion script is exactly the same, it's just that you have to install it yourself. Each system may have a slightly different technique, and you'll need to figure it out. On Debian/Ubuntu, you would use [these instructions](https://www.cyberciti.biz/faq/add-bash-auto-completion-in-ubuntu-linux/) to enable bash-completion, and then `sudo mkdir -p /etc/bash_completion.d && sudo cp /usr/bin/ddev_bash_completion.sh /etc/bash_completion.d`. This deploys the ddev_bash_completion.sh script where it needs to be. Again, every Linux distro has a different technique, and you may have to figure yours out.
 
 === "Zsh Completion with Homebrew"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
Bash without homebrew completion docs assumed you were in the running the commands from `/usr/bin` which is never the case.

## How this PR Solves The Problem:
Update the command so it can be run from anywhere and still install the proper file from everywhere.

Note: these docs might be good to be revisited now that there is an apt repo