### PR TITLE
Use proper post-start hook label everywhere

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -275,7 +275,7 @@ can override the existing values, and
 ```yaml
 override_config: true
 hooks:
-  post_start: []
+  post-start: []
 ```
 
 or

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -224,7 +224,7 @@ const ConfigInstructions = `
 # However, with "override_config: true" in a particular config.*.yaml file,
 # 'nfs_mount_enabled: false' can override the existing values, and
 # hooks:
-#   post_start: []
+#   post-start: []
 # or
 # web_environment: []
 # or


### PR DESCRIPTION
Post-start hook is wrongly stated on two places, fixed that.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4265"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

