### PR TITLE
[docs] typo: small typo error in drupal git clone section

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -201,7 +201,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
 
         ```bash
         git clone https://github.com/example/my-drupal-site
-        cd example-site
+        cd my-drupal-site
         ddev config # Follow the prompts to set Drupal version and docroot
         ddev composer install # If a composer build
         ddev launch


### PR DESCRIPTION
## The Issue
The git clone example do a new directory named my-drupal-site but the cd go to example-site. Modify for consistency.

## How This PR Solves The Issue
Change `cd` directory


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4534"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

