### PR TITLE
[docs] Don't use inappropriate ~ for path in PhpStorm location for docker-compose

### DIFF
--- a/docs/content/users/topics/phpstorm.md
+++ b/docs/content/users/topics/phpstorm.md
@@ -6,7 +6,7 @@ For full integration of PhpStorm and DDEV, it’s easiest to use the [DDEV Integ
 
 For any setup, including the [DDEV Integration Plugin](https://plugins.jetbrains.com/plugin/18813-ddev-integration):
 
-1. In *Preferences* → *Build, Execution, Deployment* → *Docker* → *Tools*, set the docker-compose executable to DDEV’s private docker-compose, `~/.ddev/bin/docker-compose`. If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’t use docker-compose from WSL2, so at least configure Docker Desktop in *Settings* → *General* to “Use Docker Compose V2” and use a recent version of Docker Desktop.
+1. In *Preferences* → *Build, Execution, Deployment* → *Docker* → *Tools*, set the docker-compose executable to DDEV’s private docker-compose using the full path to `.ddev/bin/docker-compose` in your home directory. If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’t use docker-compose from WSL2, so at least configure Docker Desktop in *Settings* → *General* to “Use Docker Compose V2” and use a recent version of Docker Desktop.
 
 ### Requirements
 


### PR DESCRIPTION
Updated documentation to indicate needing to use the full path.

## The Problem/Issue/Bug:
Following the docs at https://ddev.readthedocs.io/en/latest/users/topics/phpstorm/ was not working because a path with `~` didn't work.


I got this error from PhpStorm:

```
Error while parsing <projectroot>.ddev/.ddev-docker-compose-full.yaml
Cannot run program "~/.ddev/bin/docker-compose" in directory ...
No such file or directory
```

Related:
* https://github.com/php-perfect/ddev-intellij-plugin/issues/123

## How this PR Solves The Problem:
Updates the documentation to indicate that the full path is necessary.

## Manual Testing Instructions:
Review text changes.

## Automated Testing Overview:
NA

## Related Issue Link(s):
NA

## Release/Deployment notes:
NA



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4368"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

