### PR TITLE
WIP adding Symfony project type + inject DATABASE_URL to envVars

### DIFF
--- a/docs/content/developers/project-types.md
+++ b/docs/content/developers/project-types.md
@@ -4,9 +4,9 @@ Adding and maintaining project types (like `typo3`, `magento2`, etc.) is not too
 
 To add a new project type:
 
-* Add the new type to the list in `nodeps.go`
-* Add to `appTypeMatrix` in `apptypes.go`
-* Create a new go file for your project type, like `django.go`.
+* Add the new type to the list in `pkg/nodeps/values.go`
+* Add to `appTypeMatrix` in `pkg/ddevapp/apptypes.go`
+* Create a new go file for your project type, like `django.go` in `pkg/ddevapp` folder.
 * Implement the functions that you think are needed for your project type and add references to them in your `appTypeMatrix` stanza. There are lots of examples that you can start with in places like `drupal.go` and `typo3.go`, `shopware6.go`, etc. The comments in the code in `apptypes.go` for the `appTypeFuncs` for each type of action tell what these are for, but here's a quick summary.
     * `settingsCreator` is the function that will create a main settings file if none exists.
     * `uploadDir` returns the filepath of the user-uploaded files directory for the project type, like `sites/default/files` for Drupal or `pub/media` for magento2.

--- a/docs/content/users/code-of-conduct.md
+++ b/docs/content/users/code-of-conduct.md
@@ -129,4 +129,4 @@ For answers to common questions about this code of conduct, see the FAQ at
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
+[translations]: https://www.contributor-covenant.org/translations/

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -117,6 +117,10 @@ func init() {
 		nodeps.AppTypeWordPress: {
 			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: wordpressImportFilesAction,
 		},
+
+        nodeps.AppTypeSymfony: {
+            uploadDir: getSymfonyUploadDir, postStartAction: symfonyPostStartAction, importFilesAction: symfonyImportFilesAction,
+        },
 	}
 }
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -117,10 +117,9 @@ func init() {
 		nodeps.AppTypeWordPress: {
 			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: wordpressImportFilesAction,
 		},
-
-        nodeps.AppTypeSymfony: {
-            uploadDir: getSymfonyUploadDir, postStartAction: symfonyPostStartAction, importFilesAction: symfonyImportFilesAction,
-        },
+		nodeps.AppTypeSymfony: {
+			uploadDir: getSymfonyUploadDir, postStartAction: symfonyPostStartAction,
+		},
 	}
 }
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -118,7 +118,7 @@ func init() {
 			settingsCreator: createWordpressSettingsFile, uploadDir: getWordpressUploadDir, hookDefaultComments: getWordpressHooks, apptypeSettingsPaths: setWordpressSiteSettingsPaths, appTypeDetect: isWordpressApp, postImportDBAction: nil, configOverrideAction: nil, postConfigAction: nil, postStartAction: nil, importFilesAction: wordpressImportFilesAction,
 		},
 		nodeps.AppTypeSymfony: {
-			uploadDir: getSymfonyUploadDir, postStartAction: symfonyPostStartAction,
+			uploadDir: getSymfonyUploadDir, postStartAction: symfonyPostStartAction, configOverrideAction: symfonyConfigOverrideAction,
 		},
 	}
 }

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -73,6 +73,7 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeMagento:   nodeps.PHP74,
 		nodeps.AppTypeMagento2:  nodeps.PHP81,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,
+		nodeps.AppTypeSymfony:   nodeps.PHP82,
 	}
 
 	for appType, expectedPHPVersion := range appTypes {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -259,6 +259,20 @@ var (
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "Thanks for installing Craft CMS"},
 			FilesImageURI:                 "/files/happy-brad.jpg",
 		},
+        // 14: Symfony
+        //TODO change with a symfony archive
+        {
+            Name:                          "TestPkgSymfony",
+            SourceURL:                     "https://github.com/drud/ddev-test-php-repo/archive/refs/tags/v1.1.0.tar.gz",
+            ArchiveInternalExtractionPath: "ddev-test-php-repo-1.1.0/",
+            FullSiteTarballURL:            "",
+            FilesTarballURL:               "https://github.com/drud/ddev_test_tarballs/releases/download/v1.1/drupal6_files.tar.gz",
+            Docroot:                       "",
+            Type:                          nodeps.AppTypeSymfony,
+            Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/README.txt", Expect: "This is a simple readme."},
+            DynamicURI:                    testcommon.URIWithExpect{URI: "/index.php", Expect: "This program makes use of the Zend Scripting Language Engine"},
+        },
+
 	}
 
 	FullTestSites = TestSites

--- a/pkg/ddevapp/symfony.go
+++ b/pkg/ddevapp/symfony.go
@@ -12,32 +12,25 @@ func symfonyPostStartAction(app *DdevApp) error {
 			return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 		}
 	}
-	// We won't touch env if disable_settings_management: true
-	if app.DisableSettingsManagement {
-		return nil
-	}
-	_, envText, err := ReadProjectEnvFile(app)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("Unable to read .env file: %v", err)
-	}
-	port := "3306"
-	dbConnection := "mysql"
-	if app.Database.Type == nodeps.Postgres {
-		dbConnection = "pgsql"
-		port = "5432"
-	}
-	envMap := map[string]string{
-		"DATABASE_URL": dbConnection + "://db:db@db:" + port + "/db",
-	}
-	err = WriteProjectEnvFile(app, envMap, envText)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
 // getPHPUploadDir will return a custom upload dir if defined
 func getSymfonyUploadDir(app *DdevApp) string {
 	return app.UploadDir
+}
+
+// symfonyConfigOverrideAction overrides php_version for Symfony 6, requires PHP8.1
+func symfonyConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP82
+	port := "3306"
+    dbConnection := "mysql"
+    if app.Database.Type == nodeps.Postgres {
+        dbConnection = "pgsql"
+        port = "5432"
+    }
+    app.envMap := map[string]string{
+        "DATABASE_URL": dbConnection + "://db:db@db:" + port + "/db",
+    }
+	return nil
 }

--- a/pkg/ddevapp/symfony.go
+++ b/pkg/ddevapp/symfony.go
@@ -1,0 +1,54 @@
+package ddevapp
+
+import (
+	"fmt"
+	"github.com/drud/ddev/pkg/archive"
+	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/pkg/errors"
+	"os"
+	"path/filepath"
+)
+
+func symfonyPostStartAction(app *DdevApp) error {
+	if !app.DisableSettingsManagement {
+		if _, err := app.CreateSettingsFile(); err != nil {
+			return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
+		}
+	}
+	return nil
+}
+
+func symfonyPostStartAction(app *DdevApp) error {
+	// We won't touch env if disable_settings_management: true
+	if app.DisableSettingsManagement {
+		return nil
+	}
+	_, envText, err := ReadProjectEnvFile(app)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("Unable to read .env file: %v", err)
+	}
+	port := "3306"
+	dbConnection := "mysql"
+	if app.Database.Type == nodeps.Postgres {
+		dbConnection = "pgsql"
+		port = "5432"
+	}
+	envMap := map[string]string{
+		"DATABASE_URL": fmt.Printf("%c://db:db@db:%p/db", dbConnection, port)
+	}
+	err = WriteProjectEnvFile(app, envMap, envText)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// getPHPUploadDir will return a custom upload dir if defined
+func getSymfonyUploadDir(app *DdevApp) string {
+	return app.UploadDir
+}
+
+
+
+

--- a/pkg/ddevapp/symfony.go
+++ b/pkg/ddevapp/symfony.go
@@ -2,11 +2,8 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/drud/ddev/pkg/archive"
-	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/pkg/errors"
+	"github.com/drud/ddev/pkg/nodeps"
 	"os"
-	"path/filepath"
 )
 
 func symfonyPostStartAction(app *DdevApp) error {
@@ -15,10 +12,6 @@ func symfonyPostStartAction(app *DdevApp) error {
 			return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 		}
 	}
-	return nil
-}
-
-func symfonyPostStartAction(app *DdevApp) error {
 	// We won't touch env if disable_settings_management: true
 	if app.DisableSettingsManagement {
 		return nil
@@ -34,7 +27,7 @@ func symfonyPostStartAction(app *DdevApp) error {
 		port = "5432"
 	}
 	envMap := map[string]string{
-		"DATABASE_URL": fmt.Printf("%c://db:db@db:%p/db", dbConnection, port)
+		"DATABASE_URL": dbConnection + "://db:db@db:" + port + "/db",
 	}
 	err = WriteProjectEnvFile(app, envMap, envText)
 	if err != nil {
@@ -48,7 +41,3 @@ func symfonyPostStartAction(app *DdevApp) error {
 func getSymfonyUploadDir(app *DdevApp) string {
 	return app.UploadDir
 }
-
-
-
-

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -93,6 +93,7 @@ const (
 	AppTypeShopware6 = "shopware6"
 	AppTypeTYPO3     = "typo3"
 	AppTypeWordPress = "wordpress"
+	AppTypeSymfony   = "symfony"
 )
 
 // Ports and other defaults


### PR DESCRIPTION
## The Problem/Issue/Bug:
envVar `DATABASE_URL` is not injected into the ddev config and so, doctrine can't connect to DB and it raises a HTTP 500

## How this PR Solves The Problem:
It creates a new project type `symfony` that will inject DATABASE_URL into the envVar.

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
https://github.com/drud/ddev/issues/4410 (already closed)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


@rfay i don't know of to test this locally before merging it. 
Let's have a quick call if you want to discuss it. 


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4454"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

