### PR TITLE
Implement ddev mutagen logs command, fixes #4161

### DIFF
--- a/cmd/ddev/cmd/mutagen-logs.go
+++ b/cmd/ddev/cmd/mutagen-logs.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/util"
+	"github.com/spf13/cobra"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+// MutagenLogsCmd implements the ddev mutagen logs command
+var MutagenLogsCmd = &cobra.Command{
+	Use:     "logs",
+	Short:   "Show mutagen logs for debugging",
+	Example: `"ddev mutagen logs"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		projectName := ""
+		if len(args) > 1 {
+			util.Failed("This command only takes one optional argument: project-name")
+		}
+
+		if len(args) == 1 {
+			projectName = args[0]
+		}
+
+		app, err := ddevapp.GetActiveApp(projectName)
+		if err != nil {
+			util.Failed("Failed to get active project: %v", err)
+		}
+		if !(app.IsMutagenEnabled()) {
+			util.Warning("Mutagen is not enabled on project %s", app.Name)
+			return
+		}
+
+		ddevapp.StopMutagenDaemon()
+		_ = os.Setenv("MUTAGEN_LOG_LEVEL", "trace")
+
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT)
+		done := make(chan bool, 1)
+
+		go func() {
+			c := exec.Command(globalconfig.GetMutagenPath(), "daemon", "run")
+			c.Stdout = os.Stdout
+			c.Stderr = os.Stderr
+			err = c.Run()
+			if err != nil {
+				util.Warning("mutagen daemon run failed with %v", err)
+			}
+			done <- true
+		}()
+		<-done
+
+		util.Success("Completed mutagen logs, now resuming normal mutagen sync")
+		err = ddevapp.CreateOrResumeMutagenSync(app)
+		if err != nil {
+			util.Failed("Unable to resume mutagen sync: %v", err)
+		}
+	},
+}
+
+func init() {
+	MutagenCmd.AddCommand(MutagenLogsCmd)
+	MutagenLogsCmd.Flags().Bool("verbose", false, "Show full mutagen logs")
+}

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -159,15 +159,8 @@ Instructions for Mutagen and NFS are below.
 
     #### Advanced Mutagen Troubleshooting
 
-    Most people get all the information they need about mutagen by running `ddev mutagen monitor` to see the results. However, Mutagen has full logging. Here's how to run it:
+    Most people get all the information they need about mutagen by running `ddev mutagen monitor` to see the results. However, Mutagen has full logging. You can run it with `ddev mutagen logs`.
 
-    * `killall mutagen`
-    * `export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory`
-    * `export MUTAGEN_LOG_LEVEL=debug` or `export MUTAGEN_LOG_LEVEL=trace`
-    * `~/.ddev/bin/mutagen daemon run`
-    * Work with your project various actions and watch the output.
-
-    When you're done, you can `ddev poweroff` and `<ctrl-c>` the running mutagen daemon to get back to normal.
 
     ### Mutagen Strategies and Design Considerations
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4161 

## How this PR Solves The Problem:

Add `ddev mutagen logs`

## Manual Testing Instructions:

Run the `ddev mutagen logs` command. See the output. Try to understand it.

## Automated Testing Overview:

I didn't add a test.

