### PR TITLE
[docs] Removes redundant `start` command

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -356,8 +356,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         # Set up the DDEV environment:
         ddev config --project-type=craftcms --docroot=web --create-docroot
 
-        # Boot the project and install the starter project:
-        ddev start
+        # Scaffold the project with Composer:
         ddev composer create -y --no-scripts craftcms/craft
 
         # Run the Craft installer:
@@ -379,8 +378,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         # Set up the DDEV environment:
         ddev config --project-type=craftcms
 
-        # Boot the project and install Composer packages:
-        ddev start
+        # Install packages:
         ddev composer install
 
         # Import a database backup and open the site in your browser:


### PR DESCRIPTION
## The Problem/Issue/Bug:

With changes in 1.21.4, the process of installing Craft has been simplified. Most of the significant/required changes have already been applied to the installation instructions—this is just a redundant piece that we'd like to remove, to bring the DDEV quick-start into alignment with the official documentation (see https://github.com/craftcms/docs/pull/455).

## How this PR Solves The Problem:

The `ddev start` command is no longer required, thanks to some improvements to how Composer commands are handled.

## Manual Testing Instructions:

—

## Automated Testing Overview:

—

## Related Issue Link(s):

- https://github.com/drud/ddev/issues/4477
- https://github.com/craftcms/docs/pull/450
- https://github.com/drud/ddev/pull/4340

## Release/Deployment notes:

This is a docs-only PR, and does not change DDEV functionality.


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4486"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

