### PR TITLE
Add Plausible analytics snippet

### DIFF
--- a/docs/overrides/partials/integrations/analytics/plausible.html
+++ b/docs/overrides/partials/integrations/analytics/plausible.html
@@ -1,0 +1,1 @@
+<script defer data-domain="ddev.readthedocs.io" src="https://plausible.io/js/script.js"></script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ docs_dir: docs/content
 # Configuration
 theme:
   name: material
+  custom_dir: docs/overrides
   palette:
   - scheme: default
     primary: indigo
@@ -67,6 +68,8 @@ extra:
   - icon: fontawesome/brands/twitter
     link: https://twitter.com/search?q=%23ddev&src=unknown&f=live
   generator: false
+  analytics:
+    provider: plausible
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
## The Issue

We needed to add a snippet.

## How This PR Solves The Issue

This adds a snippet, though I guess it will only be live on the “latest” docs and take a while to get to “stable”.

I tested this locally to be sure the snippet’s included in `<head>`, which indeed it is. ~~Will verify that individual page views are tracked.~~

Used the preview build to confirm that individual pageviews are tracked as a visitor moves around the site, so all good!

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the automatic build.

## Automated Testing Overview

n/a

## Related Issue Link(s)

#4367

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4540"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

