### PR TITLE
upload_dir support in Craft CMS, fixes #4302

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -452,7 +452,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ```bash
         mkdir my-craft-project
         cd my-craft-project
-        ddev config --project-type=craftcms
+        ddev config --project-type=craftcms --docroot=web --create-docroot
         ddev composer create -y --no-scripts --no-install craftcms/craft
         ddev start
         ddev composer update

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -68,7 +68,7 @@ func init() {
 			settingsCreator: createBackdropSettingsFile, uploadDir: getBackdropUploadDir, hookDefaultComments: getBackdropHooks, apptypeSettingsPaths: setBackdropSiteSettingsPaths, appTypeDetect: isBackdropApp, postImportDBAction: backdropPostImportDBAction, configOverrideAction: nil, postConfigAction: nil, postStartAction: backdropPostStartAction, importFilesAction: backdropImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,
 		},
 		nodeps.AppTypeCraftCms: {
-			uploadDir: getCraftCmsUploadDir, importFilesAction: craftCmsImportFilesAction, appTypeDetect: isCraftCmsApp, configOverrideAction: craftCmsConfigOverrideAction, postConfigAction: craftCmsPostConfigAction, postStartAction: craftCmsPostStartAction,
+			uploadDir: nil, importFilesAction: craftCmsImportFilesAction, appTypeDetect: isCraftCmsApp, configOverrideAction: nil, postConfigAction: craftCmsPostConfigAction, postStartAction: craftCmsPostStartAction,
 		},
 		nodeps.AppTypeDrupal6: {
 			settingsCreator: createDrupalSettingsPHP, uploadDir: getDrupalUploadDir, hookDefaultComments: getDrupal6Hooks, apptypeSettingsPaths: setDrupalSiteSettingsPaths, appTypeDetect: isDrupal6App, postImportDBAction: nil, configOverrideAction: drupal6ConfigOverrideAction, postConfigAction: nil, postStartAction: drupal6PostStartAction, importFilesAction: drupalImportFilesAction, defaultWorkingDirMap: docrootWorkingDir,

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -16,22 +16,6 @@ func isCraftCmsApp(app *DdevApp) bool {
 	return fileutil.FileExists(filepath.Join(app.AppRoot, "craft"))
 }
 
-// Set the Docroot to web
-func craftCmsConfigOverrideAction(app *DdevApp) error {
-	if app.Docroot == "" {
-		app.Docroot = "web"
-	}
-
-	return nil
-}
-
-// Returns the upload directory for importing files, if not already set
-func getCraftCmsUploadDir(app *DdevApp) string {
-	app.UploadDir = "files"
-
-	return app.UploadDir
-}
-
 // craftCmsImportFilesAction defines the workflow for importing project files.
 func craftCmsImportFilesAction(app *DdevApp, importPath, extPath string) error {
 	if app.UploadDir == "" {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -255,6 +255,7 @@ var (
 			Type:                          nodeps.AppTypeCraftCms,
 			Docroot:                       "web",
 			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/test.html", Expect: "Thanks for testing Craft CMS"},
+			UploadDir:                     "files",
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "Thanks for installing Craft CMS"},
 			FilesImageURI:                 "/files/happy-brad.jpg",
 		},

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -67,6 +67,8 @@ type TestSite struct {
 	Safe200URIWithExpectation URIWithExpect
 	// DynamicURI provides a dynamic (after db load) URI with contents we can expect.
 	DynamicURI URIWithExpect
+	// UploadDir overrides the dir used for upload_dir
+	UploadDir string
 	// FilesImageURI is URI to a file loaded by import-files that is a jpg.
 	FilesImageURI string
 	// FullSiteArchiveExtPath is the path that should be extracted from inside an archive when
@@ -116,6 +118,7 @@ func (site *TestSite) Prepare() error {
 	// ignore app name defined in config file if present.
 	app.Name = site.Name
 	app.Docroot = site.Docroot
+	app.UploadDir = site.UploadDir
 	app.Type = app.DetectAppType()
 	if app.Type != site.Type {
 		return errors.Errorf("Detected apptype (%s) does not match provided apptype (%s)", app.Type, site.Type)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4302 
* Related attempt and conversation in #4303

## How this PR Solves The Problem:

* Remove the wired upload_dir
* Remove the wired docroot (seems inappropriate? DDEV will autodetect, and people should be able to override?)
* Support specifying upload_dir in tests

## TODO:
- [x] The Craft CMS test in TestDdevFullSiteSetup is leaving cruft in the project directory (.env file) - need to fix that.

## Manual Testing Instructions:

- [ ] `ddev config --upload-dir=files` on a craft project and see if it works with mutagen and `ddev start` - it should not warn. 



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4317"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

