### PR TITLE
[docs] Colima installation steps order change

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -21,8 +21,8 @@
         If you don't have the `docker` client installed, you'll need to install it. It is not provided with colima. (If `docker help` returns an error, you don't have it.) Use `brew install docker` to install it.
 
     1. Install colima with `brew install colima` using homebrew or see the other [installation options](https://github.com/abiosoft/colima/blob/main/docs/INSTALL.md).
-    2. After installing DDEV configure your system to use mutagen, which is essential for DDEV with Colima, by running `ddev config global --mutagen-enabled`.
-    3. Start colima: `colima start --cpu 4 --memory 6 --disk 100 --dns=1.1.1.1` will set up a colima instance with 4 CPUs and 4GB of memory allocated and using DNS server 1.1.1.1 (Cloudflare). Your needs may vary. After the first start you can just use `colima start`. Use `colima start -e` to edit the configuration file. (Configuring the DNS server is critical if you're using Pantheon or other tenants of `storage.googleapis.com`.)
+    2. Start colima: `colima start --cpu 4 --memory 6 --disk 100 --dns=1.1.1.1` will set up a colima instance with 4 CPUs and 4GB of memory allocated and using DNS server 1.1.1.1 (Cloudflare). Your needs may vary. After the first start you can just use `colima start`. Use `colima start -e` to edit the configuration file. (Configuring the DNS server is critical if you're using Pantheon or other tenants of `storage.googleapis.com`.)
+    3. After installing DDEV configure your system to use mutagen, which is essential for DDEV with Colima, by running `ddev config global --mutagen-enabled`.
     4. `colima status` will show colima's status.
     5. After a computer restart you'll need to `colima start` again. This will eventually be automated in later versions of colima.
     

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -21,7 +21,7 @@
         If you don't have the `docker` client installed, you'll need to install it. It is not provided with colima. (If `docker help` returns an error, you don't have it.) Use `brew install docker` to install it.
 
     1. Install colima with `brew install colima` using homebrew or see the other [installation options](https://github.com/abiosoft/colima/blob/main/docs/INSTALL.md).
-    2. Start colima: `colima start --cpu 4 --memory 6 --disk 100 --dns=1.1.1.1` will set up a colima instance with 4 CPUs and 4GB of memory allocated and using DNS server 1.1.1.1 (Cloudflare). Your needs may vary. After the first start you can just use `colima start`. Use `colima start -e` to edit the configuration file. (Configuring the DNS server is critical if you're using Pantheon or other tenants of `storage.googleapis.com`.)
+    2. Start colima: `colima start --cpu 4 --memory 6 --disk 100 --dns=1.1.1.1` will set up a colima instance with 4 CPUs and 6GB of memory allocated and using DNS server 1.1.1.1 (Cloudflare). Your needs may vary. After the first start you can just use `colima start`. Use `colima start -e` to edit the configuration file. (Configuring the DNS server is critical if you're using Pantheon or other tenants of `storage.googleapis.com`.)
     3. After installing DDEV configure your system to use mutagen, which is essential for DDEV with Colima, by running `ddev config global --mutagen-enabled`.
     4. `colima status` will show colima's status.
     5. After a computer restart you'll need to `colima start` again. This will eventually be automated in later versions of colima.


### PR DESCRIPTION
## The Problem/Issue/Bug:
If you run this first: ´ddev config global --mutagen-enabled´ You get this error-message: Could not connect to a docker provider. Please start or install a docker provider. For install help go to: https://ddev.readthedocs.io/en/latest/users/install/

## How this PR Solves The Problem:
To solve this error I first run: ´colima start --cpu 4 --memory 6 --disk 100 --dns=1.1.1.1´ and then ´ddev config global --mutagen-enabled´ (Just changed the order)

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
It's a cmd command.

## Related Issue Link(s):
https://ddev.readthedocs.io/en/latest/users/install/docker-installation/#colima

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
no



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4254"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

