### PR TITLE
Make ddev settings management less chatty for Drupal

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -100,9 +100,9 @@ func manageDrupalSettingsFile(app *DdevApp, drupalConfig *DrupalSettings, appTyp
 	}
 
 	if included {
-		output.UserOut.Printf("Existing %s file includes %s", drupalConfig.SiteSettings, drupalConfig.SiteSettingsDdev)
+		util.Debug("Existing %s file includes %s", drupalConfig.SiteSettings, drupalConfig.SiteSettingsDdev)
 	} else {
-		output.UserOut.Printf("Existing %s file does not include %s, modifying to include ddev settings", drupalConfig.SiteSettings, drupalConfig.SiteSettingsDdev)
+		util.Debug("Existing %s file does not include %s, modifying to include ddev settings", drupalConfig.SiteSettings, drupalConfig.SiteSettingsDdev)
 
 		if err := appendIncludeToDrupalSettingsFile(app.SiteSettingsPath, app.Type); err != nil {
 			return fmt.Errorf("failed to include %s in %s: %v", drupalConfig.SiteSettingsDdev, drupalConfig.SiteSettings, err)
@@ -422,7 +422,7 @@ func drupal6PostStartAction(app *DdevApp) error {
 // drupalEnsureWritePerms will ensure sites/default and sites/default/settings.php will
 // have the appropriate permissions for development.
 func drupalEnsureWritePerms(app *DdevApp) error {
-	output.UserOut.Printf("Ensuring write permissions for %s", app.GetName())
+	util.Debug("Ensuring write permissions for %s", app.GetName())
 	var writePerms os.FileMode = 0200
 
 	settingsDir := path.Dir(app.SiteSettingsPath)


### PR DESCRIPTION
## The Problem/Issue/Bug:

On [Stack Overflow](https://stackoverflow.com/questions/74190777/error-when-creating-drupal-project-with-ddev-existing-settings-php-file-includ) a user thought that the general startup output from Drupal was error output. It would be better as debug output (when DDEV_DEBUG=true). Changing those to util.Debug().

## Manual Testing Instructions:

- [x] Normally `ddev start` should not say the stuff about "setting permissions" and "settings.php already has include"
- [x] With `export DDEV_DEBUG=true` it should output that stuff on `ddev start`



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4334"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

