### PR TITLE
Optimize composer create to also work without --no-install

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -153,9 +153,8 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         cd my-drupal9-site
         ddev config --project-type=drupal9 --docroot=web --create-docroot
         ddev start
-        ddev composer create "drupal/recommended-project" --no-install
-        ddev composer require drush/drush --no-install
-        ddev composer install
+        ddev composer create "drupal/recommended-project"
+        ddev composer require drush/drush
         ddev drush site:install -y
         ddev drush uli
         ddev launch
@@ -172,9 +171,8 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         cd my-drupal10-site
         ddev config --project-type=drupal10 --docroot=web --create-docroot
         ddev start
-        ddev composer create --no-install drupal/recommended-project:^10@alpha
-        ddev composer require drush/drush --no-install
-        ddev composer install
+        ddev composer create drupal/recommended-project:^10@alpha
+        ddev composer require drush/drush
         ddev drush site:install -y
         ddev drush uli
         ddev launch
@@ -450,7 +448,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         mkdir my-craft-project
         cd my-craft-project
         ddev config --project-type=craftcms --docroot=web --create-docroot
-		ddev start
+        ddev start
         ddev composer create -y --no-scripts --no-install craftcms/craft
         ddev craft install
         ddev launch

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -450,9 +450,8 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         mkdir my-craft-project
         cd my-craft-project
         ddev config --project-type=craftcms --docroot=web --create-docroot
+		ddev start
         ddev composer create -y --no-scripts --no-install craftcms/craft
-        ddev start
-        ddev composer update
         ddev craft install
         ddev launch
         ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -224,9 +224,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         cd my-typo3-site
         ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
         ddev start
-        ddev composer create "typo3/cms-base-distribution" --no-install
-        ddev composer install
-        ddev restart
+        ddev composer create "typo3/cms-base-distribution"
         ddev exec touch public/FIRST_INSTALL
         ddev launch
         ```
@@ -276,8 +274,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
     ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --create-docroot --disable-settings-management
     ddev get drud/ddev-elasticsearch
     ddev start
-    ddev composer create --no-install --repository=https://repo.magento.com/ magento/project-community-edition -y
-    ddev composer install
+    ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition -y
     rm -f app/etc/env.php
     # Change the base-url below to your project's URL
     ddev magento setup:install --base-url='https://ddev-magento2.ddev.site/' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US


### PR DESCRIPTION
## The Problem/Issue/Bug:

`composer create-project` executes a `git clone` which is possible only into empty directories. Therefor the `ddev composer create` command was introduced to automatically bypass this problem and make the initialization easier for the user. This is achieved by running the `composer create-project` command automatically providing the directory argument and rsync the the files and folders from this directory afterwards to the project root directory. This can be very slow depending on the number of files and folders which must be synchronized and therefor using the `--no-install` option is suggested in many places to avoid issues and make the process faster but requires the user to run `ddev composer install` afterwards, once the `ddev composer create` command has finished. This workflow can be optimized again by handling the `--no-install` option automatically.

## How this PR Solves The Problem:

The `composer create` command now checks if the `--no-install` option is provided by the user. If not, it's now added by default and once the rsync is completed, `composer install` is called afterwards. This makes the project initialization easier.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4273"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

