### PR TITLE
[docs] “Developers” → “Development”

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,7 +168,7 @@ nav:
       - users/topics/phpstorm.md
       - users/topics/webserver.md
       - users/topics/cms-specific-help.md
-  - 'Developers':
+  - 'Development':
       - developers/index.md
       - developers/building-contributing.md
       - developers/buildkite-testmachine-setup.md


### PR DESCRIPTION
## The Issue

The navigation includes a section called “Developers”, which has two problems:

1. It breaks the naming convention that roughly describes actions (_Usage_, _Configuration_, _Extending_, _Debugging & Profiling_, _Hosting & Deployment_).
2. The section doesn’t actually describe DDEV’s _developers_, but processes and conventions for DDEV _development_.

## How This PR Solves The Issue

This renames the section to _Development_.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the automatic build.

## Automated Testing Overview

n/a

## Related Issue Link(s)

- #4188 

## Release/Deployment Notes

n/a



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4503"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

