### PR TITLE
[docs] Stylistic cleanup

### DIFF
--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -137,11 +137,11 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
 
     ### Troubleshooting Mutagen Sync Issues
 
-    * Please make sure that DDEV projects work *without* mutagen before troubleshooting mutagen. `ddev config --mutagen-enabled=false && ddev restart`.
-    * Rename your project's .ddev/mutagen/mutagen.yml to .ddev/mutagen/mutagen.yml.bak and `ddev restart`. This makes sure you'll have a fresh version in case the file has been changed and `#ddev-generated` removed.
-    * `export DDEV_DEBUG=true` will provide more information about what's going on with mutagen.
-    * As of DDEV v1.21.2, DDEV's mutagen daemon keeps its data in a DDEV-only MUTAGEN_DATA_DIRECTORY, `~/.ddev_mutagen_data_directory`.
-    * DDEV's private mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory` and running the mutagen binary in `~/.ddev/bin/mutagen`, for example:and `~/.ddev/bin/mutagen daemon stop`.
+    * Please make sure that DDEV projects work *without* Mutagen before troubleshooting it. Run `ddev config --mutagen-enabled=false && ddev restart`.
+    * Rename your project’s `.ddev/mutagen/mutagen.yml` file to `.ddev/mutagen/mutagen.yml.bak` and run `ddev restart`. This ensures you’ll have a fresh version in case the file has been changed and `#ddev-generated` removed.
+    * `export DDEV_DEBUG=true` will provide more information about what’s going on with Mutagen.
+    * As of DDEV v1.21.2, DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY`, `~/.ddev_mutagen_data_directory`.
+    * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of Mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory` and running the Mutagen binary in `~/.ddev/bin/mutagen`, for example:and `~/.ddev/bin/mutagen daemon stop`.
 
         ```bash
         export DDEV_DEBUG=true


### PR DESCRIPTION
## The Problem/Issue/Bug:

Looks like I missed some minor stylistic edits on the Performance page!

## How this PR Solves The Problem:

This fixes a few stylistic issues to adhere to the writing guide, capitalizing “Mutagen”, making sure to “run” commands, using backticks consistently, and making tiny edits for brevity.

## Manual Testing Instructions:

[Preview locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or by visiting the [automatic build preview](https://ddev--4386.org.readthedocs.build/en/4386/users/install/performance/#troubleshooting-mutagen-sync-issues).

## Automated Testing Overview:

n/a

## Related Issue Link(s):

#4188

## Release/Deployment notes:

n/a



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4386"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

