### PR TITLE
Fix example "debug dockercheck" on Commands page

### DIFF
--- a/docs/content/users/basics/commands.md
+++ b/docs/content/users/basics/commands.md
@@ -323,7 +323,7 @@ Example:
 
 ```shell
 # Output contextual details for the Docker provider
-ddev debug dockerchck
+ddev debug dockercheck
 ```
 
 ### `debug download-images`


### PR DESCRIPTION
This is just a documentation fix.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4489"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

