### PR TITLE
[docs] Enable SmartyPants

### DIFF
--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -100,10 +100,10 @@ Debugging should be working. You can step through your code, set breakpoints, vi
 
 Set the PhpStorm terminal path (*Settings* → *Tools* → *Terminal* → *Shell Path*) to `C:\Windows\System32\wsl.exe`. That way when you use the terminal Window in WSL2 it’s using the Bash shell in WSL2.
 
-### PhpStorm with "Remote Development" option
+### PhpStorm with "Remote Development" Option
 
-1. Open your WSL2 project using *File* → *Remote Development* → *WSL*: Choose the distro and then the project.
-2. For xdebug you'll want to use `ddev config global --xdebug-ide-location=wsl2` because essentially the IDE is running inside WSL2 (and listening there).
+1. Open your WSL2 project using *File* → *Remote Development* → *WSL* and choose the distro, then the project.
+2. For Xdebug you'll want to use `ddev config global --xdebug-ide-location=wsl2` because essentially the IDE is running inside WSL2 (and listening there).
 3. Use `ddev xdebug on` as normal; test with a simple breakpoint in your `index.php`.
 
 ### PhpStorm Inside WSL2 in Linux

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ markdown_extensions:
 - pymdownx.tasklist:
     custom_checkbox: true
 - pymdownx.tilde
+- smarty
 
 nav:
   - "Start!":


### PR DESCRIPTION
## The Issue

The documentation guy has been whining about smart punctuation ever since he started digging around here, and we’ve generally agreed that modern typography is lovely but it shouldn’t be a burden to the Markdown-writer.

## How This PR Solves The Issue

[SmartyPants](https://daringfireball.net/projects/smartypants/) was created so long ago it’s old enough to drive and vote and almost buy cigarettes. To my embarrassment, it was trivially easy to enable and it now handles quotes and apostrophes automatically.

Take [this Markdown excerpt](https://github.com/drud/ddev/blob/master/docs/content/users/install/phpstorm.md?plain=1#L103-L106), for example:

```markdown
### PhpStorm with "Remote Development" Option

1. Open your WSL2 project using *File* → *Remote Development* → *WSL* and choose the distro, then the project.
2. For Xdebug you'll want to use `ddev config global --xdebug-ide-location=wsl2` because essentially the IDE is running inside WSL2 
```

We’ve got straight quotes in the heading, `"Remote Development"` and a `you'll` in step two. SmartyPants takes care of that for us with no change to the source Markdown:

![Screen Shot 2023-01-06 at 12 14 02 PM@2x](https://user-images.githubusercontent.com/2488775/211092184-c01c9fcf-76e3-4f9c-942d-e4504f17c58a.png)

There shouldn’t be any adverse side effects.:tm:

Also fixes some minor wording/formatting issues because I saw them.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect [the automatic build](https://ddev--4531.org.readthedocs.build/en/4531/users/install/phpstorm/#system-requirements).

## Automated Testing Overview

n/a

## Related Issue Link(s)

#4188

## Release/Deployment Notes

n/a
