### PR TITLE
Bump .gitpod.yml to new image [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drud/ddev-gitpod-base:20220817
+image: drud/ddev-gitpod-base:20221018
 tasks:
   - name: build-run
     init: |

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update >/dev/null && sudo apt-get install -y aspell autojump ddev fi
 
 RUN pip3 install mkdocs pyspelling pymdown-extensions
 RUN npm install -g markdownlint-cli
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.46.2
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.50.0
 
-RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.18.4.linux-amd64.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz && ln -s /usr/local/go/bin/go /usr/local/bin/go
+RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.19.2.linux-amd64.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 USER gitpod
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

New version means bumping .gitpod.yml



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4311"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

