### PR TITLE
Fix ddev import-db with postgres on gitpod by changing PGHOST=127.0.0.1

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -61,7 +61,7 @@ services:
       - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-db/mysql_history
       - MYSQL_PWD=db
       - PGDATABASE=db
-      - PGHOST=localhost
+      - PGHOST=127.0.0.1
       - PGPASSWORD=db
       - PGUSER=db
       - POSTGRES_PASSWORD=db


### PR DESCRIPTION
## Change PGHOST from Localhost to 127.0.0.1 for ddev psql in Gitpod

## The Problem/Issue/Bug:
On GITPOD, ddev in combination with posgress DB was not working correct. 
`ddev import-db --src=sql/db.sql.gz` or `ddev export-db` 
throws an:
`  psql: error: connection to server at "localhost" (::1), port 5432 failed: FATAL:  no pg_hba.conf entry for host "::1", user "db", database "postgres", no encryption`
error.

## How this PR Solves The Problem:
We set the  PGHOST=localhost env in app_compose_template.yaml to PGHOST=127.0.0.1

## Manual Testing Instructions:
- Create a ddev Container from scratch with:   `ddev config --project-type=drupal9 --docroot=web --database=postgres:14 --create-docroot`
- try to export the db with `ddev export-db`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
https://discord.com/channels/664580571770388500/1034154179192696996

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4328"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

