### PR TITLE
[docs] Fix linter fragment complaint

### DIFF
--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -79,7 +79,7 @@ But here are the steps for building:
 
 1. The `drud/ddev-php-base` image must be updated as necessary with a new tag before pushing `ddev-webserver`. You can do this using the [process above](#pushing-docker-images-with-the-github-actions-workflow).
 2. The `drud/ddev-webserver` Dockerfile must `FROM drud/ddev-php-base:<tag>` before building/pushing `ddev-webserver`. But then it can be pushed using either the GitHub Actions or the manual technique.
-3. If you’re bumping `ddev-dbserver` 8.0 minor release, follow the [upstream instructions](#maintaining-ddev-dbserver-mysql-57-80-arm64-images).
+3. If you’re bumping `ddev-dbserver` 8.0 minor release, follow the upstream [Maintaining ddev-dbserver MySQL 5.7 & 8.0 ARM64 Images](#maintaining-ddev-dbserver-mysql-57--80-arm64-images) instructions.
 4. Update `pkg/version/version.go` with the correct versions for the new images, and run all the tests.
 
 ## Manually Updating Homebrew Formulas


### PR DESCRIPTION
## The Problem/Issue/Bug:

On my local markdownlint, this fragment seems to be wrong somehow, just fixing here. It doesn't seem to be caught by the markdownlint in the docs checker on github actions.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4260"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

