### PR TITLE
Improve output of ddev get in failure cases and add --verbose flag

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -198,10 +198,12 @@ ddev get --list --all
 			err = processAction(action, dict, bash, verbose)
 			if err != nil {
 				desc := getDdevDescription(action)
-				if !verbose {
-					util.Failed("could not process pre-install action (%d) '%s'. For more detail use ddev get --verbose", i, desc)
-				} else {
-					util.Failed("could not process pre-install action (%d) '%s'; error=%v\n action=%s", i, desc, err, action)
+				if err != nil {
+					if !verbose {
+						util.Failed("could not process pre-install action (%d) '%s'. For more detail use ddev get --verbose", i, desc)
+					} else {
+						util.Failed("could not process pre-install action (%d) '%s'; error=%v\n action=%s", i, desc, err, action)
+					}
 				}
 			}
 		}
@@ -258,10 +260,12 @@ ddev get --list --all
 		for i, action := range s.PostInstallActions {
 			err = processAction(action, dict, bash, verbose)
 			desc := getDdevDescription(action)
-			if !verbose {
-				util.Failed("could not process pre-install action (%d) '%s'", i, desc)
-			} else {
-				util.Failed("could not process pre-install action (%d) '%s': %v", i, desc, err)
+			if err != nil {
+				if !verbose {
+					util.Failed("could not process post-install action (%d) '%s'", i, desc)
+				} else {
+					util.Failed("could not process post-install action (%d) '%s': %v", i, desc, err)
+				}
 			}
 		}
 

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -50,6 +50,8 @@ ddev get --list --all
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		officialOnly := true
+		verbose := false
+
 		if cmd.Flag("list").Changed {
 			if cmd.Flag("all").Changed {
 				officialOnly = false
@@ -65,6 +67,10 @@ ddev get --list --all
 			out := renderRepositoryList(repos)
 			output.UserOut.WithField("raw", repos).Print(out)
 			return
+		}
+
+		if cmd.Flags().Changed("verbose") {
+			verbose = true
 		}
 
 		if len(args) < 1 {
@@ -188,10 +194,15 @@ ddev get --list --all
 		if len(s.PreInstallActions) > 0 {
 			util.Success("\nExecuting pre-install actions:")
 		}
-		for _, action := range s.PreInstallActions {
-			err = processAction(action, dict, bash)
+		for i, action := range s.PreInstallActions {
+			err = processAction(action, dict, bash, verbose)
 			if err != nil {
-				util.Failed("could not process pre-install action '%s': %v", action, err)
+				desc := getDdevDescription(action)
+				if !verbose {
+					util.Failed("could not process pre-install action (%d) '%s'. For more detail use ddev get --verbose", i, desc)
+				} else {
+					util.Failed("could not process pre-install action (%d) '%s'; error=%v\n action=%s", i, desc, err, action)
+				}
 			}
 		}
 
@@ -244,10 +255,13 @@ ddev get --list --all
 		if len(s.PostInstallActions) > 0 {
 			util.Success("\nExecuting post-install actions:")
 		}
-		for _, action := range s.PostInstallActions {
-			err = processAction(action, dict, bash)
-			if err != nil {
-				util.Failed("could not process post-install action '%s': %v", action, err)
+		for i, action := range s.PostInstallActions {
+			err = processAction(action, dict, bash, verbose)
+			desc := getDdevDescription(action)
+			if !verbose {
+				util.Failed("could not process pre-install action (%d) '%s'", i, desc)
+			} else {
+				util.Failed("could not process pre-install action (%d) '%s': %v", i, desc, err)
 			}
 		}
 
@@ -260,7 +274,7 @@ ddev get --list --all
 }
 
 // processAction takes a stanza from yaml exec section and executes it.
-func processAction(action string, dict map[string]interface{}, bashPath string) error {
+func processAction(action string, dict map[string]interface{}, bashPath string, verbose bool) error {
 	action = "set -eu -o pipefail\n" + action
 	t, err := template.New("processAction").Funcs(sprig.TxtFuncMap()).Parse(action)
 	if err != nil {
@@ -275,13 +289,16 @@ func processAction(action string, dict map[string]interface{}, bashPath string) 
 	action = doc.String()
 
 	desc := getDdevDescription(action)
+	if verbose {
+		action = "set -x; " + action
+	}
 	out, err := exec.RunHostCommand(bashPath, "-c", action)
+	if len(out) > 0 {
+		util.Warning(out)
+	}
 	if err != nil {
 		util.Warning("%c %s", '\U0001F44E', desc)
 		return fmt.Errorf("Unable to run action %v: %v, output=%s", action, err, out)
-	}
-	if len(out) > 0 {
-		output.UserOut.Print(out)
 	}
 	if desc != "" {
 		util.Success("%c %s", '\U0001F44D', desc)
@@ -337,6 +354,7 @@ func renderRepositoryList(repos []github.Repository) string {
 func init() {
 	Get.Flags().Bool("list", true, fmt.Sprintf(`List available add-ons for 'ddev get'`))
 	Get.Flags().Bool("all", true, fmt.Sprintf(`List unofficial add-ons for 'ddev get' in addition to the official ones`))
+	Get.Flags().BoolP("verbose", "v", false, "Extended/verbose output for ddev get")
 	RootCmd.AddCommand(Get)
 }
 

--- a/docs/content/users/basics/commands.md
+++ b/docs/content/users/basics/commands.md
@@ -550,6 +550,7 @@ Flags:
 
 * `--all`: List unofficial *and* official add-ons. (default `true`)
 * `--list`: List official add-ons. (default `true`)
+* `--verbose` or `-v`: Output verbose error information with bash `set -x` (default `false`)
 
 Example:
 
@@ -562,6 +563,10 @@ ddev get --list --all
 
 # Download the official Redis add-on
 ddev get drud/ddev-redis
+
+# Get debug info about `ddev get` failure
+ddev get drud/ddev-redis --verbose
+
 
 # Download the Drupal 9 Solr add-on from its v0.0.5 release tarball
 ddev get https://github.com/drud/ddev-drupal9-solr/archive/refs/tags/v0.0.5.tar.gz


### PR DESCRIPTION
## The Problem/Issue/Bug:

When `ddev get` fails it can emit a lot of ugliness that is hard to parse

## How this PR Solves The Problem:

By default, don't show all the extra info. Just show the item that failed and prompt them to use `ddev get -v` to figure it out.

## Manual Testing Instructions:

Break an addon locally, make sure it has #ddev-description in it, `ddev get` it. Use --verbose to get more info.

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

