### PR TITLE
Fix help message when deleting a project

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2092,7 +2092,7 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 	// Ensure that db container is up.
 	err = app.Wait([]string{"db"})
 	if err != nil {
-		return "", fmt.Errorf("unable to snapshot database, \nyour db container in project %v is not running. \nPlease start the project if you want to snapshot it. \nIf deleting project, you can delete without a snapshot using \n'ddev delete --remove-data --yes', \nwhich will destroy your database", app.Name)
+		return "", fmt.Errorf("unable to snapshot database, \nyour db container in project %v is not running. \nPlease start the project if you want to snapshot it. \nIf deleting project, you can delete without a snapshot using \n'ddev delete --omit-snapshot --yes', \nwhich will destroy your database", app.Name)
 	}
 
 	util.Success("Creating database snapshot %s", snapshotName)


### PR DESCRIPTION
It references an old option to skip creating a snapshot.

From `ddev delete --remove-data --yes`

To `ddev delete --omit-snapshot --yes`

## The Problem/Issue/Bug:

When you try deleting a project with `ddev delete`, you get the following output:

```
...
your db container in project drupalcms is not running. 
Please start the project if you want to snapshot it. 
If deleting project, you can delete without a snapshot using 
'ddev delete --remove-data --yes', 
which will destroy your database
```

The above is incorrect because `--remove-data` does not exist.

## How this PR Solves The Problem:

It replaces `--remove-data` by `--omit-snapshot`.

## Manual Testing Instructions:

This is a documentation change so there is no need to test anything manually.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4438"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

