### PR TITLE
fix: no need for SSH when using terminus token

### DIFF
--- a/docs/content/users/basics/developer-tools.md
+++ b/docs/content/users/basics/developer-tools.md
@@ -116,4 +116,4 @@ To use terminus, you'll first need to:
 2. Use `ddev ssh` to tunnel into your container
 3. Issue a command using the keyword `terminus`. For help using terminus try `terminus list` to get a list of possible commands.
 
-Terminus also allows you to issue [drush](https://www.drush.org/), [WP-CLI](https://wp-cli.org/), and [composer](https://getcomposer.org/) commands to your pantheon server. These are all usable from within the container as well, but will require authentication via either your Pantheon password or an SSH key. To use your host machine's SSH key, you can use the `ddev auth ssh` command [described here](cli-usage.md#ssh-into-containers).
+Terminus also allows you to issue [drush](https://www.drush.org/), [WP-CLI](https://wp-cli.org/), and [composer](https://getcomposer.org/) commands to your pantheon server. These are all usable from within the container as well.

--- a/docs/content/users/providers/pantheon.md
+++ b/docs/content/users/providers/pantheon.md
@@ -17,22 +17,22 @@ If you have ddev installed, and have an active Pantheon account with an active s
    - TERMINUS_MACHINE_TOKEN=abcdeyourtoken
    ```
 
-1. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at `https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/`, the site ID is `009a2cda-2c22-4eee-8f9d-96f017321555`.
+2. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at `https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/`, the site ID is `009a2cda-2c22-4eee-8f9d-96f017321555`.
 
-1. On the pantheon dashboard for the site, make sure that at least one backup has been created. (When you need to refresh what you pull, create a new backup.)
+3. On the pantheon dashboard for the site, make sure that at least one backup has been created. (When you need to refresh what you pull, create a new backup.)
 
-1. Check out the project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
+4. Check out the project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
 
-1. Configure the local checkout for ddev using `ddev config`
+5. Configure the local checkout for ddev using `ddev config`
 
-1. If using Drupal 8+, verify that drush is installed in your project, `ddev composer require drush/drush`. If using Drupal 6 or 7, drush8 is already provided in the web container's /usr/local/bin/drush, so you can skip this step.
+6. If using Drupal 8+, verify that drush is installed in your project, `ddev composer require drush/drush`. If using Drupal 6 or 7, drush8 is already provided in the web container's /usr/local/bin/drush, so you can skip this step.
 
-1. In your **project's** .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml (_Note that this refers to your project .ddev folder and not the global .ddev folder_).  Edit the `project` environment variable under `environment_variables`. It will be in the format `<projectname>.<environment>`, for example `yourprojectname.dev` or (in cases of ambiguity) `<project_uuid>.<environment>`, for example `009a2cda-2c22-4eee-8f9d-96f017321555.dev`.
+7. In your **project's** .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml (_Note that this refers to your project .ddev folder and not the global .ddev folder_).  Edit the `project` environment variable under `environment_variables`. It will be in the format `<projectname>.<environment>`, for example `yourprojectname.dev` or (in cases of ambiguity) `<project_uuid>.<environment>`, for example `009a2cda-2c22-4eee-8f9d-96f017321555.dev`.
 
-1. If using Colima, may need to set an explicit nameserver in `~/.colima/default/colima.yaml` like `1.1.1.1`. If this configuration is changed, may also need to restart Colima.
+8. If using Colima, may need to set an explicit nameserver in `~/.colima/default/colima.yaml` like `1.1.1.1`. If this configuration is changed, may also need to restart Colima.
 
-1. `ddev restart`
+9. `ddev restart`
 
-1. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
+10. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
 
-1. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+11. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.

--- a/docs/content/users/providers/pantheon.md
+++ b/docs/content/users/providers/pantheon.md
@@ -12,29 +12,27 @@ If you have ddev installed, and have an active Pantheon account with an active s
    a. Login to your Pantheon Dashboard, and [Generate a Machine Token](https://pantheon.io/docs/machine-tokens/) for ddev to use.
    b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml
 
-   ```
+   ```yaml
    web_environment:
    - TERMINUS_MACHINE_TOKEN=abcdeyourtoken
    ```
 
-2. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at `https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/`, the site ID is `009a2cda-2c22-4eee-8f9d-96f017321555`.
+1. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site ID, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at `https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/`, the site ID is `009a2cda-2c22-4eee-8f9d-96f017321555`.
 
-3. On the pantheon dashboard for the site, make sure that at least one backup has been created. (When you need to refresh what you pull, create a new backup.)
+1. On the pantheon dashboard for the site, make sure that at least one backup has been created. (When you need to refresh what you pull, create a new backup.)
 
-4. Make sure your public ssh key is configured in Pantheon (Account->SSH Keys)
+1. Check out the project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
 
-5. Check out the project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
+1. Configure the local checkout for ddev using `ddev config`
 
-6. Configure the local checkout for ddev using `ddev config`
+1. If using Drupal 8+, verify that drush is installed in your project, `ddev composer require drush/drush`. If using Drupal 6 or 7, drush8 is already provided in the web container's /usr/local/bin/drush, so you can skip this step.
 
-7. If using Drupal 8+, verify that drush is installed in your project, `ddev composer require drush/drush`. If using Drupal 6 or 7, drush8 is already provided in the web container's /usr/local/bin/drush, so you can skip this step.
+1. In your **project's** .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml (_Note that this refers to your project .ddev folder and not the global .ddev folder_).  Edit the `project` environment variable under `environment_variables`. It will be in the format `<projectname>.<environment>`, for example `yourprojectname.dev` or (in cases of ambiguity) `<project_uuid>.<environment>`, for example `009a2cda-2c22-4eee-8f9d-96f017321555.dev`.
 
-8. In your **project's** .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml (_Note that this refers to your project .ddev folder and not the global .ddev folder_).  Edit the `project` environment variable under `environment_variables`. It will be in the format `<projectname>.<environment>`, for example `yourprojectname.dev` or (in cases of ambiguity) `<project_uuid>.<environment>`, for example `009a2cda-2c22-4eee-8f9d-96f017321555.dev`.  
+1. If using Colima, may need to set an explicit nameserver in `~/.colima/default/colima.yaml` like `1.1.1.1`. If this configuration is changed, may also need to restart Colima.
 
-9. If using Colima, may need to set an explicit nameserver in `~/.colima/default/colima.yaml` like `1.1.1.1`. If this configuration is changed, may also need to restart Colima.
+1. `ddev restart`
 
-10. `ddev restart`
+1. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
 
-11. Run `ddev pull pantheon`. The ddev environment  download the Pantheon database and files, and import the database and files into the ddev environment. You should now be able to access the project locally.
-
-12. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+1. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -18,23 +18,21 @@
 #
 # 3. On the pantheon dashboard, make sure that at least one backup has been created. (When you need to refresh what you pull, do a new backup.)
 #
-# 4. Make sure your public ssh key is configured in Pantheon (Account->SSH Keys)
+# 4. Check out project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
 #
-# 5. Check out project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
+# 5. Verify that drush is installed in your project, `ddev composer require drush/drush`
 #
-# 6. Verify that drush is installed in your project, `ddev composer require drush/drush`
+# 6. Configure the local checkout for ddev using `ddev config`
 #
-# 7. Configure the local checkout for ddev using `ddev config`
+# 7. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the "project" under `environment_variables` (change it from `yourproject.dev`). If you want to use a different environment than "dev", change `dev` to the name of the environment.
 #
-# 8. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the "project" under `environment_variables` (change it from `yourproject.dev`). If you want to use a different environment than "dev", change `dev` to the name of the environment.
+# 8. If using Colima, may need to set an explicit nameserver in `~/.colima/default/colima.yaml` like `1.1.1.1`. If this configuration is changed, may also need to restart Colima.
 #
-# 9. If using Colima, may need to set an explicit nameserver in `~/.colima/default/colima.yaml` like `1.1.1.1`. If this configuration is changed, may also need to restart Colima.
+# 9. `ddev restart`
 #
-# 10. `ddev restart`
+# 10. Run `ddev pull pantheon`. The ddev environment will download the Pantheon database and files using terminus and will import the database and files into the ddev environment. You should now be able to access the project locally.
 #
-# 11. Run `ddev pull pantheon`. The ddev environment will download the Pantheon database and files using terminus and will import the database and files into the ddev environment. You should now be able to access the project locally.
-#
-# 12. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+# 11. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 #
 
 # Debugging: Use `ddev exec terminus auth:whoami` to see what terminus knows about
@@ -46,7 +44,6 @@ environment_variables:
 auth_command:
   command: |
     set -eu -o pipefail
-    ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     if [ -z "${TERMINUS_MACHINE_TOKEN:-}" ]; then echo "Please make sure you have set TERMINUS_MACHINE_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
     terminus auth:login --machine-token="${TERMINUS_MACHINE_TOKEN}" || ( echo "terminus auth login failed, check your TERMINUS_MACHINE_TOKEN" && exit 1 )

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -2,10 +2,6 @@ package ddevapp_test
 
 import (
 	"fmt"
-	"github.com/drud/ddev/pkg/exec"
-	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"os"
@@ -13,6 +9,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/testcommon"
@@ -298,4 +299,17 @@ func isPullSiteValid(siteURL string, siteExpectation string) bool {
 		return false
 	}
 	return strings.Contains(string(body), siteExpectation)
+}
+
+// setupSSHKey takes a privatekey string and turns it into a file and then does `ddev auth ssh`
+func setupSSHKey(t *testing.T, privateKey string, expectScriptDir string) error {
+	// Provide an ssh key for `ddev auth ssh`
+	err := os.Mkdir("sshtest", 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join("sshtest", "id_rsa_test"), []byte(privateKey), 0600)
+	require.NoError(t, err)
+	out, err := exec.RunHostCommand("expect", filepath.Join(expectScriptDir, "ddevauthssh.expect"), DdevBin, "./sshtest")
+	require.NoError(t, err)
+	require.Contains(t, string(out), "Identity added:")
+	return nil
 }

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -2,14 +2,15 @@ package ddevapp_test
 
 import (
 	"fmt"
-	"github.com/drud/ddev/pkg/exec"
-	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/testcommon"
@@ -31,14 +32,9 @@ const pantheonSiteExpectation = "DDEV DRUPAL8 TEST SITE"
 // TestPantheonPull ensures we can pull from pantheon.
 func TestPantheonPull(t *testing.T) {
 	token := ""
-	sshkey := ""
 	if token = os.Getenv("DDEV_PANTHEON_API_TOKEN"); token == "" {
 		t.Skipf("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping %v", t.Name())
 	}
-	if sshkey = os.Getenv("DDEV_PANTHEON_SSH_KEY"); sshkey == "" {
-		t.Skipf("No DDEV_PANTHEON_SSH_KEY env var has been set. Skipping %v", t.Name())
-	}
-	sshkey = strings.Replace(sshkey, "<SPLIT>", "\n", -1)
 
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
@@ -55,9 +51,6 @@ func TestPantheonPull(t *testing.T) {
 	err = os.MkdirAll(filepath.Join(siteDir, "sites/default"), 0777)
 	require.NoError(t, err)
 	err = os.Chdir(siteDir)
-	require.NoError(t, err)
-
-	err = setupSSHKey(t, sshkey, filepath.Join(origDir, "testdata", t.Name()))
 	require.NoError(t, err)
 
 	app, err := NewApp(siteDir, true)
@@ -131,14 +124,9 @@ func TestPantheonPull(t *testing.T) {
 // TestPantheonPush ensures we can push to pantheon for a configured environment.
 func TestPantheonPush(t *testing.T) {
 	token := ""
-	sshkey := ""
 	if token = os.Getenv("DDEV_PANTHEON_API_TOKEN"); token == "" {
 		t.Skipf("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping %v", t.Name())
 	}
-	if sshkey = os.Getenv("DDEV_PANTHEON_SSH_KEY"); sshkey == "" {
-		t.Skipf("No DDEV_PANTHEON_SSH_KEY env var has been set. Skipping %v", t.Name())
-	}
-	sshkey = strings.Replace(sshkey, "<SPLIT>", "\n", -1)
 
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
@@ -161,9 +149,6 @@ func TestPantheonPush(t *testing.T) {
 	_ = app.Stop(true, false)
 
 	err = os.Chdir(d9code.Dir)
-	require.NoError(t, err)
-
-	err = setupSSHKey(t, sshkey, filepath.Join(origDir, "testdata", t.Name()))
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -264,17 +249,4 @@ func TestPantheonPush(t *testing.T) {
 	assert.NoError(err)
 	err = os.Remove("hello-post-push-" + app.Name)
 	assert.NoError(err)
-}
-
-// setupSSHKey takes a privatekey string and turns it into a file and then does `ddev auth ssh`
-func setupSSHKey(t *testing.T, privateKey string, expectScriptDir string) error {
-	// Provide an ssh key for `ddev auth ssh`
-	err := os.Mkdir("sshtest", 0755)
-	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join("sshtest", "id_rsa_test"), []byte(privateKey), 0600)
-	require.NoError(t, err)
-	out, err := exec.RunHostCommand("expect", filepath.Join(expectScriptDir, "ddevauthssh.expect"), DdevBin, "./sshtest")
-	require.NoError(t, err)
-	require.Contains(t, string(out), "Identity added:")
-	return nil
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

Terminus token allow users to connect to Pantheon without SSH.

## How this PR Solves The Problem:

This PR remove the check for SSH, and update documentation to reflect that change.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4184"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

