### PR TITLE
Fix up test_ddev.sh [skip ci]

### DIFF
--- a/cmd/ddev/cmd/debug-dockercheck.go
+++ b/cmd/ddev/cmd/debug-dockercheck.go
@@ -79,7 +79,7 @@ var DebugDockercheckCmd = &cobra.Command{
 			util.Success("Able to run simple container that mounts a volume.")
 		}
 
-		_, _, err = dockerutil.RunSimpleContainer(versionconstants.GetWebImage(), "", []string{"curl", "-sLI", "https://google.com"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-globa-cache"}, uid, true, false, nil)
+		_, _, err = dockerutil.RunSimpleContainer(versionconstants.GetWebImage(), "", []string{"curl", "-sfLI", "https://google.com"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-globa-cache"}, uid, true, false, nil)
 		if err != nil {
 			util.Warning("Unable to run use internet inside container, many things will fail: %v", err)
 		} else {

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -49,14 +49,7 @@ echo "DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-notset}"
 echo "======= Mutagen Info ========="
 if [ -f ~/.ddev/bin/mutagen ]; then
   echo "Mutagen is installed in ddev, version=$(~/.ddev/bin/mutagen version)"
-  ~/.ddev/bin/mutagen sync list
-fi
-if command -v mutagen >/dev/null ; then
-  echo "mutagen additionally installed in PATH at $(command -v mutagen), version $(mutagen version)"
-fi
-if killall -0 mutagen 2>/dev/null; then
-  echo "mutagen is running on this system:"
-  ps -ef | grep mutagen
+  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync list -l
 fi
 
 echo "======= Docker Info ========="
@@ -124,7 +117,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "======== Project ownership on host:"
-ls -ld ~/tmp/${PROJECT_NAME}
+ls -ld ${PROJECT_DIR}
 echo "======== Project ownership in container:"
 ddev exec ls -ld /var/www/html
 echo "======== In-container filesystem:"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* test_ddev.sh had a syntax error from previous editing
* Clean up mutagen as it can be simpler now, and doesn't have to warn about other mutagen instances



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4164"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

