### PR TITLE
Fix typo on primary relationship command

### DIFF
--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -47,7 +47,7 @@ as the 'db' primary database on DDEV, and that will be the one pulled or pushed.
 Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example,
 
 ```
-ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=main`
+ddev config --web-environment-add="PLATFORM_PRIMARY_RELATIONSHIP=main"
 ```
 
 or run `ddev pull platform` with the `--environment` flag, for example,


### PR DESCRIPTION
## The Problem/Issue/Bug:
A typo in docs

## How this PR Solves The Problem:
Fixes the typo



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4457"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

