### PR TITLE
[docs] Fixing indentation in multiple exposed ports example YAML.

### DIFF
--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -31,17 +31,17 @@ That approach usually isn’t sustainable because two projects might want to use
 
 ```yaml
 services:
-    someservice:
-        container_name: "ddev-${DDEV_SITENAME}-someservice"
-        labels:
-        com.ddev.site-name: ${DDEV_SITENAME}
-        com.ddev.approot: ${DDEV_APPROOT}
-        expose: 
-        - "9999"
-        environment:
-        - VIRTUAL_HOST=$DDEV_HOSTNAME
-        - HTTP_EXPOSE=9998:9999
-        - HTTPS_EXPOSE=9999:9999
+  someservice:
+    container_name: "ddev-${DDEV_SITENAME}-someservice"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    expose:
+      - "9999"
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=9998:9999
+      - HTTPS_EXPOSE=9999:9999
 ```
 
 ## Confirming docker-compose Configurations


### PR DESCRIPTION
## The Problem/Issue/Bug:

The code sample at https://ddev.readthedocs.io/en/latest/users/extend/custom-compose-files/#docker-composeyaml-examples has an indentation problem in the `labels` section.

![image](https://user-images.githubusercontent.com/100206/204420773-e5340972-5f26-4520-a433-37fc1ed6e501.png)

## How this PR Solves The Problem:

Reformats the whole section to use 2-spaces like the other examples on this page.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4412"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

