### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/drud/ddev/pkg/globalconfig"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
@@ -34,7 +34,6 @@ func TestCustomCommands(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		origHome = os.Getenv("USERPROFILE")
 	}
-	origDebug := os.Getenv("DDEV_DEBUG")
 
 	site := TestSites[0]
 	err = os.Chdir(site.Dir)
@@ -51,9 +50,9 @@ func TestCustomCommands(t *testing.T) {
 	tmpHome := testcommon.CreateTmpDir(t.Name() + "-tempHome")
 
 	// Change the homedir temporarily
-	_ = os.Setenv("HOME", tmpHome)
-	_ = os.Setenv("USERPROFILE", tmpHome)
-	_ = os.Setenv("DDEV_DEBUG", "")
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	t.Setenv("DDEV_DEBUG", "")
 
 	// Make sure we have the .ddev/bin dir we need
 	err = fileutil.CopyDir(filepath.Join(origHome, ".ddev/bin"), filepath.Join(tmpHome, ".ddev/bin"))
@@ -72,9 +71,6 @@ func TestCustomCommands(t *testing.T) {
 		err = app.WriteConfig()
 		assert.NoError(err)
 		_ = os.RemoveAll(tmpHome)
-		_ = os.Setenv("HOME", origHome)
-		_ = os.Setenv("USERPROFILE", origHome)
-		_ = os.Setenv("DDEV_DEBUG", origDebug)
 		err = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
 		assert.NoError(err)
 		err = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", ".global_commands"))
@@ -278,7 +274,7 @@ func TestLaunchCommand(t *testing.T) {
 	err := os.Chdir(tmpdir)
 	assert.NoError(err)
 
-	_ = os.Setenv("DDEV_DEBUG", "true")
+	t.Setenv("DDEV_DEBUG", "true")
 	app, err := ddevapp.NewApp(tmpdir, false)
 	require.NoError(t, err)
 	err = app.WriteConfig()

--- a/cmd/ddev/cmd/debug-download-images_test.go
+++ b/cmd/ddev/cmd/debug-download-images_test.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDebugDownloadImages tests ddev debug download-images
@@ -34,7 +34,7 @@ func TestDebugDownloadImages(t *testing.T) {
 	out, err := exec.RunHostCommand(DdevBin, "config", "--project-name", t.Name())
 	require.NoError(t, err, "Failed to run ddev config: %s", out)
 
-	_ = os.Setenv("DDEV_DEBUG", "true")
+	t.Setenv("DDEV_DEBUG", "true")
 	out, err = exec.RunHostCommand(DdevBin, "debug", "download-images")
 	require.NoError(t, err, "Failed to run ddev debug download-images: %s", out)
 	assert.Contains(out, "ddev-webserver")

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -2,6 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
@@ -10,10 +14,6 @@ import (
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"runtime"
-	"testing"
 )
 
 // TestHomeadditions makes sure that extra files added to
@@ -28,13 +28,9 @@ func TestHomeadditions(t *testing.T) {
 	testdata := filepath.Join(origDir, "testdata", t.Name())
 
 	tmpHome := testcommon.CreateTmpDir(t.Name() + "tempHome")
-	origHome := os.Getenv("HOME")
-	if runtime.GOOS == "windows" {
-		origHome = os.Getenv("USERPROFILE")
-	}
 	// Change the homedir temporarily
-	_ = os.Setenv("HOME", tmpHome)
-	_ = os.Setenv("USERPROFILE", tmpHome)
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
 
 	site := TestSites[0]
 	projectHomeadditionsDir := filepath.Join(site.Dir, ".ddev", "homeadditions")
@@ -67,8 +63,6 @@ func TestHomeadditions(t *testing.T) {
 		assert.NoError(err)
 		err = os.RemoveAll(tmpHome)
 		assert.NoError(err)
-		_ = os.Setenv("HOME", origHome)
-		_ = os.Setenv("USERPROFILE", origHome)
 	})
 
 	// Before we can symlink global, need to make sure anything is already gone

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -2,19 +2,18 @@ package cmd
 
 import (
 	"bufio"
-	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/stretchr/testify/require"
 	"os"
+	oexec "os/exec"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	oexec "os/exec"
-
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/globalconfig"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCmdList runs the binary with "ddev list" and checks the results
@@ -151,11 +150,7 @@ func TestCmdListContinuous(t *testing.T) {
 
 	assert := asrt.New(t)
 
-	oldDdevDebug := os.Getenv("DDEV_DEBUG")
-	_ = os.Setenv("DDEV_DEBUG", "")
-	t.Cleanup(func() {
-		_ = os.Setenv("DDEV_DEBUG", oldDdevDebug)
-	})
+	t.Setenv("DDEV_DEBUG", "")
 	// Execute "ddev list --continuous"
 	cmd := oexec.Command(DdevBin, "list", "-j", "--continuous")
 	stdout, err := cmd.StdoutPipe()

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -250,21 +250,20 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 
 	// Create an extra junk project to make sure it gets shut down on our start
 	junkName := t.Name() + "-tmpjunkproject"
-	tmpJunkProject := testcommon.CreateTmpDir(junkName)
-	err = os.Chdir(tmpJunkProject)
+	tmpJunkProjectDir := testcommon.CreateTmpDir(junkName)
+	err = os.Chdir(tmpJunkProjectDir)
 	assert.NoError(err)
-	_, err = exec.RunHostCommand(DdevBin, "config", "--auto")
-	assert.NoError(err)
+	out, err := exec.RunHostCommand(DdevBin, "config", "--project-name", junkName)
+	assert.NoError(err, "out=%s", out)
 	_, err = exec.RunHostCommand(DdevBin, "start", "-y")
 	assert.NoError(err)
 	t.Cleanup(func() {
-		err = os.Chdir(tmpJunkProject)
+		_, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", junkName)
 		assert.NoError(err)
-		_, _ = exec.RunHostCommand(DdevBin, "delete", "-Oy")
 
 		err = os.Chdir(origDir)
 		assert.NoError(err)
-		_ = os.RemoveAll(tmpJunkProject)
+		_ = os.RemoveAll(tmpJunkProjectDir)
 
 		// Because the start has done a poweroff (new ddev version),
 		// make sure sites are running again.
@@ -302,7 +301,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	// Make sure we have starting version that is not v0.0
 	err = fileutil.AppendStringToFile(filepath.Join(globalconfig.GetGlobalDdevDir(), "global_config.yaml"), "last_started_version: v0.1")
 	require.NoError(t, err)
-	out, err := exec.RunHostCommand(DdevBin, "start")
+	out, err = exec.RunHostCommand(DdevBin, "start")
 	assert.NoError(err)
 	assert.Contains(out, "ddev-ssh-agent container has been removed")
 	assert.Contains(out, "ssh-agent container is running")

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -2,15 +2,16 @@ package ddevapp_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/testcommon"
 	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 // TestProcessHooks tests execution of commands defined in config.yaml
@@ -19,9 +20,8 @@ func TestProcessHooks(t *testing.T) {
 
 	site := TestSites[0]
 	origDir, _ := os.Getwd()
-	oldDdevDebug := os.Getenv("DDEV_DEBUG")
 	// We don't get the expected task debug output without DDEV_DEBUG
-	_ = os.Setenv("DDEV_DEBUG", "true")
+	t.Setenv("DDEV_DEBUG", "true")
 	runTime := util.TimeTrack(time.Now(), t.Name())
 
 	testcommon.ClearDockerEnv()
@@ -37,7 +37,6 @@ func TestProcessHooks(t *testing.T) {
 		assert.NoError(err)
 		err = os.RemoveAll(filepath.Join(app.AppRoot, "composer.json"))
 		assert.NoError(err)
-		_ = os.Setenv("DDEV_DEBUG", oldDdevDebug)
 	})
 	err = app.Start()
 	assert.NoError(err)

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -1,12 +1,6 @@
 package ddevapp_test
 
 import (
-	"github.com/drud/ddev/pkg/dockerutil"
-	"github.com/drud/ddev/pkg/exec"
-	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/netutil"
-	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,9 +8,15 @@ import (
 	"testing"
 
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/netutil"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPortOverride makes sure that the router_http_port and router_https_port
@@ -171,7 +171,7 @@ func TestRouterConfigOverride(t *testing.T) {
 	assert.NoError(err)
 
 	answer := fileutil.RandomFilenameBase()
-	os.Setenv("ANSWER", answer)
+	t.Setenv("ANSWER", answer)
 	assert.NoError(err)
 	t.Cleanup(func() {
 		err = app.Stop(true, false)

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -1,6 +1,12 @@
 package ddevapp_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
@@ -10,11 +16,6 @@ import (
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/versionconstants"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
-	"time"
 
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -147,7 +148,7 @@ func TestSshAuthConfigOverride(t *testing.T) {
 	assert.NoError(err)
 
 	answer := fileutil.RandomFilenameBase()
-	_ = os.Setenv("ANSWER", answer)
+	t.Setenv("ANSWER", answer)
 	assert.NoError(err)
 	assert.NoError(err)
 	t.Cleanup(func() {

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -1,17 +1,18 @@
 package dockerutil_test
 
 import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
 	"github.com/drud/ddev/pkg/dockerutil"
 	exec2 "github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"os/exec"
-	"runtime"
-	"strings"
-	"testing"
 )
 
 var DdevBin = "ddev"
@@ -25,18 +26,14 @@ func TestDockerComposeDownload(t *testing.T) {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
 	}
 
-	origHome := os.Getenv("HOME")
-	if runtime.GOOS == "windows" {
-		origHome = os.Getenv("USERPROFILE")
-	}
 	tmpHome := testcommon.CreateTmpDir(t.Name() + "tempHome")
 	// Unusual case where we need to alter the RequiredDockerComposeVersion
 	// just so we can make sure the one in PATH is different.
 	origRequiredComposeVersion := globalconfig.RequiredDockerComposeVersion
 
 	// Change the homedir temporarily
-	_ = os.Setenv("HOME", tmpHome)
-	_ = os.Setenv("USERPROFILE", tmpHome)
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
 
 	// Make sure we have the .ddev/bin dir we need to verify against
 	//err = fileutil.CopyDir(filepath.Join(origHome, ".ddev/bin"), filepath.Join(tmpHome, ".ddev/bin"))
@@ -51,7 +48,6 @@ func TestDockerComposeDownload(t *testing.T) {
 
 		err = os.RemoveAll(tmpHome)
 		assert.NoError(err)
-		_ = os.Setenv("HOME", origHome)
 		globalconfig.RequiredDockerComposeVersion = origRequiredComposeVersion
 	})
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -2,19 +2,19 @@ package dockerutil_test
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/versionconstants"
 	logOutput "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"log"
-	"os"
-	"path"
-	"runtime"
-	"strings"
-	"testing"
-
-	"path/filepath"
 
 	. "github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/fileutil"
@@ -582,10 +582,6 @@ subdir1.txt
 func TestGetDockerIP(t *testing.T) {
 	assert := asrt.New(t)
 
-	origDOCKERHOST := os.Getenv("DOCKER_HOST")
-	t.Cleanup(func() {
-		_ = os.Setenv("DOCKER_HOST", origDOCKERHOST)
-	})
 	expectations := map[string]string{
 		"":                            "127.0.0.1",
 		"unix:///var/run/docker.sock": "127.0.0.1",
@@ -595,7 +591,7 @@ func TestGetDockerIP(t *testing.T) {
 	}
 
 	for k, v := range expectations {
-		_ = os.Setenv("DOCKER_HOST", k)
+		t.Setenv("DOCKER_HOST", k)
 		// DockerIP is cached, so we have to reset it to check
 		DockerIP = ""
 		result, err := GetDockerIP()


### PR DESCRIPTION
## The Problem/Issue/Bug:

## How this PR Solves The Problem:

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

Reference: https://pkg.go.dev/testing#T.Setenv

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4126"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

