### PR TITLE
[Tests only] Refresh homebrew/lima caches since colima/lima upgraded

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Homebrew cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-homebrew-cache-8
+          cache-name: cache-homebrew-cache-9
         with:
           path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-build-${{ env.cache-name }}
@@ -71,7 +71,7 @@ jobs:
       - name: Lima cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-lima-8
+          cache-name: cache-lima-9
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.lima


### PR DESCRIPTION
## The Problem/Issue/Bug:

Colima tests are failing, and the homebrew cache there is old

## How this PR Solves The Problem:

See if starting a new cache will fix colima tests.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4458"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

