### PR TITLE
[docs] Minor tidying for `ddev pull platform` PRs #4441 and #4426

### DIFF
--- a/docs/content/users/basics/commands.md
+++ b/docs/content/users/basics/commands.md
@@ -550,7 +550,7 @@ Flags:
 
 * `--all`: List unofficial *and* official add-ons. (default `true`)
 * `--list`: List official add-ons. (default `true`)
-* `--verbose` or `-v`: Output verbose error information with bash `set -x` (default `false`)
+* `--verbose`, `-v`: Output verbose error information with Bash `set -x` (default `false`)
 
 Example:
 
@@ -566,7 +566,6 @@ ddev get drud/ddev-redis
 
 # Get debug info about `ddev get` failure
 ddev get drud/ddev-redis --verbose
-
 
 # Download the Drupal 9 Solr add-on from its v0.0.5 release tarball
 ddev get https://github.com/drud/ddev-drupal9-solr/archive/refs/tags/v0.0.5.tar.gz

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -42,11 +42,13 @@ web_environment:
 4. Run `ddev pull platform`. After you agree to the prompt, the current upstream databases and files will be downloaded.
 5. Optionally use `ddev push platform` to push local files and database to Platform.sh. The [`ddev push`](../basics/commands.md#push) command can potentially damage your production site, so we don’t recommend using it.
 
-### Designating a Primary Database
+### Managing Multiple Databases
 
-All databases for your Platform.sh project will be pulled locally, with each name matching its remote. When you have more than one, you can optionally tell DDEV which to use as the primary and load into the default `'db'` database.
+If your project has only one database, it will automatically be pulled into and pushed from DDEV’s `'db'` database.
 
-You can do this by setting `PLATFORM_PRIMARY_RELATIONSHIP`:
+If your project has multiple databases, they’ll all be pulled into DDEV with their respective remote names. You can optionally designate a *primary* to use DDEV’s default `'db'` database, which may be useful in some cases—particularly if you’ve been using the default solo-database behavior and happened to add another one to your project.
+
+You can designate the primary database using the `PLATFORM_PRIMARY_RELATIONSHIP` environment variable:
 
 ```
 ddev config --web-environment-add="PLATFORM_PRIMARY_RELATIONSHIP=main"

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -44,7 +44,7 @@ web_environment:
 
 ### Designating a Primary Database
 
-If you have more than one database on your Platform.sh project, you must choose and designate the one you’d like to use as DDEV’s primary `'db'`. Every database will be pulled with the integration, but you’ll need to specify which one DDEV loads into its default `'db'` database.
+If you have more than one database on your Platform.sh project, you must choose and designate the one you’d like to use as DDEV’s primary `'db'`. Every database will be pulled with the integration, but you’ll need to specify which one DDEV loads into its default `'db'` database. Each non-primary database will be imported using the same name as its remote.
 
 You can do this by setting `PLATFORM_PRIMARY_RELATIONSHIP`:
 

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -42,15 +42,17 @@ web_environment:
 4. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 5. Optionally use `ddev push platform` to push local files and database to Platform.sh. The [`ddev push`](../basics/commands.md#push) command can potentially damage your production site, so we don’t recommend using it.
 
-If you have more than one database on your Platform.sh project, you'll need to choose which one you want to use
-as the 'db' primary database on DDEV, and that will be the one pulled or pushed.
-Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example,
+### Designating a Primary Database
+
+If you have more than one database on your Platform.sh project, you must choose and designate the one you’d like to use as DDEV’s primary `'db'`. Every database will be pulled with the integration, but you’ll need to specify which one DDEV loads into its default `'db'` database.
+
+You can do this by setting `PLATFORM_PRIMARY_RELATIONSHIP`:
 
 ```
 ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=main`
 ```
 
-or run `ddev pull platform` with the `--environment` flag, for example,
+You can also do the same thing by running `ddev pull platform` and using the `--environment` flag:
 
 ```
 ddev pull platform --environment="PLATFORM_PRIMARY_RELATIONSHIP=main"

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -44,7 +44,7 @@ web_environment:
 
 ### Designating a Primary Database
 
-If you have more than one database on your Platform.sh project, you must choose and designate the one you’d like to use as DDEV’s primary `'db'`. Every database will be pulled with the integration, but you’ll need to specify which one DDEV loads into its default `'db'` database. Each non-primary database will be imported using the same name as its remote.
+All databases for your Platform.sh project will be pulled locally, with each name matching its remote. When you have more than one, you can optionally tell DDEV which to use as the primary and load into the default `'db'` database.
 
 You can do this by setting `PLATFORM_PRIMARY_RELATIONSHIP`:
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Documentation guy is too slow right now and trying to catch up.

## How this PR Solves The Problem:

This makes some minor edits for consistency and hopefully clearer phrasing about how databases are handled in the Platform.sh integration.

I brought this up to date with the `master` branch and had to fix a conflict in `docs/content/users/providers/platform.md`, which I think looks good and doesn’t omit any improvements. But you may want to double-check.

## Manual Testing Instructions:

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the automatic build:

- [Commands → `get`](https://ddev--4469.org.readthedocs.build/en/4469/users/basics/commands/#get)
- [Platforms → Platform.sh → Designating a Primary Database](https://ddev--4469.org.readthedocs.build/en/4469/users/providers/platform/#designating-a-primary-database)

## Automated Testing Overview:

n/a

## Related Issue Link(s):

- #4441 
- #4426 
- #4188

## Release/Deployment notes:

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4469"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

