### PR TITLE
Bump docker-compose to v2.13.0

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -602,7 +602,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.12.2"
+var RequiredDockerComposeVersion = "v2.13.0"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Problem/Issue/Bug:

In preparation for DDEV v1.21.4, bump docker-compose to current release 2.13.0



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4422"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

