### PR TITLE
[docs] Remove inappropriate link from chocolatey deploy

### DIFF
--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -108,7 +108,7 @@ cd .gotmp/bin/windows_amd64/chocolatey
 rm .gotmp/bin/windows_amd64/chocolatey/*.nupkg
 export CHOCOLATEY_API_KEY=key33333
 docker run --rm -v "/$PWD:/tmp/chocolatey" -w "//tmp/chocolatey" linuturk/mono-choco pack ddev.nuspec;
-docker run --rm -v $PWD:/tmp/chocolatey -w /tmp/chocolatey linuturk/mono-choco push -s [https://push.chocolatey.org/](https://push.chocolatey.org/) --api-key "${CHOCOLATEY_API_KEY}"
+docker run --rm -v $PWD:/tmp/chocolatey -w /tmp/chocolatey linuturk/mono-choco push -s https://push.chocolatey.org/ --api-key "${CHOCOLATEY_API_KEY}"
 
 ```
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

docs fix removing broken chocolatey deploy instructions.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4316"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

