### PR TITLE
Gitignore `.DS_Store` and similar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 /.ddev
 /artifacts
 *.DS_Store
+nbproject/
+.idea
+*.orig
+*.rej

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /dist
 /.ddev
 /artifacts
+*.DS_Store


### PR DESCRIPTION
## The Problem/Issue/Bug:

One might easily and accidentally commit those annoying macOS `.DS_Store` files to their commit, adding cruft to the project.

## How this PR Solves The Problem:

This uses the `.gitignore` file to prevent those from being noticed or committed by Git.

## Manual Testing Instructions:

🤔 Stage this change, then purposefully try to commit a file named `.DS_Store`. It’ll be trickier, at least.

## Automated Testing Overview:

n/a

## Related Issue Link(s):

Faintly related to #4188; came up during #4336.

## Release/Deployment notes:

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4337"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

