### PR TITLE
AUR: bring dependencies back to PKGBUILD recipe

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -330,7 +330,6 @@ aurs:
   - docker
   optdepends:
   - 'bash-completion: subcommand completion support'
-  - 'docker-compose: for use_docker_compose_from_path option'
 
   package: |-
     # bin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -293,7 +293,6 @@ aurs:
   - docker
   optdepends:
   - 'bash-completion: subcommand completion support'
-  - 'docker-compose: for use_docker_compose_from_path option'
 
   package: |-
     # bin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -293,6 +293,7 @@ aurs:
   - docker
   optdepends:
   - 'bash-completion: subcommand completion support'
+  - 'docker-compose: for use_docker_compose_from_path option'
 
   package: |-
     # bin
@@ -330,6 +331,7 @@ aurs:
   - docker
   optdepends:
   - 'bash-completion: subcommand completion support'
+  - 'docker-compose: for use_docker_compose_from_path option'
 
   package: |-
     # bin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -291,6 +291,8 @@ aurs:
   git_url: '{{ .Env.AUR_STABLE_GIT_URL }}'
   depends:
   - docker
+  optdepends:
+  - 'bash-completion: subcommand completion support'
 
   package: |-
     # bin
@@ -326,6 +328,8 @@ aurs:
   git_url: '{{ .Env.AUR_EDGE_GIT_URL }}'
   depends:
   - docker
+  optdepends:
+  - 'bash-completion: subcommand completion support'
 
   package: |-
     # bin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -289,6 +289,8 @@ aurs:
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
   # AUR_EDGE_GIT_URL should be something like ssh://aur@aur.archlinux.org/ddev-bin.git or ssh://aur@aur.archlinux.org/rfay-test-ddev-bin.git
   git_url: '{{ .Env.AUR_STABLE_GIT_URL }}'
+  depends:
+  - docker
 
   package: |-
     # bin
@@ -322,6 +324,8 @@ aurs:
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
   # AUR_EDGE_GIT_URL should be something like ssh://aur@aur.archlinux.org/ddev-edge-bin.git or ssh://aur@aur.archlinux.org/rfay-test-ddev-edge-bin.git
   git_url: '{{ .Env.AUR_EDGE_GIT_URL }}'
+  depends:
+  - docker
 
   package: |-
     # bin


### PR DESCRIPTION
## The Problem/Issue/Bug:
After moving to GoReleaser, dependencies for AUR were lost.

## How this PR Solves The Problem:
Brings back missing `depends` and `optdepends`.
I moved `docker-compose` to `optdepends` because it is not required now.

## Manual Testing Instructions:
Check `PKGBUILD` for the options above in [ddev-bin](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ddev-bin) and [ddev-edge-bin](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ddev-edge-bin) after release.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
https://github.com/drud/ddev/issues/3723

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4396"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

