### PR TITLE
Fix TYPO3 project detection to work with non existent symlinks, fixes #4326

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -152,9 +152,18 @@ func setTypo3SiteSettingsPaths(app *DdevApp) {
 
 // isTypoApp returns true if the app is of type typo3
 func isTypo3App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "typo3")); err == nil {
+	typo3Folder := filepath.Join(app.AppRoot, app.Docroot, "typo3")
+
+	// Check if the folder exists, fails if a symlink target does not exist.
+	if _, err := os.Stat(typo3Folder); !os.IsNotExist(err) {
 		return true
 	}
+
+	// Check if a symlink exists, succeeds even if the target does not exist.
+	if _, err := os.Lstat(typo3Folder); !os.IsNotExist(err) {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

If the `typo3` folder is a symlink to a non existing target the detection fails currently.

## How this PR Solves The Problem:

If the first check fails, an additional check for an existing symlink is introduced.

## Manual Testing Instructions:

- Set up a TYPO3 according the [legacy installation](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/LegacyInstallation.html)
- Rename the source folder extracted from the package
- Remove `AddintionalConfiguration.php`

The `AddintionalConfiguration.php` is not longer created during `ddev start` or `ddev restart`.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

#4326 

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4330"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

