### PR TITLE
Set NFS wsize/rsize options for Ventura (Fixes #4122)

### DIFF
--- a/cmd/ddev/cmd/debug-nfsmount.go
+++ b/cmd/ddev/cmd/debug-nfsmount.go
@@ -53,7 +53,7 @@ var DebugNFSMountCmd = &cobra.Command{
 		if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", app.AppRoot)) {
 			shareDir = filepath.Join("/System/Volumes/Data", app.AppRoot)
 		}
-		volume, err := dockerutil.CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": fmt.Sprintf("addr=%s,hard,nolock,rw", nfsServerAddr), "device": ":" + dockerutil.MassageWindowsNFSMount(shareDir)}, nil)
+		volume, err := dockerutil.CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": fmt.Sprintf("addr=%s,hard,nolock,rw,wsize=32768,rsize=32768", nfsServerAddr), "device": ":" + dockerutil.MassageWindowsNFSMount(shareDir)}, nil)
 		//nolint: errcheck
 		defer dockerutil.RemoveVolume(testVolume)
 		if err != nil {

--- a/cmd/ddev/cmd/debug-nfsmount.go
+++ b/cmd/ddev/cmd/debug-nfsmount.go
@@ -43,10 +43,7 @@ var DebugNFSMountCmd = &cobra.Command{
 
 		nfsServerAddr, err := dockerutil.GetNFSServerAddr()
 		if err != nil {
-			util.Failed("failed to GetHostDockerInternalIP(): %v", err)
-		}
-		if nfsServerAddr == "" {
-			nfsServerAddr = "host.docker.internal"
+			util.Failed("failed to GetNFSServerAddr(): %v", err)
 		}
 		shareDir := app.AppRoot
 		// Workaround for Catalina sharing nfs as /System/Volumes/Data

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -305,7 +305,7 @@ volumes:
     driver: local
     driver_opts:
       type: nfs
-      o: "addr={{ if .NFSServerAddr }}{{ .NFSServerAddr }}{{ else }}host.docker.internal{{end}},hard,nolock,rw"
+      o: "addr={{ if .NFSServerAddr }}{{ .NFSServerAddr }}{{ else }}host.docker.internal{{end}},hard,nolock,rw,wsize=32768,rsize=32768"
       device: ':{{ .NFSSource }}'
   {{ end }}{{/* end if and .NFSMountEnabled (not .NoProjectMount) */}}
   {{ if and .MutagenEnabled (not .NoProjectMount) }}

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -305,7 +305,7 @@ volumes:
     driver: local
     driver_opts:
       type: nfs
-      o: "addr={{ if .NFSServerAddr }}{{ .NFSServerAddr }}{{ else }}host.docker.internal{{end}},hard,nolock,rw,wsize=32768,rsize=32768"
+      o: "addr={{ .NFSServerAddr }},hard,nolock,rw,wsize=32768,rsize=32768"
       device: ':{{ .NFSSource }}'
   {{ end }}{{/* end if and .NFSMountEnabled (not .NoProjectMount) */}}
   {{ if and .MutagenEnabled (not .NoProjectMount) }}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3396,9 +3396,9 @@ func TestCaptureLogs(t *testing.T) {
 // This requires that the test machine must have NFS shares working
 // Tests using both app-specific nfs_mount_enabled and global nfs_mount_enabled
 func TestNFSMount(t *testing.T) {
-	if dockerutil.IsWSL2() || dockerutil.IsColima() {
-		t.Skip("Skipping on WSL2/Colima")
-	}
+	//if dockerutil.IsWSL2() || dockerutil.IsColima() {
+	//	t.Skip("Skipping on WSL2/Colima")
+	//}
 	if nodeps.MutagenEnabledDefault == true || nodeps.NoBindMountsDefault {
 		t.Skip("Skipping because mutagen/nobindmounts enabled")
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3396,9 +3396,9 @@ func TestCaptureLogs(t *testing.T) {
 // This requires that the test machine must have NFS shares working
 // Tests using both app-specific nfs_mount_enabled and global nfs_mount_enabled
 func TestNFSMount(t *testing.T) {
-	//if dockerutil.IsWSL2() || dockerutil.IsColima() {
-	//	t.Skip("Skipping on WSL2/Colima")
-	//}
+	if dockerutil.IsWSL2() || dockerutil.IsColima() {
+		t.Skip("Skipping on WSL2/Colima")
+	}
 	if nodeps.MutagenEnabledDefault == true || nodeps.NoBindMountsDefault {
 		t.Skip("Skipping because mutagen/nobindmounts enabled")
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1081,9 +1081,9 @@ func GetHostDockerInternalIP() (string, error) {
 // GetNFSServerAddr gets the addrss that can be used for the NFS server.
 // It's almost the same as GetDockerHostInternalIP() but we have
 // to get the actual addr in the case of linux; still, linux rarely
-// is used with NFS.
+// is used with NFS. Returns "host.docker.internal" by default (not empty)
 func GetNFSServerAddr() (string, error) {
-	nfsAddr := ""
+	nfsAddr := "host.docker.internal"
 
 	switch {
 	case IsColima():

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -509,7 +509,7 @@ func TestRemoveVolume(t *testing.T) {
 	if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", source)) {
 		source = filepath.Join("/System/Volumes/Data", source)
 	}
-	volume, err := CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": "addr=host.docker.internal,hard,nolock,rw",
+	volume, err := CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": "addr=host.docker.internal,hard,nolock,rw,wsize=32768,rsize=32768",
 		"device": ":" + MassageWindowsNFSMount(source)}, nil)
 	assert.NoError(err)
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -509,7 +509,8 @@ func TestRemoveVolume(t *testing.T) {
 	if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", source)) {
 		source = filepath.Join("/System/Volumes/Data", source)
 	}
-	volume, err := CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": "addr=host.docker.internal,hard,nolock,rw,wsize=32768,rsize=32768",
+        nfsServerAddr, _ := dockerutils.GetNFSServerAddr()
+	volume, err := CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": fmt.Sprintf("addr=%s,hard,nolock,rw,wsize=32768,rsize=32768", nfsServerAddr),
 		"device": ":" + MassageWindowsNFSMount(source)}, nil)
 	assert.NoError(err)
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -509,7 +509,7 @@ func TestRemoveVolume(t *testing.T) {
 	if runtime.GOOS == "darwin" && fileutil.IsDirectory(filepath.Join("/System/Volumes/Data", source)) {
 		source = filepath.Join("/System/Volumes/Data", source)
 	}
-        nfsServerAddr, _ := dockerutils.GetNFSServerAddr()
+	nfsServerAddr, _ := GetNFSServerAddr()
 	volume, err := CreateVolume(testVolume, "local", map[string]string{"type": "nfs", "o": fmt.Sprintf("addr=%s,hard,nolock,rw,wsize=32768,rsize=32768", nfsServerAddr),
 		"device": ":" + MassageWindowsNFSMount(source)}, nil)
 	assert.NoError(err)

--- a/pkg/dockerutil/wsl.go
+++ b/pkg/dockerutil/wsl.go
@@ -15,7 +15,7 @@ func IsWSL2() bool {
 		}
 		// But that doesn't always work, so check for existence of wsl.exe
 		_, err := exec.RunHostCommand("command -v wsl.exe")
-		if err != nil {
+		if err == nil {
 			return true
 		}
 	}

--- a/pkg/dockerutil/wsl.go
+++ b/pkg/dockerutil/wsl.go
@@ -1,7 +1,7 @@
 package dockerutil
 
 import (
-	"github.com/drud/ddev/pkg/exec"
+	"github.com/drud/ddev/pkg/fileutil"
 	"os"
 	"runtime"
 )
@@ -14,8 +14,7 @@ func IsWSL2() bool {
 			return true
 		}
 		// But that doesn't always work, so check for existence of wsl.exe
-		_, err := exec.RunHostCommand("command -v wsl.exe")
-		if err == nil {
+		if isWSL2, _ := fileutil.FgrepStringInFile("/proc/version", "-microsoft"); isWSL2 {
 			return true
 		}
 	}


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4122 

## How this PR Solves The Problem:

Sets `wsize`/`rsize` to 32768

## Manual Testing Instructions:

See 
* #4122 

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

@rfay unsure how you'd like to test. I've been using a 100MB zip file and running md5sum on it from inside a container, but I bet you don't want a 100MB object in the git repo 🙃

## Related Issue Link(s):

* #4122
* docker/for-mac#6544

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

Existing NFS volumes would need to be deleted/recreated to pick up the new options.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4359"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

