### PR TITLE
[docs] auto-install recommended packages

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -71,7 +71,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
         sudo apt-get update && sudo apt-get install ca-certificates curl gnupg lsb-release
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/    linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-        sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io
+        sudo apt-get update && sudo apt-get -y install docker-ce docker-ce-cli containerd.io
         sudo groupadd docker && sudo usermod -aG docker $USER
         ```
     * You have to start `docker-ce` yourself on login, or use a script to automate it. To have it start on entry to Git Bash, add a startup line to your (Windows-side) `~/.bashrc` with:


### PR DESCRIPTION
## The Problem/Issue/Bug:
When trying to copy all the commands and paste them in terminal of Ubuntu so they all run at once, the `-y` is missing.

## How this PR Solves The Problem:
Adding `-y` to auto-confirm installing Ubuntu packages.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4275"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

