### PR TITLE
[docs] Private docker-compose not available until a project has been started

### DIFF
--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -15,6 +15,8 @@ In PhpStorm, navigate to *Preferences* → *Build, Execution, Deployment* → *D
 
 If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’t use docker-compose from WSL2, so configure Docker Desktop in *Settings* → *General* to “Use Docker Compose V2” and use a recent version of Docker Desktop.
 
+Note: to be able to find DDEV's private docker-compose, you should have at least once started a DDEV environment, which takes care of installing the docker-compose file.
+
 ## DDEV Integration Plugin
 
 It’s easiest to use the DDEV Integration Plugin, which you can install from [its landing page](https://plugins.jetbrains.com/plugin/18813-ddev-integration) or by searching the in-app marketplace (*Preferences* → *Plugins* → *Marketplace*) for “DDEV”. The integration plugin handles nearly everything on this page automatically, and works on all platforms.

--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -6,7 +6,7 @@ If you work with the [PhpStorm](https://www.jetbrains.com/phpstorm/) IDE, you ca
 
 - PhpStorm 2022.2 or higher.
 - DDEV v1.21.1 or higher.
-- You should have a least ran `ddev start` once before (so all required software is installed)
+- Make sure to get at least one project going with `ddev start` before trying to set up the plugin, because the plugin assumes it has a project to work with.
 
 ## Prerequisite
 

--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -6,6 +6,7 @@ If you work with the [PhpStorm](https://www.jetbrains.com/phpstorm/) IDE, you ca
 
 - PhpStorm 2022.2 or higher.
 - DDEV v1.21.1 or higher.
+- You should have a least ran `ddev start` once before (so all required software is installed)
 
 ## Prerequisite
 
@@ -14,8 +15,6 @@ Regardless of your setup, you need to have PhpStorm use DDEV’s private docker-
 In PhpStorm, navigate to *Preferences* → *Build, Execution, Deployment* → *Docker* → *Tools*, and set the docker-compose executable to the full path of your `.ddev/bin/docker-compose` file relative to your home directory.
 
 If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’t use docker-compose from WSL2, so configure Docker Desktop in *Settings* → *General* to “Use Docker Compose V2” and use a recent version of Docker Desktop.
-
-Note: to be able to find DDEV's private docker-compose, you should have at least once started a DDEV environment, which takes care of installing the docker-compose file.
 
 ## DDEV Integration Plugin
 


### PR DESCRIPTION
Added a little note on finding the DDEV docker-compose file

## The Issue
I searched and searched after installing DDEV. I thought I should be prepared well and already install the plugin and appointing the right docker-compose file. This was before I did a `ddev start`.

## How This PR Solves The Issue
It might not solve, but maybe give someone like me a hint :-)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4513"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

