### PR TITLE
Update process of adding the gpg key

### DIFF
--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -5,8 +5,8 @@ USER root
 
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 
-RUN curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
-RUN echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
+RUN curl -fsSL https://apt.fury.io/drud/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
+RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
 
 RUN apt-get update >/dev/null && sudo apt-get install -y aspell autojump ddev file mysql-client netcat nodejs python3-pip telnet >/dev/null
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -53,8 +53,8 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     DDEV’s Debian and RPM packages work with `apt` and `yum` repositories and most variants that use them, including Windows WSL2:
 
     ```bash
-    curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
-    echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
+    curl -fsSL https://apt.fury.io/drud/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
     sudo apt update && sudo apt install -y ddev
     ```
 

--- a/docs/content/users/topics/phpstorm.md
+++ b/docs/content/users/topics/phpstorm.md
@@ -97,8 +97,8 @@ Set the PhpStorm terminal path (*Settings* → *Tools* → *Terminal* → *Shell
 4. Install the DDEV apt repository:
 
     ```bash
-    curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
-    echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
+    curl -fsSL https://apt.fury.io/drud/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
     sudo apt update && sudo apt install -y ddev
     ```
 


### PR DESCRIPTION
To allow adding the key without a warning in recent Ubuntu versions, the variant using a key within /etc/apt/trusted.gpg.d/ is provided since `apt-key` is deprecated.

## The Problem/Issue/Bug:
Usage of `apt-key` is deprecated

## How this PR Solves The Problem:
The suggestion of adding the keyring to the local trusted.gpg.d directory is explained

## Manual Testing Instructions:
On an Ubuntu machine use the new instruction commands

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
* https://github.com/drud/ddev/issues/3997

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4324"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

