### PR TITLE
[docs] Craft CMS quickstart should  not have --no-install, fixes #4338

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -449,7 +449,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         cd my-craft-project
         ddev config --project-type=craftcms --docroot=web --create-docroot
         ddev start
-        ddev composer create -y --no-scripts --no-install craftcms/craft
+        ddev composer create -y --no-scripts craftcms/craft
         ddev craft install
         ddev launch
         ```


### PR DESCRIPTION
## The Problem/Issue/Bug:

I must have made a mistake with a merge conflict, and `--no-install` remained in the Craft CMS quickstart

## How this PR Solves The Problem:

Remove it.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4340"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

