### PR TITLE
Web image maintenance: Bump mkcert, yq versions, use real mkcert repo

### DIFF
--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -47,31 +47,31 @@ fi
 
 # Generate macOS-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_amd64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64 && chmod +x mkcert
+curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=darwin/amd64" && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate macOS-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64 && chmod +x mkcert
+curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=darwin/arm64" && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate linux-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_amd64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64 && chmod +x mkcert
+curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate linux-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_arm64 >/dev/null
-curl -sSL -o mkcert https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm64 && chmod +x mkcert
+curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=linux/arm64" && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # generate windows-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
-curl -sSL -o mkcert.exe https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe
+curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=windows/amd64"
 tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe  mkcert.exe
 popd >/dev/null
 

--- a/.ci-scripts/linux_arm64_setup.sh
+++ b/.ci-scripts/linux_arm64_setup.sh
@@ -28,7 +28,7 @@ curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz -o /tmp/go.tg
 git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local
 
 # Install mkcert
-sudo curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=darwin/arm64" && sudo chmod +x /usr/local/bin/mkcert
+sudo curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/arm64" && sudo chmod +x /usr/local/bin/mkcert
 mkcert -install
 
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')

--- a/.ci-scripts/linux_arm64_setup.sh
+++ b/.ci-scripts/linux_arm64_setup.sh
@@ -28,7 +28,7 @@ curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz -o /tmp/go.tg
 git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local
 
 # Install mkcert
-sudo curl -sSL https://github.com/drud/mkcert/releases/download/v1.4.6/mkcert-v1.4.6-linux-arm64 -o /usr/local/bin/mkcert && sudo chmod +x /usr/local/bin/mkcert
+sudo curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=darwin/arm64" && sudo chmod +x /usr/local/bin/mkcert
 mkcert -install
 
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(GOTMP)/bin/darwin_arm64/mkcert $(GOTMP)/bin/darwin_amd64/mkcert $(GOTMP)/bin/l
 	@export TARGET=$(word 3, $(subst /, ,$@)) && \
 	export GOOS="$${TARGET%_*}" GOARCH="$${TARGET#*_}" && \
 	mkdir -p $(GOTMP)/bin/$${GOOS}_$${GOARCH} && \
-	curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=${GOOS}/${GOARCH}" && chmod +x $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert
+	curl --fail -JL -s -o $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert "https://dl.filippo.io/mkcert/latest?for=$${GOOS}/$${GOARCH}" && chmod +x $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert
 
 TEST_TIMEOUT=4h
 BUILD_ARCH = $(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ GOLANGCI_LINT_ARGS ?= --out-format=line-number --disable-all --enable=gofmt --en
 WINDOWS_GSUDO_VERSION=v0.7.3
 WINNFSD_VERSION=2.4.0
 NSSM_VERSION=2.24-101-g897c7ad
-MKCERT_VERSION=v1.4.6
 
 TESTTMP=/tmp/testresults
 
@@ -97,7 +96,7 @@ $(GOTMP)/bin/darwin_arm64/mkcert $(GOTMP)/bin/darwin_amd64/mkcert $(GOTMP)/bin/l
 	@export TARGET=$(word 3, $(subst /, ,$@)) && \
 	export GOOS="$${TARGET%_*}" GOARCH="$${TARGET#*_}" && \
 	mkdir -p $(GOTMP)/bin/$${GOOS}_$${GOARCH} && \
-	curl -sL --fail -o $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert https://github.com/drud/mkcert/releases/download/$(MKCERT_VERSION)/mkcert-$(MKCERT_VERSION)-$${GOOS}-$${GOARCH} && chmod +x $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert
+	curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=${GOOS}/${GOARCH}" && chmod +x $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert
 
 TEST_TIMEOUT=4h
 BUILD_ARCH = $(shell go env GOARCH)
@@ -241,8 +240,8 @@ chocolatey: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe
 	fi
 
 $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.txt:
-	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/mkcert.exe https://github.com/drud/mkcert/releases/download/$(MKCERT_VERSION)/mkcert-$(MKCERT_VERSION)-windows-amd64.exe
-	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/mkcert_license.txt -O https://raw.githubusercontent.com/drud/mkcert/master/LICENSE
+	curl --fail -JL -s -o $(GOTMP)/bin/windows_amd64/mkcert.exe "https://dl.filippo.io/mkcert/latest?for=windows/amd64"
+	curl --fail -sSL -o $(GOTMP)/bin/windows_amd64/mkcert_license.txt -O https://raw.githubusercontent.com/FiloSottile/mkcert/master/LICENSE
 
 $(GOTMP)/bin/windows_amd64/sudo_license.txt:
 	set -x

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -40,7 +40,7 @@ ARG PHP_DEFAULT_VERSION="8.0"
 ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
-ENV YQ_VERSION=v4.26.1
+ENV YQ_VERSION=v4.30.5
 ENV DRUSH_VERSION=8.4.8
 ENV NODE_LTS=16
 # composer normally screams about running as root, we don't need that.

--- a/containers/ddev-router/Dockerfile
+++ b/containers/ddev-router/Dockerfile
@@ -34,8 +34,7 @@ RUN mkdir -p /etc/nginx/certs /mnt/ddev-global-cache/mkcert
 
 # curl mkcert and install it
 RUN set -eu -o pipefail && \
-    curl -sSL https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-${TARGETARCH} -o /usr/local/bin/mkcert && \
-    chmod +x /usr/local/bin/mkcert && \
+    curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/${TARGETARCH}" && chmod +x /usr/local/bin/mkcert && \
     mkdir -p /root/.local/share && \
     ln -s /mnt/ddev-global-cache/mkcert /root/.local/share/mkcert && \
     mkcert -install

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -6,7 +6,6 @@
 FROM drud/ddev-php-base:v1.21.3 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
-ENV MKCERT_VERSION=v1.4.6
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
@@ -59,15 +58,6 @@ RUN apt-get update
 
 SHELL ["/bin/bash", "-c"]
 
-RUN mkdir /tmp/ddev && \
-    if [[ $TARGETPLATFORM == "linux/arm64" ]]; then \
-        printf 'MKCERT_ARCH="linux-arm64" \n\
-        MAILHOG_ARCH="linux_arm64"' > /tmp/ddev/vars; \
-    else \
-        printf 'MKCERT_ARCH="linux-amd64" \n\
-        MAILHOG_ARCH="linux_amd64"' > /tmp/ddev/vars; \
-    fi
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     blackfire \
     blackfire-php \
@@ -93,13 +83,16 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     unzip \
     zip
 
+RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=${TARGETPLATFORM}" && chmod +x /usr/local/bin/mkcert
+
 # blackfire user by default is set up with /dev/null as homedir, and 999 as uid, which
 # can break people. Use a real homedir
 RUN mkdir -p /home/blackfire && chown blackfire:blackfire /home/blackfire && usermod -d /home/blackfire blackfire
 
 ADD ddev-webserver-dev-base-files /
 RUN phpdismod blackfire xhprof
-RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_${MAILHOG_ARCH} -o /usr/local/bin/mailhog;
+
+RUN set -x; curl --fail -sSL "https://github.com/drud/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_${TARGETPLATFORM##linux/}" -o /usr/local/bin/mailhog && chmod +x /usr/local/bin/mailhog
 
 RUN phpdismod xdebug && curl -sSL --fail --output /usr/local/bin/phive "https://phar.io/releases/phive.phar" && chmod 777 /usr/local/bin/phive && phpenmod xdebug
 RUN set -o pipefail && curl -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus
@@ -130,8 +123,6 @@ RUN mkdir -p /mnt/ddev-global-cache/mkcert /run/{php,blackfire} /var/cache/nginx
 
 RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /var/lib/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php /etc/apache2 /var/log/apache2/ /var/run/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
 
-RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-${MKCERT_ARCH} -o /usr/local/bin/mkcert && chmod 777 /usr/local/bin/mkcert
-
 RUN mkdir -p /var/xhprof && curl -o /tmp/xhprof.tgz -sSL https://pecl.php.net/get/xhprof && tar -zxf /tmp/xhprof.tgz --strip-components=1 -C /var/xhprof && chmod 777 /var/xhprof/xhprof_html && rm /tmp/xhprof.tgz
 
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
@@ -151,7 +142,7 @@ RUN chmod ugo+w /etc/ssl/certs /usr/local/share/ca-certificates
 
 HEALTHCHECK --interval=1s --retries=120 --timeout=120s --start-period=120s CMD ["/healthcheck.sh"]
 CMD ["/start.sh"]
-RUN apt-get -qq clean -y && rm -rf /var/lib/apt/lists/* /tmp/ddev
+RUN apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 #END ddev-webserver-dev-base
 
 ### ---------------------------ddev-webserver--------------------------------------
@@ -186,19 +177,13 @@ CMD ["/start.sh"]
 FROM ddev-webserver-base as ddev-webserver-prod-base
 ENV CAROOT /mnt/ddev-global-cache/mkcert
 ENV PHP_DEFAULT_VERSION="8.0"
+ARG TARGETPLATFORM
 
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add -
 RUN echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
 RUN apt-get update
 
 SHELL ["/bin/bash", "-c"]
-
-RUN mkdir /tmp/ddev && \
-    if [[ $TARGETPLATFORM == "linux/arm64" ]]; then \
-        echo 'MKCERT_ARCH="linux-arm64"' > /tmp/ddev/vars; \
-    else \
-        echo 'MKCERT_ARCH="linux-amd64"' >/tmp/ddev/vars; \
-    fi
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     blackfire-php \
@@ -219,6 +204,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     sqlite3 \
     unzip \
     zip
+
+RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=${TARGETPLATFORM}" && chmod +x /usr/local/bin/mkcert
 
 ADD ddev-webserver-prod-files /
 RUN phpdismod blackfire xhprof
@@ -242,8 +229,6 @@ RUN chmod -R 777 /var/log
 RUN mkdir -p /mnt/ddev-global-cache/mkcert /run/php /var/cache/nginx /var/lib/nginx && chmod -R ugo+rw /home /mnt/ddev-global-cache/
 
 RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /var/lib/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php /etc/apache2 /var/lock/apache2 /var/log/apache2/ /var/run/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
-
-RUN source /tmp/ddev/vars && curl -sSL https://github.com/drud/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-${MKCERT_ARCH} -o /usr/local/bin/mkcert && chmod +x /usr/local/bin/mkcert
 
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
   chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.21.3 as ddev-webserver-base
+FROM drud/ddev-php-base:20221205_yq_update as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -31,7 +31,7 @@ var DBAImg = "phpmyadmin"
 // DBATag defines the default phpmyadmin image tag used for applications.
 var DBATag = "5" // Note that this can be overridden by make
 
-const TraditionalRouterImage = "drud/ddev-router:20220918_traefik"
+const TraditionalRouterImage = "drud/ddev-router:20221205_yq_update"
 const TraefikRouterImage = "traefik:v2.9"
 
 // SSHAuthImage is image for agent

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20221031_healthcheck_no_profile" // Note that this can be overridden by make
+var WebTag = "20221205_webimage_direct_downloads" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20221205_webimage_direct_downloads" // Note that this can be overridden by make
+var WebTag = "20221205_yq_update" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Problem/Issue/Bug:

* Bump mkcert and yq versions
* Use real mkcert repo instead of our fork

