### PR TITLE
Bump mutagen (v0.16.0-beta1) and set it to use windows 777 permissions

### DIFF
--- a/.buildkite/test.cmd
+++ b/.buildkite/test.cmd
@@ -1,4 +1,7 @@
 @echo "Building using bash and build.sh"
+
+TASKKILL /T /F /IM mutagen.exe
+
 "C:\Program Files\git\bin\bash" .buildkite/test.sh
 
 if %ERRORLEVEL% EQU 0 (

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -44,12 +44,11 @@ if ! docker ps >/dev/null 2>&1 ; then
   exit 1
 fi
 
-# Make sure we have a reasonable mutagen setup
-if command -v mutagen >/dev/null ; then
-  mutagen daemon stop || true
-fi
-if [ -f ~/.ddev/.mutagen/bin/mutagen ]; then
-  ~/.ddev/.mutagen/bin/mutagen daemon stop || true
+# Make sure we start with mutagen daemon off.
+unset MUTAGEN_DATA_DIRECTORY
+if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
+  MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
+  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
 fi
 if command -v killall >/dev/null ; then
   killall mutagen || true

--- a/cmd/ddev/cmd/debug-mutagen.go
+++ b/cmd/ddev/cmd/debug-mutagen.go
@@ -13,7 +13,11 @@ import (
 var DebugMutagenCmd = &cobra.Command{
 	Use:   "mutagen",
 	Short: "Allows access to any mutagen command",
-	Long:  "This simply passes through any mutagen command to the embedded mutagen itself. See Mutagen docs at https://mutagen.io/documentation/introduction",
+	FParseErrWhitelist: cobra.FParseErrWhitelist{
+		UnknownFlags: true,
+	},
+
+	Long: "This simply passes through any mutagen command to the embedded mutagen itself. See Mutagen docs at https://mutagen.io/documentation/introduction",
 	Example: `ddev debug mutagen sync list
 ddev debug mutagen daemon stop
 ddev debug mutagen
@@ -26,7 +30,7 @@ ddev d mutagen sync list
 			util.Warning("mutagen does not seem to be set up in %s, not executing command", mutagenPath)
 			return
 		}
-		out, err := exec.RunHostCommand(mutagenPath, args...)
+		out, err := exec.RunHostCommand(mutagenPath, os.Args[3:]...)
 		output.UserOut.Printf(out)
 		if err != nil {
 			util.Failed("Error running '%s %v': %v", globalconfig.GetMutagenPath(), args, err)

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -108,6 +108,10 @@ ddev stop --remove-data`,
 			}
 			if unlist {
 				project.RemoveGlobalProjectInfo()
+				err = ddevapp.TerminateMutagenSync(project)
+				if err != nil {
+					util.Warning("Unable to terminate mutagen sync for project %s", project.Name)
+				}
 			}
 
 			util.Success("Project %s has been stopped.", project.GetName())

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -975,6 +975,9 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	if app.IsMutagenEnabled() {
+		if app.GetUploadDir() == "" {
+			util.Warning("Mutagen is enabled but no upload_dir is specified, so you may be syncing many more files than necessary.")
+		}
 		if ok, volumeExists, info := CheckMutagenVolumeSyncCompatibility(app); !ok {
 			util.Debug("mutagen sync session and docker volume are in incompatible status: '%s', Removing mutagen sync session '%s' and docker volume %s", info, MutagenSyncName(app.Name), GetMutagenVolumeName(app))
 			terminateErr := TerminateMutagenSync(app)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -975,9 +975,6 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	if app.IsMutagenEnabled() {
-		if app.GetUploadDir() == "" {
-			util.Warning("Mutagen is enabled but no upload_dir is specified, so you may be syncing many more files than necessary.")
-		}
 		if ok, volumeExists, info := CheckMutagenVolumeSyncCompatibility(app); !ok {
 			util.Debug("mutagen sync session and docker volume are in incompatible status: '%s', Removing mutagen sync session '%s' and docker volume %s", info, MutagenSyncName(app.Name), GetMutagenVolumeName(app))
 			terminateErr := TerminateMutagenSync(app)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -180,6 +180,11 @@ func CreateOrResumeMutagenSync(app *DdevApp) error {
 		if configFile != "" {
 			args = append(args, fmt.Sprintf(`--configuration-file=%s`, configFile))
 		}
+		// On Windows, permissions can't be inferred from what is on the host side, so just force 777 for
+		// most things
+		if runtime.GOOS == "windows" {
+			args = append(args, []string{"--permissions-mode=manual", "--default-file-mode-beta=0777", "--default-directory-mode-beta=0777"}...)
+		}
 		util.Debug("Creating mutagen sync: mutagen %v", args)
 		out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), args...)
 		if err != nil {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -495,6 +495,11 @@ func StopMutagenDaemon() {
 			util.Warning("Unable to stop mutagen daemon: %v; MUTAGEN_DATA_DIRECTORY=%s", err, mutagenDataDirectory)
 		}
 		util.Success("Stopped mutagen daemon")
+		// There may be an old mutagen daemon running against ~/.mutagen; try to stop it as well
+		out, err = exec.RunHostCommand("sh", "-c", fmt.Sprintf("MUTAGEN_DATA_DIRECTORY=~/.mutagen %s daemon  stop", globalconfig.GetMutagenPath()))
+		if err != nil && !strings.Contains(out, "unable to connect to daemon") {
+			util.Warning("Unable to stop old mutagen daemon: %v; MUTAGEN_DATA_DIRECTORY=~/.mutagen", err)
+		}
 	}
 }
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -54,7 +54,7 @@ var BUILDINFO = "BUILDINFO should have new info"
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.15.1"
+const RequiredMutagenVersion = "v0.16.0-beta1"
 
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -54,7 +54,7 @@ var BUILDINFO = "BUILDINFO should have new info"
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "v0.16.0-beta1"
+const RequiredMutagenVersion = "0.16.0-beta1"
 
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {


### PR DESCRIPTION
## The Problem/Issue/Bug:

* non-utf8 filenames aren't handled well in lots of places, but Mutagen in this version can at least detect and report the problem.
* On traditional Windows, mutagen doesn't know what permissions to use with directories and files, so with this version of mutagen that can be forced to 777 as Docker Desktop also does.

## TODO

- [x] Make `ddev debug mutagen ...` work with flags; we can use that to terminate mutagen sessions
- [x] Figure out how to completely terminate mutagen on Windows. sudo?
- [x] Completely terminate mutagen on test start

## How this PR Solves The Problem:

## Manual Testing Instructions:

- [x] Verify that the non-utf8-filename problem can be recreated without this. [This tarball](https://www.dropbox.com/s/1ul5qbq4rpbp50j/nonutf8.tgz?dl=0) or [this code](https://github.com/mutagen-io/mutagen/blob/1194f4646a3e030191287aecc12a3a237b3fb4f9/pkg/synchronization/core/scan_test.go#L156-L166) might work to recreate, or @ursbraem may have files that can be used to recreate it.
- [x] Verify that mutagen doesn't croak *with* this PR if those are being synced, but instead reports the problem
- [x] Verify on traditional Windows that permissions inside container are 777. Especially check vendor/bin/drush, for example.

## Automated Testing Overview:

- [x] Consider a test that checks the problem files
- [x] Consider a test for windows that checks for 777 when using mutagen

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4206"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

