### PR TITLE
`ddev self-upgrade` command, fixes #2680

### DIFF
--- a/docs/content/users/basics/commands.md
+++ b/docs/content/users/basics/commands.md
@@ -977,6 +977,19 @@ ddev restart my-project my-other-project
 ddev restart --all
 ```
 
+## `self-upgrade`
+
+Give instructions on how to update or upgrade DDEV. Although the command doesn't actually do the upgrade (since it must be handled differently on different systems) it tries to figure out what you need to do and explain it to you. It must be executed in the context of a project.
+
+Example:
+
+```
+$ ddev self-upgrade
+
+DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.
+curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash
+```
+
 ## `service`
 
 Add or remove, enable or disable [extra services](../extend/additional-services.md).

--- a/docs/content/users/basics/commands.md
+++ b/docs/content/users/basics/commands.md
@@ -979,12 +979,12 @@ ddev restart --all
 
 ## `self-upgrade`
 
-Give instructions on how to update or upgrade DDEV. Although the command doesn't actually do the upgrade (since it must be handled differently on different systems) it tries to figure out what you need to do and explain it to you. It must be executed in the context of a project.
+Output instructions for updating or upgrading DDEV. The command doesn’t perform the upgrade, but tries to provide instructions relevant to your installation. Must be executed from the project context.
 
 Example:
 
 ```
-$ ddev self-upgrade
+→  ddev self-upgrade
 
 DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.
 curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash

--- a/docs/content/users/basics/faq.md
+++ b/docs/content/users/basics/faq.md
@@ -109,11 +109,7 @@ Start by completely turning NFS off for your projects with `ddev config --nfs-mo
 
 You’ll want to update DDEV using the same method you chose to install it. Since upgrading is basically the same as installing, you can follow [DDEV Installation](../install/ddev-installation.md) to upgrade.
 
-DDEV can help you figure out how you installed and how you can upgrade:
-
-```bash
-ddev self-upgrade
-```
+You can use the [`self-upgrade`](../basics/commands.md#self-upgrade) command for getting instructions tailored to your installation.
 
 * On macOS you likely installed via Homebrew; run `brew update && brew upgrade ddev`.
 <!-- markdownlint-disable-next-line -->

--- a/docs/content/users/basics/faq.md
+++ b/docs/content/users/basics/faq.md
@@ -109,6 +109,12 @@ Start by completely turning NFS off for your projects with `ddev config --nfs-mo
 
 You’ll want to update DDEV using the same method you chose to install it. Since upgrading is basically the same as installing, you can follow [DDEV Installation](../install/ddev-installation.md) to upgrade.
 
+DDEV can help you figure out how you installed and how you can upgrade:
+
+```bash
+ddev self-upgrade
+```
+
 * On macOS you likely installed via Homebrew; run `brew update && brew upgrade ddev`.
 <!-- markdownlint-disable-next-line -->
 * On Linux + WSL2 using Debian/Ubuntu’s `apt install` technique, run `sudo apt update && sudo apt upgrade ddev` like any other package on your system.

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -11,8 +11,9 @@ mypath=$(which ddev)
 case $mypath in
   "/usr/bin/ddev")
     if [[ ${OSTYPE} = "linux-gnu"* ]]; then
-      if command -v apt; then echo "You seem to have an apt-installed ddev, upgrade with 'sudo apt update && sudo apt upgrade -y ddev'"; fi
-      if command -v dnf; then echo "You seem to have dnf-installed ddev, upgrade with 'sudo dnf install --refresh ddev'"; fi
+      if command -v apt; then echo "You seem to have an apt-installed ddev, upgrade with 'sudo apt update && sudo apt upgrade -y ddev'";
+      elif [ -f /etc/arch-release ] && command -v yay >/dev/null ; then echo "You seem to have yay-installed ddev (AUR), upgrade with 'yay -Syu ddev'";
+      elif command -v dnf; then echo "You seem to have dnf-installed ddev, upgrade with 'sudo dnf install --refresh ddev'"; fi
     fi
     ;;
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -24,8 +24,8 @@ case $mypath in
     fi
     ;;
 
-  "/opt/homebrew/bin/ddev")
-    if [ -L /usr/local/bin/ddev ] && command -v brew; then
+  "/opt/homebrew/bin/ddev" | "/home/linuxbrew/.linuxbrew/bin/ddev")
+    if [ -L "$(which ddev)" ] && command -v brew; then
       echo "DDEV appears to have been installed with homebrew, upgrade with 'brew update && brew upgrade ddev'"
     fi
     ;;
@@ -35,7 +35,7 @@ case $mypath in
     echo "You can upgrade with 'choco upgrade -y ddev'"
     echo "Or by downloading the Windows installer from https://github.com/drud/ddev/releases"
     ;;
-  
+
   *)
     echo "Unable to determine how you installed ddev, but you can remove $mypath and reinstall with one of the techniques in https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/"
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#ddev-generated
+
+## Description: Explain how to upgrade DDEV
+## Usage: self-upgrade
+## Example: "ddev self-upgrade"
+
+mypath=$(which ddev)
+
+case $mypath in
+  "/usr/bin/ddev")
+    if [[ ${OSTYPE} = "linux-gnu"* ]]; then
+      if command -v apt; then echo "You seem to have an apt-installed ddev, upgrade with 'sudo apt update && sudo apt upgrade -y ddev'"; fi
+      if command -v dnf; then echo "You seem to have dnf-installed ddev, upgrade with 'sudo dnf install --refresh ddev'"; fi
+    fi
+    ;;
+
+  "/usr/local/bin/ddev")
+    if [ ! -L /usr/local/bin/ddev ]; then
+      printf "DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.\ncurl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash\n"
+    elif command -v brew; then
+      echo "DDEV appears to have been installed with homebrew, upgrade with 'brew update && brew upgrade ddev'"
+    fi
+    ;;
+
+  "/opt/homebrew/bin/ddev")
+    if [ -L /usr/local/bin/ddev ] && command -v brew; then
+      echo "DDEV appears to have been installed with homebrew, upgrade with 'brew update && brew upgrade ddev'"
+    fi
+    ;;
+
+  "/c/Program Files/DDEV/ddev")
+    echo "DDEV was either installed with\nchoco install -y ddev\nor with the installer package."
+    echo "You can upgrade with 'choco upgrade -y ddev'"
+    echo "Or by downloading the Windows installer from https://github.com/drud/ddev/releases"
+    ;;
+  
+  *)
+    echo "Unable to determine how you installed ddev, but you can remove $mypath and reinstall with one of the techniques in https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/"
+
+esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -32,7 +32,7 @@ case $mypath in
     ;;
 
   "/c/Program Files/DDEV/ddev")
-    echo "DDEV was either installed with\nchoco install -y ddev\nor with the installer package."
+    printf "DDEV was either installed with\nchoco install -y ddev\nor with the installer package.\n"
     echo "You can upgrade with 'choco upgrade -y ddev'"
     echo "Or by downloading the Windows installer from https://github.com/drud/ddev/releases"
     ;;


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #2680 

DDEV users sometimes don't know how to upgrade

## How this PR Solves The Problem:

Add `ddev self-upgrade` command to give clues

## Manual Testing Instructions:

Test it on
- [x] macOS homebrew
- [x] macOS install_ddev.sh
- [x] Linux/WSL2 homebrew
- [x] Linux/WSL2 install_ddev.sh
- [x] Linux/WSL2 apt
- [x] CentOS dnf
- [x] Arch
- [x] Windows (git-bash)
- [x] Windows (PowerShell)


## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4419"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

