### PR TITLE
Document pull from platform with multiple DBs

### DIFF
--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -47,7 +47,6 @@ web_environment:
 * `ddev pull platform` will connect to Platform.sh to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
 * If you need to change the `platform.yaml` recipe, you can change it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.
 
-
 ## Edge Cases
 
 ### Multiple databases in a project

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -46,3 +46,30 @@ web_environment:
 
 * `ddev pull platform` will connect to Platform.sh to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
 * If you need to change the `platform.yaml` recipe, you can change it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.
+
+
+## Edge Cases
+
+### Multiple databases in a project
+
+Platform.sh allows for multiple databases to be available in a project. This is done via [relationships](https://docs.platform.sh/create-apps/app-reference.html#relationships). When using multiple databases `ddev pull` won't work as it [doesn't know which database to pull](https://github.com/drud/ddev/issues/4415).
+
+To bypass the problem, you can use this command (from host):
+```
+ddev platform db:dump --yes --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --relationship RELATIONSHIP_NAME
+```
+
+To identify the name of the relationship look into you `.platform.app.yaml` file, left hand column is the name:
+```
+relationships:
+  database: 'mysqldb:mysql'
+  legacy: 'legacydb:mysql'
+  redis: 'rediscache:redis'
+```
+
+Once the download has finished, you'll need to import the DB to DDEV:
+```
+ddev import-db --src=.ddev/.downloads/db.sql.gz
+```
+
+The above commands can easily be added in a `host` command, to facilitate things.

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -67,9 +67,13 @@ relationships:
   redis: 'rediscache:redis'
 ```
 
-Once the download has finished, you'll need to import the DB to DDEV:
+Once the download has finished, you'll need to import to the **default** DDEV DB (named `db`):
 ```
 ddev import-db --src=.ddev/.downloads/db.sql.gz
 ```
 
+If you also have a need for [more than one database in DDEV](https://ddev.readthedocs.io/en/latest/users/basics/database-management) then adapt the above command as needed:
+```
+ddev import-db --target-db=backend --src=.ddev/.downloads/backend.sql.gz
+```
 The above commands can easily be added in a `host` command, to facilitate things.

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -72,7 +72,7 @@ Once the download has finished, you'll need to import to the **default** DDEV DB
 ddev import-db --src=.ddev/.downloads/db.sql.gz
 ```
 
-If you also have a need for [more than one database in DDEV](https://ddev.readthedocs.io/en/latest/users/basics/database-management) then adapt the above command as needed:
+If you also have a need for [more than one database in DDEV](../../basics/database-management) then adapt the above command as needed:
 ```
 ddev import-db --target-db=backend --src=.ddev/.downloads/backend.sql.gz
 ```

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -54,11 +54,13 @@ web_environment:
 Platform.sh allows for multiple databases to be available in a project. This is done via [relationships](https://docs.platform.sh/create-apps/app-reference.html#relationships). When using multiple databases `ddev pull` won't work as it [doesn't know which database to pull](https://github.com/drud/ddev/issues/4415).
 
 To bypass the problem, you can use this command (from host):
+
 ```
-ddev platform db:dump --yes --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --relationship RELATIONSHIP_NAME
+ddev exec platform db:dump --yes --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --relationship <RELATIONSHIP_NAME>
 ```
 
 To identify the name of the relationship look into you `.platform.app.yaml` file, left hand column is the name:
+
 ```
 relationships:
   database: 'mysqldb:mysql'
@@ -67,12 +69,15 @@ relationships:
 ```
 
 Once the download has finished, you'll need to import to the **default** DDEV DB (named `db`):
+
 ```
 ddev import-db --src=.ddev/.downloads/db.sql.gz
 ```
 
 If you also have a need for [more than one database in DDEV](../../basics/database-management) then adapt the above command as needed:
+
 ```
 ddev import-db --target-db=backend --src=.ddev/.downloads/backend.sql.gz
 ```
+
 The above commands can easily be added in a `host` command, to facilitate things.


### PR DESCRIPTION
## The Problem/Issue/Bug:

`ddev pull` won't work when multiple mysql databases are configured in a platformsh project (called `relationships`)

## How this PR Solves The Problem:

It doesn't, but provides documentation about it, which is equally good :)
A two command workaround are provided to achieve what `ddev pull` would do.

## Manual Testing Instructions:

Create a platformsh project with multiple mysql databases in relationships and follow the docs.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

- #4415 
- https://github.com/platformsh/ddev-platformsh/issues/59

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
It's just documentation.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

