### PR TITLE
[tests only] xq and yq are no longer needed

### DIFF
--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -38,7 +38,7 @@ npm install --global markdownlint-cli
 markdownlint --version
 # readthedocs has ancient version of mkdocs in it.
 pyenv global 3.9.7 # added to make CircleCi give us pip3
-pip3 install -q yq mkdocs==0.17.5
+pip3 install -q mkdocs==0.17.5
 
 # Get the Stubs and Plugins for makensis; the linux makensis build doesn't do this.
 pwd && ./.ci-scripts/nsis_setup.sh /usr/local/share/nsis

--- a/.circleci/macos_circle_vm_setup.sh
+++ b/.circleci/macos_circle_vm_setup.sh
@@ -29,8 +29,6 @@ mkdir -p "$(brew --prefix)/etc/my.cnf.d"
 
 mkcert -install
 
-pip3 install -q yq
-
 sudo bash -c "cat <<EOF >/etc/exports
 ${HOME} -alldirs -mapall=$(id -u):$(id -g) localhost
 /private/var -alldirs -mapall=$(id -u):$(id -g) localhost

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: "setup macOS"
         run: |
-          brew install coreutils gnu-getopt jq xq yq
+          brew install coreutils gnu-getopt jq
       - uses: actions/checkout@v3
         with:
           # We need to get all branches and tags for git describe to work properly

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -664,7 +664,6 @@ yml
 you
 your
 yoursite
-yq
 zcompdump
 zsh
 zshrc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DDEV
 
-[![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2022.svg)
+[![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2023.svg)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/drud/ddev)
 
 ![DDEV Logo](images/ddev-logo.svg)


### PR DESCRIPTION
## The Problem/Issue/Bug:

xq and yq are not needed in the build any more.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4370"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

