### PR TITLE
Craft CMS: Return existing upload directory, if already set, fixes #4302

### DIFF
--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -27,7 +27,9 @@ func craftCmsConfigOverrideAction(app *DdevApp) error {
 
 // Returns the upload directory for importing files, if not already set
 func getCraftCmsUploadDir(app *DdevApp) string {
-	app.UploadDir = "files"
+	if app.UploadDir == "" {
+		return "files"
+	}
 
 	return app.UploadDir
 }


### PR DESCRIPTION
Fixes 
* https://github.com/drud/ddev/issues/4302 
by returning the existing upload directory, if already set.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4303"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

