### PR TITLE
[docs] correct url in the docker install command

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -70,7 +70,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
         sudo apt-get remove docker docker-engine docker.io containerd runc
         sudo apt-get update && sudo apt-get install ca-certificates curl gnupg lsb-release
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/    linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
         sudo apt-get update && sudo apt-get -y install docker-ce docker-ce-cli containerd.io
         sudo groupadd docker && sudo usermod -aG docker $USER
         ```


### PR DESCRIPTION
## The Problem/Issue/Bug:
The docker installation with the command mentioned in the docs [https://ddev.readthedocs.io/en/latest/users/install/docker-installation/#docker-ce-inside-windows-wsl2](https://ddev.readthedocs.io/en/latest/users/install/docker-installation/#docker-ce-inside-windows-wsl2) does not work:

```
sudo apt-get remove docker docker-engine docker.io containerd runc
sudo apt-get update && sudo apt-get install ca-certificates curl gnupg lsb-release
curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/    linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
sudo apt-get update && sudo apt-get -y install docker-ce docker-ce-cli containerd.io
sudo groupadd docker && sudo usermod -aG docker $USER
```

## How this PR Solves The Problem:

I removed the whitespaces seperating the url path.

## Manual Testing Instructions:
Copy the command and watch docker-ce getting installed correctly.

## Automated Testing Overview:

No automated Tests because only the docs spelling are getting changed.

## Automated Testing Overview:
n/a

## Related Issue Link(s):
n/a

## Release/Deployment notes:
n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4361"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

