### PR TITLE
[docs] nginx/snippet/restart cleanup for #4456

### DIFF
--- a/docs/content/users/basics/commands.md
+++ b/docs/content/users/basics/commands.md
@@ -148,6 +148,9 @@ ddev config
 
 # Configure a Drupal 8 project with a `web` document root
 ddev config --docroot=web --project-type=drupal8
+
+# Switch the project’s default `nginx-fpm` to `apache-fpm`
+ddev config --webserver-type=apache-fpm
 ```
 
 Flags:

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -558,6 +558,14 @@ Whether Xdebug should be enabled for [step debugging](../debugging-profiling/ste
 | -- | -- | --
 | :octicons-file-directory-16: project | `nginx-fpm` | Can be `nginx-fpm` or `apache-fpm`.
 
+To change from the default `nginx-fpm` to `apache-fpm`, for example, you would need to edit your project’s `.ddev/config.yaml` to include the following:
+
+```yaml
+webserver_type: apache-fpm
+```
+
+Then run the [`ddev restart`](../basics/commands.md#restart) command to have the change take effect.
+
 ## `working_dir`
 
 Working directories used by [`ddev exec`](../basics/commands.md#exec) and [`ddev ssh`](../basics/commands.md#ssh).

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -12,7 +12,7 @@ The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php
 
 ## Changing Web Server Type
 
-DDEV supports nginx with php-fpm by default (`nginx-fpm`), and Apache with php-fpm (`apache-fpm`). These can be changed using [`webserver_type`](../configuration/config.md#webserver_type) in `.ddev/config.yaml`, for example `webserver_type: apache-fpm`, then `ddev restart`.
+DDEV supports nginx with php-fpm by default (`nginx-fpm`), and Apache with php-fpm (`apache-fpm`). You can change this with the [`webserver_type`](../configuration/config.md#webserver_type) config option, or using the [`ddev config`](../basics/commands.md#config) command with the `--webserver-type` flag.
 
 ## Adding Services to a Project
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -162,15 +162,15 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 ## Custom nginx Configuration
 
-When you [`ddev restart`](../basics/commands.md#restart) using `nginx-fpm`, DDEV creates a configuration customized to your project type in `.ddev/nginx_full/nginx-site.conf`. You can edit and override the configuration by removing the `#ddev-generated` line and doing whatever you need with it. After each change, `ddev restart`.
+When you run [`ddev restart`](../basics/commands.md#restart) using `nginx-fpm`, DDEV creates a configuration customized to your project type in `.ddev/nginx_full/nginx-site.conf`. You can edit and override the configuration by removing the `#ddev-generated` line and doing whatever you need with it. After each change, run `ddev restart`.
 
-You can also have more than one config file in the `.ddev/nginx_full` directory, they will all get loaded when DDEV starts. This can be used for [serving multiple docroots](#multiple-docroots-in-nginx-advanced) and other techniques.
+You can also have more than one config file in the `.ddev/nginx_full` directory, and each will be loaded when DDEV starts. This can be used for [serving multiple docroots](#multiple-docroots-in-nginx-advanced) and other techniques.
 
 ### Troubleshooting nginx Configuration
 
 * Any errors in your configuration may cause the `web` container to fail and try to restart. If you see that behavior, use [`ddev logs`](../basics/commands.md#logs) to diagnose.
 * You can run `ddev exec nginx -t` to test whether your configuration is valid. (Or run [`ddev ssh`](../basics/commands.md#ssh) and run `nginx -t`.)
-* You can reload the nginx configuration either with [`ddev restart`](../basics/commands.md#restart) or `ddev exec nginx -s reload`.
+* You can reload the nginx configuration by running either [`ddev restart`](../basics/commands.md#restart) or `ddev exec nginx -s reload`.
 * The alias `Alias "/phpstatus" "/var/www/phpstatus.php"` is required for the health check script to work.
 
 !!!warning "Important!"
@@ -194,7 +194,7 @@ For example, to make all HTTP URLs redirect to their HTTPS equivalents you might
     }
 ```
 
-After adding a snippet, `ddev restart` to make it take effect.
+After adding a snippet, run `ddev restart` to make it take effect.
 
 ## Custom Apache Configuration
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -65,7 +65,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     Docker Desktop for Windows can be downloaded via [Chocolatey](https://chocolatey.org/install) with `choco install docker-desktop` or it can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has extensive automated testing with DDEV, and works with DDEV both on traditional Windows and in WSL2.
 
-    Full instructions for installing DDEV with Docker Desktop on WSL2 are provided in the [WSL2 DDEV Installation](ddev-installation.md#windows-wsl2) section.
+    See [WSL2 DDEV Installation](ddev-installation.md#windows-wsl2) for help installing DDEV with Docker Desktop on WSL2.
 
 === "Linux"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Need to catch up!

## How this PR Solves The Problem:

This adds more minor edits to some of the remaining documentation updates in #4456. Mainly fixing up some wording and again emphasizing and improving reference materials.

## Manual Testing Instructions:

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the automatic build:

- [Commands → config](https://ddev--4470.org.readthedocs.build/en/4470/users/basics/commands/#config)
- [Config Options → `webserver_type`](https://ddev--4470.org.readthedocs.build/en/4470/users/configuration/config/#webserver_type)
- [Extending and Customizing Environments](https://ddev--4470.org.readthedocs.build/en/4470/users/extend/customization-extendibility/)
    - [Changing Web Server Type](https://ddev--4470.org.readthedocs.build/en/4470/users/extend/customization-extendibility/#changing-web-server-type) 
    - [Custom nginx Configuration](https://ddev--4470.org.readthedocs.build/en/4470/users/extend/customization-extendibility/#custom-nginx-configuration) 
    - [Troubleshooting nginx Configuration](https://ddev--4470.org.readthedocs.build/en/4470/users/extend/customization-extendibility/#troubleshooting-nginx-configuration) 
    - [nginx Snippets](https://ddev--4470.org.readthedocs.build/en/4470/users/extend/customization-extendibility/#nginx-snippets) 
- [Docker Installation → Windows](https://ddev--4470.org.readthedocs.build/en/4470/users/install/docker-installation/#windows)

## Automated Testing Overview:

n/a

## Related Issue Link(s):

- #4456 
- #4188 

## Release/Deployment notes:

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4470"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

