### PR TITLE
Do IsInternetActive() less often, and do it more efficiently, fixes #4131

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -87,7 +87,8 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		// Do not report these commands
-		ignores := map[string]bool{"auth": true, "exec": true, "help": true, "hostname": true, "list": true, "ssh": true, "version": true}
+		ignores := map[string]bool{"describe": true, "auth": true, "blackfire": false, "clean": true, "composer": true, "debug": true, "delete": true, "drush": true, "exec": true, "export-db": true, "get": true, "help": true, "hostname": true, "import-db": true, "import-files": true, "list": true, "logs": true, "mutagen": true, "mysql": true, "npm": true, "nvm": true, "pause": true, "php": true, "poweroff": true, "pull": true, "push": true, "service": true, "share": true, "snapshot": true, "ssh": true, "stop": true, "version": true, "xdebug": true, "xhprof": true, "yarn": true}
+
 		if _, ok := ignores[cmd.CalledAs()]; ok {
 			return
 		}

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -538,8 +538,10 @@ func IsInternetActive() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	randomURL := nodeps.RandomString(10) + ".ddev.site"
-	addrs, err := IsInternetActiveNetResolver.LookupHost(ctx, randomURL)
+	// Using a random URL is more conclusive, but it's more intrusive because
+	// DNS may take some time, and it's really annoying.
+	testURL := "test.ddev.site"
+	addrs, err := IsInternetActiveNetResolver.LookupHost(ctx, testURL)
 
 	// Internet is active (active == true) if both err and ctx.Err() were nil
 	active := err == nil && ctx.Err() == nil
@@ -547,7 +549,7 @@ func IsInternetActive() bool {
 		if active == false {
 			output.UserErr.Println("Internet connection not detected, DNS may not work, see https://ddev.readthedocs.io/en/stable/users/basics/faq/ for info.")
 		}
-		output.UserErr.Printf("IsInternetActive DEBUG: err=%v ctx.Err()=%v addrs=%v IsInternetactive==%v, randomURL=%v internet_detection_timeout_ms=%dms\n", err, ctx.Err(), addrs, active, randomURL, DdevGlobalConfig.InternetDetectionTimeout)
+		output.UserErr.Printf("IsInternetActive DEBUG: err=%v ctx.Err()=%v addrs=%v IsInternetactive==%v, testURL=%v internet_detection_timeout_ms=%dms\n", err, ctx.Err(), addrs, active, testURL, DdevGlobalConfig.InternetDetectionTimeout)
 	}
 
 	// remember the result to not call this twice


### PR DESCRIPTION

## The Problem/Issue/Bug:

* #4131
* https://github.com/php-perfect/ddev-intellij-plugin/issues/83#issuecomment-1218700136

## How this PR Solves The Problem:

* Only do IsInternetActive on start/restart
* Only test `test.ddev.site` (and always use that instead of a random url)

## Manual Testing Instructions:

export DDEV_DEBUG=true
- [x] You should only see the check happen on `ddev start` and `ddev restart`

## Automated Testing Overview:


## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4134"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

