### PR TITLE
Fix typo in project type

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -389,7 +389,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         ```
 
     !!!tip "Upgrading or using a generic project type?"
-        If you previously set up DDEV in a Craft project using the generic `php` project type, update the `type:` setting in `.ddev/config.yaml` to `craft`, then run [`ddev restart`](../users/basics/commands.md#restart) apply the changes.
+        If you previously set up DDEV in a Craft project using the generic `php` project type, update the `type:` setting in `.ddev/config.yaml` to `craftcms`, then run [`ddev restart`](../users/basics/commands.md#restart) apply the changes.
 
     ### Running Craft in a Sub-directory
 


### PR DESCRIPTION
This fixes a typo in the docs when suggesting switching to the `craftcms` project type: `craft → craftcms`

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4491"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

