### PR TITLE
ddev list: Truncate app list table text to avoid wrapping

### DIFF
--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -14,6 +14,9 @@ var activeOnly bool
 // continuousSleepTime is time to sleep between reads with --continuous
 var continuousSleepTime = 1
 
+// wrapListTable allow that the text in the table of ddev list wraps instead of cutting it to fit the terminal width
+var wrapListTableText bool
+
 // ListCmd represents the list command
 var ListCmd = &cobra.Command{
 	Use:   "list",
@@ -23,13 +26,14 @@ var ListCmd = &cobra.Command{
 ddev list --active-only
 ddev list -A`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ddevapp.List(activeOnly, continuous, continuousSleepTime)
+		ddevapp.List(activeOnly, continuous, wrapListTableText, continuousSleepTime)
 	},
 }
 
 func init() {
 	ListCmd.Flags().BoolVarP(&activeOnly, "active-only", "A", false, "If set, only currently active projects will be displayed.")
 	ListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted until the command is stopped.")
+	ListCmd.Flags().BoolVarP(&wrapListTableText, "wrap-table", "W", false, "Display table with wrapped text if required.")
 	ListCmd.Flags().IntVarP(&continuousSleepTime, "continuous-sleep-interval", "I", 1, "Time in seconds between ddev list --continuous output lists.")
 
 	RootCmd.AddCommand(ListCmd)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -41,7 +41,7 @@ func TestCmdList(t *testing.T) {
 	assert.NoError(err)
 
 	// Execute "ddev list" and harvest plain text output.
-	out, err := exec.RunHostCommand(DdevBin, "list")
+	out, err := exec.RunHostCommand(DdevBin, "list", "-W")
 	assert.NoError(err, "error running ddev list: %v output=%s", out)
 
 	// Execute "ddev list -j" and harvest the json output
@@ -92,7 +92,7 @@ func TestCmdList(t *testing.T) {
 
 	// Execute "ddev list" and harvest json output.
 	// Now there should be one less active project in list
-	jsonOut, err = exec.RunHostCommand(DdevBin, "list", "-jA")
+	jsonOut, err = exec.RunHostCommand(DdevBin, "list", "-jA", "-W")
 	assert.NoError(err, "error running ddev list: %v output=%s", err, jsonOut)
 
 	siteList = getTestingSitesFromList(t, jsonOut)

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -74,7 +74,7 @@ func List(activeOnly bool, continuous bool, wrapTableText bool, continuousSleepT
 // CreateAppTable will create a new app table for describe and list output
 func CreateAppTable(out *bytes.Buffer, wrapTableText bool) table.Writer {
 	t := table.NewWriter()
-	t.AppendHeader(table.Row{"Name", "Status", "Type", "Location", "URL"})
+	t.AppendHeader(table.Row{"Name", "Status", "Location", "URL", "Type"})
 	termWidth, _ := nodeps.GetTerminalWidthHeight()
 	usableWidth := termWidth - 15
 	statusWidth := 7 // Maybe just "running"
@@ -87,12 +87,12 @@ func CreateAppTable(out *bytes.Buffer, wrapTableText bool) table.Writer {
 		locationWidth = locationWidth + (termWidth-80)/2
 		statusWidth = statusWidth + (termWidth-80)/3
 	}
-	totUsedWidth := nameWidth + typeWidth + locationWidth + urlWidth + statusWidth
+	totUsedWidth := nameWidth + statusWidth + locationWidth + urlWidth + typeWidth
 	if !wrapTableText {
 		t.SetAllowedRowLength(termWidth)
 	}
 
-	util.Debug("detected terminal width=%v usableWidth=%d statusWidth=%d nameWidth=%d typeWIdth=%d locationWidth=%d urlWidth=%d totUsedWidth=%d", termWidth, usableWidth, statusWidth, nameWidth, typeWidth, locationWidth, urlWidth, totUsedWidth)
+	util.Debug("detected terminal width=%v usableWidth=%d statusWidth=%d nameWidth=%d locationWidth=%d urlWidth=%d typeWidth=%d totUsedWidth=%d", termWidth, usableWidth, statusWidth, nameWidth, locationWidth, urlWidth, typeWidth, totUsedWidth)
 	t.SortBy([]table.SortBy{{Name: "Name"}})
 
 	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
@@ -107,16 +107,16 @@ func CreateAppTable(out *bytes.Buffer, wrapTableText bool) table.Writer {
 				WidthMax: statusWidth,
 			},
 			{
-				Name:     "Type",
-				WidthMax: int(typeWidth),
-			},
-			{
 				Name: "Location",
 				//WidthMax: locationWidth,
 			},
 			{
 				Name: "URL",
 				//WidthMax: urlWidth,
+			},
+			{
+				Name:     "Type",
+				WidthMax: int(typeWidth),
 			},
 		})
 	}

--- a/pkg/ddevapp/list_test.go
+++ b/pkg/ddevapp/list_test.go
@@ -85,7 +85,7 @@ func TestListWithoutDir(t *testing.T) {
 	// This could be done otherwise, but we'd have to go find the site in the
 	// array first.
 	out := bytes.Buffer{}
-	table := ddevapp.CreateAppTable(&out)
+	table := ddevapp.CreateAppTable(&out, true)
 	for _, site := range apps {
 		desc, err := site.Describe(false)
 		if err != nil {
@@ -104,5 +104,5 @@ func TestListWithoutDir(t *testing.T) {
 // TestDdevList tests the ddevapp.List() functionality
 // It's only here for profiling at this point.
 func TestDdevList(t *testing.T) {
-	ddevapp.List(true, false, 1)
+	ddevapp.List(true, false, true, 1)
 }

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -86,7 +86,7 @@ func RenderAppRow(t table.Writer, row map[string]interface{}) {
 	status = FormatSiteStatus(status)
 
 	t.AppendRow(table.Row{
-		row["name"], row["type"], row["shortroot"], urls, status,
+		row["name"], status, row["type"], row["shortroot"], urls,
 	})
 
 }

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -86,7 +86,7 @@ func RenderAppRow(t table.Writer, row map[string]interface{}) {
 	status = FormatSiteStatus(status)
 
 	t.AppendRow(table.Row{
-		row["name"], status, row["type"], row["shortroot"], urls,
+		row["name"], status, row["shortroot"], urls, row["type"],
 	})
 
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

If I run `ddev list` in most of the cases the text is wrapped.
That's because the text of the path and the URL in the table is to long for my terminal window.
In most of the cases a user want to get an overview about the existing projects and the current status of
them.

Example screenshot:

![image](https://user-images.githubusercontent.com/211294/185803968-bd872b69-7148-4c7c-b10f-8d35bf86fbbf.png)

The size of the *type* column was increased to prevent a wrap of longer project types than "drupal7". The project types "wordpress" and "magento2" are not wrapped anymore with this PR.

## How this PR Solves The Problem:

I moved the *status* column from the end of the table right after the name.
If the terminal width is not enough the text will now be truncated.

Screenshot:

![image](https://user-images.githubusercontent.com/211294/185803991-fafd9cf0-57ac-4d96-8992-d33b3ea9c699.png)

For users who want to have the previous behavior the flag `-W` was added to force the old text wrapping.

## Manual Testing Instructions:

Run `ddev list` and change terminal window size.

## Related Issue Link(s):

It's a temporary solution until we use one of the bigger libraries listed in #2110.

## Release/Deployment notes:

If someone parses the raw output of the `ddev list` command then maybe scripts must be changed due to the changed order of the columns.
The order of JSON rendered table is also changed. This should not provide any issues. The key is still the same.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4137"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

