### PR TITLE
[docs] Contributing to open source URL no longer at github

### DIFF
--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -173,8 +173,6 @@ Once you’ve opened a pull request, a discussion will start around your propose
 
 If your pull request is merged, great! If not, no sweat; it may not be what the project maintainer had in mind, or they were already working on it. This happens, so our recommendation is to take any feedback you’ve received and go forth and pull request again. Or create your own open source project.
 
-Adapted from [GitHub Guides](https://guides.github.com/activities/contributing-to-open-source/).
-
 ## Coding Style
 
 Unless explicitly stated, we follow all coding guidelines from the Go community. While some of these standards may seem arbitrary, they somehow seem to result in a solid, consistent codebase.


### PR DESCRIPTION
## The Problem/Issue/Bug:

The content https://guides.github.com/activities/contributing-to-open-source/ is gone from github. 

## How this PR Solves The Problem:

Remove the reference

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

