### PR TITLE
Alphabetize `ddev get` services list

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -1,6 +1,7 @@
 ARG
 AdditionalConfig
 AdditionalConfiguration
+Adminer
 Apache
 Acquia
 Autocompletion

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -291,10 +291,7 @@ func renderRepositoryList(repos []github.Repository) string {
 		},
 	})
 	sort.Slice(repos, func(i, j int) bool {
-		if repos[i].GetOwner().GetLogin() == "drud" {
-			return true
-		}
-		return false
+		return strings.Compare(strings.ToLower(repos[i].GetFullName()), strings.ToLower(repos[j].GetFullName())) == -1
 	})
 	t.AppendHeader(table.Row{"Add-on", "Description"})
 

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -1,4 +1,3 @@
-
 # Additional Service Configurations & Add-ons
 
 DDEV projects can be extended to provide additional add-ons, including services. You can define these add-ons using docker-compose files in the project’s `.ddev` directory.
@@ -14,53 +13,53 @@ For example,
 ┌───────────────────────────┬──────────────────────────────────────────────────┐
 │ ADD-ON                    │ DESCRIPTION                                      │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-memcached       │ Install Memcached as an extra service in DDEV*   │
+│ drud/ddev-adminer         │ Adminer service for DDEV*                        │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-beanstalkd      │ Beanstalkd for DDEV*                             │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-browsersync     │ Auto-refresh HTTPS page on changes with DDEV*    │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-cron            │ Schedule commands to execute within DDEV*        │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-drupal9-solr    │ Drupal 9 Apache Solr installation for DDEV*      │
+├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-elasticsearch   │ Elasticsearch add-on for DDEV*                   │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-memcached       │ Install Memcached as an extra service in DDEV*   │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-mongo           │ MongoDB add-on for DDEV*                         │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-pdfreactor      │ PDFreactor service for DDEV*                     │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-browsersync     │ Auto-refresh HTTPS page on changes with DDEV*    │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-drupal9-solr    │ Drupal 9 Apache Solr installation for DDEV*      │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-varnish         │ Varnish reverse proxy add-on for DDEV*           │
+│ drud/ddev-proxy-support   │ Support HTTP/HTTPS proxies with DDEV*            │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-redis           │ Redis service for DDEV*                          │
 ├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-adminer         │ Adminer service for DDEV*                        │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-cron            │ Schedule commands to execute within DDEV*        │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-proxy-support   │ Support HTTP/HTTPS proxies with DDEV*            │
-├───────────────────────────┼──────────────────────────────────────────────────┤
 │ drud/ddev-redis-commander │ Redis Commander for use with DDEV Redis service* │
+├───────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-varnish         │ Varnish reverse proxy add-on for DDEV*           │
 └───────────────────────────┴──────────────────────────────────────────────────┘
 Add-ons marked with '*' are official, maintained DDEV add-ons.
 ```
 
 !!!tip
-    If you need a service not provided here, see [Defining an Additional Service with Docker Compose](custom-compose-files.md).
+If you need a service not provided here, see [Defining an Additional Service with Docker Compose](custom-compose-files.md).
 
 Officially-supported add-ons:
 
-* [Adminer](https://github.com/drud/ddev-adminer): `ddev get drud/ddev-adminer`.
-* [Apache Solr for Drupal 9](https://github.com/drud/ddev-drupal9-solr): `ddev get drud/ddev-drupal9-solr`.
-* [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev get drud/ddev-beanstalkd`.
-* [Browsersync](https://github.com/drud/ddev-browsersync): `ddev get drud/ddev-browsersync`.
-* [cron](https://github.com/drud/ddev-cron): `ddev get drud/ddev-cron`.
-* [Elasticsearch](https://github.com/drud/ddev-elasticsearch): `ddev get drud/ddev-elasticsearch`.
-* [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
-* [MongoDB](https://github.com/drud/ddev-mongo): `ddev get drud/ddev-mongo`.
-* [PDFreactor](https://github.com/drud/ddev-pdfreactor): `ddev get drud/ddev-pdfreactor`
-* [Proxy Support](https://github.com/drud/ddev-proxy-support): `ddev get drud/ddev-proxy-support`.
-* [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
-* [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.
-* [Varnish](https://github.com/drud/ddev-varnish): `ddev get drud/ddev-varnish`.
+- [Adminer](https://github.com/drud/ddev-adminer): `ddev get drud/ddev-adminer`.
+- [Apache Solr for Drupal 9](https://github.com/drud/ddev-drupal9-solr): `ddev get drud/ddev-drupal9-solr`.
+- [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev get drud/ddev-beanstalkd`.
+- [Browsersync](https://github.com/drud/ddev-browsersync): `ddev get drud/ddev-browsersync`.
+- [cron](https://github.com/drud/ddev-cron): `ddev get drud/ddev-cron`.
+- [Elasticsearch](https://github.com/drud/ddev-elasticsearch): `ddev get drud/ddev-elasticsearch`.
+- [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
+- [MongoDB](https://github.com/drud/ddev-mongo): `ddev get drud/ddev-mongo`.
+- [PDFreactor](https://github.com/drud/ddev-pdfreactor): `ddev get drud/ddev-pdfreactor`
+- [Proxy Support](https://github.com/drud/ddev-proxy-support): `ddev get drud/ddev-proxy-support`.
+- [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
+- [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.
+- [Varnish](https://github.com/drud/ddev-varnish): `ddev get drud/ddev-varnish`.
 
 ## Creating an Additional Service for `ddev get`
 
@@ -77,11 +76,11 @@ Anyone can create an add-on for `ddev get`. See [this screencast](https://www.yo
 
 The `install.yaml` is a simple YAML file with a few main sections:
 
-* `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
-* `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
-* `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
-* `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
-* `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
+- `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
+- `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
+- `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
+- `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
+- `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
 
 You can see a simple `install.yaml` in [`ddev-addon-template`’s `install.yaml`](https://github.com/drud/ddev-addon-template/blob/main/install.yaml).
 
@@ -100,8 +99,8 @@ value1: xxx
 is referenced using
 
 ```yaml
-yaml_read_files: 
- example: example_yaml.yaml
+yaml_read_files:
+  example: example_yaml.yaml
 ```
 
 then `value1` can be used throughout the `install.yaml` as `{{ example.value1 }}` and it will be replaced with the value `xxx`.
@@ -110,17 +109,17 @@ More exotic template-based replacements can be seen in an advanced test [example
 
 Go templating resources:
 
-* [Official Go template docs](https://pkg.go.dev/text/template)
-* [Lots of intro to Golang templates](https://www.google.com/search?q=golang+templates+intro&oq=golang+templates+intro&aqs=chrome..69i57j0i546l4.3161j0j4&sourceid=chrome&ie=UTF-8)
-* [masterminds/sprig](http://masterminds.github.io/sprig/) extra functions.
+- [Official Go template docs](https://pkg.go.dev/text/template)
+- [Lots of intro to Golang templates](https://www.google.com/search?q=golang+templates+intro&oq=golang+templates+intro&aqs=chrome..69i57j0i546l4.3161j0j4&sourceid=chrome&ie=UTF-8)
+- [masterminds/sprig](http://masterminds.github.io/sprig/) extra functions.
 
 ## Additional services in ddev-contrib (MongoDB, Elasticsearch, etc)
 
 Commonly-used services will be migrated from the [ddev-contrib](https://github.com/drud/ddev-contrib) repository to individual, tested, supported repositories, but the repository already has a wealth of additional examples and instructions:
 
-* **Headless Chrome**: See [Headless Chrome for Behat Testing](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/headless-chrome)
-* **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/old_php)
-* **RabbitMQ**: See [RabbitMQ](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
-* **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/typo3-solr)
+- **Headless Chrome**: See [Headless Chrome for Behat Testing](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/headless-chrome)
+- **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/old_php)
+- **RabbitMQ**: See [RabbitMQ](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
+- **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/typo3-solr)
 
 Your pull requests to integrate other services are welcome at [ddev-contrib](https://github.com/drud/ddev-contrib).

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -47,19 +47,19 @@ If you need a service not provided here, see [Defining an Additional Service wit
 
 Officially-supported add-ons:
 
-- [Adminer](https://github.com/drud/ddev-adminer): `ddev get drud/ddev-adminer`.
-- [Apache Solr for Drupal 9](https://github.com/drud/ddev-drupal9-solr): `ddev get drud/ddev-drupal9-solr`.
-- [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev get drud/ddev-beanstalkd`.
-- [Browsersync](https://github.com/drud/ddev-browsersync): `ddev get drud/ddev-browsersync`.
-- [cron](https://github.com/drud/ddev-cron): `ddev get drud/ddev-cron`.
-- [Elasticsearch](https://github.com/drud/ddev-elasticsearch): `ddev get drud/ddev-elasticsearch`.
-- [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
-- [MongoDB](https://github.com/drud/ddev-mongo): `ddev get drud/ddev-mongo`.
-- [PDFreactor](https://github.com/drud/ddev-pdfreactor): `ddev get drud/ddev-pdfreactor`
-- [Proxy Support](https://github.com/drud/ddev-proxy-support): `ddev get drud/ddev-proxy-support`.
-- [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
-- [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.
-- [Varnish](https://github.com/drud/ddev-varnish): `ddev get drud/ddev-varnish`.
+* [Adminer](https://github.com/drud/ddev-adminer): `ddev get drud/ddev-adminer`.
+* [Apache Solr for Drupal 9](https://github.com/drud/ddev-drupal9-solr): `ddev get drud/ddev-drupal9-solr`.
+* [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev get drud/ddev-beanstalkd`.
+* [Browsersync](https://github.com/drud/ddev-browsersync): `ddev get drud/ddev-browsersync`.
+* [cron](https://github.com/drud/ddev-cron): `ddev get drud/ddev-cron`.
+* [Elasticsearch](https://github.com/drud/ddev-elasticsearch): `ddev get drud/ddev-elasticsearch`.
+* [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
+* [MongoDB](https://github.com/drud/ddev-mongo): `ddev get drud/ddev-mongo`.
+* [PDFreactor](https://github.com/drud/ddev-pdfreactor): `ddev get drud/ddev-pdfreactor`
+* [Proxy Support](https://github.com/drud/ddev-proxy-support): `ddev get drud/ddev-proxy-support`.
+* [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
+* [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.
+* [Varnish](https://github.com/drud/ddev-varnish): `ddev get drud/ddev-varnish`.
 
 ## Creating an Additional Service for `ddev get`
 
@@ -76,11 +76,11 @@ Anyone can create an add-on for `ddev get`. See [this screencast](https://www.yo
 
 The `install.yaml` is a simple YAML file with a few main sections:
 
-- `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
-- `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
-- `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
-- `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
-- `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
+* `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
+* `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
+* `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
+* `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
+* `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
 
 You can see a simple `install.yaml` in [`ddev-addon-template`’s `install.yaml`](https://github.com/drud/ddev-addon-template/blob/main/install.yaml).
 
@@ -109,17 +109,17 @@ More exotic template-based replacements can be seen in an advanced test [example
 
 Go templating resources:
 
-- [Official Go template docs](https://pkg.go.dev/text/template)
-- [Lots of intro to Golang templates](https://www.google.com/search?q=golang+templates+intro&oq=golang+templates+intro&aqs=chrome..69i57j0i546l4.3161j0j4&sourceid=chrome&ie=UTF-8)
-- [masterminds/sprig](http://masterminds.github.io/sprig/) extra functions.
+* [Official Go template docs](https://pkg.go.dev/text/template)
+* [Lots of intro to Golang templates](https://www.google.com/search?q=golang+templates+intro&oq=golang+templates+intro&aqs=chrome..69i57j0i546l4.3161j0j4&sourceid=chrome&ie=UTF-8)
+* [masterminds/sprig](http://masterminds.github.io/sprig/) extra functions.
 
 ## Additional services in ddev-contrib (MongoDB, Elasticsearch, etc)
 
 Commonly-used services will be migrated from the [ddev-contrib](https://github.com/drud/ddev-contrib) repository to individual, tested, supported repositories, but the repository already has a wealth of additional examples and instructions:
 
-- **Headless Chrome**: See [Headless Chrome for Behat Testing](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/headless-chrome)
-- **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/old_php)
-- **RabbitMQ**: See [RabbitMQ](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
-- **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/typo3-solr)
+* **Headless Chrome**: See [Headless Chrome for Behat Testing](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/headless-chrome)
+* **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/old_php)
+* **RabbitMQ**: See [RabbitMQ](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
+* **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/typo3-solr)
 
 Your pull requests to integrate other services are welcome at [ddev-contrib](https://github.com/drud/ddev-contrib).

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -46,17 +46,21 @@ Add-ons marked with '*' are official, maintained DDEV add-ons.
 !!!tip
     If you need a service not provided here, see [Defining an Additional Service with Docker Compose](custom-compose-files.md).
 
-Some of the officially-supported add-ons:
+Officially-supported add-ons:
 
-* [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.
-* [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
-* [elasticsearch](https://github.com/drud/ddev-elasticsearch): `ddev get drud/ddev-elasticsearch`.
+* [Adminer](https://github.com/drud/ddev-adminer): `ddev get drud/ddev-adminer`.
 * [Apache Solr for Drupal 9](https://github.com/drud/ddev-drupal9-solr): `ddev get drud/ddev-drupal9-solr`.
+* [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev get drud/ddev-beanstalkd`.
+* [Browsersync](https://github.com/drud/ddev-browsersync): `ddev get drud/ddev-browsersync`.
+* [cron](https://github.com/drud/ddev-cron): `ddev get drud/ddev-cron`.
+* [Elasticsearch](https://github.com/drud/ddev-elasticsearch): `ddev get drud/ddev-elasticsearch`.
 * [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
-* [Varnish](https://github.com/drud/ddev-varnish): `ddev get drud/ddev-varnish`.
 * [MongoDB](https://github.com/drud/ddev-mongo): `ddev get drud/ddev-mongo`.
 * [PDFreactor](https://github.com/drud/ddev-pdfreactor): `ddev get drud/ddev-pdfreactor`
-* [Beanstalkd](https://github.com/drud/ddev-beanstalkd): `ddev get drud/ddev-beanstalkd`.
+* [Proxy Support](https://github.com/drud/ddev-proxy-support): `ddev get drud/ddev-proxy-support`.
+* [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
+* [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.
+* [Varnish](https://github.com/drud/ddev-varnish): `ddev get drud/ddev-varnish`.
 
 ## Creating an Additional Service for `ddev get`
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

1. `ddev get --list` returns its results in no particular order, requiring the user to read the whole list in search of something specific.
2. The bulleted list on the [Additional Service Configurations & Add-ons](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/) page is incomplete and also randomly organized.

## How this PR Solves The Problem:

This PR updates the page in the docs and changes the existing sort (favoring `drud` only), so that results are alphabetized by project name.

This happens to group `drud/*` projects at the top, even though their accompanying asterisk `*` already identifies first-party add-ons regardless of where they appear in the table. (So arguably not a problem if `acme/ddev-foo` comes along.)

### Before

```
❯ ddev get --list
┌───────────────────────────┬──────────────────────────────────────────────────┐
│ ADD-ON                    │ DESCRIPTION                                      │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-memcached       │ Install Memcached as an extra service in DDEV*   │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-beanstalkd      │ Beanstalkd for DDEV*                             │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-elasticsearch   │ Elasticsearch add-on for DDEV*                   │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-mongo           │ MongoDB add-on for DDEV*                         │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-pdfreactor      │ PDFreactor service for DDEV*                     │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-browsersync     │ Auto-refresh HTTPS page on changes with DDEV*    │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-drupal9-solr    │ Drupal 9 Apache Solr installation for DDEV*      │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-varnish         │ Varnish reverse proxy add-on for DDEV*           │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-redis           │ Redis service for DDEV*                          │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-adminer         │ Adminer service for DDEV*                        │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-cron            │ Schedule commands to execute within DDEV*        │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-proxy-support   │ Support HTTP/HTTPS proxies with DDEV*            │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-redis-commander │ Redis Commander for use with DDEV Redis service* │
└───────────────────────────┴──────────────────────────────────────────────────┘
Add-ons marked with '*' are official, maintained DDEV add-ons.
```

```
❯ ddev get --list --all
┌───────────────────────────────────┬────────────────────────────────────────────────────┐
│ ADD-ON                            │ DESCRIPTION                                        │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-pdfreactor              │ PDFreactor service for DDEV*                       │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-mongo                   │ MongoDB add-on for DDEV*                           │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-memcached               │ Install Memcached as an extra service in DDEV*     │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-redis-commander         │ Redis Commander for use with DDEV Redis service*   │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-drupal9-solr            │ Drupal 9 Apache Solr installation for DDEV*        │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-redis                   │ Redis service for DDEV*                            │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-adminer                 │ Adminer service for DDEV*                          │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-varnish                 │ Varnish reverse proxy add-on for DDEV*             │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-beanstalkd              │ Beanstalkd for DDEV*                               │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-cron                    │ Schedule commands to execute within DDEV*          │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-proxy-support           │ Support HTTP/HTTPS proxies with DDEV*              │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-browsersync             │ Auto-refresh HTTPS page on changes with DDEV*      │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-elasticsearch           │ Elasticsearch add-on for DDEV*                     │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ JanoPL/ddev-kibana                │ Kibana add-on for DDEV                             │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ Lullabot/ddev-printenv            │ A ddev addon to print and obfuscate environment    │
│                                   │ variables                                          │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ tyler36/ddev-laravel-queue        │ Start a Laravel queue worker automatically in DDEV │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ platformsh/ddev-platformsh        │ Add integration with Platform.sh hosting service   │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ tyler36/ddev-cypress              │ Cypress E2E testing for use with ddev              │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ thunder/ddev-selenium-chrome      │ Selenium standalone for ddev                       │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ hanoii/ddev-starship              │ Adding startship prompt to ddev with some sensible │
│                                   │ defaults                                           │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ haase-fabian/ddev-neos            │ neos environment variables for ddev                │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ hanoii/ddev-ahoy                  │ Adds ahoy to ddev                                  │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ torenware/ddev-viteserve          │ An add-on to run the Vite dev server from inside   │
│                                   │ the DDEV environment.                              │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ hanoii/ddev-z                     │ Adding wonderful z to ddev                         │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ tyler36/ddev-db-init              │ Automatically run SQL-like files when initializing │
│                                   │ the DDEV database service                          │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ sebastian-ehrling/ddev-opensearch │ Opensearch add-on for DDEV                         │
└───────────────────────────────────┴────────────────────────────────────────────────────┘
Add-ons marked with '*' are official, maintained DDEV add-ons.
```

### After

```
❯ ddev get --list
┌───────────────────────────┬──────────────────────────────────────────────────┐
│ ADD-ON                    │ DESCRIPTION                                      │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-adminer         │ Adminer service for DDEV*                        │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-beanstalkd      │ Beanstalkd for DDEV*                             │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-browsersync     │ Auto-refresh HTTPS page on changes with DDEV*    │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-cron            │ Schedule commands to execute within DDEV*        │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-drupal9-solr    │ Drupal 9 Apache Solr installation for DDEV*      │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-elasticsearch   │ Elasticsearch add-on for DDEV*                   │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-memcached       │ Install Memcached as an extra service in DDEV*   │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-mongo           │ MongoDB add-on for DDEV*                         │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-pdfreactor      │ PDFreactor service for DDEV*                     │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-proxy-support   │ Support HTTP/HTTPS proxies with DDEV*            │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-redis           │ Redis service for DDEV*                          │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-redis-commander │ Redis Commander for use with DDEV Redis service* │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ drud/ddev-varnish         │ Varnish reverse proxy add-on for DDEV*           │
└───────────────────────────┴──────────────────────────────────────────────────┘
Add-ons marked with '*' are official, maintained DDEV add-ons.
```

```
❯ ddev get --list --all
┌───────────────────────────────────┬────────────────────────────────────────────────────┐
│ ADD-ON                            │ DESCRIPTION                                        │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-adminer                 │ Adminer service for DDEV*                          │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-beanstalkd              │ Beanstalkd for DDEV*                               │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-browsersync             │ Auto-refresh HTTPS page on changes with DDEV*      │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-cron                    │ Schedule commands to execute within DDEV*          │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-drupal9-solr            │ Drupal 9 Apache Solr installation for DDEV*        │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-elasticsearch           │ Elasticsearch add-on for DDEV*                     │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-memcached               │ Install Memcached as an extra service in DDEV*     │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-mongo                   │ MongoDB add-on for DDEV*                           │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-pdfreactor              │ PDFreactor service for DDEV*                       │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-proxy-support           │ Support HTTP/HTTPS proxies with DDEV*              │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-redis                   │ Redis service for DDEV*                            │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-redis-commander         │ Redis Commander for use with DDEV Redis service*   │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ drud/ddev-varnish                 │ Varnish reverse proxy add-on for DDEV*             │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ haase-fabian/ddev-neos            │ neos environment variables for ddev                │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ hanoii/ddev-ahoy                  │ Adds ahoy to ddev                                  │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ hanoii/ddev-starship              │ Adding startship prompt to ddev with some sensible │
│                                   │ defaults                                           │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ hanoii/ddev-z                     │ Adding wonderful z to ddev                         │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ JanoPL/ddev-kibana                │ Kibana add-on for DDEV                             │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ Lullabot/ddev-printenv            │ A ddev addon to print and obfuscate environment    │
│                                   │ variables                                          │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ platformsh/ddev-platformsh        │ Add integration with Platform.sh hosting service   │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ sebastian-ehrling/ddev-opensearch │ Opensearch add-on for DDEV                         │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ thunder/ddev-selenium-chrome      │ Selenium standalone for ddev                       │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ torenware/ddev-viteserve          │ An add-on to run the Vite dev server from inside   │
│                                   │ the DDEV environment.                              │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ tyler36/ddev-cypress              │ Cypress E2E testing for use with ddev              │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ tyler36/ddev-db-init              │ Automatically run SQL-like files when initializing │
│                                   │ the DDEV database service                          │
├───────────────────────────────────┼────────────────────────────────────────────────────┤
│ tyler36/ddev-laravel-queue        │ Start a Laravel queue worker automatically in DDEV │
└───────────────────────────────────┴────────────────────────────────────────────────────┘
Add-ons marked with '*' are official, maintained DDEV add-ons.
```

## Manual Testing Instructions:

Follow [Building](https://ddev.readthedocs.io/en/stable/developers/building-contributing/#building) instructions to `make` a local binary and execute it. (Example: `./.gotmp/bin/darwin_arm64/ddev get --list`.)

## Automated Testing Overview:

There don’t appear to be existing tests for making sure `drud/*` repos are at the top of the results, so I figure we don’t need them to check the modified sort either.

## Related Issue Link(s):

Vaguely related to #4188.

## Release/Deployment notes:

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4296"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

