### PR TITLE
[docs] Remove notes about composer limitations

### DIFF
--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -61,10 +61,6 @@ Use [`ddev composer`](../usage/commands.md#composer) (Composer inside the contai
     ![Finding developer mode](../../images/developer-mode-1.png)  
     ![Setting developer mode](../../images/developer-mode-2.png)
 
-### Limitations of `ddev composer`
-
-* Using `ddev composer --version` or `ddev composer -V` will not work, since `ddev` tries to utilize the command for itself. Use `ddev composer -- --version` instead.
-
 ## Email Capture and Review (MailHog)
 
 [MailHog](https://github.com/MailHog/MailHog) is a mail catcher that’s configured to capture and display emails sent by PHP in the development environment.


### PR DESCRIPTION
Since [v1.21.4](https://github.com/drud/ddev/releases/tag/v1.21.4) command flags for wrapper commands work as expected, `ddev composer --help` works out of the box.

## The Issue

The [docs](https://ddev.readthedocs.io/en/latest/users/usage/developer-tools/#limitations-of-ddev-composer) mention limitions when using composer through ddev. This is not true since latest release v1.21.4.

## How This PR Solves The Issue

It removes the composer limitations part in the docs.

## Manual Testing Instructions

## Automated Testing Overview

## Related Issue Link(s)

## Release/Deployment Notes

Maybe it is too early to remove this notes for users with older ddev version stumpling upon this limitation. I don't know how you handle this..


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4532"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

