### PR TITLE
Add package build for install-ddev (for github codespaces) [skip ci]

### DIFF
--- a/.github/devcontainers/src/install-ddev/README.md
+++ b/.github/devcontainers/src/install-ddev/README.md
@@ -1,0 +1,3 @@
+# Install DDEV
+
+This installs DDEV in your devcontainer.

--- a/.github/devcontainers/src/install-ddev/devcontainer-feature.json
+++ b/.github/devcontainers/src/install-ddev/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+    "name": "Install DDEV for Codespaces",
+    "id": "install-ddev",
+    "version": "0.1.0",
+    "description": "DDEV feature for Codespaces/devcontainers"
+}

--- a/.github/devcontainers/src/install-ddev/install.sh
+++ b/.github/devcontainers/src/install-ddev/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# This will eventually move to a simple apt install
+DDEV_URL=https://nightly.link/drud/ddev/actions/artifacts/485751722.zip
+echo "Installing DDEV"
+
+sudo apt update && sudo apt install -y curl wget xdg-utils
+sudo apt remove ddev >/dev/null 2>&1 || true
+
+cd /tmp && curl -s -L -O ${DDEV_URL}
+zipball=$(basename ${DDEV_URL})
+unzip ${zipball}
+chmod +x ddev && sudo mv ddev /usr/local/bin
+rm -f ${zipball}

--- a/.github/devcontainers/src/install-ddev/install.sh
+++ b/.github/devcontainers/src/install-ddev/install.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -eu -o pipefail
 
+sudo apt update && sudo apt install -y curl wget xdg-utils
+
 # This will eventually move to a simple apt install
+sudo apt remove ddev >/dev/null 2>&1 || true
 DDEV_URL=https://nightly.link/drud/ddev/actions/artifacts/485751722.zip
 echo "Installing DDEV"
-
-sudo apt update && sudo apt install -y curl wget xdg-utils
-sudo apt remove ddev >/dev/null 2>&1 || true
 
 cd /tmp && curl -s -L -O ${DDEV_URL}
 zipball=$(basename ${DDEV_URL})

--- a/.github/workflows/devcontainer-feature-release.yaml
+++ b/.github/workflows/devcontainer-feature-release.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: devcontainers/action@v1
         with:
           publish-features: "true"
-          base-path-to-features: "../devcontainers/src"
+          base-path-to-features: ".github/devcontainers/src"
           generate-docs: "false"
 
         env:

--- a/.github/workflows/devcontainer-feature-release.yaml
+++ b/.github/workflows/devcontainer-feature-release.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/20221222_devcontainer' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,30 +18,30 @@ jobs:
         with:
           publish-features: "true"
           base-path-to-features: "../devcontainers/src"
-          generate-docs: "true"
+          generate-docs: "false"
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create PR for Documentation
-        id: push_image_info
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -e
-          echo "Start."
-          # Configure git and Push updates
-          git config --global user.email github-actions@github.com
-          git config --global user.name github-actions
-          git config pull.rebase false
-          branch=automated-documentation-update-$GITHUB_RUN_ID
-          git checkout -b $branch
-          message='Automated documentation update'
-          # Add / update and commit
-          git add */**/README.md
-          git commit -m 'Automated documentation update [skip ci]' || export NO_UPDATES=true
-          # Push
-          if [ "$NO_UPDATES" != "true" ] ; then
-              git push origin "$branch"
-              gh pr create --title "$message" --body "$message"
-          fi
+#      - name: Create PR for Documentation
+#        id: push_image_info
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          set -e
+#          echo "Start."
+#          # Configure git and Push updates
+#          git config --global user.email github-actions@github.com
+#          git config --global user.name github-actions
+#          git config pull.rebase false
+#          branch=automated-documentation-update-$GITHUB_RUN_ID
+#          git checkout -b $branch
+#          message='Automated documentation update'
+#          # Add / update and commit
+#          git add */**/README.md
+#          git commit -m 'Automated documentation update [skip ci]' || export NO_UPDATES=true
+#          # Push
+#          if [ "$NO_UPDATES" != "true" ] ; then
+#              git push origin "$branch"
+#              gh pr create --title "$message" --body "$message"
+#          fi

--- a/.github/workflows/devcontainer-feature-release.yaml
+++ b/.github/workflows/devcontainer-feature-release.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/20221222_devcontainer' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/devcontainer-feature-release.yaml
+++ b/.github/workflows/devcontainer-feature-release.yaml
@@ -1,0 +1,47 @@
+name: "Release dev container features & Generate Documentation"
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Publish Features"
+        uses: devcontainers/action@v1
+        with:
+          publish-features: "true"
+          base-path-to-features: "../devcontainers/src"
+          generate-docs: "true"
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PR for Documentation
+        id: push_image_info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          echo "Start."
+          # Configure git and Push updates
+          git config --global user.email github-actions@github.com
+          git config --global user.name github-actions
+          git config pull.rebase false
+          branch=automated-documentation-update-$GITHUB_RUN_ID
+          git checkout -b $branch
+          message='Automated documentation update'
+          # Add / update and commit
+          git add */**/README.md
+          git commit -m 'Automated documentation update [skip ci]' || export NO_UPDATES=true
+          # Push
+          if [ "$NO_UPDATES" != "true" ] ; then
+              git push origin "$branch"
+              gh pr create --title "$message" --body "$message"
+          fi


### PR DESCRIPTION
## The Problem/Issue/Bug:

The preferred technique to use DDEV in GitHub codespaces is to use a feature.

This builds the feature for codespaces.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4484"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

