### PR TITLE
Don't try to stop default mutagen daemon on `ddev poweroff`

### DIFF
--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -495,11 +495,6 @@ func StopMutagenDaemon() {
 			util.Warning("Unable to stop mutagen daemon: %v; MUTAGEN_DATA_DIRECTORY=%s", err, mutagenDataDirectory)
 		}
 		util.Success("Stopped mutagen daemon")
-		// There may be an old mutagen daemon running against ~/.mutagen; try to stop it as well
-		out, err = exec.RunHostCommand("sh", "-c", fmt.Sprintf("MUTAGEN_DATA_DIRECTORY=~/.mutagen %s daemon  stop", globalconfig.GetMutagenPath()))
-		if err != nil && !strings.Contains(out, "unable to connect to daemon") {
-			util.Warning("Unable to stop old mutagen daemon: %v; MUTAGEN_DATA_DIRECTORY=~/.mutagen", err)
-		}
 	}
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Currently, `ddev poweroff` tries to stop an existing mutagen daemon running against the traditional/normal ~/.mutagen, which we don't use any more. 

This is probably a bit too intrusive, as that daemon may have reasonable non-DDEV versions for running. 

It also results in creation of ~/.mutagen, as discovered by @rpkoller (thanks!)

## How this PR Solves The Problem:

Just don't try. 

## Manual Testing Instructions:

Remove ~/.mutagen, then `ddev start && ddev poweroff`, no mutagen daemons should be running, and ~/.mutagen should not exist.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4291"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

