### PR TITLE
[docs] QuickStart Laravel Git Clone 

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -320,18 +320,30 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
 
     The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) just as it can for Laravel.
 
-    ```bash
-    mkdir my-laravel-app
-    cd my-laravel-app
-    ddev config --project-type=laravel --docroot=public --create-docroot
-    ddev start
-    ddev composer create --prefer-dist laravel/laravel
-    ddev exec "cat .env.example | sed  -E 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' > .env"
-    ddev exec 'sed -i "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" .env'
-    ddev exec "php artisan key:generate"
-    ddev launch
-    ```
-
+    === "Composer"
+        ```bash
+        mkdir my-laravel-app
+        cd my-laravel-app
+        ddev config --project-type=laravel --docroot=public --create-docroot
+        ddev start
+        ddev composer create --prefer-dist laravel/laravel
+        ddev exec "cat .env.example | sed  -E 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' > .env"
+        ddev exec 'sed -i "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" .env'
+        ddev exec "php artisan key:generate"
+        ddev launch
+        ```
+    === "Git Clone"
+        ```bash
+        git clone https://github.com/example/example-site my-laravel-app
+        cd my-laravel-app
+        ddev config --project-type=laravel --docroot=public --create-docroot
+        ddev start
+        ddev composer install 
+        ddev exec "cat .env.example | sed  -E 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' > .env"
+        ddev exec 'sed -i "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" .env'
+        ddev exec "php artisan key:generate"
+        ddev launch
+        ```
     In the examples above, we used a one-liner to copy `.env.example` as `env` and set the `DB_HOST`, `DB_DATABASE`, `DB_USERNAME` and `DB_PASSWORD` environment variables to the value of `db`.
 
     These DDEV’s default values for the database connection.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -334,7 +334,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ```
     === "Git Clone"
         ```bash
-        git clone https://github.com/ibrah3m/laravel.git my-laravel-app
+        git clone <your-laravel-repo>
         cd my-laravel-app
         ddev config --project-type=laravel --docroot=public --create-docroot
         ddev start

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -335,7 +335,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
     === "Git Clone"
         ```bash
         git clone <your-laravel-repo>
-        cd my-laravel-app
+        cd <your-laravel-project>
         ddev config --project-type=laravel --docroot=public --create-docroot
         ddev start
         ddev composer install 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -334,7 +334,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ```
     === "Git Clone"
         ```bash
-        git clone https://github.com/example/example-site my-laravel-app
+        git clone https://github.com/ibrah3m/laravel.git my-laravel-app
         cd my-laravel-app
         ddev config --project-type=laravel --docroot=public --create-docroot
         ddev start
@@ -344,6 +344,10 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ddev exec "php artisan key:generate"
         ddev launch
         ```
+        !!!tip
+            In this example, we used a repo that has laravel version 9 due to the manual tests. So are you looking to use the latest laravel version?
+            If yes, please use the following repo https://github.com/laravel/laravel.git
+
     In the examples above, we used a one-liner to copy `.env.example` as `env` and set the `DB_HOST`, `DB_DATABASE`, `DB_USERNAME` and `DB_PASSWORD` environment variables to the value of `db`.
 
     These DDEV’s default values for the database connection.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -344,9 +344,6 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ddev exec "php artisan key:generate"
         ddev launch
         ```
-        !!!tip
-            In this example, we used a repo that has laravel version 9 due to the manual tests. So are you looking to use the latest laravel version?
-            If yes, please use the following repo https://github.com/laravel/laravel.git
 
     In the examples above, we used a one-liner to copy `.env.example` as `env` and set the `DB_HOST`, `DB_DATABASE`, `DB_USERNAME` and `DB_PASSWORD` environment variables to the value of `db`.
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
Update QuickStart in the Laravel section
## How this PR Solves The Problem:
Adding example explain how to make Git Clone
## Manual Testing Instructions:
```
  git clone https://github.com/ibrah3m/laravel.git my-laravel-app
  cd my-laravel-app
  ddev config --project-type=laravel --docroot=public --create-docroot
  ddev start
  ddev composer install 
  ddev exec "cat .env.example | sed  -E 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' > .env"
  ddev exec 'sed -i "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" .env'
  ddev exec "php artisan key:generate"
  ddev launch
```
## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4320"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

