### PR TITLE
[docs] apt-key is deprecated

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -53,8 +53,8 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     DDEV’s Debian and RPM packages work with `apt` and `yum` repositories and most variants that use them, including Windows WSL2:
 
     ```bash
-    curl -fsSL https://apt.fury.io/drud/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
-    echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
+    curl -sS https://apt.fury.io/drud/gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/ddev.gpg
+    echo "deb [signed-by=/usr/share/keyrings/ddev.gpg] https://apt.fury.io/drud/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
     sudo apt update && sudo apt install -y ddev
     ```
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
apt-key is deprecated

## How this PR Solves The Problem:
Update documentation with suggestion from https://itsfoss.com/apt-key-deprecated/