### PR TITLE
[TASK] Add missing quote in test_ddev.sh

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -77,7 +77,7 @@ cat <<END >web/index.php
   mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
   \$mysqli = new mysqli('db', 'db', 'db', 'db');
   printf("Success accessing database... %s\n", \$mysqli->host_info);
-  print "ddev is working. You will want to delete this project with 'ddev delete -Oy ${PROJECT_NAME}\n";
+  print "ddev is working. You will want to delete this project with 'ddev delete -Oy ${PROJECT_NAME}'\n";
 END
 ddev config --project-type=php --docroot=web
 trap cleanup EXIT


### PR DESCRIPTION
## The Problem/Issue/Bug:

The message `Success accessing database... db via TCP/IP ddev is working. You will want to delete this project with 'ddev delete -Oy tryddevproject-15988` misses a single `'`.


## How this PR Solves The Problem:

The quote is added

## Manual Testing Instructions:

Use `ddev debug test` and see response




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4140"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

