### PR TITLE
ddev share --subdomain should use ngrok --subdomain, fixes #4390

### DIFF
--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -50,7 +50,7 @@ ddev share myproject`,
 				if err != nil {
 					util.Failed("unable to get --subdomain flag: %v", err)
 				}
-				ngrokArgs = append(ngrokArgs, "-subdomain="+sub)
+				ngrokArgs = append(ngrokArgs, "--subdomain="+sub)
 			}
 
 			ngrokCmd := exec.Command(ngrokLoc, ngrokArgs...)


### PR DESCRIPTION
## The Problem/Issue/Bug:

ngrok no longer accepts `-subdomain` as an arg, now `--subdomain`, 
* #4390

(Note: You don't need this PR to solve the problem, but instead can just use the technique in the docs, https://ddev.readthedocs.io/en/latest/users/topics/sharing/#setting-up-a-stable-ngrok-subdomain - put the ngrok args in config.yaml)

## How this PR Solves The Problem:

Use --subdomain

## Manual Testing Instructions:

With paid ngrok account, `ddev share --subdomain=xxxsomething`


