### PR TITLE
Bump images to v1.21.2 for upcoming release

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:20220921_php_8.2 as ddev-webserver-base
+FROM drud/ddev-php-base:v1.21.2 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -23,7 +23,7 @@ var WebTag = "v1.21.2" // Note that this can be overridden by make
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.20.2"
+var BaseDBTag = "v1.21.2"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,13 +17,13 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20220928_fix_yarnrc_edit_problem" // Note that this can be overridden by make
+var WebTag = "v1.21.2" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.20.0"
+var BaseDBTag = "v1.20.2"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"
@@ -35,7 +35,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.20.0" // Note that this can be overridden by make
+var RouterTag = "v1.21.2" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 // var SSHAuthImage = "drud/ddev-ssh-agent"
@@ -43,7 +43,7 @@ var SSHAuthImage = "drud/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
 // var SSHAuthTag = "v1.19.0"
-var SSHAuthTag = "v1.20.0"
+var SSHAuthTag = "v1.21.2"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Bump images, see what happens.

Check carefully:
* https://github.com/drud/ddev/issues/3748


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4261"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

