### PR TITLE
[docs] Multiple release prep docs changes, fixes #4411

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -12,7 +12,7 @@ The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php
 
 ## Changing Web Server Type
 
-DDEV supports nginx with php-fpm by default (`nginx-fpm`), and Apache with php-fpm (`apache-fpm`). These can be changed using [`webserver_type`](../configuration/config.md#webserver_type) in `.ddev/config.yaml`, for example `webserver_type: apache-fpm`.
+DDEV supports nginx with php-fpm by default (`nginx-fpm`), and Apache with php-fpm (`apache-fpm`). These can be changed using [`webserver_type`](../configuration/config.md#webserver_type) in `.ddev/config.yaml`, for example `webserver_type: apache-fpm`, then `ddev restart`.
 
 ## Adding Services to a Project
 
@@ -162,7 +162,7 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 ## Custom nginx Configuration
 
-When you [`ddev start`](../basics/commands.md#start) using `nginx-fpm`, DDEV creates a configuration customized to your project type in `.ddev/nginx_full/nginx-site.conf`. You can edit and override the configuration by removing the `#ddev-generated` line and doing whatever you need with it. After each change, `ddev start`.
+When you [`ddev restart`](../basics/commands.md#restart) using `nginx-fpm`, DDEV creates a configuration customized to your project type in `.ddev/nginx_full/nginx-site.conf`. You can edit and override the configuration by removing the `#ddev-generated` line and doing whatever you need with it. After each change, `ddev restart`.
 
 You can also have more than one config file in the `.ddev/nginx_full` directory, they will all get loaded when DDEV starts. This can be used for [serving multiple docroots](#multiple-docroots-in-nginx-advanced) and other techniques.
 
@@ -170,7 +170,7 @@ You can also have more than one config file in the `.ddev/nginx_full` directory,
 
 * Any errors in your configuration may cause the `web` container to fail and try to restart. If you see that behavior, use [`ddev logs`](../basics/commands.md#logs) to diagnose.
 * You can run `ddev exec nginx -t` to test whether your configuration is valid. (Or run [`ddev ssh`](../basics/commands.md#ssh) and run `nginx -t`.)
-* You can reload the nginx configuration either with [`ddev start`](../basics/commands.md#start) or `ddev exec nginx -s reload`.
+* You can reload the nginx configuration either with [`ddev restart`](../basics/commands.md#restart) or `ddev exec nginx -s reload`.
 * The alias `Alias "/phpstatus" "/var/www/phpstatus.php"` is required for the health check script to work.
 
 !!!warning "Important!"
@@ -194,13 +194,15 @@ For example, to make all HTTP URLs redirect to their HTTPS equivalents you might
     }
 ```
 
+After adding a snippet, `ddev restart` to make it take effect.
+
 ## Custom Apache Configuration
 
 If you’re using [`webserver_type: apache-fpm`](../configuration/config.md#webserver_type) in your `.ddev/config.yaml`, you can override the default site configuration by editing or replacing the DDEV-provided `.ddev/apache/apache-site.conf` configuration.
 
 * Edit the `.ddev/apache/apache-site.conf`.
 * Add your configuration changes.
-* Save your configuration file and run [`ddev start`](../basics/commands.md#start) to reload the project. If you encounter issues with your configuration or the project fails to start, use [`ddev logs`](../basics/commands.md#logs) to inspect the logs for possible Apache configuration errors.
+* Save your configuration file and run [`ddev restart`](../basics/commands.md#restart). If you encounter issues with your configuration or the project fails to start, use [`ddev logs`](../basics/commands.md#logs) to inspect the logs for possible Apache configuration errors.
 * Use `ddev exec apachectl -t` to do a general Apache syntax check.
 * The alias `Alias "/phpstatus" "/var/www/phpstatus.php"` is required for the health check script to work.
 * Any errors in your configuration may cause the `web` container to fail. If you see that behavior, use `ddev logs` to diagnose.

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -55,11 +55,11 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     If you’re working inside WSL2, which we recommend, you can [install Docker Engine (docker-ce) inside of it](#docker-ce-inside-windows-wsl2). Otherwise, you can [install Docker Desktop](#docker-desktop-for-windows), which works with both traditional Windows and WSL2.
 
-    ## Docker CE Inside Windows WSL2
+    ### Docker CE Inside Windows WSL2
 
     Many have moved away from using Docker Desktop in favor of the Docker-provided open-source `docker-ce` package inside WSL2.
 
-The instructions for [DDEV Installation in WSL2](ddev-installation.md#windows-wsl2) include Docker CE setup and a script that does almost all the work. Please use those.
+    The instructions for [DDEV Installation in WSL2](ddev-installation.md#windows-wsl2) include Docker CE setup and a script that does almost all the work. Please use those.
 
     ### Docker Desktop for Windows
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -59,42 +59,13 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     Many have moved away from using Docker Desktop in favor of the Docker-provided open-source `docker-ce` package inside WSL2.
 
-    Most of the installation is the same as on Linux:
-
-    * If you already have Docker Desktop installed, make sure to disable its integration with your WSL2 distro. In *Resources* → *WSL Integration*, disable integration with the default distro and with your particular distro.
-    * If you don’t already have WSL2, install it with `wsl --install`. This will likely require a reboot.
-    * Run `wsl --set-default-version 2`.
-    * If the `Ubuntu` distro is not already installed and the default distro (see `wsl -l -v`) then install it with `wsl --install Ubuntu`.
-    * Install `docker-ce` in WSL2 using the normal Linux instructions. For Debian/Ubuntu, run the following inside the WSL2 distro:
-        ```bash
-        sudo apt-get remove docker docker-engine docker.io containerd runc
-        sudo apt-get update && sudo apt-get install ca-certificates curl gnupg lsb-release
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-        sudo apt-get update && sudo apt-get -y install docker-ce docker-ce-cli containerd.io
-        sudo groupadd docker && sudo usermod -aG docker $USER
-        ```
-    * You have to start `docker-ce` yourself on login, or use a script to automate it. To have it start on entry to Git Bash, add a startup line to your (Windows-side) `~/.bashrc` with:
-        ```bash
-        echo "wsl.exe -u root service docker status > /dev/null || wsl.exe -u root service docker start > /dev/null" >> ~/.bashrc
-        ```
-
-        `source ~/.bashrc` to start immediately, or it should start with your next Git Bash session.
-
-    * [Install mkcert](https://github.com/FiloSottile/mkcert#windows) on the Windows side, which may be easiest with [Chocolatey](https://chocolatey.org/install): 
-        * In an administrative PowerShell: 
-            ```
-            Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.        ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/        install.ps1'))
-            ```
-        * In an administrative PowerShell: `choco install -y mkcert`.
-        * In an administrative PowerShell, run `mkcert -install` and follow prompts to install the Certificate Authority.
-        * In an administrative PowerShell, run `setx CAROOT "$(mkcert -CAROOT)"; If ($Env:WSLENV -notlike "*CAROOT/up:*") { setx WSLENV "CAROOT/up:$Env:WSLENV" }`. This will set WSL2 to use the Certificate Authority installed on the Windows side.
-        * Double-check in Ubuntu (or your distro): `echo $CAROOT` should show something like `/mnt/c/Users/<you>/AppData/Local/mkcert`.
-        * Inside your WSL2 distro, `mkcert -install`.
+The instructions for [DDEV Installation in WSL2](ddev-installation.md#windows-wsl2) include Docker CE setup and a script that does almost all the work. Please use those.
 
     ### Docker Desktop for Windows
 
     Docker Desktop for Windows can be downloaded via [Chocolatey](https://chocolatey.org/install) with `choco install docker-desktop` or it can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has extensive automated testing with DDEV, and works with DDEV both on traditional Windows and in WSL2.
+
+    Full instructions for installing DDEV with Docker Desktop on WSL2 are provided in the [WSL2 DDEV Installation](ddev-installation.md#windows-wsl2) section.
 
 === "Linux"
 

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -5,7 +5,7 @@ DDEV provides integration with the [Platform.sh Website Management Platform](htt
 !!!tip
     Consider using `ddev get platformsh/ddev-platformsh` ([platformsh/ddev-platformsh](https://github.com/platformsh/ddev-platformsh)) for more complete Platform.sh integration.
 
-DDEV’s Platform.sh integration pulls database and files from an existing Platform.sh site/environment into your local system so you can develop locally.
+DDEV’s Platform.sh integration pulls databases and files from an existing Platform.sh site/environment into your local system so you can develop locally.
 
 ## Platform.sh Global Configuration
 
@@ -39,11 +39,11 @@ web_environment:
         ```
 
 3. Run [`ddev restart`](../basics/commands.md#restart).
-4. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
+4. Run `ddev pull platform`. After you agree to the prompt, the current upstream databases and files will be downloaded.
 5. Optionally use `ddev push platform` to push local files and database to Platform.sh. The [`ddev push`](../basics/commands.md#push) command can potentially damage your production site, so we don’t recommend using it.
 
 If you have more than one database on your Platform.sh project, you'll need to choose which one you want to use
-as the 'db' primary database on DDEV, and that will be the one pulled or pushed.
+as the 'db' primary database on DDEV, and that one will be pulled to the database named `db`.
 Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example,
 
 ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -157,7 +157,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ddev start
         ddev composer create drupal/recommended-project
         ddev composer require drush/drush
-        ddev drush site:install -y
+        ddev drush site:install --account-name=admin --account-pass=admin -y
         ddev drush uli
         ddev launch
         ```
@@ -174,7 +174,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ddev start
         ddev composer create "drupal/recommended-project:^9"
         ddev composer require drush/drush
-        ddev drush site:install -y
+        ddev drush site:install --account-name=admin --account-pass=admin -y
         ddev drush uli
         ddev launch
         ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -144,22 +144,6 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
 
     ## Drupal
 
-    === "Drupal 9"
-
-        ### Drupal 9 via Composer
-
-        ```bash
-        mkdir my-drupal9-site
-        cd my-drupal9-site
-        ddev config --project-type=drupal9 --docroot=web --create-docroot
-        ddev start
-        ddev composer create "drupal/recommended-project"
-        ddev composer require drush/drush
-        ddev drush site:install -y
-        ddev drush uli
-        ddev launch
-        ```
-
     === "Drupal 10"
 
         ### Drupal 10 via Composer
@@ -171,15 +155,29 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         cd my-drupal10-site
         ddev config --project-type=drupal10 --docroot=web --create-docroot
         ddev start
-        ddev composer create drupal/recommended-project:^10@rc
+        ddev composer create drupal/recommended-project
         ddev composer require drush/drush
         ddev drush site:install -y
         ddev drush uli
         ddev launch
         ```
 
-        !!!tip
-            As Drupal 10 moves from beta and to release, you’ll want to change the tag from `^10@rc` to `^10`.
+
+    === "Drupal 9"
+
+        ### Drupal 9 via Composer
+
+        ```bash
+        mkdir my-drupal9-site
+        cd my-drupal9-site
+        ddev config --project-type=drupal9 --docroot=web --create-docroot
+        ddev start
+        ddev composer create "drupal/recommended-project:^9"
+        ddev composer require drush/drush
+        ddev drush site:install -y
+        ddev drush uli
+        ddev launch
+        ```
 
     === "Drupal 6/7"
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -578,7 +578,7 @@ func (app *DdevApp) CheckCustomConfig() {
 		}
 	}
 	if customConfig {
-		util.Warning("Custom configuration takes effect when the container is created.\nShould something go wrong and no effect be visible use 'ddev restart'.")
+		util.Warning("Custom configuration takes effect when the container is created.\nUse 'ddev restart' for force it to take effect.")
 	}
 
 }

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -23,7 +23,7 @@
 # 5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 # 6. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
-# If you have more than one database on your Platform.sh proect,
+# If you have more than one database on your Platform.sh project,
 # you will likely to choose which one you want to use
 # as the primary database ('db').
 # Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example, `ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=main`

--- a/version-history.md
+++ b/version-history.md
@@ -2,10 +2,19 @@
 
 This version history has been driven by what we hear from our wonderful community of users. If you have lobbying for a favorite item or think things should be re-prioritized, just lobby in the [issue queue](https://github.com/drud/ddev/issues). We listen. Or talk to us in any of the [support locations](https://ddev.readthedocs.io/en/stable/#support).
 
-## v1.21 (Released 2022-08)
+## v1.21 (Released 2022-08 to 2022-12)
 
-- [x] PHP 8.2
+- [x] PHP 8.2.0 with all extensions
+- [x] Full Drupal 10 support, with needed database extensions on PostgreSQL and MariaDB/MySQL
+- [x] TYPO3 v12 support
+- [x] FIG spec generation
 - [x] Craft CMS explict project type
+- [x] Improved WSL2 support, with install scripts
+- [x] Optional new Traefik replacement for ddev-router
+- [x] Support for `.ddev/.env` files to set environment variables
+- [x] Improved `ddev pull` and `ddev pull platform`
+- [x] `ddev self-upgrade`, `ddev debug migrate-database`, `ddev debug get-volume-db-version`, `ddev debug check-db-match`, `ddev querious` commands
+-
 
 ## v1.20 (Released 2022-08)
 

--- a/version-history.md
+++ b/version-history.md
@@ -14,7 +14,6 @@ This version history has been driven by what we hear from our wonderful communit
 - [x] Support for `.ddev/.env` files to set environment variables
 - [x] Improved `ddev pull` and `ddev pull platform`
 - [x] `ddev self-upgrade`, `ddev debug migrate-database`, `ddev debug get-volume-db-version`, `ddev debug check-db-match`, `ddev querious` commands
--
 
 ## v1.20 (Released 2022-08)
 


### PR DESCRIPTION
## How this PR Solves The Problem:

* See https://github.com/drud/ddev/issues/4452 - there were duplicate handling of WSL2 docker installation in the docker and DDEV installation sections.
* PhpStorm WSL2 instructions update
* Drupal 10 and Drupal 9 quickstart updates with release of Drupal 10
* version_history.md update for release of v.1.21.4
* #4411


* Much shorter Docker installation sections for WSL2, with links

## Manual Testing Instructions:

https://ddev--4456.org.readthedocs.build/en/4456/users/install/docker-installation/#windows

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4456"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

