### PR TITLE
Bump docker-compose to 2.14.0

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -602,7 +602,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.13.0"
+var RequiredDockerComposeVersion = "v2.14.0"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Problem/Issue/Bug:

docker-compose 2.14.0 was released. Test it.

