### PR TITLE
Platform integration: Download all databases, Allow a primary relationship for the main 'db', fixes #4415, fixes platformsh/ddev-platformsh#59

### DIFF
--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -67,7 +67,7 @@ func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 		for _, v := range envVars {
 			split := strings.Split(v, "=")
 			if len(split) != 2 {
-				util.Failed("unable to parse commanad-line environment variable setting: '%v'", v)
+				util.Failed("unable to parse command-line environment variable setting: '%v'", v)
 			}
 			provider.EnvironmentVariables[split[0]] = split[1]
 		}

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -62,13 +62,15 @@ func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 	}
 
 	// Add or override the command-line provided environment variables
-	envVars := strings.Split(env, ",")
-	for _, v := range envVars {
-		split := strings.Split(v, "=")
-		if len(split) != 2 {
-			util.Failed("unable to parse environment variable setting: %v", v)
+	if env != "" {
+		envVars := strings.Split(env, ",")
+		for _, v := range envVars {
+			split := strings.Split(v, "=")
+			if len(split) != 2 {
+				util.Failed("unable to parse commanad-line environment variable setting: '%v'", v)
+			}
+			provider.EnvironmentVariables[split[0]] = split[1]
 		}
-		provider.EnvironmentVariables[split[0]] = split[1]
 	}
 
 	if err := app.Pull(provider, skipDbArg, skipFilesArg, skipImportArg); err != nil {

--- a/cmd/ddev/cmd/push.go
+++ b/cmd/ddev/cmd/push.go
@@ -60,14 +60,16 @@ func apppush(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 		util.Failed("Failed to get provider: %v", err)
 	}
 
-	// Add or override the command-line provided environment variables
-	envVars := strings.Split(env, ",")
-	for _, v := range envVars {
-		split := strings.Split(v, "=")
-		if len(split) != 2 {
-			util.Failed("unable to parse environment variable setting: %v", v)
+	if env != "" {
+		// Add or override the command-line provided environment variables
+		envVars := strings.Split(env, ",")
+		for _, v := range envVars {
+			split := strings.Split(v, "=")
+			if len(split) != 2 {
+				util.Failed("unable to parse environment variable setting: %v", v)
+			}
+			provider.EnvironmentVariables[split[0]] = split[1]
 		}
-		provider.EnvironmentVariables[split[0]] = split[1]
 	}
 
 	if err := app.Push(provider, skipDbArg, skipFilesArg); err != nil {

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -42,6 +42,14 @@ web_environment:
 4. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 5. Optionally use `ddev push platform` to push local files and database to Platform.sh. The [`ddev push`](../basics/commands.md#push) command can potentially damage your production site, so we don’t recommend using it.
 
+If you have more than one database on your Platform.sh project, you'll need to choose which one you want to use
+as the 'db' primary database on DDEV, and that will be the one pulled or pushed.
+Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example,
+
+```
+ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=maindb`
+```
+
 ## Usage
 
 * `ddev pull platform` will connect to Platform.sh to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -47,7 +47,13 @@ as the 'db' primary database on DDEV, and that will be the one pulled or pushed.
 Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example,
 
 ```
-ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=maindb`
+ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=main`
+```
+
+or run `ddev pull platform` with the `--environment` flag, for example,
+
+```
+ddev pull platform --environment="PLATFORM_PRIMARY_RELATIONSHIP=main"
 ```
 
 ## Usage

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -23,10 +23,12 @@
 # 5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 # 6. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
-# If you have more than one database on platform, you'll currently need to choose which one you want to use
-# as the primary database, and that will be the one pulled or pushed.
-# Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example, `ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=maindb`
-
+# If you have more than one database on your Platform.sh proect,
+# you will likely to choose which one you want to use
+# as the primary database ('db').
+# Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example, `ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=main`
+# or run `ddev pull platform` with the environment variable, for example
+# `ddev pull platform -y --environment=PLATFORM_PRIMARY_RELATIONSHIP=main`
 # If you need to change this `platform.yaml` recipe, you can change it to suit your needs, but remember to remove the "ddev-generated" line from the top.
 
 # Debugging: Use `ddev exec platform` to see what platform.sh knows about
@@ -51,13 +53,14 @@ db_pull_command:
     db_relationships=($(yq ' keys | .[] ' ${db_relationships_file}))
     db_names=($(yq '.[][].path' ${db_relationships_file}))
     db_count=${#db_relationships[@]}
-    # echo "db_relationships=${db_relationships} sizeof db_relationships=${#db_relationships[@]} db_names=${db_names} db_count=${db_count}"
+    # echo "db_relationships=${db_relationships} sizeof db_relationships=${#db_relationships[@]} db_names=${db_names} db_count=${db_count} PLATFORM_PRIMARY_RELATIONSHIP=${PLATFORM_PRIMARY_RELATIONSHIP}"
     # If we have only one database, import it into local database named 'db'
     if [ ${#db_names[@]} -eq 1 ]; then db_names[0]="db"; fi
 
     for (( i=0; i<${#db_relationships[@]}; i++ )); do
       db_name=${db_names[$i]}
       rel=${db_relationships[$i]}
+      # if PLATFORM_PRIMARY_RELATIONSHIP is set, then when doing that one, import it into local database 'db'
       if [ "${rel}" = "${PLATFORM_PRIMARY_RELATIONSHIP:-notset}" ] ; then
         echo "PLATFORM_PRIMARY_RELATIONSHIP=${PLATFORM_PRIMARY_RELATIONSHIP:-} so using it as database 'db' instead of the upstream '${db_name}'"
         db_name="db"
@@ -65,7 +68,7 @@ db_pull_command:
 
       platform db:dump --yes --relationship=${rel} --gzip --file=/var/www/html/.ddev/.downloads/${db_name}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
     done
-    echo "Downloaded and created databases '${db_names[@]}'"
+    echo "Downloaded db dumps for databases '${db_names[@]}'"
 
 files_import_command:
   command: |

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -23,6 +23,10 @@
 # 5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 # 6. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
+# If you have more than one database on platform, you'll currently need to choose which one you want to use
+# as the primary database, and that will be the one pulled or pushed.
+# Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example, `ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=maindb`
+
 # If you need to change this `platform.yaml` recipe, you can change it to suit your needs, but remember to remove the "ddev-generated" line from the top.
 
 # Debugging: Use `ddev exec platform` to see what platform.sh knows about
@@ -31,14 +35,19 @@
 auth_command:
   command: |
     set -eu -o pipefail
-    if [ -z "${PLATFORMSH_CLI_TOKEN:-}" ]; then echo "Please make sure you have set PLATFORMSH_CLI_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
+    if [ -z "${PLATFORMSH_CLI_TOKEN:-}" ]; then echo "Please make sure you have set PLATFORMSH_CLI_TOKEN." && exit 1; fi
+    if [ -z "${PLATFORM_PROJECT:-}" ]; then echo "Please make sure you have set PLATFORM_PROJECT." && exit 1; fi
+    if [ -z "${PLATFORM_ENVIRONMENT:-}" ]; then echo "Please make sure you have set PLATFORM_ENVIRONMENT." && exit 1; fi
 
 db_pull_command:
   command: |
     #set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    platform db:dump --yes --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"
+    if [ "${PLATFORM_PRIMARY_RELATIONSHIP:-}" != "" ] ; then
+      rel="--relationship ${PLATFORM_PRIMARY_RELATIONSHIP}"
+    fi
+    platform db:dump --yes ${rel:-} --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
 
 files_import_command:
   command: |
@@ -56,7 +65,10 @@ db_push_command:
     set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
-    gzip -dc db.sql.gz | platform db:sql --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"
+    if [ "${PLATFORM_PRIMARY_RELATIONSHIP:-}" != "" ] ; then
+      rel="--relationship ${PLATFORM_PRIMARY_RELATIONSHIP}"
+    fi
+    gzip -dc db.sql.gz | platform db:sql --project="${PLATFORM_PROJECT}" ${rel:-} --environment="${PLATFORM_ENVIRONMENT}"
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 # TODO: This is a naive, Drupal-centric push, which needs adjustment for the mount to be pushed.

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -47,11 +47,15 @@ db_pull_command:
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     # /tmp/db_relationships.yaml is the full yaml output of the database relationships
     db_relationships_file=/tmp/db_relationships.yaml
-    PLATFORM_RELATIONSHIPS="" platform relationships -y | yq 'with_entries(select(.[][].type == "mariadb:*" or .[][].type == "*mysql:*" or .[][].type == "postgresql:*")) ' >${db_relationships_file}
-    relationships=($(yq ' keys | .[] ' ${db_relationships_file}))
+    PLATFORM_RELATIONSHIPS="" platform relationships -y  -e "${PLATFORM_ENVIRONMENT}" | yq 'with_entries(select(.[][].type == "mariadb:*" or .[][].type == "*mysql:*" or .[][].type == "postgresql:*")) ' >${db_relationships_file}
+    db_relationships=($(yq ' keys | .[] ' ${db_relationships_file}))
     db_names=($(yq '.[][].path' ${db_relationships_file}))
-    for i in ${!relationships[@]}; do
-      platform db:dump --yes --relationship=${relationships[$i]} --gzip --file=/var/www/html/.ddev/.downloads/${db_names[$i]}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
+    db_count=${#db_relationships[@]}
+    # echo "db_relationships=${db_relationships} sizeof db_relationships=${#db_relationships[@]} db_names=${db_names} db_count=${db_count}"
+    # If we have only one database, import it into 'db'
+    if [ ${#db_names[@]} -eq 1 ]; then db_names[0]="db"; fi
+    for (( i=0; i<${#db_relationships[@]}; i++ )); do
+      platform db:dump --yes --relationship=${db_relationships[$i]} --gzip --file=/var/www/html/.ddev/.downloads/${db_names[$i]}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
     done
     echo "Downloaded and created databases '${db_names[@]}'"
 

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -41,18 +41,25 @@ auth_command:
 
 db_pull_command:
   command: |
-    #set -x   # You can enable bash debugging output by uncommenting
+    # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    export PLATFORMSH_CLI_NO_INTERACTION=1
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    if [ "${PLATFORM_PRIMARY_RELATIONSHIP:-}" != "" ] ; then
-      rel="--relationship ${PLATFORM_PRIMARY_RELATIONSHIP}"
-    fi
-    platform db:dump --yes ${rel:-} --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
+    # /tmp/db_relationships.yaml is the full yaml output of the database relationships
+    db_relationships_file=/tmp/db_relationships.yaml
+    PLATFORM_RELATIONSHIPS="" platform relationships -y | yq 'with_entries(select(.[][].type == "mariadb:*" or .[][].type == "*mysql:*" or .[][].type == "postgresql:*")) ' >${db_relationships_file}
+    relationships=($(yq ' keys | .[] ' ${db_relationships_file}))
+    db_names=($(yq '.[][].path' ${db_relationships_file}))
+    for i in ${!relationships[@]}; do
+      platform db:dump --yes --relationship=${relationships[$i]} --gzip --file=/var/www/html/.ddev/.downloads/${db_names[$i]}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
+    done
+    echo "Downloaded and created databases '${db_names[@]}'"
 
 files_import_command:
   command: |
     #set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    export PLATFORMSH_CLI_NO_INTERACTION=1
     # Use $PLATFORM_MOUNTS if it exists to get list of mounts to download, otherwise just web/sites/default/files (drupal)
     declare -a mounts=(${PLATFORM_MOUNTS:-/web/sites/default/files})
     platform mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"  --target=/var/www/html
@@ -63,6 +70,7 @@ db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    export PLATFORMSH_CLI_NO_INTERACTION=1
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
     if [ "${PLATFORM_PRIMARY_RELATIONSHIP:-}" != "" ] ; then
@@ -76,6 +84,7 @@ files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    export PLATFORMSH_CLI_NO_INTERACTION=1
     ls "${DDEV_FILES_DIR}" >/dev/null # This just refreshes stale NFS if possible
     platform mount:upload --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files
 

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -52,10 +52,18 @@ db_pull_command:
     db_names=($(yq '.[][].path' ${db_relationships_file}))
     db_count=${#db_relationships[@]}
     # echo "db_relationships=${db_relationships} sizeof db_relationships=${#db_relationships[@]} db_names=${db_names} db_count=${db_count}"
-    # If we have only one database, import it into 'db'
+    # If we have only one database, import it into local database named 'db'
     if [ ${#db_names[@]} -eq 1 ]; then db_names[0]="db"; fi
+
     for (( i=0; i<${#db_relationships[@]}; i++ )); do
-      platform db:dump --yes --relationship=${db_relationships[$i]} --gzip --file=/var/www/html/.ddev/.downloads/${db_names[$i]}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
+      db_name=${db_names[$i]}
+      rel=${db_relationships[$i]}
+      if [ "${rel}" = "${PLATFORM_PRIMARY_RELATIONSHIP:-notset}" ] ; then
+        echo "PLATFORM_PRIMARY_RELATIONSHIP=${PLATFORM_PRIMARY_RELATIONSHIP:-} so using it as database 'db' instead of the upstream '${db_name}'"
+        db_name="db"
+      fi
+
+      platform db:dump --yes --relationship=${rel} --gzip --file=/var/www/html/.ddev/.downloads/${db_name}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
     done
     echo "Downloaded and created databases '${db_names[@]}'"
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -233,7 +233,7 @@ func (p *Provider) GetBackup(backupType string) ([]string, []string, error) {
 
 	importPaths := make([]string, len(fileNames))
 	// We don't use importPaths for the providers
-	for i, _ := range fileNames {
+	for i := range fileNames {
 		importPaths[i] = ""
 	}
 

--- a/pkg/ddevapp/providerPlatform_test.go
+++ b/pkg/ddevapp/providerPlatform_test.go
@@ -90,7 +90,7 @@ func TestPlatformPull(t *testing.T) {
 	err = app.Start()
 	require.NoError(t, err)
 	err = app.Pull(provider, false, false, false)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "victoria-sponge-umami.jpg"))
 	out, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="margaret.hopper@example.com";' | %s mysql -N`, DdevBin))


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #4415 
* https://github.com/platformsh/ddev-platformsh/issues/59
* https://github.com/drud/ddev/pull/4417
* DDEV was focused on downloading a single database

## How this PR Solves The Problem:

* Use relationships to download all the upstream databases
* If one should be primary, set it with PLATFORM_PRIMARY_RELATIONSHIP and it will go into the database named 'db'

This also fixes a bug in handling blank `--environment` in `ddev pull`

## Manual Testing Instructions:

Try it out on a multisite or whatever, `ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=maindb` or `ddev pull platform --environment=PLATFORM_PRIMARY_RELATIONSHIP=maindb` 

## Automated Testing Overview:

Multiple databases are not yet covered in TestPlatformPull. 

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4426"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

