### PR TITLE
Make `ddev launch` work right on gitpod

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -58,7 +58,11 @@ fi
 
 case $OSTYPE in
   linux-gnu)
-    xdg-open ${FULLURL}
+    if [[ ! -z "${GITPOD_INSTANCE_ID}" ]]; then
+        gp preview ${FULLURL}
+    else
+        xdg-open ${FULLURL}
+    fi
     ;;
   "darwin"*)
     open ${FULLURL}


### PR DESCRIPTION
## The Problem/Issue/Bug:
xd-open fails on gitpod environments. 

## How this PR Solves The Problem:
Check if we have a env with GITPOD_INSTANCE_ID and open the "gp previev" with FULLURL

Please consider that there is a other Issue in GITPOD with gp preview ( https://github.com/gitpod-io/gitpod/issues/7825 )

## Manual Testing Instructions:
- Open a GITPOD, `ddev start` and test `ddev launch`  (in Vscode Browser edition be sure that popups are enabled :) )
- Test `ddev launch` with phpstorm EAP
- Test `ddev launch` on a linux environment **NOT** running gitpod to verify that xd-open still works

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

