### PR TITLE
Fix over-eager project env replacement, for #4197

### DIFF
--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -98,7 +98,7 @@ func craftCmsPostStartAction(app *DdevApp) error {
 		return nil
 	}
 	// Read in the .env file
-	envMap, envText, err := ReadEnvFile(app)
+	envMap, envText, err := ReadProjectEnvFile(app)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Unable to read .env file: %v", err)
 	}
@@ -138,7 +138,7 @@ func craftCmsPostStartAction(app *DdevApp) error {
 		}
 	}
 
-	err = WriteEnvFile(app, envMap, envText)
+	err = WriteProjectEnvFile(app, envMap, envText)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/envfile.go
+++ b/pkg/ddevapp/envfile.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 )
 
-// ReadEnvFile reads the .env in the project root into a envText and envMap
+// ReadProjectEnvFile reads the .env in the project root into a envText and envMap
 // The map has the envFile content, but without comments
-func ReadEnvFile(app *DdevApp) (envMap map[string]string, envText string, err error) {
+func ReadProjectEnvFile(app *DdevApp) (envMap map[string]string, envText string, err error) {
 	envFilePath := filepath.Join(app.AppRoot, ".env")
 	envText, _ = fileutil.ReadFileIntoString(envFilePath)
 	envMap, err = godotenv.Read(envFilePath)
@@ -19,16 +19,16 @@ func ReadEnvFile(app *DdevApp) (envMap map[string]string, envText string, err er
 	return envMap, envText, err
 }
 
-// WriteEnvFile writes the passed envText into the project-root .env file
+// WriteProjectEnvFile writes the passed envText into the project-root .env file
 // with all items in envMap changed in envText there
-func WriteEnvFile(app *DdevApp, envMap map[string]string, envText string) error {
+func WriteProjectEnvFile(app *DdevApp, envMap map[string]string, envText string) error {
 	envFilePath := filepath.Join(app.AppRoot, ".env")
 	for k, v := range envMap {
 		// If the item is already in envText, use regex to replace it
 		// otherwise, append it to the envText.
-		if strings.Contains(envText, k+"=") {
-			exp := regexp.MustCompile(fmt.Sprintf(`%s=(.*)`, k))
-			envText = exp.ReplaceAllString(envText, fmt.Sprintf(`%s="%s"`, k, v))
+		exp := regexp.MustCompile(fmt.Sprintf(`((^|[\r\n]+)%s)=(.*)`, k))
+		if exp.MatchString(envText) {
+			envText = exp.ReplaceAllString(envText, fmt.Sprintf(`$1="%s"`, v))
 		} else {
 			envText = strings.TrimSuffix(envText, "\n")
 			envText = fmt.Sprintf("%s\n%s=%s\n", envText, k, v)

--- a/pkg/ddevapp/envfile_test.go
+++ b/pkg/ddevapp/envfile_test.go
@@ -1,0 +1,77 @@
+package ddevapp_test
+
+import (
+	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/fileutil"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteProjectEnvFile(t *testing.T) {
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+
+	site := TestSites[0]
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = os.RemoveAll(app.GetConfigPath(".env"))
+	})
+
+	testEnvFiles, err := fileutil.ListFilesInDirFullPath(filepath.Join(origDir, "testdata", t.Name()))
+	require.NoError(t, err)
+	appEnvFile := filepath.Join(app.AppRoot, ".env")
+	for _, envFileName := range testEnvFiles {
+		_ = os.RemoveAll(appEnvFile)
+		err = fileutil.CopyFile(envFileName, appEnvFile)
+		require.NoError(t, err)
+		readEnvMap, readEnvText, err := ddevapp.ReadProjectEnvFile(app)
+		require.NoError(t, err)
+		_ = readEnvMap
+
+		// Override with some new items
+		writeEnvMap := map[string]string{
+			"DB_VAL_DIDNOTEXIST": "new_db_val_didnotexist",
+			"DB_HOST":            "newdbhost",
+			"DB_DATABASE":        "newdbdatabase",
+			"DB_USERNAME":        "newdbusername",
+			"DB_PASSWORD":        "newdbpassword",
+			"DB_CONNECTION":      "new_mysql://root:root@somehost/somedb",
+		}
+		err = ddevapp.WriteProjectEnvFile(app, writeEnvMap, readEnvText)
+		require.NoError(t, err)
+
+		postWriteEnvMap, postWriteEnvText, err := ddevapp.ReadProjectEnvFile(app)
+		require.NoError(t, err)
+
+		// Make sure that the values we intended to change got changed
+		for k := range writeEnvMap {
+			assert.Equal(writeEnvMap[k], postWriteEnvMap[k], "Expected values for %s to match but writeEnvMap[%s]='%s' and postWriteEnvMap[%s]='%s' (envfile=%s)", k, k, writeEnvMap[k], k, postWriteEnvMap[k], envFileName)
+		}
+
+		// Now examine all values that should not have been changed
+		for k := range readEnvMap {
+			if _, ok := writeEnvMap[k]; ok {
+				// If we intended to write the var, don't test, as we deliberately overwrite and tested above.
+				continue
+			}
+			assert.Equal(readEnvMap[k], postWriteEnvMap[k], "Expected (unchanged) values for %s to match but readEnvMap[%s]='%s' and postWriteEnvMap[%s]='%s' (envfile=%s)", k, k, readEnvMap[k], k, postWriteEnvMap[k], envFileName)
+		}
+
+		// Look for comments that should have been preserved
+		origLines := strings.Split(readEnvText, "\n")
+		newLines := strings.Split(postWriteEnvText, "\n")
+		for i, l := range origLines {
+			if strings.HasPrefix(l, `#`) {
+				assert.Equal(l, newLines[i], "comment '%s' in original .env expected in revised .env but doesn't match (envfile=%s)", l, envFileName)
+			}
+		}
+
+	}
+}

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -26,7 +26,7 @@ func laravelPostStartAction(app *DdevApp) error {
 	if app.DisableSettingsManagement {
 		return nil
 	}
-	_, envText, err := ReadEnvFile(app)
+	_, envText, err := ReadProjectEnvFile(app)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Unable to read .env file: %v", err)
 	}
@@ -36,7 +36,7 @@ func laravelPostStartAction(app *DdevApp) error {
 			util.Debug("laravel: .env.example does not exist yet, not trying to process it")
 			return nil
 		}
-		_, envText, err = ReadEnvFile(app)
+		_, envText, err = ReadProjectEnvFile(app)
 		if err != nil {
 			return err
 		}
@@ -56,7 +56,7 @@ func laravelPostStartAction(app *DdevApp) error {
 		"DB_PASSWORD":   "db",
 		"DB_CONNECTION": dbConnection,
 	}
-	err = WriteEnvFile(app, envMap, envText)
+	err = WriteProjectEnvFile(app, envMap, envText)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -82,7 +82,7 @@ func shopware6PostStartAction(app *DdevApp) error {
 	if app.DisableSettingsManagement {
 		return nil
 	}
-	_, envText, err := ReadEnvFile(app)
+	_, envText, err := ReadProjectEnvFile(app)
 	var envMap = map[string]string{
 		"DATABASE_URL": `mysql://db:db@db:3306/db`,
 		"APP_URL":      app.GetPrimaryURL(),
@@ -91,7 +91,7 @@ func shopware6PostStartAction(app *DdevApp) error {
 	// Shopware 6 refuses to do bin/console system:setup if the env file exists,
 	// so if it doesn't exist, wait for it to be created
 	if err == nil {
-		err := WriteEnvFile(app, envMap, envText)
+		err := WriteProjectEnvFile(app, envMap, envText)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/testdata/TestWriteProjectEnvFile/env-ambiguousvar.txt
+++ b/pkg/ddevapp/testdata/TestWriteProjectEnvFile/env-ambiguousvar.txt
@@ -1,0 +1,9 @@
+DB_HOST=old_somehost
+DB_PORT=old_9999
+DB_DATABASE=old_somerandomdb
+DB_USERNAME=old_root
+DB_PASSWORD=old_root
+SOMEENV=old_someenvval
+APP_URL=old_http://some.ddev.site
+DB_CONNECTION=old_mysql://x:x@x/x
+DYNAMODB_CONNECTION=old_dynamodb-something

--- a/pkg/ddevapp/testdata/TestWriteProjectEnvFile/env-commentsnewlines.txt
+++ b/pkg/ddevapp/testdata/TestWriteProjectEnvFile/env-commentsnewlines.txt
@@ -1,0 +1,11 @@
+# this is a comment in the first line
+
+DB_HOST=old_somehost
+DB_PORT=old_9999
+DB_DATABASE=old_somerandomdb
+DB_USERNAME=old_root
+DB_PASSWORD=old_root
+SOMEENV=old_someenvval
+APP_URL=old_http://some.ddev.site
+DB_CONNECTION=old_mysql://x:x@x/x
+# this is a comment in the last line

--- a/pkg/ddevapp/testdata/TestWriteProjectEnvFile/env-normalthings.txt
+++ b/pkg/ddevapp/testdata/TestWriteProjectEnvFile/env-normalthings.txt
@@ -1,0 +1,8 @@
+DB_HOST=old_somehost
+DB_PORT=old_9999
+DB_DATABASE=old_somerandomdb
+DB_USERNAME=old_root
+DB_PASSWORD=old_root
+SOMEENV=old_someenvval
+APP_URL=old_http://some.ddev.site
+DB_CONNECTION=old_mysql://x:x@x/x


### PR DESCRIPTION
## The Problem/Issue/Bug:

See bug reported in 
* https://github.com/drud/ddev/pull/4197#issuecomment-1340843620 Thanks @stasadev

The application .env file replacement (for laravel, shopware, etc.) was matching partials on the key, so 

> For example, I have DYNAMODB_CONNECTION in my .env (from [this](https://github.com/baopham/laravel-dynamodb/blob/963811691313124e7562a02aefdcc31fdbd75e78/config/dynamodb.php#L14) package) and ddev thinks it is the same as DB_CONNECTION, and replaced my config with DYNAMODB_CONNECTION="mysql".


## How this PR Solves The Problem:

* Use a more sophisticated pattern for replacement
* Add TestWriteProjectEnvFile that covers (hopefully) all the things

## Manual Testing Instructions:

Try the env file suggested by @stasadev 

## Automated Testing Overview:

Added significant test in TestWriteProjectEnvFile

## Related Issue Link(s):

* https://github.com/drud/ddev/pull/4197#issuecomment-1340843620 
* #3636 
* #3590 



