### PR TITLE
Set version constraint for docker-compose to current, fixes #4135

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:2022.07.1
     working_directory: ~/ddev
     environment:
       DDEV_NONINTERACTIVE: "true"

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -961,6 +961,12 @@ func (app *DdevApp) Start() error {
 	app.DockerEnv()
 	dockerutil.EnsureDdevNetwork()
 
+	if err = dockerutil.CheckDockerCompose(); err != nil {
+		util.Failed(`Your docker-compose version is set to an invalid version. 
+Please use the built-in docker-compose.
+Fix with 'ddev config global --required-docker-compose-version="" --use-docker-compose-from-path=false': %v`, err)
+	}
+
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 		// OK to start if dbType is empty (nonexistent) or if it matches
 		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -962,7 +962,7 @@ func (app *DdevApp) Start() error {
 	dockerutil.EnsureDdevNetwork()
 
 	if err = dockerutil.CheckDockerCompose(); err != nil {
-		util.Failed(`Your docker-compose version is set to an invalid version. 
+		util.Failed(`Your docker-compose version does not exist or is set to an invalid version. 
 Please use the built-in docker-compose.
 Fix with 'ddev config global --required-docker-compose-version="" --use-docker-compose-from-path=false': %v`, err)
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -630,6 +630,10 @@ func CheckDockerCompose() error {
 	runTime := util.TimeTrack(time.Now(), "CheckDockerComposeVersion()")
 	defer runTime()
 
+	_, err := DownloadDockerComposeIfNeeded()
+	if err != nil {
+		return err
+	}
 	versionConstraint := DockerComposeVersionConstraint
 
 	v, err := GetDockerComposeVersion()
@@ -1446,7 +1450,7 @@ func GetLiveDockerComposeVersion() (string, error) {
 
 	if !fileutil.FileExists(composePath) {
 		globalconfig.DockerComposeVersion = ""
-		return globalconfig.DockerComposeVersion, nil
+		return globalconfig.DockerComposeVersion, fmt.Errorf("docker-compose does not exist at %s", composePath)
 	}
 	out, err := exec.Command(composePath, "version", "--short").Output()
 	if err != nil {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1419,7 +1419,7 @@ func GetDockerVersion() (string, error) {
 // REMEMBER TO CHANGE docs/ddev-installation.md if you touch this!
 // The constraint MUST HAVE a -pre of some kind on it for successful comparison.
 // See https://github.com/drud/ddev/pull/738.. and regression https://github.com/drud/ddev/issues/1431
-var DockerComposeVersionConstraint = ">= 1.25.0-alpha1 < 2.0.0-alpha1 || >= v2.0.0-rc.2"
+var DockerComposeVersionConstraint = ">= 2.5.1"
 
 // DockerComposeFileFormatVersion is the compose version to be used
 var DockerComposeFileFormatVersion = "3.6"

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -318,6 +318,7 @@ func TestComposeWithStreams(t *testing.T) {
 func TestCheckCompose(t *testing.T) {
 	assert := asrt.New(t)
 
+	globalconfig.DockerComposeVersion = ""
 	composeErr := CheckDockerCompose()
 	if composeErr != nil {
 		out, err := exec.RunHostCommand(DdevBin, "config", "global")

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -2,6 +2,7 @@ package dockerutil_test
 
 import (
 	"fmt"
+	"github.com/drud/ddev/pkg/globalconfig"
 	"log"
 	"os"
 	"path"
@@ -317,8 +318,14 @@ func TestComposeWithStreams(t *testing.T) {
 func TestCheckCompose(t *testing.T) {
 	assert := asrt.New(t)
 
-	err := CheckDockerCompose()
-	assert.NoError(err)
+	composeErr := CheckDockerCompose()
+	if composeErr != nil {
+		out, err := exec.RunHostCommand(DdevBin, "config", "global")
+		require.NoError(t, err)
+		ddevVersion, err := exec.RunHostCommand(DdevBin, "version")
+		require.NoError(t, err)
+		assert.NoError(composeErr, "RequiredDockerComposeVersion=%s global config=%s ddevVersion=%s", globalconfig.RequiredDockerComposeVersion, out, ddevVersion)
+	}
 }
 
 // TestGetAppContainers looks for container with sitename dockerutils-test


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4135 

As of v1.21.1, docker-compose v1 is not allowed, but the docker-compose version constraint was not updated

## How this PR Solves The Problem:

Update the version constraint, check it on start, and explain what to do about it.

## Manual Testing Instructions:

- [x] Set docker-compose to v1 in Docker Desktiop, 
- [x] `ddev config global --use-docker-compose-from-path`
- [x] `ddev start`

See explanatory error message. 
 



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4142"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

