### PR TITLE
Don't run /etc/bash_profile  ~/.bash_profile or .bashrc in ddev-webserver healthcheck

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/sh
+
+# This uses /bin/sh so it doesn't initialize profile/bashrc/etc
 
 # ddev-webserver healthcheck
 
-set -eo pipefail
+set -e
 
 sleeptime=59
 

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/healthcheck.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/healthcheck.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/sh
+
+# This uses /bin/sh so it doesn't initialize profile/bashrc/etc
 
 # ddev-webserver healthcheck
 
-set -eo pipefail
+set -e
 
 sleeptime=59
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20221026_uid_collision" // Note that this can be overridden by make
+var WebTag = "20221031_healthcheck_no_profile" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

@weitzman noticed that something he added to .bashrc.d in homeadditions was being executed by the healthcheck every minute.

The healthcheck should not be loading any profile or bashrc scripts.

## How this PR Solves The Problem:

Run the healthcheck without bashrc or profile

## Manual Testing Instructions:

TODO:

- [ ] Create and make executable a `junk.sh` file in project .ddev/homeadditions/bashrc.d/junk.sh with contents 
```bash
echo "junk.sh got run"
```
- [ ] ddev restart
- [ ] Demonstrate the problem with a simple bashrc addition to homeadditions (with older version)
- [ ] `docker inspect --format "{{json .State.Health }}" ddev-<projectname>-web | jq` will show "junk.sh got run" for each healthcheck run before this version, and not after. 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4356"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

