### PR TITLE
Add support for .ddev/.env file, fixes #4309

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -111,33 +111,28 @@ web_extra_exposed_ports:
 
 ## Providing Custom Environment Variables to a Container
 
-Custom environment variables may be set in the project’s `.ddev/config.yaml` or the global `~/.ddev/global_config.yaml` with the [`web_environment`](../configuration/config.md#web_environment) key:
+Custom environment variables may be set in
 
-```yaml
-web_environment:
-- SOMEENV=someval
-- SOMEOTHERENV=someotherval
-```
+* The project `.ddev/.env file`, which could look something like this:
+
+    ```
+    SOMEENV='someval'
+    SOMEOTHERENV='someotherval'
+    ```
+
+* The project `.ddev/config.yaml` with the [`web_environment`](../configuration/config.md#web_environment) key:
+
+    ```yaml
+    web_environment:
+    - SOMEENV=someval
+    - SOMEOTHERENV=someotherval
+    ```
+
+* The global `.ddev/global_config.yaml` (in your home directory) with the same `web_environment` key.
 
 You can also use `ddev config global --web-environment-add="SOMEENV=someval"` or `ddev config --web-environment-add="SOMEENV=someval"` for the same purpose. The command just sets the values in the configuration files. (The `--web-environment` option is also available, but it overwrites existing contents.)
 
-The docker-compose web environment can also provide `.env` file support. To enable this, create a new docker-compose YAML partial like `.ddev/docker-compose.env-file.yaml`:
-
-```
-services:
-  web:
-    env_file:
-      - ../.env
-```
-
-You would create the `.env` file in the project root and provide globals within it as such:
-
-```
-SOMEENV='someval'
-SOMEOTHERENV='someotherval'
-```
-
-The globals from the env file would be available on the next DDEV start. It’s important to note that typically the `.env` file should *not* be placed under source control, especially if it contains private API keys or passwords.
+Note that sensitive variables should not be checked in with your project, so the `.env` file, for example, is not normally checked in. People also often use global configuration for sensitive values, as it's not normally checked in.
 
 ### Altering the In-Container `$PATH`
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -90,6 +90,10 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
+    {{ if .EnvFile }}
+    env_file: "{{ .EnvFile }}"
+    {{ end }}
+
     {{ if .UseHostDockerInternalExtraHosts }}
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -91,7 +91,7 @@ services:
         gid: '{{ .GID }}'
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
     {{ if .EnvFile }}
-    env_file: "{{ .EnvFile }}"
+    env_file: '{{ .EnvFile }}'
     {{ end }}
 
     {{ if .UseHostDockerInternalExtraHosts }}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -685,6 +685,7 @@ type composeYAMLVars struct {
 	WebExtraHTTPPorts               string
 	WebExtraHTTPSPorts              string
 	WebExtraExposedPorts            string
+	EnvFile                         string
 }
 
 // RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.
@@ -781,6 +782,12 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	if fileutil.IsDirectory(filepath.Join(app.AppRoot, ".git")) {
 		templateVars.GitDirMount = true
 	}
+
+	envFile := app.GetConfigPath(".env")
+	if fileutil.FileExists(envFile) {
+		templateVars.EnvFile = envFile
+	}
+
 	// And we don't want to bind-mount upload dir if it doesn't exist.
 	// templateVars.UploadDir is relative path rooted in approot.
 	if app.GetHostUploadDirFullPath() == "" || !fileutil.FileExists(app.GetHostUploadDirFullPath()) {


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4309 

## How this PR Solves The Problem:

Import environment variables from project .ddev/.env file if it exists. 

## Manual Testing Instructions:

Create a .ddev/.env file, `ddev restart`, verify that your env vars appear in the web container.

## Automated Testing Overview:

Added TestEnvFile

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4418"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

