### PR TITLE
Drop the manual download instructions for Craft CMS

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -463,8 +463,6 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
     
     === "New projects"
     
-        ### Composer project
-        
         Use this to create a new Craft CMS project from the official [Craft starter project](https://github.com/craftcms/craft) or a third-party starter project using Composer.
         
         ```bash
@@ -473,21 +471,6 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ddev config --project-type=craftcms --docroot=web --create-docroot
         ddev start
         ddev composer create -y --no-scripts craftcms/craft
-        ddev craft install
-        ddev launch
-        ```
-
-        ### Manual download
-        
-        Use this to create a new Craft CMS project using a zipped archive.
-        
-        ```bash
-        mkdir my-craft-project
-        cd my-craft-project
-        curl -LO https://craftcms.com/latest-v4.zip
-        unzip latest-v4.zip && rm latest-v4.zip
-        ddev config --project-type=craftcms
-        ddev start
         ddev craft install
         ddev launch
         ```


### PR DESCRIPTION
## The Problem/Issue/Bug:

The CMS quickstart guide for Craft CMS includes instructions for downloading Craft from a zip file. The zip installation is not going to be supported for much longer though, so these need to be removed.

## How this PR Solves The Problem:

Manual download instructions have been removed.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4432"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

