### PR TITLE
Rework yarn and npm cache dirs, fixes #4215

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -78,17 +78,17 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
-sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn}
+sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 # The following ensures a persistent and shared "global" cache for
 # yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache
 # will only be used if the project is configured to use it through it's own
 # enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
 # global folder.
-(cd && yarn config set cache-folder /mnt/ddev-global-cache/yarn || true)
+(cd && yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic || true)
 # ensure default yarn2 global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
-ln -sf /mnt/ddev-global-cache/yarn ~/.yarn/berry/cache
+ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -80,7 +80,6 @@ sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm/${HOSTNAME},yarn/${HOSTNAME}}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
-yarn config set cache-folder /mnt/ddev-global-cache/yarn/${HOSTNAME} || yarn config set cacheFolder /mnt/ddev-global-cache/yarn/${HOSTNAME} || true
 npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME} || true
 
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -78,8 +78,17 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
-sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm/${HOSTNAME},yarn/${HOSTNAME}}
+sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn}}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
+# The following ensures a persistent and shared "global" cache for
+# yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache
+# will only be used if the project is configured to use it through it's own
+# enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
+# global folder.
+(cd && yarn config set cache-folder /mnt/ddev-global-cache/yarn || true)
+# ensure default yarn2 global folder is there to symlink cache afterwards
+mkdir -p ~/.yarn/berry
+ln -sf /mnt/ddev-global-cache/yarn ~/.yarn/berry/cache
 
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -80,7 +80,6 @@ sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm/${HOSTNAME},yarn/${HOSTNAME}}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
-npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME} || true
 
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -78,7 +78,7 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
-sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn}}
+sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 # The following ensures a persistent and shared "global" cache for
 # yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -75,7 +75,7 @@ disable_xhprof
 
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
-mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn}
+mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry}
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 
@@ -84,10 +84,10 @@ if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 # will only be used if the project is configured to use it through it's own
 # enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
 # global folder.
-(cd && yarn config set cache-folder /mnt/ddev-global-cache/yarn || true)
+(cd && yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic || true)
 # ensure default yarn2 global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
-ln -sf /mnt/ddev-global-cache/yarn ~/.yarn/berry/cache
+ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 
 # chown of ddev-global-cache must be done with privileged container in app.Start()
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -79,7 +79,6 @@ mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 
-npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME}
 
 # chown of ddev-global-cache must be done with privileged container in app.Start()
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -79,7 +79,6 @@ mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 
-yarn config set cache-folder /mnt/ddev-global-cache/yarn/${HOSTNAME}
 npm config set cache /mnt/ddev-global-cache/npm/${HOSTNAME}
 
 # chown of ddev-global-cache must be done with privileged container in app.Start()

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -75,10 +75,19 @@ disable_xhprof
 
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
-mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm/${HOSTNAME} yarn/${HOSTNAME}}
+mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn}
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
 if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 
+# The following ensures a persistent and shared "global" cache for
+# yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache
+# will only be used if the project is configured to use it through it's own
+# enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
+# global folder.
+(cd && yarn config set cache-folder /mnt/ddev-global-cache/yarn || true)
+# ensure default yarn2 global folder is there to symlink cache afterwards
+mkdir -p ~/.yarn/berry
+ln -sf /mnt/ddev-global-cache/yarn ~/.yarn/berry/cache
 
 # chown of ddev-global-cache must be done with privileged container in app.Start()
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -204,7 +204,6 @@ services:
     - TZ={{ .Timezone }}
     - USER={{ .Username }}
     - VIRTUAL_HOST=${DDEV_HOSTNAME}
-    - YARN_CACHE_FOLDER=/mnt/ddev-global-cache/yarn
     {{ range $env := .WebEnvironment }}- "{{ $env }}"
     {{ end }}
     labels:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -204,7 +204,7 @@ services:
     - TZ={{ .Timezone }}
     - USER={{ .Username }}
     - VIRTUAL_HOST=${DDEV_HOSTNAME}
-    - YARN_CACHE_FOLDER=/mnt/ddev-global-cache/yarn/${DDEV_PROJECT}-web
+    - YARN_CACHE_FOLDER=/mnt/ddev-global-cache/yarn
     {{ range $env := .WebEnvironment }}- "{{ $env }}"
     {{ end }}
     labels:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -204,7 +204,7 @@ services:
     - TZ={{ .Timezone }}
     - USER={{ .Username }}
     - VIRTUAL_HOST=${DDEV_HOSTNAME}
-    - YARN_CACHE_FOLDER =/mnt/ddev-global-cache/yarn/${DDEV_PROJECT}-web
+    - YARN_CACHE_FOLDER=/mnt/ddev-global-cache/yarn/${DDEV_PROJECT}-web
     {{ range $env := .WebEnvironment }}- "{{ $env }}"
     {{ end }}
     labels:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -194,6 +194,7 @@ services:
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history
     - MYSQL_PWD=db
     - NODE_EXTRA_CA_CERTS=/mnt/ddev-global-cache/mkcert/rootCA.pem
+    - npm_config_cache=/mnt/ddev-global-cache/npm/${DDEV_PROJECT}-web
     - PGDATABASE=db
     - PGHOST=db
     - PGPASSWORD=db

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -204,7 +204,7 @@ services:
     - TZ={{ .Timezone }}
     - USER={{ .Username }}
     - VIRTUAL_HOST=${DDEV_HOSTNAME}
-    - YARN_CACHE_DIR=/mnt/ddev-global-cache/yarn/${DDEV_PROJECT}-web
+    - YARN_CACHE_FOLDER =/mnt/ddev-global-cache/yarn/${DDEV_PROJECT}-web
     {{ range $env := .WebEnvironment }}- "{{ $env }}"
     {{ end }}
     labels:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -194,7 +194,7 @@ services:
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history
     - MYSQL_PWD=db
     - NODE_EXTRA_CA_CERTS=/mnt/ddev-global-cache/mkcert/rootCA.pem
-    - npm_config_cache=/mnt/ddev-global-cache/npm/${DDEV_PROJECT}-web
+    - npm_config_cache=/mnt/ddev-global-cache/npm
     - PGDATABASE=db
     - PGHOST=db
     - PGPASSWORD=db

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -203,6 +203,7 @@ services:
     - TZ={{ .Timezone }}
     - USER={{ .Username }}
     - VIRTUAL_HOST=${DDEV_HOSTNAME}
+    - YARN_CACHE_DIR=/mnt/ddev-global-cache/yarn/${DDEV_PROJECT}-web
     {{ range $env := .WebEnvironment }}- "{{ $env }}"
     {{ end }}
     labels:

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220921_php_8.2" // Note that this can be overridden by make
+var WebTag = "20220928_fix_yarnrc_edit_problem" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4215 

This is also related to the previous yarn v3 fix, 
* #4090 
* #4088 

## How this PR Solves The Problem:

More subtle approach to cache for yarn:

* For yarn v1, the global config is set by running yarn config outside the project directory
* For yarn v2/3+ the global config is there if wanted, but not used by default.

## Manual Testing Instructions:

- [ ] Make sure to `docker pull drud/ddev-webserver:20220928_fix_yarnrc_edit_problem` to get latest version if it's changed.
- [ ] Remove previous cache with `ddev exec 'rm -rf /mnt/ddev-global-cache/{yarn*,npm*}' && ddev restart`
- [ ] If you're using mutagen, disable it temporarily. `ddev poweroff && ddev config --mutagen-enabled=false && ddev config global --mutagen-enabled=false`
- [ ] Check out https://github.com/hanoii/ddev-yarn-issue-4215 and `ddev start`. You should see no changes afterward in `git status`
- [ ] Do a `ddev yarn install` and `ddev npm install` and verify correct behavior
- [ ] Verify that yarn installations get cached properly in the docker volume. Do something with yarn and `ddev exec 'ls -lR $YARN_CACHE_FOLDER'`
- [ ] Verify that npm installations get cached properly in the docker volume. `npm install` something and `ddev exec 'ls -lR $npm_config_cache'`
- [ ] Make sure that `ddev start` works correctly in both yarn v1 and yarn v3 environments

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4234"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

