### PR TITLE
Bump all images for v1.21.4

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:20221205_yq_update as ddev-webserver-base
+FROM drud/ddev-php-base:v1.21.4 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,13 +17,13 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20221205_yq_update" // Note that this can be overridden by make
+var WebTag = "v1.21.4" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20221026_uid_collision"
+var BaseDBTag = "v1.21.4"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"
@@ -31,7 +31,7 @@ var DBAImg = "phpmyadmin"
 // DBATag defines the default phpmyadmin image tag used for applications.
 var DBATag = "5" // Note that this can be overridden by make
 
-const TraditionalRouterImage = "drud/ddev-router:20221205_yq_update"
+const TraditionalRouterImage = "drud/ddev-router:v1.21.4"
 const TraefikRouterImage = "traefik:v2.9"
 
 // SSHAuthImage is image for agent
@@ -40,7 +40,7 @@ var SSHAuthImage = "drud/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
 // var SSHAuthTag = "v1.19.0"
-var SSHAuthTag = "v1.21.3"
+var SSHAuthTag = "v1.21.4"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Problem/Issue/Bug:

Time to prepare images including php 8.2.0 in ddev-webserver, preparing DDEV v1.21.4

