### PR TITLE
Fix UID collision with host-side uid 999 and make docker-compose username override work again, fixes #4243, fixes #4313

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -72,6 +72,9 @@ RUN rm -f /etc/apt/sources.list.d/mysql.list && \
     apt-key remove "${item}" || true; \
   done;
 
+# Normal upstream image doesn't actually have /home/mysql created
+# Make sure it's there in case user 999 (mysql) is using this image.
+RUN mkdir /home/mysql && chown mysql:mysql /home/mysql
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -95,7 +95,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
 
 # blackfire user by default is set up with /dev/null as homedir, and 999 as uid, which
 # can break people. Use a real homedir
-RUN usermod -d /home/blackfire blackfire
+RUN mkdir -p /home/blackfire && chown blackfire:blackfire /home/blackfire && usermod -d /home/blackfire blackfire
 
 ADD ddev-webserver-dev-base-files /
 RUN phpdismod blackfire xhprof

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -93,6 +93,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     unzip \
     zip
 
+# blackfire user by default is set up with /dev/null as homedir, and 999 as uid, which
+# can break people. Use a real homedir
+RUN usermod -d /home/blackfire blackfire
+
 ADD ddev-webserver-dev-base-files /
 RUN phpdismod blackfire xhprof
 RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_${MAILHOG_ARCH} -o /usr/local/bin/mailhog;

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -89,8 +89,8 @@ sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 # ensure default yarn2 global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
-ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} -~/.nvm
-if [ ! -f -~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
+ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
+if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # /mnt/ddev_config/.homeadditions may be either
 # a bind-mount, or a volume mount, but we don't care,

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -4,6 +4,10 @@ set -o errexit nounset pipefail
 
 rm -f /tmp/healthy
 
+# If user has not been created via normal template (like uid 999)
+# then try to grab the required files from /etc/skel
+if [ ! -f ~/.gitconfig ]; then (sudo cp -r /etc/skel/. ~/ && sudo chown -R "$(id -u -n)" ~ ) || true; fi
+
 # If DDEV_PHP_VERSION isn't set, use a reasonable default
 DDEV_PHP_VERSION="${DDEV_PHP_VERSION:-$PHP_DEFAULT_VERSION}"
 

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -89,7 +89,6 @@ sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 # ensure default yarn2 global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
-
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-~/.nvm}
 if [ ! -f ${NVM_DIR:-~/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -90,8 +90,8 @@ sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 
-ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
-if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
+ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-~/.nvm}
+if [ ! -f ${NVM_DIR:-~/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # /mnt/ddev_config/.homeadditions may be either
 # a bind-mount, or a volume mount, but we don't care,

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -85,7 +85,7 @@ sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 # will only be used if the project is configured to use it through it's own
 # enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
 # global folder.
-(cd && yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic || true)
+( (cd ~ || echo "unable to cd to home directory"; exit 22) && yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic || true)
 # ensure default yarn2 global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -89,8 +89,8 @@ sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 # ensure default yarn2 global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
-ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-~/.nvm}
-if [ ! -f ${NVM_DIR:-~/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
+ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} -~/.nvm
+if [ ! -f -~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # /mnt/ddev_config/.homeadditions may be either
 # a bind-mount, or a volume mount, but we don't care,

--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -112,6 +112,10 @@ if ! shopt -oq posix; then
   fi
 fi
 
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
 for f in /etc/bashrc/*.bashrc; do
   source $f;
 done

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -76,7 +76,7 @@ disable_xhprof
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
 mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry}
-ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} -~/.nvm
+ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
 if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # The following ensures a persistent and shared "global" cache for

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -6,7 +6,7 @@ rm -f /tmp/healthy
 
 # If user has not been created via normal template (like blackfire uid 999)
 # then try to grab the required files from /etc/skel
-if [ ! -f ~/.gitconfig ]; then cp -r /etc/skel/ ~/ || true; fi
+if [ ! -f ~/.gitconfig ]; then cp -r /etc/skel/. ~/ || true; fi
 
 # If DDEV_PHP_VERSION isn't set, use a reasonable default
 DDEV_PHP_VERSION="${DDEV_PHP_VERSION:-$PHP_DEFAULT_VERSION}"
@@ -51,7 +51,7 @@ if [ "$DDEV_PROJECT_TYPE" = "backdrop" ] ; then
     mkdir -p ~/.drush/commands && ln -s /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
 fi
 
-if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7" ] ; then
+if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7" ] || [ "${DDEV_PROJECT_TYPE}" = "backdrop" ]; then
   ln -sf /usr/local/bin/drush8 /usr/local/bin/drush
 fi
 
@@ -88,10 +88,12 @@ if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 # will only be used if the project is configured to use it through it's own
 # enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
 # global folder.
-(cd && yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic || true)
+( (cd ~ || echo "unable to cd to home directory"; exit 22) && yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic || true)
 # ensure default yarn2 global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
+ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
+if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # chown of ddev-global-cache must be done with privileged container in app.Start()
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -76,8 +76,8 @@ disable_xhprof
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
 mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry}
-ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-${HOME}/.nvm}
-if [ ! -f ${NVM_DIR:-${HOME}/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
+ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-~/.nvm}
+if [ ! -f ${NVM_DIR:-~/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # The following ensures a persistent and shared "global" cache for
 # yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -4,6 +4,10 @@ set -o errexit nounset pipefail
 
 rm -f /tmp/healthy
 
+# If user has not been created via normal template (like blackfire uid 999)
+# then try to grab the required files from /etc/skel
+if [ ! -f ~/.gitconfig ]; then cp -r /etc/skel/ ~/ || true; fi
+
 # If DDEV_PHP_VERSION isn't set, use a reasonable default
 DDEV_PHP_VERSION="${DDEV_PHP_VERSION:-$PHP_DEFAULT_VERSION}"
 

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -76,8 +76,8 @@ disable_xhprof
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
 mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry}
-ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ${NVM_DIR:-~/.nvm}
-if [ ! -f ${NVM_DIR:-~/.nvm}/nvm.sh ]; then (install_nvm.sh || true); fi
+ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} -~/.nvm
+if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # The following ensures a persistent and shared "global" cache for
 # yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -83,9 +83,6 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 19. `nc.exe -l -p 9003` on Windows to trigger and allow Windows Defender.
 20. Run `ngrok config add-authtoken <token>` with token for free account.
 21. Copy ngrok config into `buildkite-agent` account, `sudo cp -r ~/.ngrok2 ~buildkite-agent/ && sudo chown -R buildkite-agent:buildkite--agent ~buildkite-agent/ngrok2`
-22. Add `buildkite-agent` to `sudo` group in `/etc/groups`
-23. Give `buildkite-agent` a password with `sudo passwd buildkite-agent`
-23. As `buildkite-agent` user `mkcert -install`
 24. Add `/home/linuxbrew/.linuxbrew/bin` to `PATH` in `/etc/environment`.
 
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -78,15 +78,16 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 14. Verify that `buildkite-agent` is running.
 15. In Task Scheduler, create a task that runs on User Logon and runs `C:\Windows\System32\wsl.exe` with arguments `-d Ubuntu`.
 16. Add `buildkite-agent` to the `docker` and `testbot` groups in `/etc/group`
-17. `echo "capath=/etc/ssl/certs/" >>~/.curlrc`
+17. `echo "capath=/etc/ssl/certs/" >>~/.curlrc` And then do the same as `buildkite-agent` user
 18. `sudo chmod -R ug+w /home/linuxbrew`
 19. `nc.exe -l -p 9003` on Windows to trigger and allow Windows Defender.
 20. Run `ngrok config add-authtoken <token>` with token for free account.
-21. Add `/home/linuxbrew/.linuxbrew/bin` to `PATH` in `/etc/environment`.
-22. Copy ngrok config into `buildkite-agent` account, `sudo cp -r ~/.ngrok2 ~buildkite-agent/ && sudo chown -R buildkite-agent:buildkite--agent ~buildkite-agent/ngrok2`
-23. Add `buildkite-agent` to `sudo` group in `/etc/groups`
-24. Give `buildkite-agent` a password with `sudo passwd buildkite-agent`
-25. As `buildkite-agent` user `mkcert -install`
+21. Copy ngrok config into `buildkite-agent` account, `sudo cp -r ~/.ngrok2 ~buildkite-agent/ && sudo chown -R buildkite-agent:buildkite--agent ~buildkite-agent/ngrok2`
+22. Add `buildkite-agent` to `sudo` group in `/etc/groups`
+23. Give `buildkite-agent` a password with `sudo passwd buildkite-agent`
+23. As `buildkite-agent` user `mkcert -install`
+24. Add `/home/linuxbrew/.linuxbrew/bin` to `PATH` in `/etc/environment`.
+
 
 ## Additional Windows Setup for WSL2+Docker-Inside Testing
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -84,6 +84,10 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 20. Run `ngrok config add-authtoken <token>` with token for free account.
 21. Copy ngrok config into `buildkite-agent` account, `sudo cp -r ~/.ngrok2 ~buildkite-agent/ && sudo chown -R buildkite-agent:buildkite--agent ~buildkite-agent/ngrok2`
 22. Add `/home/linuxbrew/.linuxbrew/bin` to `PATH` in `/etc/environment`.
+23. Copy ngrok config into `buildkite-agent` account, `sudo cp -r ~/.ngrok2 ~buildkite-agent/ && sudo chown -R buildkite-agent:buildkite--agent ~buildkite-agent/ngrok2`
+24. Add `buildkite-agent` to `sudo` group in `/etc/groups`
+25. Give `buildkite-agent` a password with `sudo passwd buildkite-agent`
+26. As `buildkite-agent` user `mkcert -install`
 
 ## Additional Windows Setup for WSL2+Docker-Inside Testing
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -83,8 +83,7 @@ We are using [Buildkite](https://buildkite.com/drud) for Windows and macOS testi
 19. `nc.exe -l -p 9003` on Windows to trigger and allow Windows Defender.
 20. Run `ngrok config add-authtoken <token>` with token for free account.
 21. Copy ngrok config into `buildkite-agent` account, `sudo cp -r ~/.ngrok2 ~buildkite-agent/ && sudo chown -R buildkite-agent:buildkite--agent ~buildkite-agent/ngrok2`
-24. Add `/home/linuxbrew/.linuxbrew/bin` to `PATH` in `/etc/environment`.
-
+22. Add `/home/linuxbrew/.linuxbrew/bin` to `PATH` in `/etc/environment`.
 
 ## Additional Windows Setup for WSL2+Docker-Inside Testing
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -972,7 +972,7 @@ FROM $BASE_IMAGE
 ARG username
 ARG uid
 ARG gid
-RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username")
+RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || useradd -l -m -s "/bin/bash" --comment '' $username )
 `
 	// If there are user pre.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -854,7 +854,6 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	_, _, userName := util.GetContainerUIDGid()
 
 	extraWebContent := fmt.Sprintf("\nRUN mkdir -p /home/%s && chown %s /home/%s && chmod 600 ~%s/.pgpass ~%s/.my.cnf", userName, userName, userName, userName, userName)
-	extraWebContent = extraWebContent + fmt.Sprintf("\nENV NVM_DIR=/home/%s/.nvm", userName)
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + "\nRUN (apt-get remove -y nodejs || true) && (apt purge nodejs || true)"
 		// Download of setup_*.sh seems to fail a LOT, probably a problem on their end. So try it twice

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -851,9 +851,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		return "", err
 	}
 
-	_, _, userName := util.GetContainerUIDGid()
-
-	extraWebContent := fmt.Sprintf("\nRUN mkdir -p /home/%s && chown %s /home/%s && chmod 600 ~%s/.pgpass ~%s/.my.cnf", userName, userName, userName, userName, userName)
+	extraWebContent := "\nRUN mkdir -p /home/$username && chown $username /home/$username && chmod 600 /home/$username/.pgpass"
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + "\nRUN (apt-get remove -y nodejs || true) && (apt purge nodejs || true)"
 		// Download of setup_*.sh seems to fail a LOT, probably a problem on their end. So try it twice

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -853,7 +853,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 
 	_, _, userName := util.GetContainerUIDGid()
 
-	extraWebContent := fmt.Sprintf("\nRUN chmod 600 ~%s/.pgpass ~%s/.my.cnf", userName, userName)
+	extraWebContent := fmt.Sprintf("\nRUN mkdir -p /home/%s && chown %s /home/%s && chmod 600 ~%s/.pgpass ~%s/.my.cnf", userName, userName, userName, userName, userName)
 	extraWebContent = extraWebContent + fmt.Sprintf("\nENV NVM_DIR=/home/%s/.nvm", userName)
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + "\nRUN (apt-get remove -y nodejs || true) && (apt purge nodejs || true)"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,13 +17,13 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.21.3" // Note that this can be overridden by make
+var WebTag = "20221026_uid_collision" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.21.3"
+var BaseDBTag = "20221026_uid_collision"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4313 
* #4243 
* DDEV wsl2 test runner wouldn't work right when buildkite-agent was running as uid 999

The blackfire user takes over uid 999 inside the web container, and the mysql user takes over uid 999 in the db container. There could be other conflicts, but this seems to be the main one. This affects any time the host-side user is uid 999, which includes a variety of things, including buildkite-agent. Mostly I don't see likely other conflicts. This also affects Ubuntu Live, where the default user is 999 (#4243)

## How this PR Solves The Problem:

* Use `username` for setup instead of a host-side expected username
* Put nvm setup directly into .bashrc in container instead of waiting for nvm to do it.

## Manual Testing Instructions:

* Create a user with uid 999 and use ddev with it.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4346"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

