### PR TITLE
Bump mutagen to 0.16.0-rc1

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -54,7 +54,7 @@ var BUILDINFO = "BUILDINFO should have new info"
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.16.0-beta1"
+const RequiredMutagenVersion = "0.16.0-rc1"
 
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Mutagen 0.16.0-rc1 has been released; 0.16.0 should come shortly

## How this PR Solves The Problem:

Use and run full tests on it. @xenoscopic doesn't foresee any impact from the beta1 we were using.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4277"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

