### PR TITLE
[docs] Update Arch Linux section in ddev-installation.md

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -40,6 +40,7 @@ Does
 DrupalEasy
 Dump
 Enable
+EndeavourOS
 ExecStart
 ExecStop
 Execute

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -89,7 +89,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ### Arch Linux
 
-    For Arch-based systems including `Arch Linux`, `EndeavourOS` and `Manjaro` we maintain the [ddev-bin](https://aur.archlinux.org/packages/ddev-bin/) package in AUR. To install use `yay -S ddev-bin` or whatever other AUR tool you use; to upgrade `yay -Syu ddev-bin`.
+    For Arch-based systems including Arch Linux, EndeavourOS and Manjaro, we maintain the [ddev-bin](https://aur.archlinux.org/packages/ddev-bin/) package in AUR. To install, use `yay -S ddev-bin` or whatever other AUR tool you use; to upgrade `yay -Syu ddev-bin`.
 
     As a one-time initialization, run `mkcert -install`.
 


### PR DESCRIPTION
Following on after https://github.com/drud/ddev/pull/4462 to remove unnecessary backticks and add some commas.

## The Problem/Issue/Bug:

Some commas were needed and some backticks were not.

## How this PR Solves The Problem:

Fixing some (mostly existing) stylistic issues.

## Manual Testing Instructions:

[Preview locally](https://ddev.readthedocs.io/en/latest/developers/testing-docs/#preview-changes) or inspect the [automatic build](https://ddev--4464.org.readthedocs.build/en/4464/users/install/ddev-installation/#linux).

## Automated Testing Overview:

n/a

## Related Issue Link(s):

- #4462
- #4188

## Release/Deployment notes:

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4464"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

