### PR TITLE
Ask people about upload_dir when mutagen is set

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1208,6 +1208,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	if app.IsMutagenEnabled() {
+		CheckMutagenUploadDir(app)
 		// Must wait for web container to be healthy before fiddling with mutagen
 		err = app.Wait([]string{"web"})
 		if err != nil {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -720,3 +720,11 @@ func GetDefaultMutagenVolumeSignature(app *DdevApp) string {
 	now := time.Now()
 	return fmt.Sprintf("%s-%s", dockerutil.GetDockerHostID(), now.Format("20060102150405"))
 }
+
+// CheckMutagenUploadDir just tells people if they are using mutagen without upload_dir
+func CheckMutagenUploadDir(app *DdevApp) {
+	if app.IsMutagenEnabled() && app.GetUploadDir() == "" {
+		util.Warning("You have mutagen enabled and your '%s' project type doesn't have an upload_dir set.", app.Type)
+		util.Warning("For faster startup and less disk usage,\nset upload_dir to where your user-generated files are stored.")
+	}
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

When people have mutagen turned on, it's really far better to have upload_dir. Some folks who use the 'php' project type especially don't have that set, and it causes slower startup time and disk duplication.

## How this PR Solves The Problem:

Warn on `ddev start` in this situation.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4173"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

