### PR TITLE
Updates write path for `.env` files to respect app-specific locations.

### DIFF
--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -98,7 +98,7 @@ func craftCmsPostStartAction(app *DdevApp) error {
 		return nil
 	}
 	// Read in the .env file
-	envMap, envText, err := ReadProjectEnvFile(app)
+	envMap, envText, err := ReadProjectEnvFile(envFilePath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Unable to read .env file: %v", err)
 	}
@@ -138,7 +138,7 @@ func craftCmsPostStartAction(app *DdevApp) error {
 		}
 	}
 
-	err = WriteProjectEnvFile(app, envMap, envText)
+	err = WriteProjectEnvFile(envFilePath, envMap, envText)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/envfile.go
+++ b/pkg/ddevapp/envfile.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/joho/godotenv"
-	"path/filepath"
 	"regexp"
 	"strings"
 )
 
 // ReadProjectEnvFile reads the .env in the project root into a envText and envMap
 // The map has the envFile content, but without comments
-func ReadProjectEnvFile(app *DdevApp) (envMap map[string]string, envText string, err error) {
-	envFilePath := filepath.Join(app.AppRoot, ".env")
+func ReadProjectEnvFile(envFilePath string) (envMap map[string]string, envText string, err error) {
+	// envFilePath := filepath.Join(app.AppRoot, ".env")
 	envText, _ = fileutil.ReadFileIntoString(envFilePath)
 	envMap, err = godotenv.Read(envFilePath)
 
@@ -21,8 +20,8 @@ func ReadProjectEnvFile(app *DdevApp) (envMap map[string]string, envText string,
 
 // WriteProjectEnvFile writes the passed envText into the project-root .env file
 // with all items in envMap changed in envText there
-func WriteProjectEnvFile(app *DdevApp, envMap map[string]string, envText string) error {
-	envFilePath := filepath.Join(app.AppRoot, ".env")
+func WriteProjectEnvFile(envFilePath string, envMap map[string]string, envText string) error {
+	// envFilePath := filepath.Join(app.AppRoot, ".env")
 	for k, v := range envMap {
 		// If the item is already in envText, use regex to replace it
 		// otherwise, append it to the envText.

--- a/pkg/ddevapp/envfile_test.go
+++ b/pkg/ddevapp/envfile_test.go
@@ -31,7 +31,7 @@ func TestWriteProjectEnvFile(t *testing.T) {
 		_ = os.RemoveAll(appEnvFile)
 		err = fileutil.CopyFile(envFileName, appEnvFile)
 		require.NoError(t, err)
-		readEnvMap, readEnvText, err := ddevapp.ReadProjectEnvFile(app)
+		readEnvMap, readEnvText, err := ddevapp.ReadProjectEnvFile(appEnvFile)
 		require.NoError(t, err)
 		_ = readEnvMap
 
@@ -44,10 +44,10 @@ func TestWriteProjectEnvFile(t *testing.T) {
 			"DB_PASSWORD":        "newdbpassword",
 			"DB_CONNECTION":      "new_mysql://root:root@somehost/somedb",
 		}
-		err = ddevapp.WriteProjectEnvFile(app, writeEnvMap, readEnvText)
+		err = ddevapp.WriteProjectEnvFile(appEnvFile, writeEnvMap, readEnvText)
 		require.NoError(t, err)
 
-		postWriteEnvMap, postWriteEnvText, err := ddevapp.ReadProjectEnvFile(app)
+		postWriteEnvMap, postWriteEnvText, err := ddevapp.ReadProjectEnvFile(appEnvFile)
 		require.NoError(t, err)
 
 		// Make sure that the values we intended to change got changed

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -26,7 +26,8 @@ func laravelPostStartAction(app *DdevApp) error {
 	if app.DisableSettingsManagement {
 		return nil
 	}
-	_, envText, err := ReadProjectEnvFile(app)
+	envFilePath := filepath.Join(app.AppRoot, ".env")
+	_, envText, err := ReadProjectEnvFile(envFilePath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Unable to read .env file: %v", err)
 	}
@@ -36,7 +37,7 @@ func laravelPostStartAction(app *DdevApp) error {
 			util.Debug("laravel: .env.example does not exist yet, not trying to process it")
 			return nil
 		}
-		_, envText, err = ReadProjectEnvFile(app)
+		_, envText, err = ReadProjectEnvFile(envFilePath)
 		if err != nil {
 			return err
 		}
@@ -56,7 +57,7 @@ func laravelPostStartAction(app *DdevApp) error {
 		"DB_PASSWORD":   "db",
 		"DB_CONNECTION": dbConnection,
 	}
-	err = WriteProjectEnvFile(app, envMap, envText)
+	err = WriteProjectEnvFile(envFilePath, envMap, envText)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -82,7 +82,8 @@ func shopware6PostStartAction(app *DdevApp) error {
 	if app.DisableSettingsManagement {
 		return nil
 	}
-	_, envText, err := ReadProjectEnvFile(app)
+	envFilePath := filepath.Join(app.AppRoot, ".env")
+	_, envText, err := ReadProjectEnvFile(envFilePath)
 	var envMap = map[string]string{
 		"DATABASE_URL": `mysql://db:db@db:3306/db`,
 		"APP_URL":      app.GetPrimaryURL(),
@@ -91,7 +92,7 @@ func shopware6PostStartAction(app *DdevApp) error {
 	// Shopware 6 refuses to do bin/console system:setup if the env file exists,
 	// so if it doesn't exist, wait for it to be created
 	if err == nil {
-		err := WriteProjectEnvFile(app, envMap, envText)
+		err := WriteProjectEnvFile(envFilePath, envMap, envText)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## The Issue
There were some abstractions in #4197 that led to the addition of two methods for reading and writing out `.env` files for project types where settings management is enabled: `ReadProjectEnvFile` and `WriteProjectEnvFile` respectively. These methods each presumed that the `.env` file was located at `app.AppRoot`. However, there are cases where the `.env` file might need to live somewhere else, for example, if something like Craft CMS is installed in a subdirectory. In a case like, that, the post start action would keep attempting to write out an `.env` file in the incorrect location.

## How This PR Solves The Issue
This PR makes the `envFilePath` a parameter in both `ReadProjectEnvFile` and `WriteProjectEnvFile`, which allows a given application type like Craft CMS or Laravel to be in charge of determining where it thinks its `.env` file should be. This seems like a better approach, since now the reading and writing methods don't have to have an opinion about where the `.env` file lives.

## Manual Testing Instructions
I've been testing this with Craft CMS. The general commands are:

**Configure the project:**
```
ddev config --project-type=craftcms --docroot=app/web --create-docroot --composer-root=app --web-environment-add=CRAFT_CMD_ROOT=./app
```

**Install Craft**
```
ddev composer create -y --no-scripts --no-install craftcms/craft
ddev composer install
```

With these changes, you should see an `.env` file that reads from `app/.env` and writes/appends the appropriate DDEV values to that file.

## Automated Testing Overview

## Related Issue Link(s)
* #4519
* #4197

## Release/Deployment Notes


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4526"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

