### PR TITLE
Add support for TYPO3 v12

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -226,7 +226,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ddev start
         ddev composer create "typo3/cms-base-distribution" --no-install
         ddev composer install
-        ddev config --auto
+        ddev restart
         ddev exec touch public/FIRST_INSTALL
         ddev launch
         ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -240,7 +240,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         cd example-site
         ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
         ddev composer install
-        ddev config --auto
+        ddev restart
         ddev exec touch public/FIRST_INSTALL
         ddev launch
         ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -222,10 +222,11 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ```bash
         mkdir my-typo3-site
         cd my-typo3-site
-        ddev config --project-type=typo3 --docroot=public --create-docroot
+        ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
         ddev start
         ddev composer create "typo3/cms-base-distribution" --no-install
         ddev composer install
+        ddev config --auto
         ddev exec touch public/FIRST_INSTALL
         ddev launch
         ```
@@ -237,8 +238,10 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ```bash
         git clone https://github.com/example/example-site
         cd example-site
-        ddev config
+        ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
         ddev composer install
+        ddev config --auto
+        ddev exec touch public/FIRST_INSTALL
         ddev launch
         ```
 

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -1,20 +1,17 @@
 package ddevapp_test
 
 import (
-	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/drud/ddev/pkg/util"
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
-
-	"os"
-
-	"fmt"
-
 	"time"
 
 	. "github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/testcommon"
+	"github.com/drud/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 )
 
@@ -57,6 +54,10 @@ func TestWriteSettings(t *testing.T) {
 	})
 
 	err = os.MkdirAll(filepath.Join(testDir, app.Docroot, "sites", "default"), 0777)
+	assert.NoError(err)
+
+	// Create expected folders for TYPO3.
+	err = os.MkdirAll(filepath.Join(testDir, app.Docroot, "typo3"), 0777)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(testDir, app.Docroot, "typo3conf"), 0777)

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -2,13 +2,15 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/drud/ddev/pkg/nodeps"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"text/template"
 
 	"github.com/drud/ddev/pkg/archive"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 )
@@ -17,6 +19,11 @@ import (
 // AdditionalConfiguration.php, adding things like database host, name, and
 // password. Returns the fullpath to settings file and error
 func createTypo3SettingsFile(app *DdevApp) (string, error) {
+	if filepath.Dir(app.SiteDdevSettingsFile) == app.AppRoot {
+		// As long as the final settings folder is not defined, early return
+		return app.SiteDdevSettingsFile, nil
+	}
+
 	if !fileutil.FileExists(app.SiteSettingsPath) {
 		util.Warning("TYPO3 does not seem to have been set up yet, missing %s (%s)", filepath.Base(app.SiteSettingsPath), app.SiteSettingsPath)
 	}
@@ -62,7 +69,7 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 		}
 
 		// The directory doesn't exist, create it with the appropriate permissions.
-		if err := os.Mkdir(dir, perms); err != nil {
+		if err := os.MkdirAll(dir, perms); err != nil {
 			return err
 		}
 	}
@@ -120,13 +127,25 @@ func getTypo3Hooks() []byte {
 	return []byte(Typo3Hooks)
 }
 
-// setTypo3SiteSettingsPaths sets the paths to settings.php/settings.local.php
-// for templating.
+// setTypo3SiteSettingsPaths sets the paths to settings files for templating
 func setTypo3SiteSettingsPaths(app *DdevApp) {
-	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+	settingsFileBasePath := filepath.Join(app.AppRoot, app.ComposerRoot)
 	var settingsFilePath, localSettingsFilePath string
-	settingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "LocalConfiguration.php")
-	localSettingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "AdditionalConfiguration.php")
+
+	if isTypo3v12OrHigher(app) {
+		settingsFilePath = filepath.Join(settingsFileBasePath, "config", "system", "settings.php")
+		localSettingsFilePath = filepath.Join(settingsFileBasePath, "config", "system", "additional.php")
+	} else if isTypo3App(app) {
+		settingsFilePath = filepath.Join(settingsFileBasePath, app.Docroot, "typo3conf", "LocalConfiguration.php")
+		localSettingsFilePath = filepath.Join(settingsFileBasePath, app.Docroot, "typo3conf", "AdditionalConfiguration.php")
+	} else {
+		// As long as TYPO3 is not installed, the file paths are set to the
+		// AppRoot to avoid the creation of the .gitignore in the wrong location.
+		settingsFilePath = filepath.Join(settingsFileBasePath, "LocalConfiguration.php")
+		localSettingsFilePath = filepath.Join(settingsFileBasePath, "AdditionalConfiguration.php")
+	}
+
+	// Update file paths
 	app.SiteSettingsPath = settingsFilePath
 	app.SiteDdevSettingsFile = localSettingsFilePath
 }
@@ -183,4 +202,34 @@ func typo3ImportFilesAction(app *DdevApp, importPath, extPath string) error {
 	}
 
 	return nil
+}
+
+// isTypo3v12OrHigher returns true if the TYPO3 version is 12 or higher. The
+// proper detection will fail if the vendor folder location is changed in the
+// composer.json.
+func isTypo3v12OrHigher(app *DdevApp) bool {
+	versionFilePath := filepath.Join(app.AppRoot, app.ComposerRoot, "vendor", "typo3", "cms-core", "Classes", "Information", "Typo3Version.php")
+	versionFile, err := fileutil.ReadFileIntoString(versionFilePath)
+	// Typo3Version class exists since v10.3.0. Before v11.5.0 the core was always
+	// installed into the folder public/typo3 so we can early return if the file
+	// is not found in the vendor folder.
+	if err != nil {
+		util.Debug("TYPO3 version class not found in '%s', installed version is assumed to be older than 11.5.0.", versionFilePath)
+		return false
+	}
+
+	// We may have a TYPO3 version 11 or higher and therefor have to parse the
+	// class file to properly detect the version.
+	re := regexp.MustCompile(`const VERSION += +'(\d+)\.\d+\.\d+';`)
+
+	version, err := strconv.Atoi(re.FindStringSubmatch(versionFile)[1])
+	if err != nil {
+		// This case never should happen
+		util.Warning("Unexpected error while parsing TYPO3 version: %v.", err)
+		return false
+	}
+
+	util.Debug("Found TYPO3 version %d.", version)
+
+	return version >= 12
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

The new TYPO3 v12 major version has some breaking changes regarding the settings files.

## How this PR Solves The Problem:

This patch introduces an automatic detection of the TYPO3 version 12 or higher and properly adapts the setting file paths and names.

To avoid the creation of the .gitignore in the wrong location, it is not written anymore before TYPO3 is installed or the version could be properly detected.

## Manual Testing Instructions:

Follow the quick start guide to test this change. To test it for a previous version just add a version to the composer create command e.g.:

```
ddev composer create --no-install "typo3/cms-base-distribution:^11"
```

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

https://github.com/TYPO3/get.typo3.org/issues/386

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4268"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

