### PR TITLE
Don't stop project on start failure

### DIFF
--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -101,7 +101,9 @@ ddev start --all`,
 			output.UserOut.Printf("Starting %s...", project.GetName())
 			if err := project.Start(); err != nil {
 				util.Error("Failed to start %s: %v", project.GetName(), err)
-				_ = project.Stop(false, false)
+				if project.IsMutagenEnabled() {
+					_ = ddevapp.TerminateMutagenSync(project)
+				}
 				continue
 			}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noted on some types of start failure, the project was being stopped, which means you can't then examine any of the logs, etc.

This change was made recently in
* #4156

## How this PR Solves The Problem:

Instead of stopping the project in this situation, let it be, and just make sure the mutagen session is stopped, which I think must have been the intent in #4156 

## Manual Testing Instructions:

- [x] `ddev config --fail-on-hook-fail`
- [x] Add a hook that fails. I used 
```yaml
hooks:
  post-start:
    - exec: ls kdkdd
```
- [x] `ddev start` - Everything should start, but web fails. `ddev logs` should still work.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4235"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

