### PR TITLE
Update php 8.2 extensions (xdebug, memcached, redis now there)

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -107,7 +107,7 @@ ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
 # Still to come: apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
 # Update test for these when they get added in.
-ENV php82_amd64="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip"
+ENV php82_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip"
 ENV php82_arm64=$php82_amd64
 
 RUN for v in $PHP_VERSIONS; do \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -105,9 +105,7 @@ ENV php80_arm64=$php80_amd64
 
 ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
-# Still to come: apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
-# Update test for these when they get added in.
-ENV php82_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip"
+ENV php82_amd64=$php8.1_amd64
 ENV php82_arm64=$php82_amd64
 
 RUN for v in $PHP_VERSIONS; do \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -105,7 +105,7 @@ ENV php80_arm64=$php80_amd64
 
 ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
-ENV php82_amd64=$php8.1_amd64
+ENV php82_amd64=$php81_amd64
 ENV php82_arm64=$php82_amd64
 
 RUN for v in $PHP_VERSIONS; do \

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -14,7 +14,6 @@
 }
 
 @test "enable and disable xdebug for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
-    if [ "${PHP_VERSION}" = "8.2" ]; then skip "Skipping for PHP_VERSION=8.2 because no xdebug yet"; fi
     CURRENT_ARCH=$(../get_arch.sh)
 
     docker exec -t $CONTAINER_NAME enable_xdebug
@@ -30,8 +29,6 @@
 }
 
 @test "enable and disable xhprof for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
-    # TODO: Add back in.
-    if [ "${PHP_VERSION}" = "8.2" ]; then skip "xhprof not yet available for 8.2"; fi
     CURRENT_ARCH=$(../get_arch.sh)
 
     docker exec -t $CONTAINER_NAME enable_xhprof
@@ -93,9 +90,7 @@
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
   8.2)
-    # TODO: Update this list as more extensions become available
-    # Still to come: apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
-    extensions="bcmath bz2 curl gd intl json ldap mbstring mysqli pgsql readline soap sqlite3  xml zip"
+    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
   esac
 
   run docker exec -t $CONTAINER_NAME enable_xdebug

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -793,8 +793,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 	// Most of the time there's no reason to do all versions of PHP
 	phpKeys := []string{}
-	// TODO: Re-enable 8.2 when it's available
-	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3", "8.2"}
+	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3"}
 	for k := range nodeps.ValidPHPVersions {
 		if os.Getenv("GOTEST_SHORT") != "" && !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)
@@ -942,8 +941,7 @@ func TestDdevXhprofEnabled(t *testing.T) {
 	// Does not work with php5.6 anyway (SEGV), for resource conservation
 	// skip older unsupported versions
 	phpKeys := []string{}
-	// TODO: Re-enable 8.2 when it's available. Disable more of these.
-	exclusions := []string{"5.6", "7.0", "7.1", "8.2"}
+	exclusions := []string{"5.6", "7.0", "7.1"}
 	for k := range nodeps.ValidPHPVersions {
 		if !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -829,8 +829,8 @@ func TestDdevXdebugEnabled(t *testing.T) {
 			t.Errorf("Aborting xdebug check for php%s: %v", v, err)
 			continue
 		}
-		// PHP 7.2 through 8.1 gets xdebug 3.0+
-		if nodeps.ArrayContainsString([]string{nodeps.PHP72, nodeps.PHP73, nodeps.PHP74, nodeps.PHP80, nodeps.PHP81}, app.PHPVersion) {
+		// PHP 7.2 through 8.2 get xdebug 3.0+
+		if nodeps.ArrayContainsString([]string{nodeps.PHP72, nodeps.PHP73, nodeps.PHP74, nodeps.PHP80, nodeps.PHP81, nodeps.PHP82}, app.PHPVersion) {
 			assert.Contains(stdout, "xdebug.mode => debug,develop => debug,develop", "xdebug is not enabled for %s", v)
 			assert.Contains(stdout, "xdebug.client_host => host.docker.internal => host.docker.internal")
 		} else {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -793,7 +793,9 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 	// Most of the time there's no reason to do all versions of PHP
 	phpKeys := []string{}
-	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3"}
+	// 20221211: 8.1 and 8.2 are not currently working due to upstream
+	// problems
+	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3", "8.1", "8.2"}
 	for k := range nodeps.ValidPHPVersions {
 		if os.Getenv("GOTEST_SHORT") != "" && !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -941,7 +941,7 @@ func TestDdevXhprofEnabled(t *testing.T) {
 	// Does not work with php5.6 anyway (SEGV), for resource conservation
 	// skip older unsupported versions
 	phpKeys := []string{}
-	exclusions := []string{"5.6", "7.0", "7.1"}
+	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3"}
 	for k := range nodeps.ValidPHPVersions {
 		if !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -793,9 +793,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 	// Most of the time there's no reason to do all versions of PHP
 	phpKeys := []string{}
-	// 20221211: 8.1 and 8.2 are not currently working due to upstream
-	// problems
-	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3", "8.1", "8.2"}
+	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3"}
 	for k := range nodeps.ValidPHPVersions {
 		if os.Getenv("GOTEST_SHORT") != "" && !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)
@@ -943,7 +941,9 @@ func TestDdevXhprofEnabled(t *testing.T) {
 	// Does not work with php5.6 anyway (SEGV), for resource conservation
 	// skip older unsupported versions
 	phpKeys := []string{}
-	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3"}
+	// 20221211: 8.1 and 8.2 are not currently working due to upstream
+	// problems
+	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3", "8.1", "8.2"}
 	for k := range nodeps.ValidPHPVersions {
 		if !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)


### PR DESCRIPTION
## The Problem/Issue/Bug:

deb.sury.org fixed a number of missing php 8.2 extensions, so they should all be here now.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4445"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

