### PR TITLE
[docs] Refine navigation setup

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -594,6 +594,7 @@ tls
 tlsverify
 tmp
 to
+toc
 transactional
 true
 txt

--- a/docs/content/developers/github-selfhosted-setup.md
+++ b/docs/content/developers/github-selfhosted-setup.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # GitHub Self-Hosted Agent Setup
 
 We are using GitHub Self-Hosted Agents for Windows and macOS testing. The build machines and agents must be set up before use.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # Get Started with DDEV
 
 [DDEV](https://github.com/drud/ddev) is an open source tool for launching local PHP development environments in minutes.

--- a/docs/content/users/support.md
+++ b/docs/content/users/support.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # Support
 
 We love to hear from you and want you to be successful with DDEV!

--- a/docs/content/users/topics/cms_specific_help.md
+++ b/docs/content/users/topics/cms_specific_help.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # Controlling CMS Settings Files in DDEV
 
 One DDEV feature that lots of people love is its creation and management of CMS-specific settings files. This makes starting and installing a new project a breeze, and is a fantastic time-saver for many users. People can follow one of the many DDEV [Quickstart Guides](../../users/quickstart.md) and have a project up and installed in no time. To make this happen, DDEV does a quite a bit of settings management for explicitly-supported CMSes. DDEV will:

--- a/docs/content/users/topics/webserver.md
+++ b/docs/content/users/topics/webserver.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # Webserver-Specific Help and Techniques
 
 ## Apache

--- a/docs/content/users/topics/whats_in_ddev_dir.md
+++ b/docs/content/users/topics/whats_in_ddev_dir.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # What’s in the `.ddev` Directory?
 
 It can be a little confusing trying to understand all the things that are in the project’s `.ddev` directory, this page offers a guided tour of its contents. You may have some directories or files that aren’t listed here, likely added by custom services. For example, if you see a `solr` directory, it probably pertains to a custom Solr [add-on service](../extend/additional-services.md)).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,14 +28,14 @@ theme:
 #  - content.tabs.link
   - navigation.expand
   - navigation.indexes
-#  - navigation.instant
+  - navigation.instant
   - navigation.sections
   - navigation.tabs
 #  - navigation.tabs.sticky
   - navigation.top
-#  - navigation.tracking
+  - navigation.tracking
 #  - toc.follow
-  - toc.integrate
+#  - toc.integrate
 
   favicon: favicon.png
   # readthedocs doesn't seem to do logo css right
@@ -79,6 +79,7 @@ markdown_extensions:
 - md_in_html
 - toc:
     permalink: true
+    toc_depth: 2
 - pymdownx.arithmatex:
     generic: true
 - pymdownx.betterem:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,11 +110,12 @@ nav:
       - users/install/index.md
       - users/install/docker-installation.md
       - users/install/ddev-installation.md
+    - 'Settling In':
       - users/install/performance.md
       - users/install/shell-completion.md
-    - users/quickstart.md
-    - users/support.md
-    - users/code-of-conduct.md
+      - users/quickstart.md
+      - users/support.md
+      - users/code-of-conduct.md
   - 'Basics':
     - users/basics/index.md
     - users/basics/how-ddev-works.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,7 +110,7 @@ nav:
       - users/install/index.md
       - users/install/docker-installation.md
       - users/install/ddev-installation.md
-    - 'Settling In':
+    - 'Getting Started':
       - users/install/performance.md
       - users/install/shell-completion.md
       - users/quickstart.md


### PR DESCRIPTION
## The Problem/Issue/Bug:

As demonstrated by the changes in #4293, the combined section and on-page sidebar navigation can get _in the way_ of browsing a section or page—which is its sole purpose:

![FAQ page revisions with current navigation](https://user-images.githubusercontent.com/2488775/195686902-ff70cf9e-c4ec-42fb-af36-acf4e7e7c1cf.png)

The problem isn’t just limited to suggested FAQ page revisions, though. The same imbalance is demonstrated on the [Extending and Customizing Environments](https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/) page:

![Extending page with current navigation](https://user-images.githubusercontent.com/2488775/195687834-bf5af28c-9190-4c38-aa14-156a2e803ac2.png)

## How this PR Solves The Problem:

This PR makes a few changes to the theme configuration to balance things out and make the navigation more useful for browsing:

1. Separates the on-page table of contents from section navigation by disabling [`navigation.integrate`](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=instant#navigation-integration). This makes it easier to focus on the flow of an entire section, or of a page, without confusing the two or overloading one side of the page—and with a negligible impact on line length.
2. Limits on-page table of contents to two levels ([`toc_depth: 2`](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/?h=toc_depth#+toc.toc_depth)), which further emphasizes (and encourages!) thoughtful organization without overloading the table of contents.
3. Uses frontmatter to hide the table of contents on pages where it takes visual attention without offering any value.
4. Enables instant loading with [`navigation.instant`](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=instant#instant-loading), which seems to work well and speed up browsing—which translates to better user experience.
5. Enables [`navigation.tracking`](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=instant#anchor-tracking) so the address bar updates with current anchors on scroll.
6. Slightly reorganizes the landing page’s sidebar to include a “Settling In” section meant for post-install adventures. (Currently, installation steps wander into configuration and community details, with an awkward vertical space.)

The result is cleaner, more balanced, and easier to navigate despite varying page organization and length:

![FAQ page revisions with improved navigation](https://user-images.githubusercontent.com/2488775/195691992-3a4c28a9-5e0f-4510-97fc-2a9969dde58a.png)

![Extending page with improved navigation](https://user-images.githubusercontent.com/2488775/195692661-67f8425c-7c37-470a-bd93-98c226868804.png)

<img width="940" alt="sidebar-before-and-after" src="https://user-images.githubusercontent.com/2488775/195693302-5f915829-fb66-44a3-846d-1fdbd48e3764.png">

## Manual Testing Instructions:

https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes

## Automated Testing Overview:

n/a

## Related Issue Link(s):

Part of this overall effort:

- #4188

## Release/Deployment notes:

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4294"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

