### PR TITLE
Warn about usage of Docker Desktop for Linux

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -626,6 +626,18 @@ func CheckDockerVersion(versionConstraint string) error {
 		return err
 	}
 
+	// See if they're using broken docker desktop on linux
+	if runtime.GOOS == "linux" {
+		client := GetDockerClient()
+		info, err := client.Info()
+		if err != nil {
+			return fmt.Errorf("unable to get docker info: %v", err)
+		}
+		if info.Name == "docker-desktop" {
+			return fmt.Errorf("Docker Desktop on Linux is not yet compatible with DDEV")
+		}
+	}
+
 	constraint, err := semver.NewConstraint(versionConstraint)
 	if err != nil {
 		return err


### PR DESCRIPTION
## The Problem/Issue/Bug:

* People on Linux keep finding trouble with Docker Desktop for Linux. 
* This is mentioned in the docs

## How this PR Solves The Problem:

Warn them so they maybe they won't use it.

## Manual Testing Instructions:

Try to `ddev start` with Docker Desktop for Linux

