### PR TITLE
Improve test_ddev.sh curl to show what it's doing [skip ci]

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -99,13 +99,15 @@ ddev start -y || ( \
 echo "======== Curl of site from inside container:"
 ddev exec curl --fail -I http://127.0.0.1
 
-echo "======== Curl of site from outside:"
+echo "======== curl -I of http://${PROJECT_NAME}.ddev.site from outside:"
 curl --fail -I http://${PROJECT_NAME}.ddev.site
 if [ $? -ne 0 ]; then
   set +x
   echo "Unable to curl the requested project Please provide this output in a new gist at gist.github.com."
   exit 1
 fi
+echo "======== full curl of http://${PROJECT_NAME}.ddev.site from outside:"
+curl http://${PROJECT_NAME}.ddev.site
 
 echo "======== Project ownership on host:"
 ls -ld ${PROJECT_DIR}
@@ -113,7 +115,7 @@ echo "======== Project ownership in container:"
 ddev exec ls -ld /var/www/html
 echo "======== In-container filesystem:"
 ddev exec df -T /var/www/html
-
+echo "======== curl again of ${PROJECT_NAME} from host:"
 curl --fail http://${PROJECT_NAME}.ddev.site
 if [ $? -ne 0 ]; then
   set +x


### PR DESCRIPTION
## The Problem/Issue/Bug:

A user showed an unusual `ddev debug test` that had apache output, but no header to show where the info was coming from.

We need to show `curl -I` and also `curl` output (from outside container).



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4333"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

