### PR TITLE
ddev mutagen logs should just restart daemon, not sync

### DIFF
--- a/cmd/ddev/cmd/mutagen-logs.go
+++ b/cmd/ddev/cmd/mutagen-logs.go
@@ -54,11 +54,8 @@ var MutagenLogsCmd = &cobra.Command{
 		}()
 		<-done
 
-		util.Success("Completed mutagen logs, now resuming normal mutagen sync")
-		err = ddevapp.CreateOrResumeMutagenSync(app)
-		if err != nil {
-			util.Failed("Unable to resume mutagen sync: %v", err)
-		}
+		util.Success("Completed mutagen logs, now restarting normal mutagen daemon")
+		ddevapp.StartMutagenDaemon()
 	},
 }
 

--- a/cmd/ddev/cmd/mutagen-logs.go
+++ b/cmd/ddev/cmd/mutagen-logs.go
@@ -17,23 +17,6 @@ var MutagenLogsCmd = &cobra.Command{
 	Short:   "Show mutagen logs for debugging",
 	Example: `"ddev mutagen logs"`,
 	Run: func(cmd *cobra.Command, args []string) {
-		projectName := ""
-		if len(args) > 1 {
-			util.Failed("This command only takes one optional argument: project-name")
-		}
-
-		if len(args) == 1 {
-			projectName = args[0]
-		}
-
-		app, err := ddevapp.GetActiveApp(projectName)
-		if err != nil {
-			util.Failed("Failed to get active project: %v", err)
-		}
-		if !(app.IsMutagenEnabled()) {
-			util.Warning("Mutagen is not enabled on project %s", app.Name)
-			return
-		}
 
 		ddevapp.StopMutagenDaemon()
 		_ = os.Setenv("MUTAGEN_LOG_LEVEL", "trace")
@@ -46,7 +29,7 @@ var MutagenLogsCmd = &cobra.Command{
 			c := exec.Command(globalconfig.GetMutagenPath(), "daemon", "run")
 			c.Stdout = os.Stdout
 			c.Stderr = os.Stderr
-			err = c.Run()
+			err := c.Run()
 			if err != nil {
 				util.Warning("mutagen daemon run failed with %v", err)
 			}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -503,6 +503,16 @@ func StopMutagenDaemon() {
 	}
 }
 
+// StartMutagenDaemon will make sure the daemon is running
+func StartMutagenDaemon() {
+	if fileutil.FileExists(globalconfig.GetMutagenPath()) {
+		out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "start")
+		if err != nil {
+			util.Warning("Failed to run mutagen daemon start: %v, out=%s", err, out)
+		}
+	}
+}
+
 // DownloadMutagenIfNeeded downloads the proper version of mutagen
 // if it's either not yet installed or has the wrong version.
 func DownloadMutagenIfNeeded(app *DdevApp) error {


### PR DESCRIPTION
## The Problem/Issue/Bug:

@rpkoller points out that `ddev mutagen logs` in the context of a stopped app can cause some confusion. And we don't need an app running for this. 

## How this PR Solves The Problem:

Just do a mutagen daemon start at the end, not start a sync.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4231"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

