### PR TITLE
[tests] Add xq and yq to brew install in master-build [skip ci]

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -112,8 +112,7 @@ jobs:
     steps:
       - name: "setup macOS"
         run: |
-          brew install coreutils gnu-getopt jq
-          pip3 install yq
+          brew install coreutils gnu-getopt jq xq yq
       - uses: actions/checkout@v3
         with:
           # We need to get all branches and tags for git describe to work properly


### PR DESCRIPTION
## The Problem/Issue/Bug:

We're getting errors in the master build (macOS) saying that xq isn't installed.

It seems that xq is now available via brew, so add it there. 



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4369"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

