### PR TITLE
Don't show warning when removing platform.yaml.example [skip ci]

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -600,8 +600,8 @@ func (app *DdevApp) FixObsolete() {
 	for _, providerFile := range []string{"platform.yaml.example"} {
 		providerFilePath := app.GetConfigPath(filepath.Join("providers", providerFile))
 		err := os.Remove(providerFilePath)
-		if err != nil {
-			util.Warning("attempted to remove %s but failed, you may want to remove it manually: %v", providerFilePath, err)
+		if err == nil {
+			util.Success("Removed obsolete file %s", providerFilePath)
 		}
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

After platform.yaml.example has been removed, it still was warning about not finding it.

## How this PR Solves The Problem:

Don't bother.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4145"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

