### PR TITLE
Fix test_ddev.sh so it doesn't continue if unable to create test dir [skip ci]

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -63,7 +63,8 @@ ddev poweroff
 echo "Existing docker containers: " && docker ps -a
 
 PROJECT_DIR=../${PROJECT_NAME}
-mkdir -p "${PROJECT_DIR}/web" && cd "${PROJECT_DIR}"
+mkdir -p "${PROJECT_DIR}/web" || (echo "Unable to create test project at ${PROJECT_DIR}/web, please check ownership and permissions" && exit 2 )
+cd "${PROJECT_DIR}" || exit 3
 
 cat <<END >web/index.php
 <?php


### PR DESCRIPTION
## The Problem/Issue/Bug:

If test_ddev.sh fails to create its project dir, it can continue out and alter the original project.

## How this PR Solves The Problem:

Don't do that.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4239"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

