### PR TITLE
Bump images to v1.21.3 and mutagen to 0.16.0

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:20221016_bump_max_input_vars as ddev-webserver-base
+FROM drud/ddev-php-base:v1.21.3 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV MKCERT_VERSION=v1.4.6

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,13 +17,13 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20221016_bump_max_input_vars" // Note that this can be overridden by make
+var WebTag = "v1.21.3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.21.2"
+var BaseDBTag = "v1.21.3"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"
@@ -35,7 +35,7 @@ var DBATag = "5" // Note that this can be overridden by make
 var RouterImage = "drud/ddev-router"
 
 // RouterTag defines the tag used for the router.
-var RouterTag = "v1.21.2" // Note that this can be overridden by make
+var RouterTag = "v1.21.3" // Note that this can be overridden by make
 
 // SSHAuthImage is image for agent
 // var SSHAuthImage = "drud/ddev-ssh-agent"
@@ -43,7 +43,7 @@ var SSHAuthImage = "drud/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
 // var SSHAuthTag = "v1.19.0"
-var SSHAuthTag = "v1.21.2"
+var SSHAuthTag = "v1.21.3"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"
@@ -54,7 +54,7 @@ var BUILDINFO = "BUILDINFO should have new info"
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.16.0-rc1"
+const RequiredMutagenVersion = "0.16.0"
 
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {


### PR DESCRIPTION
## The Problem/Issue/Bug:

Time for a release. Bump images.

This also bumps mutagen to 0.16.0, but there is no difference between the previous 0.16.0-rc1 and 0.16.0



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4310"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

