### PR TITLE
[Homebrew] Fix zsh completion file name

### DIFF
--- a/.ci-scripts/bump_homebrew.sh
+++ b/.ci-scripts/bump_homebrew.sh
@@ -68,7 +68,7 @@ class Ddev < Formula
       system ".gotmp/bin/linux_amd64/ddev_gen_autocomplete"
     end
     bash_completion.install ".gotmp/bin/ddev_bash_completion.sh" => "ddev"
-    zsh_completion.install ".gotmp/bin/ddev_zsh_completion.sh" => "ddev"
+    zsh_completion.install ".gotmp/bin/ddev_zsh_completion.sh" => "_ddev"
     fish_completion.install ".gotmp/bin/ddev_fish_completion.sh" => "ddev"
   end
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

ZSH completion doesn't work if DDEV was installed by Homebrew. It happens because a completion file has a wrong name: `ddev` instead of `_ddev`.

## How this PR Solves The Problem:

The file was renamed to `_ddev`

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4179"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

