### PR TITLE
Don't flush mutagen if project not running, fixes #4162, fixes #4163

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -446,7 +446,11 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	case (app.Type == "" || app.Type == nodeps.AppTypePHP) && (projectTypeArg == "" || projectTypeArg == detectedApptype): // Found an app, matches passed-in or no apptype passed
 		projectTypeArg = detectedApptype
 		app.Type = projectTypeArg
-		util.Success("Found a %s codebase at %s", detectedApptype, fullPath)
+		if app.Type == nodeps.AppTypePHP {
+			util.Success("Configuring unrecognized codebase as project type 'php' at %s", fullPath)
+		} else {
+			util.Success("Configuring a %s codebase with docroot '%s' at %s", detectedApptype, app.Docroot, fullPath)
+		}
 	case projectTypeArg != "": // apptype was passed, but we found no app at all
 		app.Type = projectTypeArg
 		util.Warning("You have specified a project type of %s but no project of that type is found in %s", projectTypeArg, fullPath)

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -73,7 +73,7 @@ func TestConfigDescribeLocation(t *testing.T) {
 	})
 	out, err := exec.RunHostCommand(DdevBin, "config", "--docroot=.", "--project-name="+t.Name())
 	assert.NoError(err)
-	assert.Contains(string(out), "Found a php codebase")
+	assert.Contains(string(out), "Configuring unrecognized codebase as project type 'php'")
 
 	// Now see if we can detect it
 	out, err = exec.RunHostCommand(DdevBin, "config", "--show-config-location")
@@ -127,7 +127,7 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	defer func() {
 		_, _ = exec.RunCommand(DdevBin, []string{"delete", "-Oy", "config-with-sitename"})
 	}()
-	assert.Contains(string(out), "Found a drupal6 codebase", nodeps.AppTypeDrupal6)
+	assert.Contains(string(out), "Configuring a drupal6 codebase with docroot", nodeps.AppTypeDrupal6)
 }
 
 // TestConfigSetValues sets all available configuration values using command flags, then confirms that the

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/updatecheck"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/versionconstants"
+	"github.com/mitchellh/go-homedir"
 	"github.com/rogpeppe/go-internal/semver"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -208,6 +210,9 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 		// If they have a new version (but not first-timer) then prompt to poweroff
 		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {
 			okPoweroff := util.Confirm("It looks like you have a new DDEV version. During an upgrade it's important to `ddev poweroff`. May I do `ddev poweroff` before continuing? This does no harm and loses no data.")
+			if globalconfig.DdevGlobalConfig.MutagenEnabledGlobal && fileutil.IsDirectory(filepath.Join(homedir.Dir(), ".mutagen")) {
+				output.UserOut.Print("Note that the global ~/.mutagen folder is no longer used by DDEV so you can delete it if you don't use it for other things")
+			}
 			if okPoweroff {
 				ddevapp.PowerOff()
 			}

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -209,10 +209,12 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 
 		// If they have a new version (but not first-timer) then prompt to poweroff
 		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {
-			okPoweroff := util.Confirm("It looks like you have a new DDEV version. During an upgrade it's important to `ddev poweroff`. May I do `ddev poweroff` before continuing? This does no harm and loses no data.")
-			if globalconfig.DdevGlobalConfig.MutagenEnabledGlobal && fileutil.IsDirectory(filepath.Join(homedir.Dir(), ".mutagen")) {
-				output.UserOut.Print("Note that the global ~/.mutagen folder is no longer used by DDEV so you can delete it if you don't use it for other things")
+			output.UserOut.Print("Congratulations, you seem to have a new DDEV version.")
+			home, _ := homedir.Dir()
+			if globalconfig.DdevGlobalConfig.MutagenEnabledGlobal && fileutil.IsDirectory(filepath.Join(home, ".mutagen")) {
+				output.UserOut.Print("Please note that the global ~/.mutagen folder is no longer used by DDEV so you can delete it if it's no longer used by other applications")
 			}
+			okPoweroff := util.Confirm("It looks like you have a new DDEV version. During an upgrade it's important to `ddev poweroff`. May I do `ddev poweroff` before continuing? This does no harm and loses no data.")
 			if okPoweroff {
 				ddevapp.PowerOff()
 			}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -397,7 +397,8 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 
 // MutagenSyncFlush performs a mutagen sync flush, waits for result, and checks for errors
 func (app *DdevApp) MutagenSyncFlush() error {
-	if app.IsMutagenEnabled() {
+	status, _ := app.SiteStatus()
+	if status == SiteRunning && app.IsMutagenEnabled() {
 		syncName := MutagenSyncName(app.Name)
 		if !MutagenSyncExists(app) {
 			return errors.Errorf("Mutagen sync session '%s' does not exist", syncName)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4162 
* #4163 

## How this PR Solves The Problem:

Fix things.

Also changes the wording when creating an unrecognized project

## Manual Testing Instructions:

- [x] `ddev config --auto` in empty directory shouldn't show mutagen failure.




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4165"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

