### PR TITLE
WSL2 Install Script: remove unnecessary escaping backslashes

### DIFF
--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -44,10 +44,10 @@ wsl -u root apt-get update
 wsl -u root apt-get install -y ca-certificates curl gnupg lsb-release
 wsl -u root mkdir -p /etc/apt/keyrings
 wsl -u root bash -c "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg"
-wsl -u root -e bash -c 'echo \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable\" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null 2>&1'
+wsl -u root -e bash -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null 2>&1'
 
 wsl -u root -e bash -c "curl -fsSL https://apt.fury.io/drud/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null"
-wsl -u root -e bash -c 'echo \"deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *\" > /etc/apt/sources.list.d/ddev.list'
+wsl -u root -e bash -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *" > /etc/apt/sources.list.d/ddev.list'
 wsl -u root -e bash -c "sudo apt update && sudo apt install -y ddev docker-ce docker-ce-cli containerd.io wslu"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 wsl bash -c 'sudo usermod -aG docker $USER'


### PR DESCRIPTION
Remove unnecessary escaping backslashes from ln 47 and ln 50

## The Problem/Issue/Bug:

Numerous errors/issues presented when executing scripts/install_ddev_wsl2_docker_inside.ps1 in PowerShell 7.3 with the following command as instructed on the docs:
`Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; 
iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev_wsl2_docker_inside.ps1'))`

The installation process gave many errors.

Upon investigation, I noticed that the files...

- /etc/apt/sources.list.d/docker.list, and
- /etc/apt/sources.list.d/ddev.list

...both contained code wrapped in double-quotes.

This caused those files not to function correctly in the context of the script and ALSO prevents the user within their linux distro (ie. Ubuntu 20.04 -- which is my distro) to update their app repositories (ie. sudo apt update), as it would attempt to read the above .list files and fail.

Additionally, ddev.list contained an entire list of all directories in my C:\Users\{Username}\ directory.  This was because the original line 50 contained an escaping backslash after the 2nd asterisk at the end of the first echo string.

Since both ln 47's and ln 50's echo string are wrapped in single-quotes, there is no need to escape double-quotes within.

Upon removing the (4) four unnecessary escaping backslashes from ln 47 and ln 50, the scripts write to both docker.list and ddev.list as expected.

Additionally, the installation process can now work correctly within PowerShell 7.x.

I am not sure why the original code with the unnecessary backslashes worked in PowerShell 5.x.  I run both PowerShell 5 and PowerShell 7 on my Windows 10 machine and can confirm that PowerShell 7 handles the original ln 47 and ln 50 differently.

I did test the proposed changes in both PowerShell 5.x and PowerShell 7.3 and the proposed changes appear to work great and fix the issues.

I do welcome other folks to test my work and test on their machines with their setups.

## How this PR Solves The Problem:

By removing unnecessary escaping backlashes from ln 47 and ln 50

## Manual Testing Instructions:

1) Within PowerShell 7.x, run the original ln 47 and ln 50 to see what the original code does to the above files:

Run the following (ln 47) in bash/zsh:
`wsl -u root -e bash -c 'echo \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable\" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null 2>&1'`

Run the following (ln 50) in bash/zsh:
`wsl -u root -e bash -c 'echo \"deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *\" > /etc/apt/sources.list.d/ddev.list'`

2) Within Ubuntu 20.04 (or whatever version you are running), open both the following files to observe their contents.  I used Vim, but any editor is fine:

- /etc/apt/sources.list.d/docker.list
- /etc/apt/sources.list.d/ddev.list

Notice how the code in both files are errantly wrapped in double quotes (ex. "deb).  This is what was causing issues to arise.

Now let's apply the corrected fix:

1) Within PowerShell 7.x, run the proposed ln 47 and ln 50 to see what removing the escaping backslashes does to the above files:

Run the following (ln 47) in bash/zsh:
`wsl -u root -e bash -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null 2>&1'`

Run the following (ln 50) in bash/zsh:
`wsl -u root -e bash -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *" > /etc/apt/sources.list.d/ddev.list'`

2) Within Ubuntu 20.04 (or whatever version you are running), open both the following files to observe their contents.  I used Vim, but any editor is fine:

- /etc/apt/sources.list.d/docker.list
- /etc/apt/sources.list.d/ddev.list

Notice now how the code within each of the above files is correct and without error.

## Automated Testing Overview:

## Related Issue Link(s):

## Release/Deployment notes:
There will likely need to be more testing and also consideration for the PowerShell script used for Docker Desktop, too.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4402"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

