### PR TITLE
Add Swift Mailer config for Mailhog in Drupal 8/9 settings, fixes #2706

### DIFF
--- a/pkg/ddevapp/drupal/drupal8/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal8/settings.ddev.php
@@ -54,3 +54,10 @@ if (version_compare(DRUPAL::VERSION, "8.8.0", '>=') &&
   empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = 'sites/default/files/sync';
 }
+
+// Override drupal/swiftmailer default config to use Mailhog
+$config['swiftmailer.transport']['transport'] = 'smtp';
+$config['swiftmailer.transport']['smtp_host'] = '127.0.0.1';
+$config['swiftmailer.transport']['smtp_port'] = '1025';
+$config['swiftmailer.transport']['smtp_encryption'] = '0';
+

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -53,3 +53,8 @@ $config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass']='';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host']='localhost';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port']='1025';
 
+// Override drupal/swiftmailer default config to use Mailhog
+$config['swiftmailer.transport']['transport'] = 'smtp';
+$config['swiftmailer.transport']['smtp_host'] = '127.0.0.1';
+$config['swiftmailer.transport']['smtp_port'] = '1025';
+$config['swiftmailer.transport']['smtp_encryption'] = '0';


### PR DESCRIPTION
## The Problem/Issue/Bug:
Fixes #2706

## How this PR Solves The Problem:

## Manual Testing Instructions:
```
mkdir my-drupal9-site
cd my-drupal9-site
ddev config --project-type=drupal9 --docroot=web --create-docroot
ddev start
ddev composer create "drupal/recommended-project" --no-install
ddev composer require drush/drush --no-install
ddev composer require drupal/swiftmailer --no-install
ddev composer install
ddev drush site:install -y
ddev drush pm:install swiftmailer
ddev drush user:login "admin/config/swiftmailer/test"
```
## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
#2706

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

