### PR TITLE
Make sure vendor/bin is in PATH even if composer_root is different, fixes #4060

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
@@ -1,4 +1,4 @@
-export PATH="~/bin:$PATH:/var/www/html/vendor/bin:/var/www/html/bin"
+export PATH="~/bin:$PATH:/var/www/html/vendor/bin:/var/www/html/bin:$DDEV_COMPOSER_ROOT/vendor/bin"
 
 [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
 [ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -159,6 +159,7 @@ services:
     environment:
     - COLUMNS
     - DOCROOT=${DDEV_DOCROOT}
+    - DDEV_COMPOSER_ROOT
     - DDEV_DATABASE
     - DDEV_DOCROOT
     - DDEV_HOSTNAME

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1852,6 +1852,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_PROJECT":                  app.Name,
 		"DDEV_WEBIMAGE":                 app.WebImage,
 		"DDEV_APPROOT":                  app.AppRoot,
+		"DDEV_COMPOSER_ROOT":            app.GetComposerRoot(true, false),
 		"DDEV_DATABASE":                 app.Database.Type + ":" + app.Database.Version,
 		"DDEV_FILES_DIR":                app.GetContainerUploadDirFullPath(),
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220824_containerwait_fail" // Note that this can be overridden by make
+var WebTag = "20220826_path_adjusted_for_composer_root" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4060 

When people have their composer_root set to non-default, the $PATH in the web container doesn't point to their vendor/bin

## How this PR Solves The Problem:

Add <composer_root>/vendor/bin to $PATH

## Manual Testing Instructions:

- [x] Set composer_root to some subdirectory
- [x] `ddev restart`
- [x] `ddev exec 'echo $PATH'` and you should see the vendor/bin associated with the composer root


## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4147"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

