### PR TITLE
[docs] Add `web_extra_daemons` and `web_extra_exposed_ports` to settings page

### DIFF
--- a/docs/content/users/configuration/config_yaml.md
+++ b/docs/content/users/configuration/config_yaml.md
@@ -511,6 +511,22 @@ Additional [custom environment variables](../extend/customization-extendibility.
 | -- | -- | --
 | :octicons-file-directory-16: project<br>:octicons-globe-16: global | `[]` |
 
+## `web_extra_daemons`
+
+Additional daemons that should [automatically be started in the web container](../extend/customization-extendibility.md#running-extra-daemons-in-the-web-container).
+
+| Type | Default | Usage
+| -- | -- | --
+| :octicons-file-directory-16: project | `[]` |
+
+## `web_extra_exposed_ports`
+
+Additional named sets of ports to [expose via `ddev-router`](../extend/customization-extendibility.md#exposing-extra-ports-via-ddev-router).
+
+| Type | Default | Usage
+| -- | -- | --
+| :octicons-file-directory-16: project | `[]` |
+
 ## `webimage`
 
 The Docker image to use for the web server.

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -58,7 +58,7 @@ hooks:
 
 ### Running Extra Daemons Using `web_extra_daemons`
 
-If you need extra daemons to start up automatically inside the web container, you can easily add them using `web_extra_daemons` in `.ddev/config.yaml`.
+If you need extra daemons to start up automatically inside the web container, you can easily add them using [`web_extra_daemons`](../configuration/config_yaml.md#web_extra_daemons) in `.ddev/config.yaml`.
 
 You might be running Node.js daemons that serve a particular purpose, like `browsersync`, or more general daemons like a `cron` daemon.
 
@@ -82,7 +82,7 @@ web_extra_daemons:
 
 ## Exposing Extra Ports via `ddev-router`
 
-If your `web` container has additional HTTP servers running inside it on different ports, those can be exposed using `web_extra_exposed_ports` in `.ddev/config.yaml`. For example, this configuration would expose a `node-vite` HTTP server running on port 3000 inside the `web` container, via `ddev-router`, to ports 9998 (HTTP) and 9999 (HTTPS), so it could be accessed via `https://<project>.ddev.site:9999`:
+If your `web` container has additional HTTP servers running inside it on different ports, those can be exposed using [`web_extra_exposed_ports`](../configuration/config_yaml.md#web_extra_exposed_ports) in `.ddev/config.yaml`. For example, this configuration would expose a `node-vite` HTTP server running on port 3000 inside the `web` container, via `ddev-router`, to ports 9998 (HTTP) and 9999 (HTTPS), so it could be accessed via `https://<project>.ddev.site:9999`:
 
 ```yaml
 web_extra_exposed_ports:


### PR DESCRIPTION
## The Problem/Issue/Bug:

Realized working on #4354 that the `web_extra_daemons` and `web_extra_exposed_ports` settings aren’t referenced on the refreshed config settings page.

## How this PR Solves The Problem:

This adds those settings and links back to them where their usage is described in more detail.

## Manual Testing Instructions:

You can test manually by checking out this branch and following [these steps](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes), or examine the [automatic preview build](https://ddev--4373.org.readthedocs.build/en/4373/users/configuration/config_yaml/#web_extra_daemons).

## Automated Testing Overview:

n/a

## Related Issue Link(s):

- #4354
- #4188

## Release/Deployment notes:

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4373"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

