### PR TITLE
[docs] Add ddev-platformsh as officially supported

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -150,7 +150,7 @@ ddev get --list --all
 		}
 
 		// 20220811: Don't auto-start because it auto-creates the wrong database in some situations, leading to a
-		// chicken-egg problem in getting database configured. See https://github.com/platformsh/ddev-platformsh/issues/24
+		// chicken-egg problem in getting database configured. See https://github.com/drud/ddev-platformsh/issues/24
 		// Automatically start, as we don't want to be taking actions with mutagen off, for example.
 		//if status, _ := app.SiteStatus(); status != ddevapp.SiteRunning {
 		//	err = app.Start()

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -60,7 +60,7 @@ Officially-supported add-ons:
 * [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
 * [MongoDB](https://github.com/drud/ddev-mongo): `ddev get drud/ddev-mongo`.
 * [PDFreactor](https://github.com/drud/ddev-pdfreactor): `ddev get drud/ddev-pdfreactor`
-* [Platformsh](https://github.com/drud/ddev-platformsh): `ddev get drud/ddev-platformsh`
+* [Platform.sh](https://github.com/drud/ddev-platformsh): `ddev get drud/ddev-platformsh`
 * [Proxy Support](https://github.com/drud/ddev-proxy-support): `ddev get drud/ddev-proxy-support`.
 * [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
 * [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -10,37 +10,39 @@ For example,
 
 ```
 →  ddev get --list
-┌──────────────────────────────────────┬──────────────────────────────────────────────────┐
-│ ADD-ON                               │ DESCRIPTION                                      │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-adminer                    │ Adminer service for DDEV*                        │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-beanstalkd                 │ Beanstalkd for DDEV*                             │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-browsersync                │ Auto-refresh HTTPS page on changes with DDEV*    │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-cron                       │ Schedule commands to execute within DDEV*        │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-drupal9-solr               │ Drupal 9 Apache Solr installation for DDEV*      │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-elasticsearch              │ Elasticsearch add-on for DDEV*                   │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-memcached                  │ Install Memcached as an extra service in DDEV*   │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-mongo                      │ MongoDB add-on for DDEV*                         │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-pdfreactor                 │ PDFreactor service for DDEV*                     │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-proxy-support              │ Support HTTP/HTTPS proxies with DDEV*            │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-redis                      │ Redis service for DDEV*                          │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-redis-commander            │ Redis Commander for use with DDEV Redis service* │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-selenium-standalone-chrome │ A DDEV service for running standalone Chrome*    │
-├──────────────────────────────────────┼──────────────────────────────────────────────────┤
-│ drud/ddev-varnish                    │ Varnish reverse proxy add-on for DDEV*           │
-└──────────────────────────────────────┴──────────────────────────────────────────────────┘
+┌──────────────────────────────────────┬───────────────────────────────────────────────────┐
+│ ADD-ON                               │ DESCRIPTION                                       │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-adminer                    │ Adminer service for DDEV*                         │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-beanstalkd                 │ Beanstalkd for DDEV*                              │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-browsersync                │ Auto-refresh HTTPS page on changes with DDEV*     │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-cron                       │ Schedule commands to execute within DDEV*         │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-drupal9-solr               │ Drupal 9 Apache Solr installation for DDEV*       │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-elasticsearch              │ Elasticsearch add-on for DDEV*                    │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-memcached                  │ Install Memcached as an extra service in DDEV*    │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-mongo                      │ MongoDB add-on for DDEV*                          │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-pdfreactor                 │ PDFreactor service for DDEV*                      │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-platformsh                 │ Add integration with Platform.sh hosting service* │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-proxy-support              │ Support HTTP/HTTPS proxies with DDEV*             │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-redis                      │ Redis service for DDEV*                           │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-redis-commander            │ Redis Commander for use with DDEV Redis service*  │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-selenium-standalone-chrome │ A DDEV service for running standalone Chrome*     │
+├──────────────────────────────────────┼───────────────────────────────────────────────────┤
+│ drud/ddev-varnish                    │ Varnish reverse proxy add-on for DDEV*            │
+└──────────────────────────────────────┴───────────────────────────────────────────────────┘
 Add-ons marked with '*' are official, maintained DDEV add-ons.
 ```
 
@@ -58,6 +60,7 @@ Officially-supported add-ons:
 * [Memcached](https://github.com/drud/ddev-memcached): `ddev get drud/ddev-memcached`.
 * [MongoDB](https://github.com/drud/ddev-mongo): `ddev get drud/ddev-mongo`.
 * [PDFreactor](https://github.com/drud/ddev-pdfreactor): `ddev get drud/ddev-pdfreactor`
+* [Platformsh](https://github.com/drud/ddev-platformsh): `ddev get drud/ddev-platformsh`
 * [Proxy Support](https://github.com/drud/ddev-proxy-support): `ddev get drud/ddev-proxy-support`.
 * [Redis Commander](https://github.com/drud/ddev-redis-commander): `ddev get drud/ddev-redis-commander`.
 * [Redis](https://github.com/drud/ddev-redis): `ddev get drud/ddev-redis`.

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -3,7 +3,7 @@
 DDEV provides integration with the [Platform.sh Website Management Platform](https://platform.sh/), which allows Platform.sh users to quickly download and provision a project from Platform.sh in a local DDEV-managed environment.
 
 !!!tip
-    Consider using `ddev get platformsh/ddev-platformsh` ([platformsh/ddev-platformsh](https://github.com/platformsh/ddev-platformsh)) for more complete Platform.sh integration.
+    Consider using `ddev get drud/ddev-platformsh` ([platformsh/ddev-platformsh](https://github.com/drud/ddev-platformsh)) for more complete Platform.sh integration.
 
 DDEV’s Platform.sh integration pulls databases and files from an existing Platform.sh site/environment into your local system so you can develop locally.
 

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -1,7 +1,7 @@
 #ddev-generated
 # Example Platform.sh provider configuration.
 
-# Consider using `ddev get platformsh/ddev-platformsh` (https://github.com/platformsh/ddev-platformsh) for more
+# Consider using `ddev get drud/ddev-platformsh` (https://github.com/drud/ddev-platformsh) for more
 # complete platform integration.
 
 # To use this configuration,


### PR DESCRIPTION
## The Problem/Issue/Bug:

drud/ddev-platformsh is now officially supported

## How this PR Solves The Problem:

Fix references to platformsh/ddev-platformsh and update the official add-ons list

## Manual Testing Instructions:

* https://ddev--4460.org.readthedocs.build/en/4460/users/providers/platform/
* https://ddev--4460.org.readthedocs.build/en/4460/users/extend/additional-services/


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4460"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

