### PR TITLE
[docs] Fixes Arch yay install/update; to match package name, fixes #4461

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -89,7 +89,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ### Arch Linux
 
-    For Arch-based systems including `Arch Linux`, `EndeavourOS` and `Manjaro` we maintain the [ddev-bin](https://aur.archlinux.org/packages/ddev-bin/) package in AUR. To install use `yay -S ddev` or whatever other AUR tool you use; to upgrade `yay -Syu ddev`.
+    For Arch-based systems including `Arch Linux`, `EndeavourOS` and `Manjaro` we maintain the [ddev-bin](https://aur.archlinux.org/packages/ddev-bin/) package in AUR. To install use `yay -S ddev-bin` or whatever other AUR tool you use; to upgrade `yay -Syu ddev-bin`.
 
     As a one-time initialization, run `mkcert -install`.
 


### PR DESCRIPTION
addresses #4461

## The Problem/Issue/Bug:
Installing ddev on Arch.
## How this PR Solves The Problem:
Fixes AUR package name.
## Manual Testing Instructions:
Run `yay -S ddev-bin` on Arch.


## Related Issue Link(s):
#4461



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4462"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

