### PR TITLE
[docs] Improve Craft CMS installation instructions

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -435,8 +435,8 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ddev config --project-type=craftcms
         ddev composer create -y --no-scripts --no-install craftcms/craft
         ddev start
-        ddev composer install
-        ddev craft setup/welcome
+        ddev composer update
+        ddev craft install
         ddev launch
         ```
 
@@ -451,8 +451,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         unzip latest-v4.zip && rm latest-v4.zip
         ddev config --project-type=craftcms
         ddev start
-        ddev composer install
-        ddev craft setup/welcome
+        ddev craft install
         ddev launch
         ```
 


### PR DESCRIPTION
This PR makes the following improvements to the Craft CMS instructions in the [CMS Quickstarts](https://ddev.readthedocs.io/en/stable/users/quickstart/) page:

- Swaps `composer install` for `composer update`, since the `craftcms/craft` project doesn't have a `composer.lock` file. (Avoids a Composer warning about the missing .lock file.)
- Swaps `ddev craft setup/welcome` for `ddev craft install`, taking advantage of a simplified install process with Craft CMS 4.2.7 + DDEV 1.21.2.
- Removes the `composer install` step from the “Manual download” instructions, since `latest-v4.zip` already has a fully-loaded `vendor/` folder.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4284"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

