### PR TITLE
Bump required docker-compose to 2.10.1

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -564,7 +564,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.9.0"
+var RequiredDockerComposeVersion = "v2.10.1"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Problem/Issue/Bug:

docker-compose v2.10.1 has been released. See if it passes tests.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4143"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

