### PR TITLE
Use --web-environment-add instead of --web-environment in blackfire error

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
@@ -10,7 +10,7 @@ function enable {
   if [ -z ${BLACKFIRE_SERVER_ID} ] || [ -z ${BLACKFIRE_SERVER_TOKEN} ]; then
     echo "BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN environment variables must be set" >&2
     echo "See docs for how to set in global or project config" >&2
-    echo "For example, ddev config global --web-environment=BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>"
+    echo "For example, ddev config global --web-environment-add=BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>"
     exit 1
   fi
   phpdismod xhprof xdebug


### PR DESCRIPTION
## The Problem/Issue/Bug:

Blindly using and running that command deleted my platform.sh CLI token and I had to generate a new one.

## How this PR Solves The Problem:

Add the env variables instead of replacing everything

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4130"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

