### PR TITLE
Mutagen followup: Make sure mutagen sync sessions are terminated

### DIFF
--- a/cmd/ddev/cmd/clean.go
+++ b/cmd/ddev/cmd/clean.go
@@ -73,7 +73,6 @@ Additional commands that can help clean up resources:
 		globalDdevDir := globalconfig.GetGlobalDdevDir()
 		_ = os.RemoveAll(filepath.Join(globalDdevDir, "testcache"))
 		_ = os.RemoveAll(filepath.Join(globalDdevDir, "bin"))
-		_ = os.RemoveAll(globalconfig.GetMutagenDataDirectory())
 
 		output.UserOut.Print("Deleting snapshots and downloads for selected projects...")
 		for _, project := range projects {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -989,7 +989,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		// Make sure the mutagen sync volume exists. It's compatible if we found it above
 		// so we can keep it in that case.
 		if !dockerutil.VolumeExists(GetMutagenVolumeName(app)) {
-			_, err = dockerutil.CreateVolume(GetMutagenVolumeName(app), "local", nil, map[string]string{mutagenSignatureLabelName: GetDefaultVolumeSignature(app)})
+			_, err = dockerutil.CreateVolume(GetMutagenVolumeName(app), "local", nil, map[string]string{mutagenSignatureLabelName: GetDefaultMutagenVolumeSignature(app)})
 			if err != nil {
 				return fmt.Errorf("Unable to create new mutagen docker volume %s: %v", GetMutagenVolumeName(app), err)
 			}
@@ -2832,10 +2832,4 @@ func (app *DdevApp) CreateUploadDirIfNecessary() {
 			util.Warning("Unable to create upload directory %s: %v", app.GetHostUploadDirFullPath(), err)
 		}
 	}
-}
-
-// GetDefaultVolumeSignature gets a new volume signature to be applied especially to mutagen volume
-func GetDefaultVolumeSignature(app *DdevApp) string {
-	now := time.Now()
-	return fmt.Sprintf("%s-%d", dockerutil.GetDockerHostID(), now.Unix())
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -976,7 +976,11 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 
 	if app.IsMutagenEnabled() {
 		if ok, info := CheckMutagenVolumeSyncCompatibility(app); !ok {
-			util.Warning("mutagen sync session and docker volume are incompatible: '%s', Removing docker volume %s", info, GetMutagenVolumeName(app))
+			util.Warning("mutagen sync session and docker volume are incompatible: '%s', Removing mutagen sync session '%s' and docker volume %s", info, MutagenSyncName(app.Name), GetMutagenVolumeName(app))
+			terminateErr := TerminateMutagenSync(app)
+			if terminateErr != nil {
+				util.Warning("Unable to terminate mutagen sync %s: %v", MutagenSyncName(app.Name), err)
+			}
 			removeVolumeErr := dockerutil.RemoveVolume(GetMutagenVolumeName(app))
 			if removeVolumeErr != nil {
 				return fmt.Errorf(`Unable to remove mismatched mutagen docker volume '%s'. Please use 'ddev mutagen reset': %v`, GetMutagenVolumeName(app), removeVolumeErr)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -686,3 +686,9 @@ func TerminateAllMutagenSync() {
 		util.Warning("could not terminate all mutagen sessions (mutagen sync terminate -a), output=%s, err=%v", out, err)
 	}
 }
+
+// GetDefaultMutagenVolumeSignature gets a new volume signature to be applied to mutagen volume
+func GetDefaultMutagenVolumeSignature(app *DdevApp) string {
+	now := time.Now()
+	return fmt.Sprintf("%s-%s", dockerutil.GetDockerHostID(), now.Format("20060102150405"))
+}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -649,8 +649,6 @@ func CheckMutagenVolumeSyncCompatibility(app *DdevApp) (bool, string) {
 	volumeLabel, volumeLabelErr := GetMutagenVolumeLabel(app)
 	dockerHostID := dockerutil.GetDockerHostID()
 
-	util.Warning("CheckMutagenVolumeSyncCompatibility: mutagenLabel='%s', volumeLabel='%s', mutagenSyncLabelErr='%v', volumeLabelErr='%v' dockerHostID=%s", mutagenLabel, volumeLabel, mutagenSyncLabelErr, volumeLabelErr, dockerHostID)
-
 	switch {
 	// If there is no volume, everything is fine, proceed.
 	case volumeLabelErr != nil && errors.Is(docker.ErrNoSuchVolume, volumeLabelErr):
@@ -681,10 +679,10 @@ func GetMutagenSyncLabel(app *DdevApp) (string, error) {
 	return "", fmt.Errorf("sync session label not found for sync session %s", MutagenSyncName(app.Name))
 }
 
-// TerminateAllMutagenSync terminates all sessions that match our signature label
+// TerminateAllMutagenSync terminates all sync sessions
 func TerminateAllMutagenSync() {
-	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "terminate", "--label-selector="+mutagenSignatureLabelName)
+	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "terminate", "-a")
 	if err != nil {
-		util.Warning("could not terminate all mutagen sessions, output=%s, err=%v", out, err)
+		util.Warning("could not terminate all mutagen sessions (mutagen sync terminate -a), output=%s, err=%v", out, err)
 	}
 }

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -19,7 +19,7 @@ func PowerOff() {
 		util.Warning("Failed removing custom certs: %v", err)
 	}
 
-	// Iterate through the list of apps built above, removing each one.
+	// Iterate through the list of apps built above, stopping each one.
 	for _, app := range apps {
 		if err := app.Stop(false, false); err != nil {
 			util.Failed("Failed to stop project %s: \n%v", app.GetName(), err)
@@ -27,7 +27,7 @@ func PowerOff() {
 		util.Success("Project %s has been stopped.", app.GetName())
 	}
 
-	TerminateAllMutagenSync()
+	StopMutagenDaemon()
 
 	if err := RemoveSSHAgentContainer(); err != nil {
 		util.Error("Failed to remove ddev-ssh-agent: %v", err)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Need to terminate session if we find a non-matching sync
* Need to stop mutagen daemon on poweroff
* Remove one util.Warning() that doesn't need to be there.

## Manual Testing Instructions:

Use 
`MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory ~/.ddev/bin/mutagen sync list -l` 

to see what's running after you've done lots of things.

You can also
```
export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory
export PATH=$PATH:~/.ddev/bin
mutagen sync list -l
```



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4153"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

