### PR TITLE
[docs] Correct a mistake in Bedrock description wording

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -72,7 +72,7 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
         
         ### Bedrock
 
-        [Bedrock](https://roots.io/bedrock/) is a modern, Composer-based installation if WordPress:
+        [Bedrock](https://roots.io/bedrock/) is a modern, Composer-based installation in WordPress:
 
         ```bash
         mkdir my-wp-bedrock-site


### PR DESCRIPTION
## The Issue
There is a mention to bedrock that is a composer-based installation where is a wording issue

## How This PR Solves The Issue
I only correct a wording issue

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4535"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

