### PR TITLE
Offer ddev restart option for failure to remove volume

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -984,7 +984,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 			if volumeExists {
 				removeVolumeErr := dockerutil.RemoveVolume(GetMutagenVolumeName(app))
 				if removeVolumeErr != nil {
-					return fmt.Errorf(`Unable to remove mismatched mutagen docker volume '%s'. Please use 'ddev mutagen reset': %v`, GetMutagenVolumeName(app), removeVolumeErr)
+					return fmt.Errorf(`Unable to remove mismatched mutagen docker volume '%s'. Please use 'ddev restart' or 'ddev mutagen reset': %v`, GetMutagenVolumeName(app), removeVolumeErr)
 				}
 			}
 		}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -978,6 +978,9 @@ func RemoveVolume(volumeName string) error {
 	if _, err := client.InspectVolume(volumeName); err == nil {
 		err := client.RemoveVolumeWithOptions(docker.RemoveVolumeOptions{Name: volumeName})
 		if err != nil {
+			if err.Error() == "volume in use and cannot be removed" {
+				return fmt.Errorf("Docker volume '%s' is in use by a container and cannot be removed. Use 'docker rm -f $(docker ps -aq)' to stop all containers", volumeName)
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

The problem where a docker volume can't be removed may be caused by the web container still being running and preventing deletion, so the simplest fix in that case is `ddev restart`. 

## How this PR Solves The Problem:

Add that to the output.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4266"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

