### PR TITLE
[docs] Fix mysqlworkbench custom command instructions

### DIFF
--- a/docs/content/users/basics/database-management.md
+++ b/docs/content/users/basics/database-management.md
@@ -54,5 +54,5 @@ Use the [`ddev snapshot restore`](../basics/commands.md#snapshot-restore) comman
     * Use the “database” tool to create a source from “localhost”, with the proper type “mysql” or “postgresql” and the port you chose, username `db` + password `db`.
     * Explore away!
 * There’s a sample custom command that will run the free [MySQL Workbench](https://dev.mysql.com/downloads/workbench/) on macOS, Windows or Linux. To use it, run:
-    * `cp ~.ddev/commands/host/mysqlworkbench.example ~.ddev/commands/host/mysqlworkbench`
+    * `cp ~/.ddev/commands/host/mysqlworkbench.example ~/.ddev/commands/host/mysqlworkbench`
     * `ddev mysqlworkbench`


### PR DESCRIPTION
## The Problem/Issue/Bug:
Incorrect directories in MySQL workbench example cp command

## How this PR Solves The Problem:
Adds missing / after ~

## Manual Testing Instructions:
Run said command(s) on machine

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4381"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

