### PR TITLE
Add Symfony Mailer config for Mailhog in Drupal 9 settings #2706

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -520,6 +520,7 @@ scalable
 scp
 screencast
 screencasts
+sendmail
 sequelace
 sequelpro
 serverName

--- a/docs/content/users/basics/developer-tools.md
+++ b/docs/content/users/basics/developer-tools.md
@@ -75,7 +75,7 @@ MailHog will **not** intercept emails if your application is configured to use S
 
 If you’re using SMTP for outgoing mail—with [Symfony Mailer](https://www.drupal.org/project/symfony_mailer) or [SMTP](https://www.drupal.org/project/smtp) modules, for example—update your application’s SMTP server configuration to use `localhost` and MailHog’s port `1025`.
 
-For Drupal 9 `settings.ddev.php` overrides the Symfony Mailer sendmail configuration to use MailHog.
+For Drupal 9+ `settings.ddev.php` overrides the Symfony Mailer sendmail configuration to use MailHog.
 
 For Laravel projects, MailHog will capture Swift messages via SMTP. Update your `.env` to use Mailhog with the following settings:
 

--- a/docs/content/users/basics/developer-tools.md
+++ b/docs/content/users/basics/developer-tools.md
@@ -75,6 +75,8 @@ MailHog will **not** intercept emails if your application is configured to use S
 
 If you’re using SMTP for outgoing mail—with [Symfony Mailer](https://www.drupal.org/project/symfony_mailer) or [SMTP](https://www.drupal.org/project/smtp) modules, for example—update your application’s SMTP server configuration to use `localhost` and MailHog’s port `1025`.
 
+For Drupal 9 `settings.ddev.php` overrides the Symfony Mailer sendmail configuration to use MailHog.
+
 For Laravel projects, MailHog will capture Swift messages via SMTP. Update your `.env` to use Mailhog with the following settings:
 
 ```env

--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -45,3 +45,10 @@ $settings['class_loader_auto_detect'] = FALSE;
 if (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = 'sites/default/files/sync';
 }
+
+// Override drupal/symfony_mailer default config to use Mailhog
+$config['symfony_mailer.mailer_transport.sendmail']['plugin'] = 'smtp';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['user']='';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass']='';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['host']='localhost';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['port']='1025';

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -45,3 +45,11 @@ $settings['class_loader_auto_detect'] = FALSE;
 if (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = 'sites/default/files/sync';
 }
+
+// Override drupal/symfony_mailer default config to use Mailhog
+$config['symfony_mailer.mailer_transport.sendmail']['plugin'] = 'smtp';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['user']='';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass']='';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['host']='localhost';
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['port']='1025';
+


### PR DESCRIPTION
## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:
```
mkdir my-drupal9-site
cd my-drupal9-site
ddev config --project-type=drupal9 --docroot=web --create-docroot
ddev start
ddev composer create "drupal/recommended-project" --no-install
ddev composer require drush/drush --no-install
ddev composer require drupal/symfony_mailer --no-install
ddev composer install
ddev drush site:install -y
ddev drush pm:install symfony_mailer
ddev drush user:login "admin/config/system/mailer/test"
```
Use the login link to go to the page send a test mail.
Verify mailhog recieves the test mail.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#2706 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4214"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

