### PR TITLE
Bump PHP container's DRUSH_VERSION to 8.4.11

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -41,7 +41,7 @@ ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ENV YQ_VERSION=v4.30.5
-ENV DRUSH_VERSION=8.4.8
+ENV DRUSH_VERSION=8.4.11
 ENV NODE_LTS=16
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER 1


### PR DESCRIPTION
## The Issue
When running i.e `ddev drush pm-update` in a D7 project with PHP 8.0.26, current drush version 8.4.8 fail with:
```sh
pm-updatestatus failed.
Drush command terminated abnormally due to an unrecoverable error
```
(Same happen when using `ddev ssh` and then `drush pm-update`)

## How This PR Solves The Issue
Using latest Drush 8.x version fix the issue.

## Manual Testing Instructions
A quick test is to run `ddev ssh` followed by `drush pm-updatestatus` and watch it fail.
Then, while still in the same ssh session, `composer global require drush/drush:8.*` and, finally `drush pm-updatestatus` 

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4510"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

