### PR TITLE
Setting the MySQL transaction isolation level (Fixes #4281)

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -28,6 +28,13 @@ $databases['default']['default'] = array(
   'prefix' => "{{ $config.DatabasePrefix }}",
 );
 
+
+// Setting the MySQL transaction isolation level.
+// @see https://www.drupal.org/docs/system-requirements/setting-the-mysql-transaction-isolation-level
+if ($driver === "mysql") {
+  $databases['default']['default']['init_commands']['isolation_level'] = 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED';
+}
+
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -28,6 +28,13 @@ $databases['default']['default'] = array(
   'prefix' => "{{ $config.DatabasePrefix }}",
 );
 
+
+// Setting the MySQL transaction isolation level.
+// @see https://www.drupal.org/docs/system-requirements/setting-the-mysql-transaction-isolation-level
+if ($driver === "mysql") {
+  $databases['default']['default']['init_commands']['isolation_level'] = 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED';
+}
+
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.


### PR DESCRIPTION
## The Problem/Issue/Bug:

This resolves the issue of #4281 which requires MySQL tranaction isolation level setting.

## How this PR Solves The Problem:

Add the required line to 'mysql' driver configurations. 

- Note: I added it on a Drupal 10 Postgres system too which appeared to load correctly, but am unaware of any side affects under "normal" usage.

## Manual Testing Instructions:

Comment out line in a Drupal 10 install and a warning appears on `/admin/reports/status`

## Related Issue Link(s):
Fixes #4281

[Setting the MySQL transaction isolation level](https://www.drupal.org/docs/system-requirements/setting-the-mysql-transaction-isolation-level)
[Suggestion for: (3285800) Setting the MySQL transaction isolation level](https://www.drupal.org/project/documentation/issues/3308909)

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

