### PR TITLE
Restore proper hosts file removal, fixes #4404

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2252,7 +2252,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		return err
 	}
 
-	// Remove data/database/projectInfo/hostname if we need to.
+	// Remove data/database/projectInfo/hosts entry if we need to.
 	if removeData {
 		err = TerminateMutagenSync(app)
 		if err != nil {

--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -8,6 +8,7 @@ import (
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
+	"github.com/lextoumbourou/goodhosts"
 	"net"
 	"os"
 	exec2 "os/exec"
@@ -134,6 +135,15 @@ func (app *DdevApp) RemoveHostsEntries() error {
 		}
 
 		if !dockerutil.IsWSL2() || !IsWindowsDdevExeAvailable() {
+			hosts, err := goodhosts.NewHosts()
+			if err != nil {
+				util.Failed("could not open hostfile: %v", err)
+			}
+
+			if !hosts.Has(dockerIP, name) {
+				continue
+			}
+
 			_, err = exec2.LookPath("sudo")
 			if os.Getenv("DDEV_NONINTERACTIVE") != "" || err != nil {
 				util.Warning("You must manually remove the following entry from your hosts file:\n%s %s\nOr with root/administrative privileges execute 'ddev hostname --remove %s %s", dockerIP, name, name, dockerIP)


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4404 - hosts file removal didn't work on non-WSL2 any more, it always tried to remove all hosts entries.

Was broken by 
* #4377


## How this PR Solves The Problem:

Check the hosts file to see if we actually need to remove

## Manual Testing Instructions:

- [x] Use `ddev delete -Oy` on any project. It shouldn't try to delete *.ddev.site
- [x] Use `ddev delete -Oy` on WSL2, same
- [x] Use `ddev delete -Oy` on a project that actually has additional_fqdns that should be deleted. They should be properly deleted on
  - [x] macOS
  - [x] Windows WSL2 (where ddev/sudo set up correctly)
  - [x] Windows WSL2 (where Windows side ddev *not* set up)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

* Preferred setup is latest version of DDEV installed on Windows side, with gsudo. (Only difference in latest version is it doesn't require docker on Windows side)
* `gsudo cache on` (on Windows side) can make things easier for WSL2 users who have additional_hostnames. `gsudo config CacheMode auto` even easier.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4408"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

