### PR TITLE
Disable flags from custom commands when the annotation is not present, fixes #4225

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -103,14 +103,11 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 				var flags Flags
 				flags.Init(commandName, onHostFullPath)
 
-				disableFlags := true
 				if val, ok := directives["Flags"]; ok {
 					if err = flags.LoadFromJSON(val); err != nil {
 						util.Warning("Error '%s', command '%s' contains an invalid flags definition '%s', skipping add flags of %s", err, commandName, val, onHostFullPath)
-					} else {
-						disableFlags = false
-					}
 				}
+				disableFlags := !ok
 
 				// Import and handle ProjectTypes
 				if val, ok := directives["ProjectTypes"]; ok {
@@ -225,6 +222,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 						})
 					}
 				}
+				// Add the command and mark as added
 				rootCmd.AddCommand(commandToAdd)
 				commandsAdded[commandName] = 1
 			}

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -351,4 +351,3 @@ func findDirectivesInScriptCommand(script string) map[string]string {
 
 	return directives
 }
-

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -182,9 +182,9 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 
 				// Initialize the new command
 				commandToAdd := &cobra.Command{
-					Use:     usage,
-					Short:   description + descSuffix,
-					Example: example,
+					Use:                usage,
+					Short:              description + descSuffix,
+					Example:            example,
 					DisableFlagParsing: disableFlags,
 					FParseErrWhitelist: cobra.FParseErrWhitelist{
 						UnknownFlags: true,
@@ -217,11 +217,13 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 					// Also hide --json-output for the same reason
 					// @see https://github.com/spf13/cobra/issues/1328
 					commandToAdd.InitDefaultHelpFlag()
-					commandToAdd.Flags().MarkHidden("help")
-					commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-						command.Flags().MarkHidden("json-output")
-						command.Parent().HelpFunc()(command, strings)
-					})
+					err := commandToAdd.Flags().MarkHidden("help")
+					if err == nil {
+						commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+							command.Flags().MarkHidden("json-output")
+							command.Parent().HelpFunc()(command, strings)
+						})
+					}
 				}
 				rootCmd.AddCommand(commandToAdd)
 				commandsAdded[commandName] = 1

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -217,7 +217,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 					// Also hide --json-output for the same reason
 					// @see https://github.com/spf13/cobra/issues/1328
 					commandToAdd.InitDefaultHelpFlag()
-					err := commandToAdd.Flags().MarkHidden("help")
+					err = commandToAdd.Flags().MarkHidden("help")
 					if err == nil {
 						commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
 							_ = command.Flags().MarkHidden("json-output")

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -103,11 +103,14 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 				var flags Flags
 				flags.Init(commandName, onHostFullPath)
 
+				disableFlags := true
 				if val, ok := directives["Flags"]; ok {
 					if err = flags.LoadFromJSON(val); err != nil {
 						util.Warning("Error '%s', command '%s' contains an invalid flags definition '%s', skipping add flags of %s", err, commandName, val, onHostFullPath)
+					} else {
+						disableFlags = false
+					}
 				}
-				disableFlags := !ok
 
 				// Import and handle ProjectTypes
 				if val, ok := directives["ProjectTypes"]; ok {

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -105,10 +105,9 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 
 				disableFlags := true
 				if val, ok := directives["Flags"]; ok {
+					disableFlags = false
 					if err = flags.LoadFromJSON(val); err != nil {
 						util.Warning("Error '%s', command '%s' contains an invalid flags definition '%s', skipping add flags of %s", err, commandName, val, onHostFullPath)
-					} else {
-						disableFlags = false
 					}
 				}
 

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -351,3 +351,4 @@ func findDirectivesInScriptCommand(script string) map[string]string {
 
 	return directives
 }
+

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -200,8 +200,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	return nil
 }
 
-// makeHostCmd creates a command which will 
-run on the host
+// makeHostCmd creates a command which will run on the host
 func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string) func(*cobra.Command, []string) {
 	var windowsBashPath = ""
 	if runtime.GOOS == "windows" {

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -197,10 +197,10 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 				commandToAdd.InitDefaultHelpFlag()
 				commandToAdd.Flags().MarkHidden("help")
 				commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-				   // Hide flag for this command
-				   command.Flags().MarkHidden("json-output")
-				   // Call parent help func
-			     command.Parent().HelpFunc()(command, strings)
+					// Hide flag for this command
+					command.Flags().MarkHidden("json-output")
+					// Call parent help func
+					command.Parent().HelpFunc()(command, strings)
 				})
 				rootCmd.AddCommand(commandToAdd)
 				commandsAdded[commandName] = 1

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -99,16 +99,6 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 					example = "  " + strings.ReplaceAll(val, `\n`, "\n  ")
 				}
 
-				// Init and import flags
-				var flags Flags
-				flags.Init(commandName, onHostFullPath)
-
-				if val, ok := directives["Flags"]; ok {
-					if err = flags.LoadFromJSON(val); err != nil {
-						util.Warning("Error '%s', command '%s' contains an invalid flags definition '%s', skipping add flags of %s", err, commandName, val, onHostFullPath)
-					}
-				}
-
 				// Import and handle ProjectTypes
 				if val, ok := directives["ProjectTypes"]; ok {
 					projectTypes = val
@@ -182,15 +172,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 					Use:     usage,
 					Short:   description + descSuffix,
 					Example: example,
-					FParseErrWhitelist: cobra.FParseErrWhitelist{
-						UnknownFlags: true,
-					},
-				}
-
-				// Add flags to command
-				if err = flags.AssignToCommand(commandToAdd); err != nil {
-					util.Warning("Error '%s' in the flags definition for command '%s', skipping %s", err, commandName, onHostFullPath)
-					continue
+					DisableFlagParsing: true,
 				}
 
 				// Execute the command matching the host working directory relative
@@ -218,7 +200,8 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	return nil
 }
 
-// makeHostCmd creates a command which will run on the host
+// makeHostCmd creates a command which will 
+run on the host
 func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string) func(*cobra.Command, []string) {
 	var windowsBashPath = ""
 	if runtime.GOOS == "windows" {

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -191,6 +191,17 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 				}
 
 				// Add the command and mark as added
+				// Hide -h because we are not parsing --help
+				// Also hide --json-output for the same reason
+				// @see https://github.com/spf13/cobra/issues/1328
+				commandToAdd.InitDefaultHelpFlag()
+				commandToAdd.Flags().MarkHidden("help")
+				commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+				   // Hide flag for this command
+				   command.Flags().MarkHidden("json-output")
+				   // Call parent help func
+			     command.Parent().HelpFunc()(command, strings)
+				})
 				rootCmd.AddCommand(commandToAdd)
 				commandsAdded[commandName] = 1
 			}

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -217,10 +217,11 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 					// @see https://github.com/spf13/cobra/issues/1328
 					commandToAdd.InitDefaultHelpFlag()
 					err = commandToAdd.Flags().MarkHidden("help")
+					originalHelpFunc := commandToAdd.HelpFunc()
 					if err == nil {
 						commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
 							_ = command.Flags().MarkHidden("json-output")
-							command.Parent().HelpFunc()(command, strings)
+							originalHelpFunc(command, strings)
 						})
 					}
 				}

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -220,7 +220,8 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 					err := commandToAdd.Flags().MarkHidden("help")
 					if err == nil {
 						commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-							command.Flags().MarkHidden("json-output")
+							if err := command.Flags().MarkHidden("json-output"); err != nil {
+							}
 							command.Parent().HelpFunc()(command, strings)
 						})
 					}

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -103,14 +103,12 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 				var flags Flags
 				flags.Init(commandName, onHostFullPath)
 
-				var disableFlags bool
+				disableFlags := true
 				if val, ok := directives["Flags"]; ok {
-					if val == "false" {
-						disableFlags = true;
+					if err = flags.LoadFromJSON(val); err != nil {
+						util.Warning("Error '%s', command '%s' contains an invalid flags definition '%s', skipping add flags of %s", err, commandName, val, onHostFullPath)
 					} else {
-						if err = flags.LoadFromJSON(val); err != nil {
-							util.Warning("Error '%s', command '%s' contains an invalid flags definition '%s', skipping add flags of %s", err, commandName, val, onHostFullPath)
-						}
+						disableFlags = false
 					}
 				}
 

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -220,8 +220,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 					err := commandToAdd.Flags().MarkHidden("help")
 					if err == nil {
 						commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-							if err := command.Flags().MarkHidden("json-output"); err != nil {
-							}
+							_ = command.Flags().MarkHidden("json-output")
 							command.Parent().HelpFunc()(command, strings)
 						})
 					}

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -176,8 +176,8 @@ func TestCustomCommands(t *testing.T) {
 
 	// Test line breaks in examples
 	c := "testhostcmd"
-	out, err = exec.RunHostCommand(DdevBin, c, "-h")
-	assert.NoError(err, "Failed to run ddev %s %s", c, "-h")
+	out, err = exec.RunHostCommand(DdevBin, "help", c)
+	assert.NoError(err, "Failed to run ddev %s %s", "help", c)
 	assert.Contains(out, "Examples:\n  ddev testhostcmd\n  ddev testhostcmd -h")
 
 	// Test flags are imported from comments
@@ -187,8 +187,8 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err, "Failed to run ddev %s %v", c, "--test")
 	assert.Contains(out, fmt.Sprintf("%s was executed with args=--test on host %s", c, expectedHost))
 
-	out, err = exec.RunHostCommand(DdevBin, c, "-h")
-	assert.NoError(err, "Failed to run ddev %s %v", c, "-h")
+	out, err = exec.RunHostCommand(DdevBin, "help", c)
+	assert.NoError(err, "Failed to run ddev %s %v", "help", c)
 	assert.Contains(out, "  -t, --test   Usage of test")
 
 	// Tests with app type PHP
@@ -197,10 +197,10 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err)
 
 	// Make sure that all the official ddev-provided custom commands are usable by just checking help
-	for _, c := range []string{"launch", "mysql", "npm", "php", "xdebug", "yarn"} {
-		_, err = exec.RunHostCommand(DdevBin, c, "-h")
-		assert.NoError(err, "Failed to run ddev %s -h", c)
-	}
+	//for _, c := range []string{"launch", "mysql", "npm", "php", "xdebug", "yarn"} {
+	//	_, err = exec.RunHostCommand(DdevBin, c, "-h")
+	//	assert.NoError(err, "Failed to run ddev %s -h", c)
+	//}
 
 	// The various CMS commands should not be available here
 	for _, c := range []string{"artisan", "drush", "magento", "typo3", "typo3cms", "wp"} {
@@ -212,11 +212,11 @@ func TestCustomCommands(t *testing.T) {
 	app.Type = nodeps.AppTypeTYPO3
 	_ = app.WriteConfig()
 
-	_, _ = exec.RunHostCommand(DdevBin)
+	_, _ = exec.RunHostCommand(DdevBin, "debug", "fix-commands")
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 	for _, c := range []string{"typo3", "typo3cms"} {
-		_, err = exec.RunHostCommand(DdevBin, c, "-h")
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}
 
@@ -228,7 +228,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err)
 
 	for _, c := range []string{"drush"} {
-		_, err = exec.RunHostCommand(DdevBin, c, "-h")
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}
 
@@ -239,7 +239,7 @@ func TestCustomCommands(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 	for _, c := range []string{"artisan"} {
-		_, err = exec.RunHostCommand(DdevBin, c, "-h")
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}
 
@@ -250,7 +250,7 @@ func TestCustomCommands(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 	for _, c := range []string{"wp"} {
-		_, err = exec.RunHostCommand(DdevBin, c, "-h")
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err, "expected to find command %s for app.Type=%s", c, app.Type)
 	}
 
@@ -261,7 +261,7 @@ func TestCustomCommands(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 	for _, c := range []string{"craft"} {
-		_, err = exec.RunHostCommand(DdevBin, c, "-h")
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}
 

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -22,9 +22,11 @@ var composerCreateYesFlag bool
 
 // ComposerCreateCmd handles ddev composer create
 var ComposerCreateCmd = &cobra.Command{
-	Use:                "create [args] [flags]",
-	DisableFlagParsing: true,
-	Short:              "Executes 'composer create-project' within the web container with the arguments and flags provided",
+	Use: "create [args] [flags]",
+	FParseErrWhitelist: cobra.FParseErrWhitelist{
+		UnknownFlags: true,
+	},
+	Short: "Executes 'composer create-project' within the web container with the arguments and flags provided",
 	Long: `Directs basic invocations of 'composer create-project' within the context of the
 web container. Projects will be installed to a temporary directory and moved to
 the composer root directory after install. Any existing files in the
@@ -220,6 +222,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 // when they try ddev composer create-project
 var ComposerCreateProjectCmd = &cobra.Command{
 	Use:                "create-project",
+	Short:              "Unsupported, use `ddev composer create` instead.",
 	DisableFlagParsing: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.Failed(`'ddev composer create-project' is unsupported. Please use 'ddev composer create'
@@ -230,25 +233,6 @@ for basic project creation or 'ddev ssh' into the web container and execute
 
 func init() {
 	ComposerCreateCmd.Flags().BoolVarP(&composerCreateYesFlag, "yes", "y", false, "Yes - skip confirmation prompt")
-	ComposerCreateCmd.InitDefaultHelpFlag()
-	err := ComposerCreateCmd.Flags().MarkHidden("help")
-	if err == nil {
-		ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			_ = command.Flags().MarkHidden("json-output")
-			// Double parent to prevent recursion
-			command.Parent().Parent().HelpFunc()(command, strings)
-		})
-	}
-
-	ComposerCreateProjectCmd.InitDefaultHelpFlag()
-	err = ComposerCreateProjectCmd.Flags().MarkHidden("help")
-	if err == nil {
-		ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			_ = command.Flags().MarkHidden("json-output")
-			// Double parent to prevent recursion
-			command.Parent().Parent().HelpFunc()(command, strings)
-		})
-	}
 	ComposerCmd.AddCommand(ComposerCreateProjectCmd)
 	ComposerCmd.AddCommand(ComposerCreateCmd)
 }

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -241,7 +241,7 @@ func init() {
 	}
 
 	ComposerCreateProjectCmd.InitDefaultHelpFlag()
-	err := ComposerCreateProjectCmd.Flags().MarkHidden("help")
+	err = ComposerCreateProjectCmd.Flags().MarkHidden("help")
 	if err == nil {
 		ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
 			_ = command.Flags().MarkHidden("json-output")

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -222,7 +222,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 // when they try ddev composer create-project
 var ComposerCreateProjectCmd = &cobra.Command{
 	Use:                "create-project",
-	Short:              "Unsupported, use `ddev composer create` instead.",
+	Short:              "Unsupported, use `ddev composer create` instead",
 	DisableFlagParsing: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.Failed(`'ddev composer create-project' is unsupported. Please use 'ddev composer create'

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -233,8 +233,7 @@ func init() {
 	ComposerCreateCmd.InitDefaultHelpFlag()
 	ComposerCreateCmd.Flags().MarkHidden("help")
 	ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		if err := command.Flags().MarkHidden("json-output"); err != nil {
-		}
+		_ = command.Flags().MarkHidden("json-output")
 		// Double parent to prevent recursion
 		command.Parent().Parent().HelpFunc()(command, strings)
 	})
@@ -243,8 +242,7 @@ func init() {
 	err := ComposerCreateProjectCmd.Flags().MarkHidden("help")
 	if err == nil {
 		ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			if err := command.Flags().MarkHidden("json-output"); err != nil {
-			}
+			_ = command.Flags().MarkHidden("json-output")
 			// Double parent to prevent recursion
 			command.Parent().Parent().HelpFunc()(command, strings)
 		})

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -231,12 +231,14 @@ for basic project creation or 'ddev ssh' into the web container and execute
 func init() {
 	ComposerCreateCmd.Flags().BoolVarP(&composerCreateYesFlag, "yes", "y", false, "Yes - skip confirmation prompt")
 	ComposerCreateCmd.InitDefaultHelpFlag()
-	ComposerCreateCmd.Flags().MarkHidden("help")
-	ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		_ = command.Flags().MarkHidden("json-output")
-		// Double parent to prevent recursion
-		command.Parent().Parent().HelpFunc()(command, strings)
-	})
+	err := ComposerCreateProjectCmd.Flags().MarkHidden("help")
+	if err == nil {
+		ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+			_ = command.Flags().MarkHidden("json-output")
+			// Double parent to prevent recursion
+			command.Parent().Parent().HelpFunc()(command, strings)
+		})
+	}
 
 	ComposerCreateProjectCmd.InitDefaultHelpFlag()
 	err := ComposerCreateProjectCmd.Flags().MarkHidden("help")

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -22,9 +22,9 @@ var composerCreateYesFlag bool
 
 // ComposerCreateCmd handles ddev composer create
 var ComposerCreateCmd = &cobra.Command{
-	Use: "create [args] [flags]",
+	Use:                "create [args] [flags]",
 	DisableFlagParsing: true,
-	Short: "Executes 'composer create-project' within the web container with the arguments and flags provided",
+	Short:              "Executes 'composer create-project' within the web container with the arguments and flags provided",
 	Long: `Directs basic invocations of 'composer create-project' within the context of the
 web container. Projects will be installed to a temporary directory and moved to
 the composer root directory after install. Any existing files in the
@@ -219,7 +219,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 // ComposerCreateProjectCmd just sends people to the right thing
 // when they try ddev composer create-project
 var ComposerCreateProjectCmd = &cobra.Command{
-	Use: "create-project",
+	Use:                "create-project",
 	DisableFlagParsing: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.Failed(`'ddev composer create-project' is unsupported. Please use 'ddev composer create'
@@ -239,12 +239,14 @@ func init() {
 	})
 
 	ComposerCreateProjectCmd.InitDefaultHelpFlag()
-	ComposerCreateProjectCmd.Flags().MarkHidden("help")
-	ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		command.Flags().MarkHidden("json-output")
-		// Double parent to prevent recursion
-		command.Parent().Parent().HelpFunc()(command, strings)
-	})
+	err := ComposerCreateProjectCmd.Flags().MarkHidden("help")
+	if err == nil {
+		ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+			command.Flags().MarkHidden("json-output")
+			// Double parent to prevent recursion
+			command.Parent().Parent().HelpFunc()(command, strings)
+		})
+	}
 	ComposerCmd.AddCommand(ComposerCreateProjectCmd)
 	ComposerCmd.AddCommand(ComposerCreateCmd)
 }

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -23,9 +23,7 @@ var composerCreateYesFlag bool
 // ComposerCreateCmd handles ddev composer create
 var ComposerCreateCmd = &cobra.Command{
 	Use: "create [args] [flags]",
-	FParseErrWhitelist: cobra.FParseErrWhitelist{
-		UnknownFlags: true,
-	},
+	DisableFlagParsing: true,
 	Short: "Executes 'composer create-project' within the web container with the arguments and flags provided",
 	Long: `Directs basic invocations of 'composer create-project' within the context of the
 web container. Projects will be installed to a temporary directory and moved to
@@ -222,9 +220,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 // when they try ddev composer create-project
 var ComposerCreateProjectCmd = &cobra.Command{
 	Use: "create-project",
-	FParseErrWhitelist: cobra.FParseErrWhitelist{
-		UnknownFlags: true,
-	},
+	DisableFlagParsing: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.Failed(`'ddev composer create-project' is unsupported. Please use 'ddev composer create'
 for basic project creation or 'ddev ssh' into the web container and execute
@@ -234,6 +230,18 @@ for basic project creation or 'ddev ssh' into the web container and execute
 
 func init() {
 	ComposerCreateCmd.Flags().BoolVarP(&composerCreateYesFlag, "yes", "y", false, "Yes - skip confirmation prompt")
+	ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+	   // Hide flag for this command
+	   command.Flags().MarkHidden("json-output")
+	   // Call parent help func
+     command.Parent().HelpFunc()(command, strings)
+	})
+	ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+	   // Hide flag for this command
+	   command.Flags().MarkHidden("json-output")
+	   // Call parent help func
+     command.Parent().HelpFunc()(command, strings)
+	})
 	ComposerCmd.AddCommand(ComposerCreateProjectCmd)
 	ComposerCmd.AddCommand(ComposerCreateCmd)
 }

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -233,19 +233,17 @@ func init() {
 	ComposerCreateCmd.InitDefaultHelpFlag()
 	ComposerCreateCmd.Flags().MarkHidden("help")
 	ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		// Hide flag for this command
 		command.Flags().MarkHidden("json-output")
-		// Call parent help func
-		command.Parent().HelpFunc()(command, strings)
+		// Double parent to prevent recursion
+		command.Parent().Parent().HelpFunc()(command, strings)
 	})
 
 	ComposerCreateProjectCmd.InitDefaultHelpFlag()
 	ComposerCreateProjectCmd.Flags().MarkHidden("help")
 	ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		// Hide flag for this command
 		command.Flags().MarkHidden("json-output")
-		// Call parent help func
-		command.Parent().HelpFunc()(command, strings)
+		// Double parent to prevent recursion
+		command.Parent().Parent().HelpFunc()(command, strings)
 	})
 	ComposerCmd.AddCommand(ComposerCreateProjectCmd)
 	ComposerCmd.AddCommand(ComposerCreateCmd)

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -231,7 +231,7 @@ for basic project creation or 'ddev ssh' into the web container and execute
 func init() {
 	ComposerCreateCmd.Flags().BoolVarP(&composerCreateYesFlag, "yes", "y", false, "Yes - skip confirmation prompt")
 	ComposerCreateCmd.InitDefaultHelpFlag()
-	err := ComposerCreateProjectCmd.Flags().MarkHidden("help")
+	err := ComposerCreateCmd.Flags().MarkHidden("help")
 	if err == nil {
 		ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
 			_ = command.Flags().MarkHidden("json-output")

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -230,17 +230,22 @@ for basic project creation or 'ddev ssh' into the web container and execute
 
 func init() {
 	ComposerCreateCmd.Flags().BoolVarP(&composerCreateYesFlag, "yes", "y", false, "Yes - skip confirmation prompt")
+	ComposerCreateCmd.InitDefaultHelpFlag()
+	ComposerCreateCmd.Flags().MarkHidden("help")
 	ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-	   // Hide flag for this command
-	   command.Flags().MarkHidden("json-output")
-	   // Call parent help func
-     command.Parent().HelpFunc()(command, strings)
+		// Hide flag for this command
+		command.Flags().MarkHidden("json-output")
+		// Call parent help func
+		command.Parent().HelpFunc()(command, strings)
 	})
+
+	ComposerCreateProjectCmd.InitDefaultHelpFlag()
+	ComposerCreateProjectCmd.Flags().MarkHidden("help")
 	ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-	   // Hide flag for this command
-	   command.Flags().MarkHidden("json-output")
-	   // Call parent help func
-     command.Parent().HelpFunc()(command, strings)
+		// Hide flag for this command
+		command.Flags().MarkHidden("json-output")
+		// Call parent help func
+		command.Parent().HelpFunc()(command, strings)
 	})
 	ComposerCmd.AddCommand(ComposerCreateProjectCmd)
 	ComposerCmd.AddCommand(ComposerCreateCmd)

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -233,7 +233,8 @@ func init() {
 	ComposerCreateCmd.InitDefaultHelpFlag()
 	ComposerCreateCmd.Flags().MarkHidden("help")
 	ComposerCreateCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		command.Flags().MarkHidden("json-output")
+		if err := command.Flags().MarkHidden("json-output"); err != nil {
+		}
 		// Double parent to prevent recursion
 		command.Parent().Parent().HelpFunc()(command, strings)
 	})
@@ -242,7 +243,8 @@ func init() {
 	err := ComposerCreateProjectCmd.Flags().MarkHidden("help")
 	if err == nil {
 		ComposerCreateProjectCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			command.Flags().MarkHidden("json-output")
+			if err := command.Flags().MarkHidden("json-output"); err != nil {
+			}
 			// Double parent to prevent recursion
 			command.Parent().Parent().HelpFunc()(command, strings)
 		})

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -11,6 +11,7 @@ import (
 
 // ComposerCmd handles ddev composer
 var ComposerCmd = &cobra.Command{
+	DisableFlagParsing: true,
 	Use:   "composer [command]",
 	Short: "Executes a composer command within the web container",
 	Long: `Executes a composer command at the composer root in the web container. Generally,
@@ -44,5 +45,4 @@ ddev composer create drupal/recommended-project`,
 
 func init() {
 	RootCmd.AddCommand(ComposerCmd)
-	ComposerCmd.Flags().SetInterspersed(false)
 }

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -44,6 +44,14 @@ ddev composer create drupal/recommended-project`,
 }
 
 func init() {
+	ComposerCmd.InitDefaultHelpFlag()
+	err := ComposerCmd.Flags().MarkHidden("help")
+	originalHelpFunc := ComposerCmd.HelpFunc()
+	if err == nil {
+		ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+			_ = command.Flags().MarkHidden("json-output")
+			originalHelpFunc(command, strings)
+		})
+	}
 	RootCmd.AddCommand(ComposerCmd)
-	ComposerCmd.Flags().SetInterspersed(false)
 }

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -12,8 +12,8 @@ import (
 // ComposerCmd handles ddev composer
 var ComposerCmd = &cobra.Command{
 	DisableFlagParsing: true,
-	Use:   "composer [command]",
-	Short: "Executes a composer command within the web container",
+	Use:                "composer [command]",
+	Short:              "Executes a composer command within the web container",
 	Long: `Executes a composer command at the composer root in the web container. Generally,
 any composer command can be forwarded to the container context by prepending
 the command with 'ddev'.`,
@@ -45,10 +45,12 @@ ddev composer create drupal/recommended-project`,
 
 func init() {
 	ComposerCmd.InitDefaultHelpFlag()
-	ComposerCmd.Flags().MarkHidden("help")
-	ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		command.Flags().MarkHidden("json-output")
-		command.Parent().HelpFunc()(command, strings)
-	})
+	err := ComposerCmd.Flags().MarkHidden("help")
+	if err == nil {
+		ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+			command.Flags().MarkHidden("json-output")
+			command.Parent().HelpFunc()(command, strings)
+		})
+	}
 	RootCmd.AddCommand(ComposerCmd)
 }

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -44,5 +44,13 @@ ddev composer create drupal/recommended-project`,
 }
 
 func init() {
+	ComposerCmd.InitDefaultHelpFlag()
+	ComposerCmd.Flags().MarkHidden("help")
+	ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		// Hide flag for this command
+		command.Flags().MarkHidden("json-output")
+		// Call parent help func
+		command.Parent().HelpFunc()(command, strings)
+	})
 	RootCmd.AddCommand(ComposerCmd)
 }

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -47,9 +47,7 @@ func init() {
 	ComposerCmd.InitDefaultHelpFlag()
 	ComposerCmd.Flags().MarkHidden("help")
 	ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		// Hide flag for this command
 		command.Flags().MarkHidden("json-output")
-		// Call parent help func
 		command.Parent().HelpFunc()(command, strings)
 	})
 	RootCmd.AddCommand(ComposerCmd)

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -44,13 +44,6 @@ ddev composer create drupal/recommended-project`,
 }
 
 func init() {
-	ComposerCmd.InitDefaultHelpFlag()
-	err := ComposerCmd.Flags().MarkHidden("help")
-	if err == nil {
-		ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			_ = command.Flags().MarkHidden("json-output")
-			command.Parent().HelpFunc()(command, strings)
-		})
-	}
 	RootCmd.AddCommand(ComposerCmd)
+	ComposerCmd.Flags().SetInterspersed(false)
 }

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -48,7 +48,8 @@ func init() {
 	err := ComposerCmd.Flags().MarkHidden("help")
 	if err == nil {
 		ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			command.Flags().MarkHidden("json-output")
+			if err := command.Flags().MarkHidden("json-output"); err != nil {
+			}
 			command.Parent().HelpFunc()(command, strings)
 		})
 	}

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -49,7 +49,7 @@ func init() {
 	originalHelpFunc := ComposerCmd.HelpFunc()
 	if err == nil {
 		ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			if (command == ComposerCmd) {
+			if command == ComposerCmd {
 				_ = command.Flags().MarkHidden("json-output")
 			}
 			originalHelpFunc(command, strings)

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -49,7 +49,9 @@ func init() {
 	originalHelpFunc := ComposerCmd.HelpFunc()
 	if err == nil {
 		ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			_ = command.Flags().MarkHidden("json-output")
+			if (command == ComposerCmd) {
+				_ = command.Flags().MarkHidden("json-output")
+			}
 			originalHelpFunc(command, strings)
 		})
 	}

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -48,8 +48,7 @@ func init() {
 	err := ComposerCmd.Flags().MarkHidden("help")
 	if err == nil {
 		ComposerCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			if err := command.Flags().MarkHidden("json-output"); err != nil {
-			}
+			_ = command.Flags().MarkHidden("json-output")
 			command.Parent().HelpFunc()(command, strings)
 		})
 	}

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -169,6 +169,13 @@ The following fields can be used for a flag definition:
 * `NoOptDefVal`: default value, if the flag is on the command line without any options
 * `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/master/bash_completions.md>)
 
+Command flags can also be disabled, meaning that you have full control over the 
+flags passed to the command without any validaton or requirement. This will 
+allow for things like `ddev platform --help` to work. To disable flags simply
+set the `## Flags` anotation to `false`.
+
+`## Flags: false`
+
 ### “ProjectTypes” Annotation
 
 If your command should only be visible for a specific project type, `ProjectTypes` will allow you to define the supported types. This is especially useful for global custom commands. See [Quickstart for many CMSes](../../users/quickstart.md) for more information about the supported project types. Multiple types are separated by a comma.

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -128,6 +128,47 @@ Usage: `## Example: <command-example>`
 
 Example: `## Example: commandname\ncommandname -h`
 
+### “Flags” Annotation
+
+`Flags` should explain any available flags, including their shorthand when relevant, for the help message. It has to be encoded according the following definition:
+
+Usage: `## Flags: <json-definition>`
+
+This is the minimal usage of a flags definition:
+
+Example: `## Flags: [{"Name":"flag","Usage":"sets the flag option"}]`
+
+Output:
+
+```bash
+Flags:
+  -h, --help          help for ddev
+  -f, --flag          sets the flag option
+```
+
+Multiple flags are separated by a comma:
+
+Example: `## Flags: [{"Name":"flag1","Shorthand":"f","Usage":"flag1 usage"},{"Name":"flag2","Usage":"flag2 usage"}]`
+
+Output:
+
+```bash
+Flags:
+  -h, --help          help for ddev
+  -f, --flag1         flag1 usage
+      --flag2         flag2 usage
+```
+
+The following fields can be used for a flag definition:
+
+* `Name`: the name as it appears on command line
+* `Shorthand`: one-letter abbreviated flag
+* `Usage`: help message
+* `Type`: possible values are `bool`, `string`, `int`, `uint` (defaults to `bool`)
+* `DefValue`: default value for usage message
+* `NoOptDefVal`: default value, if the flag is on the command line without any options
+* `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/master/bash_completions.md>)
+
 ### “ProjectTypes” Annotation
 
 If your command should only be visible for a specific project type, `ProjectTypes` will allow you to define the supported types. This is especially useful for global custom commands. See [Quickstart for many CMSes](../../users/quickstart.md) for more information about the supported project types. Multiple types are separated by a comma.

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -132,7 +132,7 @@ Example: `## Example: commandname\ncommandname -h`
 
 `Flags` should explain any available flags, including their shorthand when relevant, for the help message. It has to be encoded according the following definition:
 
-If no flags are specified, the command will have its flags parsing disabled. Global flags like `--help` and `--version` will not work unless the command supports them.
+If no flags are specified, the command will have its flags parsing disabled. Global flags like `--help` will not work unless the command supports them.
 
 You can still do `ddev help <command>` to see the command's provided usage help.
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -132,9 +132,7 @@ Example: `## Example: commandname\ncommandname -h`
 
 `Flags` should explain any available flags, including their shorthand when relevant, for the help message. It has to be encoded according the following definition:
 
-If no flags are specified, the command will have its flags parsing disabled. 
-Things like `--help` and `--version` will not work unless the command supports
-them.
+If no flags are specified, the command will have its flags parsing disabled. Things like `--help` and `--version` will not work unless the command supports them.
 
 You can still do `ddev help <command>` to see the command's provided usage help.
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -132,7 +132,7 @@ Example: `## Example: commandname\ncommandname -h`
 
 `Flags` should explain any available flags, including their shorthand when relevant, for the help message. It has to be encoded according the following definition:
 
-If no flags are specified, the command will have its flags parsing disabled. Things like `--help` and `--version` will not work unless the command supports them.
+If no flags are specified, the command will have its flags parsing disabled. Global flags like `--help` and `--version` will not work unless the command supports them.
 
 You can still do `ddev help <command>` to see the command's provided usage help.
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -170,9 +170,9 @@ The following fields can be used for a flag definition:
 * `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/master/bash_completions.md>)
 
 Command flags can also be disabled, meaning that you have full control over the 
-flags passed to the command without any validaton or requirement. This will 
+flags passed to the command without any validation or requirement. This will 
 allow for things like `ddev platform --help` to work. To disable flags simply
-set the `## Flags` anotation to `false`.
+set the `## Flags` annotation to `false`.
 
 `## Flags: false`
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -132,6 +132,12 @@ Example: `## Example: commandname\ncommandname -h`
 
 `Flags` should explain any available flags, including their shorthand when relevant, for the help message. It has to be encoded according the following definition:
 
+If no flags are specified, the command will have its flags parsing disabled. 
+Things like `--help` and `--version` will not work unless the command supports
+them.
+
+You can still do `ddev help <command>` to see the command's provided usage help.
+
 Usage: `## Flags: <json-definition>`
 
 This is the minimal usage of a flags definition:
@@ -168,13 +174,6 @@ The following fields can be used for a flag definition:
 * `DefValue`: default value for usage message
 * `NoOptDefVal`: default value, if the flag is on the command line without any options
 * `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/master/bash_completions.md>)
-
-Command flags can also be disabled, meaning that you have full control over the 
-flags passed to the command without any validation or requirement. This will 
-allow for things like `ddev platform --help` to work. To disable flags simply
-set the `## Flags` annotation to `false`.
-
-`## Flags: false`
 
 ### “ProjectTypes” Annotation
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -128,47 +128,6 @@ Usage: `## Example: <command-example>`
 
 Example: `## Example: commandname\ncommandname -h`
 
-### “Flags” Annotation
-
-`Flags` should explain any available flags, including their shorthand when relevant, for the help message. It has to be encoded according the following definition:
-
-Usage: `## Flags: <json-definition>`
-
-This is the minimal usage of a flags definition:
-
-Example: `## Flags: [{"Name":"flag","Usage":"sets the flag option"}]`
-
-Output:
-
-```bash
-Flags:
-  -h, --help          help for ddev
-  -f, --flag          sets the flag option
-```
-
-Multiple flags are separated by a comma:
-
-Example: `## Flags: [{"Name":"flag1","Shorthand":"f","Usage":"flag1 usage"},{"Name":"flag2","Usage":"flag2 usage"}]`
-
-Output:
-
-```bash
-Flags:
-  -h, --help          help for ddev
-  -f, --flag1         flag1 usage
-      --flag2         flag2 usage
-```
-
-The following fields can be used for a flag definition:
-
-* `Name`: the name as it appears on command line
-* `Shorthand`: one-letter abbreviated flag
-* `Usage`: help message
-* `Type`: possible values are `bool`, `string`, `int`, `uint` (defaults to `bool`)
-* `DefValue`: default value for usage message
-* `NoOptDefVal`: default value, if the flag is on the command line without any options
-* `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/master/bash_completions.md>)
-
 ### “ProjectTypes” Annotation
 
 If your command should only be visible for a specific project type, `ProjectTypes` will allow you to define the supported types. This is especially useful for global custom commands. See [Quickstart for many CMSes](../../users/quickstart.md) for more information about the supported project types. Multiple types are separated by a comma.

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -4,6 +4,7 @@
 ## Description: Launch a browser with the current site
 ## Usage: launch [path] [-p|--phpmyadmin] [-m|--mailhog]
 ## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php", for PHPMyAdmin "ddev launch -p", MailHog "ddev launch -m"
+## Flags: [{"Name":"phpmyadmin","Shorthand":"p","Usage":"ddev launch -p runs the PhpMyAdmin UI"},{"Name":"mailhog","Shorthand":"m","Usage":"ddev launch -m launches the mailhog UI"}]
 
 FULLURL=${DDEV_PRIMARY_URL}
 HTTPS=""
@@ -11,10 +12,6 @@ if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then HTTPS=true; fi
 
 while :; do
      case ${1:-} in
-         -h|-\?|--help)
-             show_help
-             exit
-             ;;
          -p|--phpmyadmin)
             if [ "${HTTPS}" = "" ]; then
                 FULLURL="${FULLURL%:[0-9]*}:${DDEV_PHPMYADMIN_PORT}"
@@ -71,3 +68,4 @@ case $OSTYPE in
     start ${FULLURL}
     ;;
 esac
+

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
@@ -5,6 +5,7 @@
 ## Usage: blackfire start|stop|on|off|enable|disable|true|false|status
 ## Example: "ddev blackfire" (default is "on"), "ddev blackfire off", "ddev blackfire on", "ddev blackfire status"
 ## ExecRaw: false
+## Flags: []
 
 function enable {
   if [ -z ${BLACKFIRE_SERVER_ID} ] || [ -z ${BLACKFIRE_SERVER_TOKEN} ]; then

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
@@ -5,6 +5,7 @@
 ## Usage: xdebug on|off|enable|disable|true|false|status
 ## Example: "ddev xdebug" (default is "on"), "ddev xdebug off", "ddev xdebug on", "ddev xdebug status"
 ## Execraw: false
+## Flags: []
 
 if [ $# -eq 0 ] ; then
   enable_xdebug

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xhprof
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xhprof
@@ -5,6 +5,7 @@
 ## Usage: xhprof on|off|enable|disable|true|false|status
 ## Example: "ddev xhprof" (default is "on"), "ddev xhprof off", "ddev xhprof on", "ddev xhprof status"
 ## ExecRaw: false
+## Flags: []
 
 if [ $# -eq 0 ]; then
   enable_xhprof


### PR DESCRIPTION
Disables flag parsing for custom commands and some internal ones.

Attempts to solve #4225.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4283"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

