### PR TITLE
Support PHP 8.2 in DDEV

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -55,7 +55,9 @@ jobs:
 
       - name: Build and test container ${{ matrix.containers }}
         run: |
+          source ~/.bashrc
           docker version
+          mkcert --version
           set -eu -o pipefail
 
           if [[ "${{ matrix.containers }}" == "dbserver" ]]; then

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -38,6 +38,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
       - name: Install Docker and deps (Linux)
         if: matrix.os == 'ubuntu-20.04'
         run: ./.github/workflows/linux-setup.sh

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -26,11 +26,12 @@ which brew
 ls -lL "$(which brew)"
 brew --version || exit 2
 echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
+tail ~/.bashrc
 
 # Without this .curlrc CircleCI linux image doesn't respect mkcert certs
 echo "capath=/etc/ssl/certs/" >>~/.curlrc
 
-. ~/.bashrc
+source ~/.bashrc
 
 brew tap drud/ddev >/dev/null
 for item in gcc@5 golang golangci-lint mkcert; do
@@ -39,7 +40,7 @@ done
 
 mkcert -install
 
-git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local
+git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local >/dev/null
 
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
 

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -17,14 +17,14 @@ sudo apt-get install -qq zip jq expect nfs-kernel-server build-essential curl gi
 
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 
-# TODO: We don't need this line, just for debugging
-ls -l /home/linuxbrew/.linuxbrew/bin || true
-if [ ! -f /home/linuxbrew/.linuxbrew/bin/brew ] ; then
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+if [ ! -f /home/linuxbrew/.linuxbrew/Homebrew/bin/brew ] ; then
+  rm -rf /home/linuxbrew
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
 fi
 export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH
-ls -lL $(which brew)
-brew --version
+which brew
+ls -lL "$(which brew)"
+brew --version || exit 2
 echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 
 # Without this .curlrc CircleCI linux image doesn't respect mkcert certs

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -17,7 +17,9 @@ sudo apt-get install -qq zip jq expect nfs-kernel-server build-essential curl gi
 
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 
-if [ ! -d /home/linuxbrew/.linuxbrew/bin ] ; then
+# TODO: We don't need this line, just for debugging
+ls -l /home/linuxbrew/.linuxbrew/bin || true
+if [ ! -f /home/linuxbrew/.linuxbrew/bin/brew ] ; then
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
 fi
 

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -12,8 +12,8 @@ if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
   set -x
 fi
 
-sudo apt-get update -qq
-sudo apt-get install -qq zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev postgresql-client
+sudo apt-get update -qq >/dev/null
+sudo apt-get install -qq zip jq expect nfs-kernel-server build-essential curl git libnss3-tools libcurl4-gnutls-dev postgresql-client >/dev/null
 
 curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
 

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -22,7 +22,9 @@ ls -l /home/linuxbrew/.linuxbrew/bin || true
 if [ ! -f /home/linuxbrew/.linuxbrew/bin/brew ] ; then
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
 fi
-
+export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH
+ls -lL $(which brew)
+brew --version
 echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 
 # Without this .curlrc CircleCI linux image doesn't respect mkcert certs

--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -26,6 +26,7 @@ func TestCmdXdebug(t *testing.T) {
 
 	// TestDdevXdebugEnabled has already tested enough versions, so limit it here.
 	// and this is a pretty limited test, doesn't do much but turn on and off
+	// TODO: Move from PHP81 to PHP82
 	phpVersions := []string{nodeps.PHP80, nodeps.PHP81}
 
 	pwd, _ := os.Getwd()

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
 FROM base AS ddev-php-base
 ARG PHP_DEFAULT_VERSION="7.4"
 ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
-ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1"
+ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ENV YQ_VERSION=v4.26.1
 ENV DRUSH_VERSION=8.4.8
@@ -106,6 +106,8 @@ ENV php80_arm64=$php80_amd64
 
 ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
+ENV php82_amd64=$php80_amd64
+ENV php82_arm64=$php81_amd64
 
 RUN for v in $PHP_VERSIONS; do \
     targetarch=${TARGETPLATFORM#linux/}; \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -107,7 +107,7 @@ ENV php80_arm64=$php80_amd64
 ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
 # Still to come: apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
-ENV php80_amd64="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3  xml zip"
+ENV php82_amd64="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3  xml zip"
 ENV php82_arm64=$php82_amd64
 
 RUN for v in $PHP_VERSIONS; do \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
 ### This combines the packages and features of DDEV-Local's ddev-webserver and
 ### DDEV-Live's PHP image
 FROM base AS ddev-php-base
-ARG PHP_DEFAULT_VERSION="7.4"
+ARG PHP_DEFAULT_VERSION="8.0"
 ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
@@ -107,7 +107,7 @@ ENV php80_arm64=$php80_amd64
 ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
 # Still to come: apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
-ENV php82_amd64="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3  xml zip"
+ENV php82_amd64="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip"
 ENV php82_arm64=$php82_amd64
 
 RUN for v in $PHP_VERSIONS; do \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -106,8 +106,9 @@ ENV php80_arm64=$php80_amd64
 
 ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
-ENV php82_amd64=$php80_amd64
-ENV php82_arm64=$php81_amd64
+# Still to come: apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
+ENV php80_amd64="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3  xml zip"
+ENV php82_arm64=$php82_amd64
 
 RUN for v in $PHP_VERSIONS; do \
     targetarch=${TARGETPLATFORM#linux/}; \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -107,6 +107,7 @@ ENV php80_arm64=$php80_amd64
 ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
 # Still to come: apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
+# Update test for these when they get added in.
 ENV php82_amd64="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip"
 ENV php82_arm64=$php82_amd64
 

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/apache2/php.ini
@@ -1,0 +1,197 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; php.ini reference: https://git.php.net/?p=php-src.git;a=blob_plain;f=php.ini-production;hb=refs/heads/PHP-7.0  ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[PHP]
+engine = On
+short_open_tag = Off
+precision = 14
+output_buffering = 4096
+zlib.output_compression = Off
+implicit_flush = Off
+unserialize_callback_func =
+serialize_precision = 17
+disable_functions =
+disable_classes =
+zend.enable_gc = On
+expose_php = Off
+; Resource Limits ;
+max_execution_time = 600
+request_terminate_timeout = 0
+max_input_time = -1
+;max_input_nesting_level = 64
+max_input_vars = 3000
+memory_limit = 1024M
+; Error handling and logging ;
+error_reporting = E_ALL
+display_errors = On
+display_startup_errors = On
+log_errors = On
+log_errors_max_len = 1024
+ignore_repeated_errors = Off
+ignore_repeated_source = Off
+report_memleaks = On
+;xmlrpc_errors = 0
+;xmlrpc_error_number = 0
+html_errors = On
+; Data Handling ;
+variables_order = "EGPCS"
+request_order = "GP"
+register_argc_argv = Off
+auto_globals_jit = On
+post_max_size = 100M
+auto_prepend_file =
+auto_append_file =
+default_mimetype = "text/html"
+default_charset = "UTF-8"
+; Paths and Directories ;
+doc_root =
+user_dir =
+enable_dl = Off
+cgi.fix_pathinfo=0
+; File Uploads ;
+file_uploads = On
+upload_max_filesize = 100M
+max_file_uploads = 20
+; Fopen wrappers ;
+allow_url_fopen = On
+allow_url_include = Off
+default_socket_timeout = 60
+;auto_detect_line_endings = Off
+; Dynamic Extensions ;
+
+[CLI Server]
+cli_server.color = On
+
+[Date]
+date.timezone = UTC
+
+[Pdo_mysql]
+pdo_mysql.cache_size = 2000
+pdo_mysql.default_socket=
+
+[mail function]
+SMTP = localhost
+smtp_port = 25
+mail.add_x_header = On
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+
+[SQL]
+sql.safe_mode = Off
+
+[ODBC]
+odbc.allow_persistent = On
+odbc.check_persistent = On
+odbc.max_persistent = -1
+odbc.max_links = -1
+odbc.defaultlrl = 4096
+odbc.defaultbinmode = 1
+
+[Interbase]
+ibase.allow_persistent = 1
+ibase.max_persistent = -1
+ibase.max_links = -1
+ibase.timestampformat = "%Y-%m-%d %H:%M:%S"
+ibase.dateformat = "%Y-%m-%d"
+ibase.timeformat = "%H:%M:%S"
+
+[MySQLi]
+mysqli.max_persistent = -1
+mysqli.allow_persistent = On
+mysqli.max_links = -1
+mysqli.cache_size = 2000
+mysqli.default_port = 3306
+mysqli.default_socket =
+mysqli.default_host =
+mysqli.default_user =
+mysqli.default_pw =
+mysqli.reconnect = Off
+
+[mysqlnd]
+mysqlnd.collect_statistics = On
+mysqlnd.collect_memory_statistics = Off
+
+[PostgreSQL]
+pgsql.allow_persistent = On
+pgsql.auto_reset_persistent = Off
+pgsql.max_persistent = -1
+pgsql.max_links = -1
+pgsql.ignore_notice = 0
+pgsql.log_notice = 0
+
+[bcmath]
+bcmath.scale = 0
+
+[Session]
+session.save_handler = files
+session.use_strict_mode = 0
+session.use_cookies = 1
+session.use_only_cookies = 1
+session.name = PHPSESSID
+session.auto_start = 0
+session.cookie_lifetime = 0
+session.cookie_path = /
+session.cookie_domain =
+session.cookie_httponly =
+session.serialize_handler = php
+session.gc_probability = 0
+session.gc_divisor = 1000
+session.gc_maxlifetime = 1440
+session.referer_check =
+session.cache_limiter = nocache
+session.cache_expire = 180
+session.use_trans_sid = 0
+session.hash_function = 0
+session.hash_bits_per_character = 5
+url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
+
+[Assertion]
+zend.assertions = -1
+
+[Tidy]
+tidy.clean_output = Off
+
+[soap]
+soap.wsdl_cache_enabled=1
+soap.wsdl_cache_dir="/tmp"
+soap.wsdl_cache_ttl=86400
+soap.wsdl_cache_limit = 5
+
+
+[ldap]
+ldap.max_links = -1
+
+[opcache]
+opcache.enable=1
+opcache.enable_cli=1
+opcache.memory_consumption=500
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=1000000
+;opcache.max_wasted_percentage=5
+;opcache.use_cwd=1
+opcache.validate_timestamps=1
+opcache.revalidate_freq=0
+;opcache.revalidate_path=0
+;opcache.save_comments=1
+opcache.fast_shutdown=1
+;opcache.enable_file_override=0
+;opcache.optimization_level=0xffffffff
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+;opcache.blacklist_filename=
+;opcache.max_file_size=0
+;opcache.consistency_checks=0
+;opcache.force_restart_timeout=180
+;opcache.error_log=
+;opcache.log_verbosity_level=1
+;opcache.preferred_memory_model=
+;opcache.protect_memory=0
+;opcache.restrict_api=
+;opcache.mmap_base=
+;opcache.file_cache=
+;opcache.file_cache_only=0
+;opcache.file_cache_consistency_checks=1
+;opcache.file_cache_fallback=1
+;opcache.huge_code_pages=1
+;opcache.validate_permission=0
+;opcache.validate_root=0

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/cli/php.ini
@@ -1,0 +1,197 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; php.ini reference: https://git.php.net/?p=php-src.git;a=blob_plain;f=php.ini-production;hb=refs/heads/PHP-7.0  ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[PHP]
+engine = On
+short_open_tag = Off
+precision = 14
+output_buffering = 4096
+zlib.output_compression = Off
+implicit_flush = Off
+unserialize_callback_func =
+serialize_precision = 17
+disable_functions =
+disable_classes =
+zend.enable_gc = On
+expose_php = Off
+; Resource Limits ;
+max_execution_time = 600
+request_terminate_timeout = 0
+max_input_time = -1
+;max_input_nesting_level = 64
+max_input_vars = 3000
+memory_limit = -1
+; Error handling and logging ;
+error_reporting = E_ALL
+display_errors = On
+display_startup_errors = On
+log_errors = On
+log_errors_max_len = 1024
+ignore_repeated_errors = Off
+ignore_repeated_source = Off
+report_memleaks = On
+;xmlrpc_errors = 0
+;xmlrpc_error_number = 0
+html_errors = On
+; Data Handling ;
+variables_order = "EGPCS"
+request_order = "GP"
+register_argc_argv = Off
+auto_globals_jit = On
+post_max_size = 100M
+auto_prepend_file =
+auto_append_file =
+default_mimetype = "text/html"
+default_charset = "UTF-8"
+; Paths and Directories ;
+doc_root =
+user_dir =
+enable_dl = Off
+cgi.fix_pathinfo=0
+; File Uploads ;
+file_uploads = On
+upload_max_filesize = 100M
+max_file_uploads = 20
+; Fopen wrappers ;
+allow_url_fopen = On
+allow_url_include = Off
+default_socket_timeout = 60
+;auto_detect_line_endings = Off
+; Dynamic Extensions ;
+
+[CLI Server]
+cli_server.color = On
+
+[Date]
+date.timezone = UTC
+
+[Pdo_mysql]
+pdo_mysql.cache_size = 2000
+pdo_mysql.default_socket=
+
+[mail function]
+SMTP = localhost
+smtp_port = 25
+mail.add_x_header = On
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+
+[SQL]
+sql.safe_mode = Off
+
+[ODBC]
+odbc.allow_persistent = On
+odbc.check_persistent = On
+odbc.max_persistent = -1
+odbc.max_links = -1
+odbc.defaultlrl = 4096
+odbc.defaultbinmode = 1
+
+[Interbase]
+ibase.allow_persistent = 1
+ibase.max_persistent = -1
+ibase.max_links = -1
+ibase.timestampformat = "%Y-%m-%d %H:%M:%S"
+ibase.dateformat = "%Y-%m-%d"
+ibase.timeformat = "%H:%M:%S"
+
+[MySQLi]
+mysqli.max_persistent = -1
+mysqli.allow_persistent = On
+mysqli.max_links = -1
+mysqli.cache_size = 2000
+mysqli.default_port = 3306
+mysqli.default_socket =
+mysqli.default_host =
+mysqli.default_user =
+mysqli.default_pw =
+mysqli.reconnect = Off
+
+[mysqlnd]
+mysqlnd.collect_statistics = On
+mysqlnd.collect_memory_statistics = Off
+
+[PostgreSQL]
+pgsql.allow_persistent = On
+pgsql.auto_reset_persistent = Off
+pgsql.max_persistent = -1
+pgsql.max_links = -1
+pgsql.ignore_notice = 0
+pgsql.log_notice = 0
+
+[bcmath]
+bcmath.scale = 0
+
+[Session]
+session.save_handler = files
+session.use_strict_mode = 0
+session.use_cookies = 1
+session.use_only_cookies = 1
+session.name = PHPSESSID
+session.auto_start = 0
+session.cookie_lifetime = 0
+session.cookie_path = /
+session.cookie_domain =
+session.cookie_httponly =
+session.serialize_handler = php
+session.gc_probability = 0
+session.gc_divisor = 1000
+session.gc_maxlifetime = 1440
+session.referer_check =
+session.cache_limiter = nocache
+session.cache_expire = 180
+session.use_trans_sid = 0
+session.hash_function = 0
+session.hash_bits_per_character = 5
+url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
+
+[Assertion]
+zend.assertions = -1
+
+[Tidy]
+tidy.clean_output = Off
+
+[soap]
+soap.wsdl_cache_enabled=1
+soap.wsdl_cache_dir="/tmp"
+soap.wsdl_cache_ttl=86400
+soap.wsdl_cache_limit = 5
+
+
+[ldap]
+ldap.max_links = -1
+
+[opcache]
+opcache.enable=1
+opcache.enable_cli=1
+opcache.memory_consumption=500
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=1000000
+;opcache.max_wasted_percentage=5
+;opcache.use_cwd=1
+opcache.validate_timestamps=1
+opcache.revalidate_freq=0
+;opcache.revalidate_path=0
+;opcache.save_comments=1
+opcache.fast_shutdown=1
+;opcache.enable_file_override=0
+;opcache.optimization_level=0xffffffff
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+;opcache.blacklist_filename=
+;opcache.max_file_size=0
+;opcache.consistency_checks=0
+;opcache.force_restart_timeout=180
+;opcache.error_log=
+;opcache.log_verbosity_level=1
+;opcache.preferred_memory_model=
+;opcache.protect_memory=0
+;opcache.restrict_api=
+;opcache.mmap_base=
+;opcache.file_cache=
+;opcache.file_cache_only=0
+;opcache.file_cache_consistency_checks=1
+;opcache.file_cache_fallback=1
+;opcache.huge_code_pages=1
+;opcache.validate_permission=0
+;opcache.validate_root=0

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/php-fpm.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/php-fpm.conf
@@ -1,0 +1,126 @@
+;;;;;;;;;;;;;;;;;;;;;
+; FPM Configuration ;
+;;;;;;;;;;;;;;;;;;;;;
+
+; All relative paths in this configuration file are relative to PHP's install
+; prefix (/usr). This prefix can be dynamically changed by using the
+; '-p' argument from the command line.
+
+;;;;;;;;;;;;;;;;;;
+; Global Options ;
+;;;;;;;;;;;;;;;;;;
+
+[global]
+; Pid file
+; Note: the default prefix is /var
+; Default Value: none
+pid = /run/php/php8.2-fpm.pid
+
+; Error log file
+; If it's set to "syslog", log is sent to syslogd instead of being written
+; in a local file.
+; Note: the default prefix is /var
+; Default Value: log/php-fpm.log
+; Output to stdout, where supervisord will manage it.
+error_log = /dev/stdout
+
+; syslog_facility is used to specify what type of program is logging the
+; message. This lets syslogd specify that messages from different facilities
+; will be handled differently.
+; See syslog(3) for possible values (ex daemon equiv LOG_DAEMON)
+; Default Value: daemon
+;syslog.facility = daemon
+
+; syslog_ident is prepended to every message. If you have multiple FPM
+; instances running on the same server, you can change the default value
+; which must suit common needs.
+; Default Value: php-fpm
+;syslog.ident = php-fpm
+
+; Log level
+; Possible Values: alert, error, warning, notice, debug
+; Default Value: notice
+;log_level = notice
+
+; If this number of child processes exit with SIGSEGV or SIGBUS within the time
+; interval set by emergency_restart_interval then FPM will restart. A value
+; of '0' means 'Off'.
+; Default Value: 0
+;emergency_restart_threshold = 0
+
+; Interval of time used by emergency_restart_interval to determine when
+; a graceful restart will be initiated.  This can be useful to work around
+; accidental corruptions in an accelerator's shared memory.
+; Available Units: s(econds), m(inutes), h(ours), or d(ays)
+; Default Unit: seconds
+; Default Value: 0
+;emergency_restart_interval = 0
+
+; Time limit for child processes to wait for a reaction on signals from master.
+; Available units: s(econds), m(inutes), h(ours), or d(ays)
+; Default Unit: seconds
+; Default Value: 0
+;process_control_timeout = 0
+
+; The maximum number of processes FPM will fork. This has been design to control
+; the global number of processes when using dynamic PM within a lot of pools.
+; Use it with caution.
+; Note: A value of 0 indicates no limit
+; Default Value: 0
+; process.max = 128
+
+; Specify the nice(2) priority to apply to the master process (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool process will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
+; Default Value: yes
+daemonize = no
+
+; Set open file descriptor rlimit for the master process.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit for the master process.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Specify the event mechanism FPM will use. The following is available:
+; - select     (any POSIX os)
+; - poll       (any POSIX os)
+; - epoll      (linux >= 2.5.44)
+; - kqueue     (FreeBSD >= 4.1, OpenBSD >= 2.9, NetBSD >= 2.0)
+; - /dev/poll  (Solaris >= 7)
+; - port       (Solaris >= 10)
+; Default Value: not set (auto detection)
+;events.mechanism = epoll
+
+; When FPM is build with systemd integration, specify the interval,
+; in second, between health report notification to systemd.
+; Set to 0 to disable.
+; Available Units: s(econds), m(inutes), h(ours)
+; Default Unit: seconds
+; Default value: 10
+;systemd_interval = 10
+
+;;;;;;;;;;;;;;;;;;;;
+; Pool Definitions ;
+;;;;;;;;;;;;;;;;;;;;
+
+; Multiple pools of child processes may be started with different listening
+; ports and different management options.  The name of the pool will be
+; used in logs and stats. There is no limitation on the number of pools which
+; FPM can handle. Your system will tell you anyway :)
+
+; Include one or more files. If glob(3) exists, it is used to include a bunch of
+; files from a glob(3) pattern. This directive can be used everywhere in the
+; file.
+; Relative path can also be used. They will be prefixed by:
+;  - the global prefix if it's been set (-p argument)
+;  - /usr otherwise
+include = /etc/php/8.0/fpm/pool.d/*.conf

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/php.ini
@@ -1,0 +1,197 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; php.ini reference: https://git.php.net/?p=php-src.git;a=blob_plain;f=php.ini-production;hb=refs/heads/PHP-7.0  ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[PHP]
+engine = On
+short_open_tag = Off
+precision = 14
+output_buffering = 4096
+zlib.output_compression = Off
+implicit_flush = Off
+unserialize_callback_func =
+serialize_precision = 17
+disable_functions =
+disable_classes =
+zend.enable_gc = On
+expose_php = Off
+; Resource Limits ;
+max_execution_time = 600
+request_terminate_timeout = 0
+max_input_time = -1
+;max_input_nesting_level = 64
+max_input_vars = 3000
+memory_limit = 1024M
+; Error handling and logging ;
+error_reporting = E_ALL
+display_errors = On
+display_startup_errors = On
+log_errors = On
+log_errors_max_len = 1024
+ignore_repeated_errors = Off
+ignore_repeated_source = Off
+report_memleaks = On
+;xmlrpc_errors = 0
+;xmlrpc_error_number = 0
+html_errors = On
+; Data Handling ;
+variables_order = "EGPCS"
+request_order = "GP"
+register_argc_argv = Off
+auto_globals_jit = On
+post_max_size = 100M
+auto_prepend_file =
+auto_append_file =
+default_mimetype = "text/html"
+default_charset = "UTF-8"
+; Paths and Directories ;
+doc_root =
+user_dir =
+enable_dl = Off
+cgi.fix_pathinfo=1
+; File Uploads ;
+file_uploads = On
+upload_max_filesize = 100M
+max_file_uploads = 20
+; Fopen wrappers ;
+allow_url_fopen = On
+allow_url_include = Off
+default_socket_timeout = 60
+;auto_detect_line_endings = Off
+; Dynamic Extensions ;
+
+[CLI Server]
+cli_server.color = On
+
+[Date]
+date.timezone = UTC
+
+[Pdo_mysql]
+pdo_mysql.cache_size = 2000
+pdo_mysql.default_socket=
+
+[mail function]
+SMTP = localhost
+smtp_port = 25
+mail.add_x_header = On
+sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+
+[SQL]
+sql.safe_mode = Off
+
+[ODBC]
+odbc.allow_persistent = On
+odbc.check_persistent = On
+odbc.max_persistent = -1
+odbc.max_links = -1
+odbc.defaultlrl = 4096
+odbc.defaultbinmode = 1
+
+[Interbase]
+ibase.allow_persistent = 1
+ibase.max_persistent = -1
+ibase.max_links = -1
+ibase.timestampformat = "%Y-%m-%d %H:%M:%S"
+ibase.dateformat = "%Y-%m-%d"
+ibase.timeformat = "%H:%M:%S"
+
+[MySQLi]
+mysqli.max_persistent = -1
+mysqli.allow_persistent = On
+mysqli.max_links = -1
+mysqli.cache_size = 2000
+mysqli.default_port = 3306
+mysqli.default_socket =
+mysqli.default_host =
+mysqli.default_user =
+mysqli.default_pw =
+mysqli.reconnect = Off
+
+[mysqlnd]
+mysqlnd.collect_statistics = On
+mysqlnd.collect_memory_statistics = Off
+
+[PostgreSQL]
+pgsql.allow_persistent = On
+pgsql.auto_reset_persistent = Off
+pgsql.max_persistent = -1
+pgsql.max_links = -1
+pgsql.ignore_notice = 0
+pgsql.log_notice = 0
+
+[bcmath]
+bcmath.scale = 0
+
+[Session]
+session.save_handler = files
+session.use_strict_mode = 0
+session.use_cookies = 1
+session.use_only_cookies = 1
+session.name = PHPSESSID
+session.auto_start = 0
+session.cookie_lifetime = 0
+session.cookie_path = /
+session.cookie_domain =
+session.cookie_httponly =
+session.serialize_handler = php
+session.gc_probability = 0
+session.gc_divisor = 1000
+session.gc_maxlifetime = 1440
+session.referer_check =
+session.cache_limiter = nocache
+session.cache_expire = 180
+session.use_trans_sid = 0
+session.hash_function = 0
+session.hash_bits_per_character = 5
+url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
+
+[Assertion]
+zend.assertions = -1
+
+[Tidy]
+tidy.clean_output = Off
+
+[soap]
+soap.wsdl_cache_enabled=1
+soap.wsdl_cache_dir="/tmp"
+soap.wsdl_cache_ttl=86400
+soap.wsdl_cache_limit = 5
+
+
+[ldap]
+ldap.max_links = -1
+
+[opcache]
+opcache.enable=1
+opcache.enable_cli=1
+opcache.memory_consumption=500
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=1000000
+;opcache.max_wasted_percentage=5
+;opcache.use_cwd=1
+opcache.validate_timestamps=1
+opcache.revalidate_freq=0
+;opcache.revalidate_path=0
+;opcache.save_comments=1
+opcache.fast_shutdown=1
+;opcache.enable_file_override=0
+;opcache.optimization_level=0xffffffff
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+;opcache.blacklist_filename=
+;opcache.max_file_size=0
+;opcache.consistency_checks=0
+;opcache.force_restart_timeout=180
+;opcache.error_log=
+;opcache.log_verbosity_level=1
+;opcache.preferred_memory_model=
+;opcache.protect_memory=0
+;opcache.restrict_api=
+;opcache.mmap_base=
+;opcache.file_cache=
+;opcache.file_cache_only=0
+;opcache.file_cache_consistency_checks=1
+;opcache.file_cache_fallback=1
+;opcache.huge_code_pages=1
+;opcache.validate_permission=0
+;opcache.validate_root=0

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/pool.d/www.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/pool.d/www.conf
@@ -1,0 +1,413 @@
+; Start a new pool named 'www'.
+; the variable $pool can we used in any directive and will be replaced by the
+; pool name ('www' here)
+[www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'access.log'
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or /usr) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = www-data
+group = www-data
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = 127.0.0.1:9003
+
+; Set listen(2) backlog.
+; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 511
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions.
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
+;listen.owner = nginx
+;listen.group = nginx
+listen.mode = 0666
+; When POSIX Access Control Lists are supported you can set them using
+; these options, value is a comma separated list of user/group names.
+; When set, listen.owner and listen.group are ignored
+;listen.acl_users =
+;listen.acl_groups =
+
+; List of addresses (IPv4/IPv6) of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+;listen.allowed_clients = 127.0.0.1
+
+; Specify the nice(2) priority to apply to the pool processes (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool processes will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 8
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 3
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 2
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 4
+
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 10s;
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+pm.max_requests = 200
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following informations:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example:
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: /usr/share/php/7.0/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+pm.status_path = /phpstatus
+
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+
+; The access log file
+; Default: not set
+;access.log = log/$pool.access.log
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{miliseconds}d
+;      - %{mili}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some exemples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: output header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{mili}d %{kilo}M %C%%"
+
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+;slowlog = log/$pool.log.slow
+
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot =
+
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+catch_workers_output = yes
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+clear_env = no
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; exectute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5 .php7
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'.
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or /usr)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+;php_admin_value[error_log] = /var/log/fpm-php.www.log
+;php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 32M

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/mods-available/xdebug.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/mods-available/xdebug.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug.so
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003
+xdebug.mode=debug,develop
+xdebug.start_with_request=yes

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/
 FROM ddev-webserver-base as ddev-webserver-dev-base
 ENV MAILHOG_VERSION="1.0.2"
 ENV CAROOT /mnt/ddev-global-cache/mkcert
-ENV PHP_DEFAULT_VERSION="7.4"
+ENV PHP_DEFAULT_VERSION="8.0"
 
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add -
 RUN echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
@@ -155,7 +155,7 @@ RUN apt-get -qq clean -y && rm -rf /var/lib/apt/lists/* /tmp/ddev
 ### But for historical reasons, it's just ddev-webserver
 ### Build ddev-webserver by turning ddev-webserver-dev-base into one layer
 FROM scratch as ddev-webserver
-ENV PHP_DEFAULT_VERSION="7.4"
+ENV PHP_DEFAULT_VERSION="8.0"
 ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
 ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
@@ -181,7 +181,7 @@ CMD ["/start.sh"]
 ### This image is aimed at actual hardened production environments
 FROM ddev-webserver-base as ddev-webserver-prod-base
 ENV CAROOT /mnt/ddev-global-cache/mkcert
-ENV PHP_DEFAULT_VERSION="7.4"
+ENV PHP_DEFAULT_VERSION="8.0"
 
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add -
 RUN echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
@@ -265,7 +265,7 @@ RUN apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 ### Build ddev-webserver-prod, the hardened version of ddev-webserver-base
 ### (Withut dev features, single layer)
 FROM scratch as ddev-webserver-prod
-ENV PHP_DEFAULT_VERSION="7.4"
+ENV PHP_DEFAULT_VERSION="8.0"
 ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
 ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
 ENV CAROOT /mnt/ddev-global-cache/mkcert

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.20.0 as ddev-webserver-base
+FROM drud/ddev-php-base:20220921_php_8.2 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/conf-available/php8.2-fpm.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/conf-available/php8.2-fpm.conf
@@ -1,0 +1,23 @@
+# Redirect to local php-fpm if mod_php is not available
+<IfModule !mod_php7.c>
+<IfModule proxy_fcgi_module>
+    # Enable http authorization headers
+    <IfModule setenvif_module>
+    SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
+    </IfModule>
+
+    <FilesMatch ".+\.ph(ar|p|tml)$">
+        SetHandler "proxy:unix:/var/run/php-fpm.sock|fcgi://localhost"
+    </FilesMatch>
+    <FilesMatch ".+\.phps$">
+        # Deny access to raw php sources by default
+        # To re-enable it's recommended to enable access to the files
+        # only in specific virtual host or directory
+        Require all denied
+    </FilesMatch>
+    # Deny access to files without filename (e.g. '.php')
+    <FilesMatch "^\.ph(ar|p|ps|tml)$">
+        Require all denied
+    </FilesMatch>
+</IfModule>
+</IfModule>

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/mods-available/php8.2.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/mods-available/php8.2.conf
@@ -1,0 +1,25 @@
+<FilesMatch ".+\.ph(ar|p|tml)$">
+    SetHandler application/x-httpd-php
+</FilesMatch>
+<FilesMatch ".+\.phps$">
+    SetHandler application/x-httpd-php-source
+    # Deny access to raw php sources by default
+    # To re-enable it's recommended to enable access to the files
+    # only in specific virtual host or directory
+    Require all denied
+</FilesMatch>
+# Deny access to files without filename (e.g. '.php')
+<FilesMatch "^\.ph(ar|p|ps|tml)$">
+    Require all denied
+</FilesMatch>
+
+# Running PHP scripts in user directories is disabled by default
+# 
+# To re-enable PHP in user directories comment the following lines
+# (from <IfModule ...> to </IfModule>.) Do NOT set it to On as it
+# prevents .htaccess files from disabling it.
+<IfModule mod_userdir.c>
+    <Directory /home/*/public_html>
+        php_admin_flag engine Off
+    </Directory>
+</IfModule>

--- a/containers/ddev-webserver/tests/ddev-webserver/custom_config.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/custom_config.bats
@@ -9,7 +9,7 @@
 
     # With overridden value we should have assert.active=0, not the default
     echo "--- Check that assert.active override is working"
-    docker exec -t $CONTAINER_NAME php -i | grep "assert.active.*=> 0 => 0" >/dev/null
+    docker exec -t $CONTAINER_NAME php -i | grep "assert.active.*=> Off => Off" >/dev/null
 
     # Make sure that our nginx override providing /junker99 works correctly
     curl -s http://127.0.0.1:$HOST_HTTP_PORT/junker99 | grep 'junker99!'

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -53,6 +53,9 @@
 	fi
 }
 
+@test "verify that xdebug is enabled by default when the image is not run with start.sh" {
+  docker run --rm $DOCKER_IMAGE bash -c 'php --version | grep "with Xdebug"'
+}
 
 @test "verify apt keys are not expiring" {
     DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -28,15 +28,9 @@
     curl -s 127.0.0.1:$HOST_HTTP_PORT/test/xdebug.php | grep "Xdebug is disabled"
 }
 
-@test "verify that xdebug is enabled by default when the image is not run with start.sh php${PHP_VERSION}" {
-  CURRENT_ARCH=$(../get_arch.sh)
-
-  docker run  -e "DDEV_PHP_VERSION=${PHP_VERSION}" --rm $DOCKER_IMAGE bash -c 'php --version | grep "with Xdebug"'
-}
-
 @test "enable and disable xhprof for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
     # TODO: Add back in.
-    if [ ${PHP_VERSION} = "8.2" ]; then skip "xhprof not yet available for 8.2"; fi
+    if [ "${PHP_VERSION}" = "8.2" ]; then skip "xhprof not yet available for 8.2"; fi
     CURRENT_ARCH=$(../get_arch.sh)
 
     docker exec -t $CONTAINER_NAME enable_xhprof
@@ -45,15 +39,6 @@
     docker exec -t $CONTAINER_NAME disable_xhprof
     docker exec -t $CONTAINER_NAME php --re xhprof | grep "does not exist"
     curl -s 127.0.0.1:$HOST_HTTP_PORT/test/xhprof.php | grep "XHProf is disabled"
-}
-
-@test "verify that xhprof is enabled by default when the image is not run with start.sh php${PHP_VERSION}" {
-  # TODO: Add back in.
-  if [ ${PHP_VERSION} = "8.2" ]; then skip "xhprof not yet available for 8.2"; fi
-
-  CURRENT_ARCH=$(../get_arch.sh)
-
-  docker run  -e "DDEV_PHP_VERSION=${PHP_VERSION}" --rm $DOCKER_IMAGE bash -c 'php --re xhprof | grep -v "\"xhprof\" does not exist"'
 }
 
 @test "verify mailhog for ${WEBSERVER_TYPE} php${PHP_VERSION}" {

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -35,6 +35,8 @@
 }
 
 @test "enable and disable xhprof for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
+    # TODO: Add back in.
+    if [ ${PHP_VERSION} = "8.2" ]; then skip "xhprof not yet available for 8.2"; fi
     CURRENT_ARCH=$(../get_arch.sh)
 
     docker exec -t $CONTAINER_NAME enable_xhprof
@@ -46,6 +48,9 @@
 }
 
 @test "verify that xhprof is enabled by default when the image is not run with start.sh php${PHP_VERSION}" {
+  # TODO: Add back in.
+  if [ ${PHP_VERSION} = "8.2" ]; then skip "xhprof not yet available for 8.2"; fi
+
   CURRENT_ARCH=$(../get_arch.sh)
 
   docker run  -e "DDEV_PHP_VERSION=${PHP_VERSION}" --rm $DOCKER_IMAGE bash -c 'php --re xhprof | grep -v "\"xhprof\" does not exist"'
@@ -99,8 +104,12 @@
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
   8.1)
+    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
+    ;;
+  8.2)
     # TODO: Update this list as more extensions become available
-    extensions="apcu bcmath bz2 curl gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip"
+    extensions="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip"
+
   esac
 
   run docker exec -t $CONTAINER_NAME enable_xdebug

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -14,6 +14,7 @@
 }
 
 @test "enable and disable xdebug for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
+    if [ "${PHP_VERSION}" = "8.2" ]; then skip "Skipping for PHP_VERSION=8.2 because no xdebug yet"; fi
     CURRENT_ARCH=$(../get_arch.sh)
 
     docker exec -t $CONTAINER_NAME enable_xdebug
@@ -93,8 +94,8 @@
     ;;
   8.2)
     # TODO: Update this list as more extensions become available
-    extensions="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip"
-
+    # Still to come: apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
+    extensions="bcmath bz2 curl gd intl json ldap mbstring mysqli pgsql readline soap sqlite3  xml zip"
   esac
 
   run docker exec -t $CONTAINER_NAME enable_xdebug

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -17,7 +17,7 @@ export HOST_HTTPS_PORT="8443"
 export CONTAINER_HTTP_PORT="80"
 export CONTAINER_HTTPS_PORT="443"
 export CONTAINER_NAME=webserver-test
-export PHP_VERSION=7.4
+export PHP_VERSION=8.0
 export WEBSERVER_TYPE=nginx-fpm
 
 MOUNTUID=33
@@ -91,12 +91,12 @@ for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2; do
 done
 
 for project_type in backdrop craftcms drupal6 drupal7 drupal8 drupal9 laravel magento magento2 typo3 wordpress default; do
-	export PHP_VERSION="7.4"
+	export PHP_VERSION="8.0"
     export project_type
 	if [ "$project_type" == "drupal6" ]; then
 	  PHP_VERSION="5.6"
 	fi
-	docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DOCROOT=docroot" -e "DDEV_PHP_VERSION=$PHP_VERSION" -e "DDEV_PROJECT_TYPE=$project_type" -d --name $CONTAINER_NAME -v ddev-global-cache:/mnt/ddev-global-cache -d $DOCKER_IMAGE >/dev/null
+	docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DOCROOT=docroot" -e "DDEV_PHP_VERSION=$PHP_VERSION" -e "DDEV_PROJECT_TYPE=$project_type" --name $CONTAINER_NAME -v ddev-global-cache:/mnt/ddev-global-cache -d $DOCKER_IMAGE >/dev/null
     if ! containerwait; then
         echo "=============== Failed containerwait after docker run with  DDEV_PROJECT_TYPE=${project_type} DDEV_PHP_VERSION=$PHP_VERSION ==================="
         exit 103
@@ -107,7 +107,7 @@ for project_type in backdrop craftcms drupal6 drupal7 drupal8 drupal9 laravel ma
     cleanup
 done
 
-docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=7.4" --mount "type=bind,src=$PWD/tests/ddev-webserver/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache -d --name $CONTAINER_NAME -d $DOCKER_IMAGE >/dev/null
+docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=8.0" --mount "type=bind,src=$PWD/tests/ddev-webserver/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache --name $CONTAINER_NAME -d $DOCKER_IMAGE >/dev/null
 containerwait
 
 bats tests/ddev-webserver/custom_config.bats

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 if [ $# != "1" ]; then echo "docker image spec must be \$1"; exit 1; fi
-DOCKER_IMAGE=$1
+export DOCKER_IMAGE=$1
 export IS_HARDENED=false
 DOCKER_REPO=${DOCKER_IMAGE%:*}
 if [[ "${DOCKER_REPO}" == "*prod*" ]]; then

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -90,7 +90,7 @@ for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2; do
     done
 done
 
-for project_type in backdrop craftcms drupal6 drupal7 drupal8 drupal9 laravel magento magento2 typo3 wordpress default; do
+for project_type in backdrop craftcms drupal6 drupal7 drupal8 drupal9 drupal10 laravel magento magento2 typo3 wordpress default; do
 	export PHP_VERSION="8.0"
     export project_type
 	if [ "$project_type" == "drupal6" ]; then

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -75,7 +75,7 @@ bats tests/ddev-webserver/general.bats
 
 cleanup
 
-for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0; do
+for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2; do
     for WEBSERVER_TYPE in nginx-fpm apache-fpm; do
         export PHP_VERSION WEBSERVER_TYPE DOCKER_IMAGE
         docker run -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=${PHP_VERSION}" -e "DDEV_WEBSERVER_TYPE=${WEBSERVER_TYPE}" -d --name $CONTAINER_NAME -v ddev-global-cache:/mnt/ddev-global-cache -d $DOCKER_IMAGE >/dev/null

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -793,7 +793,8 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 	// Most of the time there's no reason to do all versions of PHP
 	phpKeys := []string{}
-	exclusions := []string{"5.6", "7.0", "7.1", "7.2"}
+	// TODO: Re-enable 8.2 when it's available
+	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "8.2"}
 	for k := range nodeps.ValidPHPVersions {
 		if os.Getenv("GOTEST_SHORT") != "" && !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)
@@ -921,7 +922,8 @@ func TestDdevXhprofEnabled(t *testing.T) {
 	// Does not work with php5.6 anyway (SEGV), for resource conservation
 	// skip older unsupported versions
 	phpKeys := []string{}
-	exclusions := []string{"5.6", "7.0", "7.1"}
+	// TODO: Re-enable 8.2 when it's available. Disable more of these.
+	exclusions := []string{"5.6", "7.0", "7.1", "8.2"}
 	for k := range nodeps.ValidPHPVersions {
 		if !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)

--- a/pkg/nodeps/php_values.go
+++ b/pkg/nodeps/php_values.go
@@ -10,6 +10,7 @@ const (
 	PHP74 = "7.4"
 	PHP80 = "8.0"
 	PHP81 = "8.1"
+	PHP82 = "8.2"
 )
 
 // PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
@@ -26,6 +27,7 @@ var ValidPHPVersions = map[string]bool{
 	PHP74: true,
 	PHP80: true,
 	PHP81: true,
+	PHP82: true,
 }
 
 // Composer version default - will get latest composer v2

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220826_path_adjusted_for_composer_root" // Note that this can be overridden by make
+var WebTag = "20220921_php_8.2" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

PHP 8.2 is near release

## How this PR Solves The Problem:

* Add PHP 8.2 as an option.
* Set PHP 8.0 as the default PHP version when this is run without DDEV context.

## Caveat

* These extensions are not available in the repo yet: "apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc" so xdebug is not available.

## Manual Testing Instructions:

`ddev config --php-version=8.2`

## Automated Testing Overview:

I think the tests that need to will pick this up.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4222"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

