### PR TITLE
Add DDEV_PHP_VERSION to image build time, docs for building extension

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -80,9 +80,9 @@ ENV COMPOSER_HOME=""
 
 **Remember that the Dockerfile is building a Docker image that will be used later with DDEV.** At the time the Dockerfile is executing, your code is not mounted and the container is not running, it’s just being built. So for example, an `npm install` in `/var/www/html` will not do anything useful because the code is not there at image building time.
 
-### Available Environment Variables at Build Time
+### Build Time Environment Variables
 
-At build time the web Dockerfile can use:
+The following environment variables are available for the web Dockerfile to use at build time:
 
 * `$BASE_IMAGE`: the base image, like `drud/ddev-webserver:v1.21.4`
 * `$username`: the username inferred from your host-side username

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -10,7 +10,7 @@ It’s common to have a requirement for the `web` or `db` images which isn’t b
 You can add extra Debian packages with lines like this in `.ddev/config.yaml`:
 
 ```yaml
-webimage_extra_packages: [php-yaml, php7.3-tidy]
+webimage_extra_packages: [php-yaml, php8.2-tidy]
 dbimage_extra_packages: [telnet, netcat]
 ```
 
@@ -79,6 +79,33 @@ ENV COMPOSER_HOME=""
 ```
 
 **Remember that the Dockerfile is building a Docker image that will be used later with DDEV.** At the time the Dockerfile is executing, your code is not mounted and the container is not running, it’s just being built. So for example, an `npm install` in `/var/www/html` will not do anything useful because the code is not there at image building time.
+
+### Available Environment Variables at Build Time
+
+At build time the web Dockerfile can use:
+
+* `$BASE_IMAGE`: the base image, like `drud/ddev-webserver:v1.21.4`
+* `$username`: the username inferred from your host-side username
+* `$uid`: the user ID inferred from your host-side user ID
+* `$gid`: the group ID inferred from your host-side group ID
+* `$DDEV_PHP_VERSION`: the PHP version declared in your project configuration
+
+For example, a Dockerfile might want to build an extension for the configured PHP version like this:
+
+```Dockerfile
+ENV extension=xhprof
+ENV extension_repo=https://github.com/longxinH/xhprof
+ENV extension_version=v2.3.8
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests autoconf build-essential libc-dev php-pear php${DDEV_PHP_VERSION}-dev pkg-config zlib1g-dev
+RUN mkdir -p /tmp/php-${extension} && cd /tmp/php-${extension} && git clone ${extension_repo} .
+WORKDIR /tmp/php-${extension}/extension
+RUN git checkout ${extension_version}
+RUN phpize
+RUN ./configure
+RUN make install
+RUN echo "extension=${extension}.so" > /etc/php/${DDEV_PHP_VERSION}/mods-available/${extension}.ini
+```
 
 ### Debugging the Dockerfile Build
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -89,6 +89,7 @@ services:
         username: '{{ .Username }}'
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
+        DDEV_PHP_VERSION: ${DDEV_PHP_VERSION}
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
     {{ if .EnvFile }}
     env_file: '{{ .EnvFile }}'

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -992,6 +992,7 @@ FROM $BASE_IMAGE
 ARG username
 ARG uid
 ARG gid
+ARG DDEV_PHP_VERSION
 RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || useradd -l -m -s "/bin/bash" --comment '' $username )
 `
 	// If there are user pre.Dockerfile* files, insert their contents


### PR DESCRIPTION
## The Problem/Issue/Bug:

It was always awkward to build a PHP extension in a Dockerfile because you had to do the very fragile setting of PHP version inside the Dockefile

## How this PR Solves The Problem:

* Provide DDEV_PHP_VERSION at Dockerfile build time
* Provide docs example on how to build an extension

## Manual Testing Instructions:

Try out the doc.

## Automated Testing Overview:

Added test of this in TestCustomBuildDockerfiles




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4463"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

