### PR TITLE
Clean up messaging on new ddev version

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
-	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/updatecheck"
 	"github.com/drud/ddev/pkg/util"
 	"github.com/drud/ddev/pkg/versionconstants"
-	"github.com/mitchellh/go-homedir"
 	"github.com/rogpeppe/go-internal/semver"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -209,12 +207,8 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 
 		// If they have a new version (but not first-timer) then prompt to poweroff
 		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {
-			output.UserOut.Print("Congratulations, you seem to have a new DDEV version.")
-			home, _ := homedir.Dir()
-			if globalconfig.DdevGlobalConfig.MutagenEnabledGlobal && fileutil.IsDirectory(filepath.Join(home, ".mutagen")) {
-				output.UserOut.Print("Please note that the global ~/.mutagen folder is no longer used by DDEV so you can delete it if it's no longer used by other applications.")
-			}
-			okPoweroff := util.Confirm("It looks like you have a new DDEV version. During an upgrade it's important to `ddev poweroff`. May I do `ddev poweroff` before continuing? This does no harm and loses no data.")
+			output.UserOut.Print("You seem to have a new DDEV version.")
+			okPoweroff := util.Confirm("During an upgrade it's important to `ddev poweroff`.\nMay I do `ddev poweroff` before continuing?\nThis does no harm and loses no data.")
 			if okPoweroff {
 				ddevapp.PowerOff()
 			}


### PR DESCRIPTION
## The Problem/Issue/Bug:

I wasn't quite happy with the state of the messaging on starting up with a new version.

## How this PR Solves The Problem:

Redo it a bit:

```
$ ddev start
You seem to have a new DDEV version.
During an upgrade it's important to `ddev poweroff`.
May I do `ddev poweroff` before continuing?
This does no harm and loses no data. [Y/n] (yes):
```

## Manual Testing Instructions:

Do a `ddev start` with new version. Or fiddle with the version in global config.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4232"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

