### PR TITLE
Shorten the descriptor used for docker/mutagen label, fixes #4285

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -49,6 +49,7 @@ unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
+  MUTAGEN_DATA_DIRECTORRY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a
 fi
 if command -v killall >/dev/null ; then
   killall mutagen || true

--- a/cmd/ddev/cmd/snapshot_restore_test.go
+++ b/cmd/ddev/cmd/snapshot_restore_test.go
@@ -30,7 +30,7 @@ func TestCmdSnapshotRestore(t *testing.T) {
 		assert.NoError(err)
 	})
 
-	err = app.Start()
+	err = app.Restart()
 	require.NoError(t, err)
 
 	// Ensure that a snapshot is created

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -737,8 +737,7 @@ func TerminateAllMutagenSync() {
 
 // GetDefaultMutagenVolumeSignature gets a new volume signature to be applied to mutagen volume
 func GetDefaultMutagenVolumeSignature(app *DdevApp) string {
-	now := time.Now()
-	return fmt.Sprintf("%s-%s", dockerutil.GetDockerHostID(), now.Format("20060102150405"))
+	return fmt.Sprintf("%s-%v", dockerutil.GetDockerHostID(), time.Now().Unix())
 }
 
 // CheckMutagenUploadDir just tells people if they are using mutagen without upload_dir

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/versionconstants"
-	"github.com/mitchellh/go-homedir"
 	"io"
 	"log"
 	"net"
@@ -144,10 +143,8 @@ func GetDockerHostID() string {
 	}
 	// Make it shorter so we don't hit mutagen 63-char limit
 	dockerHost = strings.TrimPrefix(dockerHost, "unix://")
-	homeDir, _ := homedir.Dir()
-	dockerHost = strings.TrimPrefix(dockerHost, homeDir)
-	dockerHost = strings.TrimLeft(dockerHost, "/.")
-	dockerHost = strings.TrimSuffix(dockerHost, ".sock")
+	dockerHost = strings.TrimSuffix(dockerHost, "docker.sock")
+	dockerHost = strings.Trim(dockerHost, "/.")
 	// Convert remaining descriptor to alphanumeric
 	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
 	if err != nil {


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4285 

## How this PR Solves The Problem:

Shorten the label used by removing the homedir and changing the time label

## Manual Testing Instructions:

Try it out, `docker volume inspect <project>_project_mutagen` should show the shorter label. In my case it's 33 characters.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4289"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

