### PR TITLE
Allow setting environment in ddev pull on command line, fixes #4180, fixes platformsh/ddev-platformsh#63

### DIFF
--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -128,6 +128,5 @@ ddev pull %s --skip-files -y`, subCommandName, subCommandName, subCommandName),
 		subCommand.Flags().Bool("skip-files", false, "Skip pulling file archive")
 		subCommand.Flags().Bool("skip-import", false, "Downloads file and/or database archives, but does not import them")
 		subCommand.Flags().String("environment", "", "Add/override environment variables during pull. Commas and equals are not allowed in the names or values.")
-
 	}
 }

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/dockerutil"
@@ -21,7 +22,10 @@ var PullCmd = &cobra.Command{
 ddev pull platform
 ddev pull pantheon -y
 ddev pull platform --skip-files -y
-ddev pull localfile --skip-db -y`,
+ddev pull localfile --skip-db -y
+ddev pull platform --environment=PLATFORM_ENVIRONMENT=main,PLATFORMSH_CLI_TOKEN=abcdef
+`,
+
 	Args: cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		dockerutil.EnsureDdevNetwork()
@@ -29,7 +33,7 @@ ddev pull localfile --skip-db -y`,
 }
 
 // appPull() does the work of pull
-func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDbArg bool, skipFilesArg bool) {
+func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDbArg bool, skipFilesArg bool, env string) {
 
 	// If we're not performing the import step, we won't be deleting the existing db or files.
 	if !skipConfirmation && !skipImportArg && os.Getenv("DDEV_NONINTERACTIVE") == "" {
@@ -55,6 +59,16 @@ func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 	provider, err := app.GetProvider(providerType)
 	if err != nil {
 		util.Failed("Failed to get provider: %v", err)
+	}
+
+	// Add or override the command-line provided environment variables
+	envVars := strings.Split(env, ",")
+	for _, v := range envVars {
+		split := strings.Split(v, "=")
+		if len(split) != 2 {
+			util.Failed("unable to parse environment variable setting: %v", v)
+		}
+		provider.EnvironmentVariables[split[0]] = split[1]
 	}
 
 	if err := app.Pull(provider, skipDbArg, skipFilesArg, skipImportArg); err != nil {
@@ -104,7 +118,8 @@ ddev pull %s --skip-files -y`, subCommandName, subCommandName, subCommandName),
 					}
 				}
 
-				appPull(providerName, app, flags["skip-confirmation"], flags["skip-import"], flags["skip-db"], flags["skip-files"])
+				environment, _ := cmd.Flags().GetString("environment")
+				appPull(providerName, app, flags["skip-confirmation"], flags["skip-import"], flags["skip-db"], flags["skip-files"], environment)
 			},
 		}
 		PullCmd.AddCommand(subCommand)
@@ -112,6 +127,7 @@ ddev pull %s --skip-files -y`, subCommandName, subCommandName, subCommandName),
 		subCommand.Flags().Bool("skip-db", false, "Skip pulling database archive")
 		subCommand.Flags().Bool("skip-files", false, "Skip pulling file archive")
 		subCommand.Flags().Bool("skip-import", false, "Downloads file and/or database archives, but does not import them")
+		subCommand.Flags().String("environment", "", "Add/override environment variables during pull. Commas and equals are not allowed in the names or values.")
 
 	}
 }

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -51,6 +51,10 @@ func (p *Provider) Init(pType string, app *DdevApp) error {
 		return err
 	}
 
+	if p.EnvironmentVariables == nil {
+		p.EnvironmentVariables = map[string]string{}
+	}
+
 	p.ProviderType = pType
 	app.ProviderInstance = p
 	return nil

--- a/pkg/ddevapp/providerPlatform_test.go
+++ b/pkg/ddevapp/providerPlatform_test.go
@@ -169,7 +169,7 @@ func TestPlatformPush(t *testing.T) {
 
 	// Test that the database row was added
 	out, _, err := app.Exec(&ExecOpts{
-		Cmd: fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s";' | platform db:sql --project="%s" --environment="%s"`, t.Name(), tval, platformTestSiteID, platformPushTestSiteEnvironment),
+		Cmd: fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s";' | PLATFORMSH_CLI_TOKEN=%s platform db:sql --project="%s" --environment="%s"`, t.Name(), tval, token, platformTestSiteID, platformPushTestSiteEnvironment),
 	})
 	require.NoError(t, err)
 	assert.Contains(out, tval)
@@ -177,7 +177,7 @@ func TestPlatformPush(t *testing.T) {
 	// Test that the file arrived there (by rsyncing it back)
 	tmpRsyncDir := filepath.Join("/tmp", t.Name()+util.RandString(5))
 	out, _, err = app.Exec(&ExecOpts{
-		Cmd: fmt.Sprintf(`platform mount:download --yes --quiet --project="%s" --environment="%s" --mount=web/sites/default/files --target=%s && cat %s/%s && rm -rf %s`, platformTestSiteID, platformPushTestSiteEnvironment, tmpRsyncDir, tmpRsyncDir, fName, tmpRsyncDir),
+		Cmd: fmt.Sprintf(`PLATFORMSH_CLI_TOKEN=%s platform mount:download --yes --quiet --project="%s" --environment="%s" --mount=web/sites/default/files --target=%s && cat %s/%s && rm -rf %s`, token, platformTestSiteID, platformPushTestSiteEnvironment, tmpRsyncDir, tmpRsyncDir, fName, tmpRsyncDir),
 	})
 	require.NoError(t, err)
 	assert.Contains(out, tval)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4180 
* https://github.com/platformsh/ddev-platformsh/issues/63

## How this PR Solves The Problem:

Add `--environment` to `ddev pull`

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4399"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

