### PR TITLE
Make `ddev get` output friendlier

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -266,9 +266,6 @@ func processAction(action string, dict map[string]interface{}, bashPath string) 
 	if err != nil {
 		return fmt.Errorf("Unable to run action %v: %v, output=%s", action, err, out)
 	}
-	if len(out) > 0 {
-		output.UserOut.Print(out)
-	}
 	if !strings.Contains(action, `#ddev-nodisplay`) {
 		output.UserOut.Printf("Executed action '%v', output='%s'", action, out)
 	}

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -193,7 +193,7 @@ ddev get --list --all
 		}
 
 		if len(s.ProjectFiles) > 0 {
-			util.Success("Installing project-level components:")
+			util.Success("\nInstalling project-level components:")
 		}
 		for _, file := range s.ProjectFiles {
 			file := os.ExpandEnv(file)
@@ -211,7 +211,7 @@ ddev get --list --all
 		}
 		globalDotDdev := filepath.Join(globalconfig.GetGlobalDdevDir())
 		if len(s.ProjectFiles) > 0 {
-			util.Success("Installing global components:")
+			util.Success("\nInstalling global components:")
 		}
 		for _, file := range s.GlobalFiles {
 			file := os.ExpandEnv(file)
@@ -245,7 +245,7 @@ ddev get --list --all
 			}
 		}
 
-		util.Success("Installed DDEV add-on %s, use `ddev restart` to enable.", sourceRepoArg)
+		util.Success("\nInstalled DDEV add-on %s, use `ddev restart` to enable.", sourceRepoArg)
 		if argType == "github" {
 			util.Success("Please read instructions for this addon at the source repo at\nhttps://github.com/%v/%v\nPlease file issues and create pull requests there to improve it.", owner, repo)
 		}
@@ -272,10 +272,27 @@ func processAction(action string, dict map[string]interface{}, bashPath string) 
 	if err != nil {
 		return fmt.Errorf("Unable to run action %v: %v, output=%s", action, err, out)
 	}
+
 	if !strings.Contains(action, `#ddev-nodisplay`) {
 		output.UserOut.Printf("Executed action '%v', output='%s'", action, out)
 	}
+	desc := getDdevDescription(action)
+	if desc != "" {
+		util.Success("%c %s", '\U0001F44D', desc)
+	}
 	return nil
+}
+
+// getDdevDescription returns what follows #ddev-description: in any line in action
+func getDdevDescription(action string) string {
+	descLines := nodeps.GrepStringInBuffer(action, `[\r\n]+#ddev-description:.*[\r\n]+`)
+	if len(descLines) > 0 {
+		d := strings.Split(descLines[0], ":")
+		if len(d) > 1 {
+			return strings.Trim(d[1], "\r\n\t")
+		}
+	}
+	return ""
 }
 
 func renderRepositoryList(repos []github.Repository) string {

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -192,6 +192,9 @@ ddev get --list --all
 			}
 		}
 
+		if len(s.ProjectFiles) > 0 {
+			util.Success("Installing project-level components:")
+		}
 		for _, file := range s.ProjectFiles {
 			file := os.ExpandEnv(file)
 			src := filepath.Join(extractedDir, file)
@@ -201,12 +204,15 @@ ddev get --list --all
 				if err != nil {
 					util.Failed("Unable to copy %v to %v: %v", src, dest, err)
 				}
-				output.UserOut.Printf("Installed file %s", dest)
+				util.Success("%c %s", '\U0001F44D', file)
 			} else {
 				util.Warning("NOT overwriting file/directory %s. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can just remove the file and use ddev get again if you want it to be replaced: %v", dest, err)
 			}
 		}
 		globalDotDdev := filepath.Join(globalconfig.GetGlobalDdevDir())
+		if len(s.ProjectFiles) > 0 {
+			util.Success("Installing global components:")
+		}
 		for _, file := range s.GlobalFiles {
 			file := os.ExpandEnv(file)
 			src := filepath.Join(extractedDir, file)
@@ -218,7 +224,7 @@ ddev get --list --all
 				if err != nil {
 					util.Failed("Unable to copy %v to %v: %v", src, dest, err)
 				}
-				output.UserOut.Printf("Installed file %s", dest)
+				util.Success("%c %s", '\U0001F44D', file)
 			} else {
 				util.Warning("NOT overwriting file/directory %s. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can just remove the file and use ddev get again if you want it to be replaced: %v", dest, err)
 			}
@@ -239,7 +245,7 @@ ddev get --list --all
 			}
 		}
 
-		util.Success("Downloaded add-on %s, use `ddev restart` to enable.", sourceRepoArg)
+		util.Success("Installed DDEV add-on %s, use `ddev restart` to enable.", sourceRepoArg)
 		if argType == "github" {
 			util.Success("Please read instructions for this addon at the source repo at\nhttps://github.com/%v/%v\nPlease file issues and create pull requests there to improve it.", owner, repo)
 		}

--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -56,7 +56,7 @@ func TestCmdGet(t *testing.T) {
 		tarballFile} {
 		out, err := exec.RunHostCommand(DdevBin, "get", arg)
 		assert.NoError(err, "failed ddev get %s", arg)
-		assert.Contains(out, "Downloaded add-on")
+		assert.Contains(out, "Installed DDEV add-on")
 		assert.FileExists(app.GetConfigPath("docker-compose.memcached.yaml"))
 	}
 

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -10,35 +10,37 @@ For example,
 
 ```
 →  ddev get --list
-┌───────────────────────────┬──────────────────────────────────────────────────┐
-│ ADD-ON                    │ DESCRIPTION                                      │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-adminer         │ Adminer service for DDEV*                        │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-beanstalkd      │ Beanstalkd for DDEV*                             │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-browsersync     │ Auto-refresh HTTPS page on changes with DDEV*    │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-cron            │ Schedule commands to execute within DDEV*        │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-drupal9-solr    │ Drupal 9 Apache Solr installation for DDEV*      │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-elasticsearch   │ Elasticsearch add-on for DDEV*                   │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-memcached       │ Install Memcached as an extra service in DDEV*   │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-mongo           │ MongoDB add-on for DDEV*                         │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-pdfreactor      │ PDFreactor service for DDEV*                     │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-proxy-support   │ Support HTTP/HTTPS proxies with DDEV*            │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-redis           │ Redis service for DDEV*                          │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-redis-commander │ Redis Commander for use with DDEV Redis service* │
-├───────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-varnish         │ Varnish reverse proxy add-on for DDEV*           │
-└───────────────────────────┴──────────────────────────────────────────────────┘
+┌──────────────────────────────────────┬──────────────────────────────────────────────────┐
+│ ADD-ON                               │ DESCRIPTION                                      │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-adminer                    │ Adminer service for DDEV*                        │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-beanstalkd                 │ Beanstalkd for DDEV*                             │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-browsersync                │ Auto-refresh HTTPS page on changes with DDEV*    │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-cron                       │ Schedule commands to execute within DDEV*        │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-drupal9-solr               │ Drupal 9 Apache Solr installation for DDEV*      │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-elasticsearch              │ Elasticsearch add-on for DDEV*                   │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-memcached                  │ Install Memcached as an extra service in DDEV*   │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-mongo                      │ MongoDB add-on for DDEV*                         │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-pdfreactor                 │ PDFreactor service for DDEV*                     │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-proxy-support              │ Support HTTP/HTTPS proxies with DDEV*            │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-redis                      │ Redis service for DDEV*                          │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-redis-commander            │ Redis Commander for use with DDEV Redis service* │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-selenium-standalone-chrome │ A DDEV service for running standalone Chrome*    │
+├──────────────────────────────────────┼──────────────────────────────────────────────────┤
+│ drud/ddev-varnish                    │ Varnish reverse proxy add-on for DDEV*           │
+└──────────────────────────────────────┴──────────────────────────────────────────────────┘
 Add-ons marked with '*' are official, maintained DDEV add-ons.
 ```
 
@@ -59,6 +61,7 @@ Officially-supported add-ons:
 * [Proxy Support](https://github.com/drud/ddev-proxy-support): `ddev get drud/ddev-proxy-support`.
 * [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
 * [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.
+* [Selenium Standalone Chrome](https://github.com/drud/ddev-selenium-standalone-chrome): `ddev get drud/ddev-selenium-standalone-chrome`.
 * [Varnish](https://github.com/drud/ddev-varnish): `ddev get drud/ddev-varnish`.
 
 ## Creating an Additional Service for `ddev get`
@@ -81,6 +84,11 @@ The `install.yaml` is a simple YAML file with a few main sections:
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
 * `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
+
+In any stanza of `pre_install_actions` and `post_install_actions` you can:
+
+* Use `#ddev-nodisplay` on a line to suppress any output.
+* Use `#ddev-description:<some description of what stanza is doing>` to instruct DDEV to output a description of the action it's taking.
 
 You can see a simple `install.yaml` in [`ddev-addon-template`’s `install.yaml`](https://github.com/drud/ddev-addon-template/blob/main/install.yaml).
 

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"regexp"
 	"runtime"
 	"strconv"
 	"time"
@@ -117,4 +118,11 @@ func IsIPAddress(ip string) bool {
 		return true
 	}
 	return false
+}
+
+// GrepStringInBuffer finds strings that match needle
+func GrepStringInBuffer(buffer string, needle string) []string {
+	re := regexp.MustCompilePOSIX(needle)
+	matches := re.FindStringSubmatch(buffer)
+	return matches
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev get` can be pretty intimidating on a large add-on

## How this PR Solves The Problem:

Provide simpler and colored output:

<img width="1056" alt="rfay_d9-web___var_www_html" src="https://user-images.githubusercontent.com/112444/204670092-87478d50-fd8c-4c51-a7cc-c342a5dea518.png">



## Manual Testing Instructions:

Try `ddev get platformsh/ddev-platformsh`

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

