### PR TITLE
Add `craft` command transition

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -10,5 +10,8 @@
 if grep -q "type: php" ./.ddev/config.yaml; then
     echo "The craft command is only available in the craftcms project type. You can update this in your project's config file, followed by restarting the DDEV project."
 else
+    CRAFT_CMD_ROOT=${CRAFT_CMD_ROOT:="./"}
+    
+    cd "${CRAFT_CMD_ROOT}"
     php ./craft "$@"
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -3,8 +3,12 @@
 #ddev-generated
 ## Description: Run Craft CMS command inside the web container
 ## Usage: craft [flags] [args]
-## Example: "ddev craft db/backup" or "craft db/backup ./my-backups" (see https://craftcms.com/docs/4.x/console-commands.html)
-## ProjectTypes: php
+## Example: "ddev craft db/backup" or "ddev craft db/backup ./my-backups" (see https://craftcms.com/docs/4.x/console-commands.html)
+## ProjectTypes: craftcms,php
 ## ExecRaw: true
 
-php ./craft "$@"
+if grep -q "type: php" ./.ddev/config.yaml; then
+    echo "The craft command is only available in the craftcms project type. You can update this in your project's config file, followed by restarting the DDEV project."
+else
+    php ./craft "$@"
+fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -13,5 +13,5 @@ else
     CRAFT_CMD_ROOT=${CRAFT_CMD_ROOT:="./"}
     
     cd "${CRAFT_CMD_ROOT}"
-    php ./craft "$@"
+    php craft "$@"
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -7,7 +7,7 @@
 ## ProjectTypes: craftcms,php
 ## ExecRaw: true
 
-if grep -q "type: php" ./.ddev/config.yaml; then
+if [ "${DDEV_PROJECT_TYPE}" != "craftcms" ]; then
     echo "The craft command is only available in the craftcms project type. You can update this in your project's config file, followed by restarting the DDEV project."
 else
     CRAFT_CMD_ROOT=${CRAFT_CMD_ROOT:="./"}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Once https://github.com/drud/ddev/pull/4176 is merged, existing Craft projects that have the project type set to `php` will no longer have the `craft` command available to them and will output an error.

<img width="1114" alt="Screenshot 2022-09-09 at 19 36 06 2" src="https://user-images.githubusercontent.com/57572400/189411390-40d60749-0fc4-4d2f-ba91-f1784a798308.png">

## How this PR Solves The Problem:

This PR maintains the `craft` command in the `php` project type, but prompts users to switch to the `craftcms` project type in order to use it, easing the transition for existing users who update DDEV without reading the release notes.

This is primarily to aid in transitioning and the `craft` command could be dropped for`php` project types in the next minor version, if desirable.

<img width="1114" alt="Screenshot 2022-09-09 at 19 36 06" src="https://user-images.githubusercontent.com/57572400/189411442-e39f8bc5-6051-417e-b4ef-beb26c0a30e4.png">

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4199"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

