### PR TITLE
See if docker-compose v2.12.2 works with ddev

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -593,7 +593,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.10.2"
+var RequiredDockerComposeVersion = "v2.12.2"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Problem/Issue/Bug:

See if docker-compose v2.12.2 works with ddev

If it does, since docker-compose with 2.12.2 seems to handle proxies correctly, https://github.com/docker/compose/issues/9034 then we may be able to no longer use [drud/ddev-proxy-support](https://github.com/drud/ddev-proxy-support) as things may work with no intervention.


## How this PR Solves The Problem:

Use new version.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4350"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

