### PR TITLE
[docs] Expanded the Laravel quickstart with instructions on how to run Vite

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -611,6 +611,8 @@ via
 vpnkit
 vscode
 vset
+vite
+viteserve
 web
 webenv
 webhosting

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -210,6 +210,7 @@ configured
 container
 containers
 contrib
+cors
 cp
 cr
 crlf
@@ -613,6 +614,7 @@ vscode
 vset
 vite
 viteserve
+vue
 web
 webenv
 webhosting

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -613,6 +613,8 @@ vpnkit
 vscode
 vset
 vite
+vite's
+vite's
 viteserve
 vue
 web

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -411,7 +411,7 @@ Here's a quickstart instructions for a number of different environments:
     !!!tip "No need for `npm run dev`!"
         You don’t need to use `npm run dev`, since this attempts to run a local Vite server with the `vite` command. The `ddev-viteserve` add-on takes care of that Vite server for us.
 
-    A simple way to test if Vite is working properly is to make a change to `resources/js/app.js`. These changes should be made nearly instantly.
+    You can confirm Vite’s working properly by making a quick change `resources/js/app.js` and seeing it reflected immediately.
 === "Craft CMS"
 
     ## Craft CMS

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -398,7 +398,7 @@ Here's a quickstart instructions for a number of different environments:
         }
     })
     ```
-    You are free to add any plugins (like Vue) to the plugin array. **It is wise, however, to not make changes to the server properties as they often cause CORS errors.**
+    Add any plugins you need, like Vue, to the `plugins` array. **Careful with changes to server properties that often cause CORS errors!**
     
     Finally add the following to the head of the`welcome.blade.php` file
     ```php

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -343,7 +343,7 @@ Here's a quickstart instructions for a number of different environments:
     This is very handy if you have a local database installed and you want to switch between the connections faster by changing only one variable in `.env`
     
     ### Using Vite
-    The default Laravel vite template will not work with DDEV. To make DDEV and Vite play nicely a few additionaly steps are required.
+    The default Laravel Vite template will not work with DDEV. To make DDEV and Vite play nicely a few additionaly steps are required.
 
     #### Setup a Vite server
     Install the ddev-viteserve addon.
@@ -358,7 +358,7 @@ Here's a quickstart instructions for a number of different environments:
         post-start:
             - exec: .ddev/commands/web/vite-serve
     ```
-    This will spin up a vite development server on port `5173` whenever you `ddev restart`
+    This will spin up a Vite development server on port `5173` whenever you `ddev restart`
 
     Next expose your DDEV hostname by adding the following to your `.ddev/config.yaml`
     ```bash
@@ -368,7 +368,7 @@ Here's a quickstart instructions for a number of different environments:
 
     #### Configuring Laravel
     
-    The default `vite.config.js` will not yet work with our DDEV environment. Lets start by installing the vite and laravel-vite-plugin
+    The default `vite.config.js` will not yet work with our DDEV environment. Lets start by installing the Vite and laravel-vite-plugin
     ```
     ddev npm i -D laravel-vite-plugin vite
     ```
@@ -406,9 +406,9 @@ Here's a quickstart instructions for a number of different environments:
     #### Finalize
     To wrap things up run a `ddev restart`.
 
-    **Please note** that running npm run dev is **NOT** needed as this only runs the `vite` command which just attempts to run a local Vite server. The viteserve addon will handle the vite side of things for us. 
+    **Please note** that running npm run dev is **NOT** needed as this only runs the `vite` command which just attempts to run a local Vite server. The viteserve addon will handle the Vite side of things for us. 
 
-    A simple way to test if vite is working propery is to make a change to `resources/js/app.js`. These changes should be made nearly instantly.
+    A simple way to test if Vite is working properly is to make a change to `resources/js/app.js`. These changes should be made nearly instantly.
 === "Craft CMS"
 
     ## Craft CMS

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -400,7 +400,7 @@ Here's a quickstart instructions for a number of different environments:
     ```
     Add any plugins you need, like Vue, to the `plugins` array. **Careful with changes to server properties that often cause CORS errors!**
     
-    Finally add the following to the head of the`welcome.blade.php` file
+    Finally, add the following to the head of the `welcome.blade.php` file:
     ```php
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -343,7 +343,7 @@ Here's a quickstart instructions for a number of different environments:
     This is very handy if you have a local database installed and you want to switch between the connections faster by changing only one variable in `.env`
     
     ### Using Vite
-    The default Laravel Vite template will not work with DDEV. To make DDEV and Vite play nicely a few additionaly steps are required.
+    The default Laravel Vite template will not work with DDEV. To make DDEV and Vite play nicely a few additional steps are required.
 
     #### Setup a Vite server
     Install the ddev-viteserve addon.
@@ -398,7 +398,7 @@ Here's a quickstart instructions for a number of different environments:
         }
     })
     ```
-    You are free to add any plugins (like Vue) to the plugin array. **It is wise, however, to not make changes to the server properties as they often cause cors errors.**
+    You are free to add any plugins (like Vue) to the plugin array. **It is wise, however, to not make changes to the server properties as they often cause CORS errors.**
     
     Finally add the following to the head of the`welcome.blade.php` file
     ```php

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -406,7 +406,7 @@ Here's a quickstart instructions for a number of different environments:
     ```
 
     #### Finalize
-    To wrap things up run a `ddev restart`.
+    Apply the server changes and Laravel configuration by running `ddev restart`.
 
     **Please note** that running npm run dev is **NOT** needed as this only runs the `vite` command which just attempts to run a local Vite server. The viteserve addon will handle the Vite side of things for us. 
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -350,7 +350,7 @@ Here's a quickstart instructions for a number of different environments:
     ```bash
     ddev get torenware/ddev-viteserve
     ```
-    In `.ddev/.env` change `VITE_PROJECT_DIR=frontend` to `VITE_PROJECT_DIR=.`
+    In `.ddev/.env`, change `VITE_PROJECT_DIR=frontend` to `VITE_PROJECT_DIR=.`
     
     In `.ddev/.env` add `VITE_JS_PACKAGE_MGR=npm`. This tells `ddev-viteserve` to use `npm` to manage packages, and helps keep dependencies in sync.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -346,7 +346,7 @@ Here's a quickstart instructions for a number of different environments:
     The default Laravel Vite template doesn’t work with DDEV, so you’ll need to set up a Vite server and configure Laravel to use it.
 
     #### Setup a Vite server
-    Install the ddev-viteserve addon.
+    Install the [ddev-viteserve](https://github.com/torenware/ddev-viteserve) add-on.
     ```bash
     ddev get torenware/ddev-viteserve
     ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -408,7 +408,8 @@ Here's a quickstart instructions for a number of different environments:
     #### Finalize
     Apply the server changes and Laravel configuration by running `ddev restart`.
 
-    **Please note** that running npm run dev is **NOT** needed as this only runs the `vite` command which just attempts to run a local Vite server. The viteserve addon will handle the Vite side of things for us. 
+    !!!tip "No need for `npm run dev`!"
+        You don’t need to use `npm run dev`, since this attempts to run a local Vite server with the `vite` command. The `ddev-viteserve` add-on takes care of that Vite server for us.
 
     A simple way to test if Vite is working properly is to make a change to `resources/js/app.js`. These changes should be made nearly instantly.
 === "Craft CMS"

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -345,7 +345,7 @@ Here's a quickstart instructions for a number of different environments:
     ### Using Vite
     The default Laravel Vite template doesn’t work with DDEV, so you’ll need to set up a Vite server and configure Laravel to use it.
 
-    #### Setup a Vite server
+    #### Set Up a Vite Server
     Install the [ddev-viteserve](https://github.com/torenware/ddev-viteserve) add-on.
     ```bash
     ddev get torenware/ddev-viteserve

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -343,7 +343,7 @@ Here's a quickstart instructions for a number of different environments:
     This is very handy if you have a local database installed and you want to switch between the connections faster by changing only one variable in `.env`
     
     ### Using Vite
-    The default Laravel Vite template will not work with DDEV. To make DDEV and Vite play nicely a few additional steps are required.
+    The default Laravel Vite template doesn’t work with DDEV, so you’ll need to set up a Vite server and configure Laravel to use it.
 
     #### Setup a Vite server
     Install the ddev-viteserve addon.


### PR DESCRIPTION
These changes can be found under the Laravel section in the quickstart for CMSes page.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4236"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

