### PR TITLE
[docs] Add spell check instructions

### DIFF
--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -1,8 +1,9 @@
 # Working on the Docs
 
-This section is designed for people who want to contribute to the DDEV documentation.
+This section is for people who want to contribute to the DDEV documentation.
 
-On any page in the docs
+!!!tip "No need to work locally!"
+    The documentation is built and checked automatically with various [GitHub Actions workflows](https://github.com/drud/ddev/actions). It may help to check your work locally, particularly for more involved PRs, but you can just as well make suggestions using GitHub in a browser.
 
 ## Fork / Clone the DDEV Repository
 

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -3,7 +3,16 @@
 This section is for people who want to contribute to the DDEV documentation.
 
 !!!tip "No need to work locally!"
-    The documentation is built and checked automatically with various [GitHub Actions workflows](https://github.com/drud/ddev/actions). It may help to check your work locally, particularly for more involved PRs, but you can just as well make suggestions using GitHub in a browser.
+    The documentation is built and checked automatically with various [GitHub Actions workflows](https://github.com/drud/ddev/actions). It may help to check your work locally, particularly for more involved PRs, but you can just as well make suggestions using [GitHub in a browser](#fix-docs-using-web-browser).
+
+## Fix Docs Using Web Browser
+
+On any page in the docs:
+
+1. Click the pencil in the upper right. That will take you to the the right page on GitHub.
+2. Click the pencil button on GitHub and follow the instructions to create your change.
+3. Save your changes and follow the prompts to create a PR.
+4. In the checks on your PR, click the “details” link by `docs/readthedocs.org:ddev` to browse the docs build created by your PR.
 
 ## Fork / Clone the DDEV Repository
 

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -40,6 +40,26 @@ Run `make markdownlint` before you publish changes to quickly check your files f
 !!!warning "`markdownlint-cli` required!"
     The `make markdownlint` command requires you to have `markdownlint-cli` installed, which you can do by executing `npm install -g markdownlint-cli`
 
+## Check for Spelling Errors
+
+Run `make pyspelling` to check for spelling errors. Output will be brief if all goes well:
+
+```
+➜  make pyspelling
+pyspelling:
+Spelling check passed :)
+```
+
+If you’ve added a correctly-spelled word that gets flagged, like “Symfony” for example, you’ll need to add it to `.spellcheckwordlist.txt` in the [root of DDEV’s repository](https://github.com/drud/ddev/blob/master/.spellcheckwordlist.txt).
+
+!!!warning "`pyspelling` and `aspell` required!"
+    It’s probably best to install packages locally before attempting to run `make pyspelling`:
+
+    ```
+    sudo -H pip3 install pyspelling pymdown-extensions
+    sudo apt-get install aspell
+    ```
+
 ## Publish Changes
 
 If all looks good, it’s time to commit your changes and make a pull request back into the official DDEV repository.

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -2,12 +2,9 @@
 
 This section is for people who want to contribute to the DDEV documentation.
 
-!!!tip "No need to work locally!"
-    The documentation is built and checked automatically with various [GitHub Actions workflows](https://github.com/drud/ddev/actions). It may help to check your work locally, particularly for more involved PRs, but you can just as well make suggestions using [GitHub in a browser](#fix-docs-using-web-browser).
-
 ## Fix Docs Using Web Browser
 
-On any page in the docs:
+The documentation is built and checked automatically with various [GitHub Actions workflows](https://github.com/drud/ddev/actions). While it may help to [check your work locally](#fork--clone-the-ddev-repository) for more involved PRs, you can more quickly make suggestions using [GitHub in a browser](#fix-docs-using-web-browser):
 
 1. Click the pencil in the upper right. That will take you to the the right page on GitHub.
 2. Click the pencil button on GitHub and follow the instructions to create your change.


### PR DESCRIPTION
## The Problem/Issue/Bug:

The enthusiastic writer may not be aware of the spell checker, which would be ideal for the [Working on the Docs](https://ddev.readthedocs.io/en/latest/developers/testing-docs/) page.

## How this PR Solves The Problem:

This adds a “Check for Spelling Errors” section to that page:

![Screen Shot 2022-10-05 at 03 48 08 PM@2x](https://user-images.githubusercontent.com/2488775/194177746-68f1f83d-9673-47fb-8bdc-dfbc0bce6730.png)

Terminal commands are grabbed directly [from the Makefile](https://github.com/drud/ddev/blob/master/Makefile), and the `→  ` is used to indicate user CLI input since that style is used elsewhere in the docs.

## Manual Testing Instructions:

https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-your-changes

## Automated Testing Overview:

Only Markdown; no new tests needed.

## Release/Deployment notes:

n/a



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4264"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

