### PR TITLE
Improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the bug you encountered.
+      description: Please [search existing issues](https://github.com/drud/ddev/issues) to see if yours has already been reported.
       options:
         - label: I have searched the existing issues
           required: true
@@ -13,41 +13,41 @@ body:
     attributes:
       label: Run a Diagnostic and Paste Link Here
       description: |
-        If you're having trouble with ddev,
+        If you’re having trouble with DDEV, help us with context that will skip a bunch of questions:
 
-        1. Please use the latest stable version of DDEV-Local before reporting. Upgrading is easy see https://github.com/drud/ddev/releases/latest.
-        2. Please run a quick diagnostic and post the results as a new gist on gist.github.com (or on another pastebin-type site if you prefer). Just run `ddev debug test` and post the results as a gist on https://gist.github.com. That will help so we don't have to ask so many questions... And if it works, it probably means there's something wrong with your project, not ddev. Put the link to the gist here, thanks. (If you don't yet have the `ddev debug test` command, you can download [test_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/cmd/ddev/cmd/scripts/test_ddev.sh) and run it with the instructions at the top.
+        1. Make sure you’re on the [latest stable version](https://github.com/drud/ddev/releases/latest) before reporting, [upgrading](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/) if necessary.
+        2. Run a diagnostic and post the results as a new Gist (or your favorite equivalent). Run `ddev debug test`, or download and run [test_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/cmd/ddev/cmd/scripts/test_ddev.sh), and share a link to the results via https://gist.github.com. (If this works, there may be something wrong with your project and not DDEV.)
     validations:
       required: false
   - type: textarea
     attributes:
-      label: Current Behavior
-      description: A concise description of what you're experiencing.
+      label: Expected Behavior
+      description: What did you expect to happen?
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Expected Behavior
-      description: A concise description of what you expected to happen.
+      label: Actual Behavior
+      description: What actually happened instead?
     validations:
       required: true
   - type: textarea
     attributes:
       label: Steps To Reproduce
-      description: Steps to reproduce the behavior.
+      description: Specific steps to reproduce the behavior.
       placeholder: |
-        1. In this environment...
-        2. With this config...
-        3. Run '...'
-        4. See error...
+        1. In this environment... 
+        2. With this config... 
+        3. Run `...` 
+        4. See error... 
     validations:
       required: false
   - type: textarea
     attributes:
       label: Anything else?
       description: |
-        Links? References? Screenshots? Anything that will give us more context about the issue you are encountering!
+        Links? References? Screenshots? Anything that will give us more context about your issue!
 
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+        💡 Attach images or log files by clicking this area to highlight it and dragging files over it.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,6 +48,6 @@ body:
       description: |
         Links? References? Screenshots? Anything that will give us more context about your issue!
 
-        💡 Attach images or log files by clicking this area to highlight it and dragging files over it.
+        💡 Attach images or log files by clicking this area to highlight it and dragging files in.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
         If you’re having trouble with DDEV, help us with context that will skip a bunch of questions:
 
         1. Make sure you’re on the [latest stable version](https://github.com/drud/ddev/releases/latest) before reporting, [upgrading](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/) if necessary.
-        2. Run a diagnostic and post the results as a new Gist (or your favorite equivalent). Run `ddev debug test`, or download and run [test_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/cmd/ddev/cmd/scripts/test_ddev.sh), and share a link to the results via https://gist.github.com. (If this works, there may be something wrong with your project and not DDEV.)
+        2. Run a diagnostic and post the results as a new Gist (or your favorite equivalent). Run `ddev debug test`, or download and run [test_ddev.sh](https://raw.githubusercontent.com/drud/ddev/master/cmd/ddev/cmd/scripts/test_ddev.sh), and share a link to the results via https://gist.github.com. (If this works, there may not be something wrong with DDEV but something to [troubleshoot in your project](https://ddev.readthedocs.io/en/latest/users/basics/troubleshooting/).)
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,31 +5,31 @@ body:
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the feature you request.
+      description: Please [search existing issues](https://github.com/drud/ddev/issues) to see if one already exists for your request.
       options:
         - label: I have searched the existing issues
           required: true
   - type: textarea
     attributes:
-      label: Is your feature request related to a problem? Please describe
-      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when...
+      label: Is your feature request related to a problem?
+      description: Clearly and concisely describe the problem. (Ex. I’m always frustrated when...)
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen.
+      label: Describe your solution
+      description: Clearly and concisely describe what you want to happen.
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Describe alternatives you've considered
-      description: A clear and concise description of any alternative solutions or features you've considered.
+      label: Describe alternatives
+      description: Clearly and concisely describe any alternative solutions or features you’ve considered.
     validations:
       required: false
   - type: textarea
     attributes:
       label: Additional context
-      description: Add any other context or screenshots about the feature request here.
+      description: Add any other context or screenshots about the feature request.
     validations:
       required: false


### PR DESCRIPTION
Made some pedantic edits to improve brevity and add links to common jumping-off points:

- Curly punctuation (`'` → `’`) because it’s okay to have nice things.
- Link for “search existing issues” to make it more convenient and actionable.
- Reduced verbosity of diagnostic step instruction. ~~(Would be good to link to a “troubleshooting your project” guide here so there isn’t a dead end if the diagnostic is healthy—not sure if such a document exists.)~~
- Swapped order of bug report’s actual and expected result, assuming that helps better frame problems.
- Made several minor edits for brevity.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4185"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

