### PR TITLE
Fix postgres 9-11 build broken, fixes #4391

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -910,11 +910,6 @@ RUN apt-get -y install apt-transport-https
 RUN printf "deb http://apt-archive.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 `
 		}
-		if app.Database.Version == nodeps.Postgres11 {
-			extraDBContent = extraDBContent + `
-ARG BASE_IMAGE=postgres:11-bullseye
-`
-		}
 		extraDBContent = extraDBContent + `
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 ADD postgres_healthcheck.sh /

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -897,7 +897,25 @@ redirect_stderr=true
 	// Add .pgpass to homedir on postgres
 	extraDBContent := ""
 	if app.Database.Type == nodeps.Postgres {
-		extraDBContent = `
+		// Postgres 9/10/11 upstream images are stretch-based, out of support from Debian.
+		// Postgres 9/10 are out of support by Postgres and no new images being pushed, see
+		// https://github.com/docker-library/postgres/issues/1012
+		// However, they do have a postgres:11-bullseye, but we won't start using it yet
+		// because of awkward changes to $DBIMAGE. Postgres 11 will be EOL Nov 2023
+		if nodeps.ArrayContainsString([]string{nodeps.Postgres9, nodeps.Postgres10, nodeps.Postgres11}, app.Database.Version) {
+			extraDBContent = extraDBContent + `
+RUN rm -f /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update
+RUN apt-get -y install apt-transport-https
+RUN printf "deb http://apt-archive.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+`
+		}
+		if app.Database.Version == nodeps.Postgres11 {
+			extraDBContent = extraDBContent + `
+ARG BASE_IMAGE=postgres:11-bullseye
+`
+		}
+		extraDBContent = extraDBContent + `
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 ADD postgres_healthcheck.sh /
 RUN chmod ugo+rx /postgres_healthcheck.sh
@@ -991,6 +1009,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 	if extraPackages != nil {
 		contents = contents + `
 ### DDEV-injected from webimage_extra_packages or dbimage_extra_packages
+
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1470,7 +1470,7 @@ func TestDdevAllDatabases(t *testing.T) {
 	dbVersions = nodeps.RemoveItemFromSlice(dbVersions, "postgres:9")
 	//Use a smaller list if GOTEST_SHORT
 	if os.Getenv("GOTEST_SHORT") != "" {
-		dbVersions = []string{"postgres:14", "mariadb:10.3", "mariadb:10.4", "mysql:8.0", "mysql:5.7"}
+		dbVersions = []string{"postgres:10", "postgres:11", "postgres:14", "mariadb:10.3", "mariadb:10.4", "mariadb:10.6", "mysql:8.0", "mysql:5.7"}
 		t.Logf("Using limited set of database servers because GOTEST_SHORT is set (%v)", dbVersions)
 	}
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4391 
* https://github.com/docker-library/postgres/issues/1012

## How this PR Solves The Problem:

Work around by using archive versions of debian repositories.

## Manual Testing Instructions:

`ddev config --database=postgres:9 && ddev start` (and the postgres:10 and postgres:11`
Then `ddev psql`

## Automated Testing Overview:

We did miss this in the automated tests because these older versions were excluded in TestDdevAllDatabases. I added postgres:10 and postgres:11 to that test. 

