### PR TITLE
Fix postgres:9 detection of existing project, fixes #4229

### DIFF
--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -37,12 +37,13 @@ func dbTypeVersionFromString(in string) string {
 	idType := ""
 
 	postgresStyle := regexp.MustCompile(`^[0-9]+$`)
+	postgresV9Style := regexp.MustCompile(`^9\.?`)
 	oldStyle := regexp.MustCompile(`^[0-9]+\.[0-9]$`)
 	newStyleV119 := regexp.MustCompile(`^(mysql|mariadb)_[0-9]+\.[0-9]$`)
 
 	if newStyleV119.MatchString(in) {
 		idType = "current"
-	} else if postgresStyle.MatchString(in) {
+	} else if postgresStyle.MatchString(in) || postgresV9Style.MatchString(in) {
 		idType = "postgres"
 	} else if oldStyle.MatchString(in) {
 		idType = "old_pre_v1.19"
@@ -60,7 +61,8 @@ func dbTypeVersionFromString(in string) string {
 	// Postgres: value is an int
 	case "postgres":
 		dbType = nodeps.Postgres
-		dbVersion = in
+		parts := strings.Split(in, `.`)
+		dbVersion = parts[0]
 
 	case "old_pre_v1.19":
 		dbType = nodeps.MariaDB

--- a/pkg/ddevapp/db_test.go
+++ b/pkg/ddevapp/db_test.go
@@ -10,6 +10,7 @@ func TestDBTypeVersionFromString(t *testing.T) {
 
 	expectations := map[string]string{
 		"9":            "postgres:9",
+		"9.6":          "postgres:9",
 		"10":           "postgres:10",
 		"11":           "postgres:11",
 		"12":           "postgres:12",


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4229 

## How this PR Solves The Problem:

Properly handle existing postgres "9.x" as `postgres:9`

## Manual Testing Instructions:

`ddev start` and empty postgres:9 and then `ddev restart`

## Automated Testing Overview:

Added the 9.6 expectation to tests.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4241"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

