### PR TITLE
Remove requirement of docker-compose version 3.6 in docker-compose.*.yaml, for #3214

### DIFF
--- a/cmd/ddev/cmd/debug-compose-config_test.go
+++ b/cmd/ddev/cmd/debug-compose-config_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 var override = `
-version: '3.6'
 services:
   web:
     labels:

--- a/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/docker-compose.example.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/docker-compose.example.yaml
@@ -1,7 +1,5 @@
 #ddev-generated
 
-version: '3.6'
-
 services:
   memcached:
     container_name: ddev-${DDEV_SITENAME}-memcached

--- a/docs/content/users/basics/faq.md
+++ b/docs/content/users/basics/faq.md
@@ -41,7 +41,6 @@ Can different projects communicate with each other?
 : Yes, this is commonly required for situations like Drupal migrations. For the web container to access the db container of another project, use `ddev-<projectname>-db` as the hostname of the other project. For example, in project1, use `mysql -h ddev-project2-db` to access the db server of project2. For HTTP/S communication you can 1) access the web container of project2 directly with the hostname `ddev-<project2>-web` and port 80 or 443: `curl https://ddev-project2-web` or 2) Add a .ddev/docker-compose.communicate.yaml which will allow you to access the other project via the official FQDN.
 
     ```yaml
-      version: '3.6'
       services:
         web:
             external_links:

--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -21,8 +21,6 @@ To add custom configuration or additional services to your project, create docke
 * Expose an additional port 9999 to host port 9999, in a file perhaps called `docker-compose.ports.yaml`:
 
 ```yaml
-version: '3.6'
-
 services:
   someservice:
     ports:
@@ -32,8 +30,6 @@ services:
 That approach usually isn't sustainable because two projects might want to use the same port, so we *expose* the additional port (to the docker network) and then use the ddev-router to bind it to the host. This works only for services with an http API, but results in having both http and https ports (9998 and 9999).
 
 ```yaml
-version: '3.6'
-
 services:
     someservice:
         container_name: "ddev-${DDEV_SITENAME}-someservice"

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -126,7 +126,6 @@ Instructions for Mutagen and NFS are below.
     3. Add a `.ddev/docker-compose.bindmount.yaml` something like this:
 
     ```yaml
-    version: "3.6"
     services:
       web:
         volumes:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -1,5 +1,4 @@
 name: ${COMPOSE_PROJECT_NAME}
-version: '{{ .ComposeVersion }}'
   {{ .DdevGenerated }}
 services:
   {{ if not .OmitDB }}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -631,7 +631,6 @@ type composeYAMLVars struct {
 	HostPHPMyAdminPort        string
 	DdevGenerated             string
 	HostDockerInternalIP      string
-	ComposeVersion            string
 	DisableSettingsManagement bool
 	MountType                 string
 	WebMount                  string
@@ -720,7 +719,6 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		HostPHPMyAdminPort:        app.HostPHPMyAdminPort,
 		DdevGenerated:             nodeps.DdevFileSignature,
 		HostDockerInternalIP:      hostDockerInternalIP,
-		ComposeVersion:            dockerutil.DockerComposeFileFormatVersion,
 		DisableSettingsManagement: app.DisableSettingsManagement,
 		OmitDB:                    nodeps.ArrayContainsString(app.GetOmittedContainers(), nodeps.DBContainer),
 		OmitDBA:                   nodeps.ArrayContainsString(app.GetOmittedContainers(), nodeps.DBAContainer) || nodeps.ArrayContainsString(app.OmitContainers, nodeps.DBContainer),

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -128,7 +128,6 @@ func generateRouterCompose() (string, error) {
 		"router_tag":                 versionconstants.RouterTag,
 		"ports":                      exposedPorts,
 		"router_bind_all_interfaces": globalconfig.DdevGlobalConfig.RouterBindAllInterfaces,
-		"compose_version":            dockerutil.DockerComposeFileFormatVersion,
 		"dockerIP":                   dockerIP,
 		"disable_http2":              globalconfig.DdevGlobalConfig.DisableHTTP2,
 		"letsencrypt":                globalconfig.DdevGlobalConfig.UseLetsEncrypt,

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -1,4 +1,3 @@
-version: '{{ .compose_version }}'
 services:
   ddev-router:
     image: {{ .router_image }}:{{ .router_tag }}

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -107,7 +107,6 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 	templateVars := map[string]interface{}{
 		"ssh_auth_image":        versionconstants.SSHAuthImage,
 		"ssh_auth_tag":          versionconstants.SSHAuthTag,
-		"compose_version":       dockerutil.DockerComposeFileFormatVersion,
 		"AutoRestartContainers": globalconfig.DdevGlobalConfig.AutoRestartContainers,
 		"Username":              username,
 		"UID":                   uid,

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -1,4 +1,3 @@
-version: '{{ .compose_version }}'
 volumes:
   dot_ssh:
     name: "ddev-ssh-agent_dot_ssh"

--- a/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   busybox:
     image: busybox:stable

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.override.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.override.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   web:
     environment:

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z1.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z1.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   web:
     environment:

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.z2.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   web:
     environment:

--- a/pkg/ddevapp/testdata/TestNetworkAmbiguity/docker-compose.test.yaml
+++ b/pkg/ddevapp/testdata/TestNetworkAmbiguity/docker-compose.test.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   test:
     container_name: ddev-${DDEV_SITENAME}-test

--- a/pkg/ddevapp/testdata/TestRouterConfigOverride/router-compose.override.yaml
+++ b/pkg/ddevapp/testdata/TestRouterConfigOverride/router-compose.override.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   ddev-router:
     environment:

--- a/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
+++ b/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   test-ssh-server:
     container_name: test-ssh-server

--- a/pkg/ddevapp/testdata/TestSshAuthConfigOverride/ssh-auth-compose.override.yaml
+++ b/pkg/ddevapp/testdata/TestSshAuthConfigOverride/ssh-auth-compose.override.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   ddev-ssh-agent:
     environment:

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1449,9 +1449,6 @@ func GetDockerVersion() (string, error) {
 // See https://github.com/drud/ddev/pull/738.. and regression https://github.com/drud/ddev/issues/1431
 var DockerComposeVersionConstraint = ">= 2.5.1"
 
-// DockerComposeFileFormatVersion is the compose version to be used
-var DockerComposeFileFormatVersion = "3.6"
-
 // GetDockerComposeVersion runs docker-compose -v to get the current version
 func GetDockerComposeVersion() (string, error) {
 	if globalconfig.DockerComposeVersion != "" {

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -35,5 +35,3 @@ services:
       retries: 25
       start_period: 20s
       timeout: 120s
-
-version: '3.6'

--- a/pkg/dockerutil/testdata/docker-compose.override.yml
+++ b/pkg/dockerutil/testdata/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   foo:
     container_name: ddev-test-foo

--- a/pkg/dockerutil/testdata/docker-compose.yml
+++ b/pkg/dockerutil/testdata/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   db:
     container_name: ddev-test-db


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #3214 

docker-compose no longer requires `version: 3.6` (or anything like it)
DDEV now maintains its own private docker-compose, so we have a working verison.

## How this PR Solves The Problem:

Remove usages of `version: 3.6`

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4151"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

