### PR TITLE
On upgrade ,remove old provider/platform.yaml.example [skip ci]

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -596,6 +596,15 @@ func (app *DdevApp) FixObsolete() {
 		}
 	}
 
+	// Remove old provider/*.example as we migrate to not needing them.
+	for _, providerFile := range []string{"platform.yaml.example"} {
+		providerFilePath := app.GetConfigPath(filepath.Join("providers", providerFile))
+		err := os.Remove(providerFilePath)
+		if err != nil {
+			util.Warning("attempted to remove %s but failed, you may want to remove it manually: %v", providerFilePath, err)
+		}
+	}
+
 	// Remove old global commands
 	for _, command := range []string{"host/yarn"} {
 		cmdPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/", command)


### PR DESCRIPTION
## The Problem/Issue/Bug:

In the past a file named .ddev/providers/platform.yaml.example was provided, but it's no longer needed, as edits to the file are no longer required.

## How this PR Solves The Problem:

Remove the old example file.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4141"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

