### PR TITLE
[docs] Update example service list

### DIFF
--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -18,19 +18,19 @@ ddev get --list
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-varnish         │ Varnish reverse proxy add-on for DDEV*           │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-redis           │ redis service for DDEV*                          │
+│ drud/ddev-redis           │ Redis service for DDEV*                          │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-beanstalkd      │ beanstalkd for DDEV*                             │
+│ drud/ddev-beanstalkd      │ Beanstalkd for DDEV*                             │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-redis-commander │ Redis commander for use with DDEV redis service* │
+│ drud/ddev-redis-commander │ Redis Commander for use with DDEV Redis service* │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-mongo           │ mongodb addon for DDEV*                          │
+│ drud/ddev-mongo           │ MongoDB add-on for DDEV*                         │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-drupal9-solr    │ Drupal 9 Apache Solr installation for DDEV*      │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-pdfreactor      │ PDFreactor service for DDEV*                     │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-memcached       │ Install memcached as an extra service in DDEV*   │
+│ drud/ddev-memcached       │ Install Memcached as an extra service in DDEV*   │
 └───────────────────────────┴──────────────────────────────────────────────────┘
 ```
 

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -10,28 +10,37 @@ Use `ddev get --list` to see available add-ons. To see all possible add-ons (not
 For example,
 
 ```
-ddev get --list
+→  ddev get --list
 ┌───────────────────────────┬──────────────────────────────────────────────────┐
 │ ADD-ON                    │ DESCRIPTION                                      │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-memcached       │ Install Memcached as an extra service in DDEV*   │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-beanstalkd      │ Beanstalkd for DDEV*                             │
+├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-elasticsearch   │ Elasticsearch add-on for DDEV*                   │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-mongo           │ MongoDB add-on for DDEV*                         │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-pdfreactor      │ PDFreactor service for DDEV*                     │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-browsersync     │ Auto-refresh HTTPS page on changes with DDEV*    │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-drupal9-solr    │ Drupal 9 Apache Solr installation for DDEV*      │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-varnish         │ Varnish reverse proxy add-on for DDEV*           │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-redis           │ Redis service for DDEV*                          │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-beanstalkd      │ Beanstalkd for DDEV*                             │
+│ drud/ddev-adminer         │ Adminer service for DDEV*                        │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-cron            │ Schedule commands to execute within DDEV*        │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-proxy-support   │ Support HTTP/HTTPS proxies with DDEV*            │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-redis-commander │ Redis Commander for use with DDEV Redis service* │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-mongo           │ MongoDB add-on for DDEV*                         │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-drupal9-solr    │ Drupal 9 Apache Solr installation for DDEV*      │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-pdfreactor      │ PDFreactor service for DDEV*                     │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-memcached       │ Install Memcached as an extra service in DDEV*   │
 └───────────────────────────┴──────────────────────────────────────────────────┘
+Add-ons marked with '*' are official, maintained DDEV add-ons.
 ```
 
 !!!tip


### PR DESCRIPTION
## The Problem/Issue/Bug:

After #4200 and subsequent updates to some GitHub repository descriptions, the `ddev get --list` example is stale.

## How this PR Solves The Problem:

This fixes that situation, in a refreshingly small PR. Also cheats by fixing an “addon” that should be “add-on”, and capitalizing Memcached which, against all odds, [appears to be](https://www.memcached.org) a proper noun for the product.

## Manual Testing Instructions:

https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-your-changes

## Automated Testing Overview:

Only Markdown; no new tests needed.

## Release/Deployment notes:

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4263"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

