### PR TITLE
[docs] Gentler “Getting Started” with less CMS emphasis

### DIFF
--- a/docs/content/users/project.md
+++ b/docs/content/users/project.md
@@ -1,0 +1,21 @@
+# Starting a Project
+
+Once [DDEV’s installed](./install/ddev-installation.md), setting up a new project should be quick:
+
+1. Clone or create the code for your project.
+2. `cd` into the project directory and run [`ddev config`](./usage/commands.md#config) to initialize a DDEV project.  
+3. Run [`ddev start`](./usage/commands.md#start) to spin up the project.
+4. Run [`ddev launch`](./usage/commands.md#launch) to open your project in a browser.
+
+DDEV automatically detects your project type and docroot. If it guessed wrong or there’s something else you want to change, update [project options](./configuration/config.md) by editing `.ddev/config.yaml` and running [`ddev describe`](./usage/commands.md#start), or using the [`ddev config`](./usage/commands.md#config) command.
+
+!!!tip "What’s a project type?"
+    A `php` project type is the most general, ready for whatever modern PHP or static HTML/JS project you might be working on. It’s just as full-featured as other [CMS-specific options](./quickstart.md), without any assumptions about your configuration or presets. (You can use this with a CMS or framework just fine!)
+
+If you need to configure your app to connect to the database, the hostname, username, password, and database name are each `db`.
+
+While you’re getting your bearings, use [`ddev describe`](./usage/commands.md#describe) to get project details, and [`ddev help`](./usage/commands.md#help) to investigate commands.
+
+Next, you may want to run [`ddev composer install`](./usage/commands.md#composer), [import a database](./usage/commands.md#import-db), or [load user-managed files](./usage/commands.md#import-files).
+
+If you’re new to DDEV, check out [Using the `ddev` Command](./usage/cli.md) for an overview of what’s available.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -69,7 +69,6 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     !!!tip "Installing Craft"
         Read more about installing Craft in the [official documentation](https://craftcms.com/docs).
 
-
 === "Drupal"
 
     ## Drupal

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2,6 +2,305 @@
 
 While the generic `php` project type is ready to go with any CMS or framework, DDEV offers project types for more easily working with popular platforms and content management systems:
 
+=== "Backdrop"
+
+    ## Backdrop
+
+    To get started with Backdrop, clone the project repository and navigate to the project directory.
+    
+    ```bash
+    git clone https://github.com/example/example-site
+    cd example-site
+    ddev config
+    ddev start
+    ddev launch
+    ```
+
+=== "Craft CMS"
+
+    ## Craft CMS
+
+    Start a new [Craft CMS](https://craftcms.com) project or retrofit an existing one.
+
+    !!!tip "Compatibility"
+        The `craft` project type was added to DDEV in version [1.21.2](https://github.com/drud/ddev/releases/tag/v1.21.2). Check your current version with the `ddev version` command, and [upgrade](../users/usage/faq.md#how-can-i-updateupgrade-ddev) if necessary!
+
+    Environment variables will be automatically added to your `.env` file to simplify the first boot of a project. For _new_ installations, this means the default URL and database connection settings displayed during installation can be used without modification. If _existing_ projects expect environment variables to be named in a particular way, you are welcome to rename them.
+
+    === "New projects"
+
+        New Craft CMS projects can be created from the official [starter project](https://github.com/craftcms/craft) using DDEV’s [`composer create` command](../users/usage/commands.md#composer):
+
+        ```bash
+        # Create a project directory and move into it:
+        mkdir my-craft-project
+        cd my-craft-project
+
+        # Set up the DDEV environment:
+        ddev config --project-type=craftcms --docroot=web --create-docroot
+
+        # Boot the project and install the starter project:
+        ddev start
+        ddev composer create -y --no-scripts craftcms/craft
+
+        # Run the Craft installer:
+        ddev craft install
+        ddev launch
+        ```
+
+        Third-party starter projects can by used the same way—just substitute the package name when running `ddev composer create`.
+
+    === "Existing projects"
+
+        You can start using DDEV with an existing project, too—just make sure you have a database backup handy!
+
+        ```bash
+        # Clone an existing repository (or navigate to a local project directory):
+        git clone https://github.com/example/example-site my-craft-project
+        cd my-craft-project
+
+        # Set up the DDEV environment:
+        ddev config --project-type=craftcms
+
+        # Boot the project and install Composer packages:
+        ddev start
+        ddev composer install
+
+        # Import a database backup and open the site in your browser:
+        ddev import-db --src=/path/to/db.sql.gz
+        ddev launch
+        ```
+
+    !!!tip "Upgrading or using a generic project type?"
+        If you previously set up DDEV in a Craft project using the generic `php` project type, update the `type:` setting in `.ddev/config.yaml` to `craftcms`, then run [`ddev restart`](../users/usage/commands.md#restart) apply the changes.
+
+    ### Running Craft in a Sub-directory
+
+    In order for `ddev craft` to work when Craft is installed in a sub-directory, you will need to change the location of the `craft` executable by providing the `CRAFT_CMD_ROOT` environment variable to the web container. For example, if the installation lives in `my-craft-project/app`, you would run `ddev config --web-environment-add=CRAFT_CMD_ROOT=./app`. `CRAFT_CMD_ROOT` defaults to `./`, the project root directory. Run `ddev restart` to apply the change.
+
+    More information about customizing the environment and persisting configuration can be found in [Providing Custom Environment Variables to a Container](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-environment-variables-to-a-container).
+
+    !!!tip "Installing Craft"
+        Read more about installing Craft in the [official documentation](https://craftcms.com/docs).
+
+
+=== "Drupal"
+
+    ## Drupal
+
+    === "Drupal 10"
+
+        ### Drupal 10 via Composer
+    
+        [Drupal 10](https://www.drupal.org/about/10) is fully supported by DDEV.
+        
+        ```bash
+        mkdir my-drupal10-site
+        cd my-drupal10-site
+        ddev config --project-type=drupal10 --docroot=web --create-docroot
+        ddev start
+        ddev composer create drupal/recommended-project
+        ddev composer require drush/drush
+        ddev drush site:install --account-name=admin --account-pass=admin -y
+        ddev drush uli
+        ddev launch
+        ```
+
+
+    === "Drupal 9"
+
+        ### Drupal 9 via Composer
+
+        ```bash
+        mkdir my-drupal9-site
+        cd my-drupal9-site
+        ddev config --project-type=drupal9 --docroot=web --create-docroot
+        ddev start
+        ddev composer create "drupal/recommended-project:^9"
+        ddev composer require drush/drush
+        ddev drush site:install --account-name=admin --account-pass=admin -y
+        ddev drush uli
+        ddev launch
+        ```
+
+    === "Drupal 6/7"
+
+        ### Drupal 6/7
+            
+        ```bash
+        git clone https://github.com/example/my-drupal-site
+        cd my-drupal-site
+        ddev config # Follow the prompts to select type and docroot
+        ddev start
+        ddev launch /install.php
+        ```
+        
+        Drupal 7 doesn’t know how to redirect from the front page to `/install.php` if the database is not set up but the settings files *are* set up, so launching with `/install.php` gets you started with an installation. You can also `drush site-install`, then `ddev exec drush site-install --yes`.
+        
+        See [Importing a Database](#importing-a-database).
+
+    === "Git Clone"
+
+        ### Git Clone
+
+        ```bash
+        git clone https://github.com/example/my-drupal-site
+        cd my-drupal-site
+        ddev config # Follow the prompts to set Drupal version and docroot
+        ddev composer install # If a composer build
+        ddev launch
+        ```
+
+=== "Laravel"
+
+    ## Laravel
+
+    Use a new or existing Composer project, or clone a Git repository.
+
+    The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) just as it can for Laravel. DDEV automatically updates or creates the .env file with the database information.
+
+    === "Composer"
+        ```bash
+        mkdir my-laravel-app
+        cd my-laravel-app
+        ddev config --project-type=laravel --docroot=public --create-docroot
+        ddev composer create --prefer-dist --no-install --no-scripts laravel/laravel
+        ddev composer install
+        ddev exec "php artisan key:generate"
+        ddev launch
+        ```
+    === "Git Clone"
+        ```bash
+        git clone <your-laravel-repo>
+        cd <your-laravel-project>
+        ddev config --project-type=laravel --docroot=public --create-docroot
+        ddev start
+        ddev composer install
+        ddev exec "php artisan key:generate"
+        ddev launch
+        ```
+
+=== "Magento 2"
+
+    ## Magento 2
+
+    Normal details of a Composer build for Magento 2 are on the [Magento 2 site](https://devdocs.magento.com/guides/v2.4/install-gde/composer.html. You must have a public and private key to install from Magento’s repository. When prompted for “username” and “password” in `composer create`, it’s asking for your public and private keys.
+    
+    ```bash
+    mkdir ddev-magento2 && cd ddev-magento2
+    ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --create-docroot --disable-settings-management
+    ddev get drud/ddev-elasticsearch
+    ddev start
+    ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition -y
+    rm -f app/etc/env.php
+    # Change the base-url below to your project's URL
+    ddev magento setup:install --base-url='https://ddev-magento2.ddev.site/' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
+    ddev magento deploy:mode:set developer
+    ddev magento module:disable Magento_TwoFactorAuth
+    ddev config --disable-settings-management=false
+    ```
+
+    Change the admin name and related information is needed.
+
+    You may want to add the [Magento 2 Sample Data](https://devdocs.magento.com/guides/v2.4/install-gde/install/sample-data-after-composer.html) with `ddev magento sampledata:deploy && ddev magento setup:upgrade`.
+    
+    Magento 2 is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
+
+=== "Moodle"
+
+    ## Moodle
+    
+    ```bash
+    ddev config --composer-root=public --create-docroot --docroot=public --webserver-type=apache-fpm
+    ddev start
+    ddev composer create moodle/moodle -y
+    ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
+    ddev launch /login
+    ```
+    
+    In the web browser, log into your account using `admin` and `password`.
+
+    Visit the [Moodle Admin Quick Guide](https://docs.moodle.org/400/en/Admin_quick_guide) for more information.
+
+    !!!tip
+        Moodle relies on a periodic cron job—don’t forget to set that up! See [drud/ddev-cron](https://github.com/drud/ddev-cron).
+
+=== "OpenMage/Magento 1"
+
+    ## OpenMage/Magento 1
+
+    1. Download OpenMage from [release page](https://github.com/OpenMage/magento-lts/releases).
+    2. Make a directory for it, for example `mkdir ~/workspace/OpenMage` and change to the new directory `cd ~/workspace/OpenMage`.
+    3. Run [`ddev config`](../users/usage/commands.md#config) and accept the defaults.
+    4. Install sample data. (See below.)
+    5. Run [`ddev start`](../users/usage/commands.md#start).
+    6. Follow the URL to the base site.
+
+    You may want the [Magento 1 Sample Data](https://github.com/Vinai/compressed-magento-sample-data) for experimentation:
+
+    * Download Magento [1.9.2.4 Sample Data](https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz).
+    * Extract the download:  
+        `tar -zxf ~/Downloads/compressed-magento-sample-data-1.9.2.4.tgz --strip-components=1`
+    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --src=magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
+
+    OpenMage is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
+
+
+=== "Shopware 6"
+
+    ## Shopware 6
+
+    You can set up a Shopware 6 environment many ways, we recommend the following technique:
+
+    ```bash
+    git clone --branch=6.4 https://github.com/shopware/production my-shopware6
+    cd my-shopware6
+    ddev config --project-type=shopware6 --docroot=public
+    ddev start
+    ddev composer install --no-scripts
+    # During system:setup you may have to enter the Database user (db), Database password (db)
+    # Database host (db) and Database name (db). 
+    ddev exec bin/console system:setup --database-url=mysql://db:db@db:3306/db --app-url='${DDEV_PRIMARY_URL}'
+    ddev exec bin/console system:install --create-database --basic-setup
+    ddev launch /admin
+    ```
+
+    Log into the admin site (`/admin`) using the web browser. The default credentials are username `admin` and password `shopware`. You can use the web UI to install sample data or accomplish many other tasks.
+
+    For more advanced tasks like adding elasticsearch, building and watching storefront and administration, see [susi.dev](https://susi.dev/ddev-shopware-6).
+
+=== "TYPO3"
+
+    ## TYPO3
+
+    === "Composer"
+    
+        ### Composer
+        
+        ```bash
+        mkdir my-typo3-site
+        cd my-typo3-site
+        ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
+        ddev start
+        ddev composer create "typo3/cms-base-distribution"
+        ddev exec touch public/FIRST_INSTALL
+        ddev launch
+        ```
+
+    === "Git Clone"
+        
+        ### Git Clone
+    
+        ```bash
+        git clone https://github.com/example/example-site
+        cd example-site
+        ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
+        ddev composer install
+        ddev restart
+        ddev exec touch public/FIRST_INSTALL
+        ddev launch
+        ```
+
 === "WordPress"
 
     ## WordPress
@@ -108,303 +407,6 @@ While the generic `php` project type is ready to go with any CMS or framework, D
         Now start your project with [`ddev start`](../users/usage/commands.md#start).
         
         Quickstart instructions regarding database imports can be found under [Importing a database](#importing-a-database).
-
-=== "Drupal"
-
-    ## Drupal
-
-    === "Drupal 10"
-
-        ### Drupal 10 via Composer
-    
-        [Drupal 10](https://www.drupal.org/about/10) is fully supported by DDEV.
-        
-        ```bash
-        mkdir my-drupal10-site
-        cd my-drupal10-site
-        ddev config --project-type=drupal10 --docroot=web --create-docroot
-        ddev start
-        ddev composer create drupal/recommended-project
-        ddev composer require drush/drush
-        ddev drush site:install --account-name=admin --account-pass=admin -y
-        ddev drush uli
-        ddev launch
-        ```
-
-
-    === "Drupal 9"
-
-        ### Drupal 9 via Composer
-
-        ```bash
-        mkdir my-drupal9-site
-        cd my-drupal9-site
-        ddev config --project-type=drupal9 --docroot=web --create-docroot
-        ddev start
-        ddev composer create "drupal/recommended-project:^9"
-        ddev composer require drush/drush
-        ddev drush site:install --account-name=admin --account-pass=admin -y
-        ddev drush uli
-        ddev launch
-        ```
-
-    === "Drupal 6/7"
-
-        ### Drupal 6/7
-            
-        ```bash
-        git clone https://github.com/example/my-drupal-site
-        cd my-drupal-site
-        ddev config # Follow the prompts to select type and docroot
-        ddev start
-        ddev launch /install.php
-        ```
-        
-        Drupal 7 doesn’t know how to redirect from the front page to `/install.php` if the database is not set up but the settings files *are* set up, so launching with `/install.php` gets you started with an installation. You can also `drush site-install`, then `ddev exec drush site-install --yes`.
-        
-        See [Importing a Database](#importing-a-database).
-
-    === "Git Clone"
-
-        ### Git Clone
-
-        ```bash
-        git clone https://github.com/example/my-drupal-site
-        cd my-drupal-site
-        ddev config # Follow the prompts to set Drupal version and docroot
-        ddev composer install # If a composer build
-        ddev launch
-        ```
-
-=== "TYPO3"
-
-    ## TYPO3
-
-    === "Composer"
-    
-        ### Composer
-        
-        ```bash
-        mkdir my-typo3-site
-        cd my-typo3-site
-        ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
-        ddev start
-        ddev composer create "typo3/cms-base-distribution"
-        ddev exec touch public/FIRST_INSTALL
-        ddev launch
-        ```
-
-    === "Git Clone"
-        
-        ### Git Clone
-    
-        ```bash
-        git clone https://github.com/example/example-site
-        cd example-site
-        ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
-        ddev composer install
-        ddev restart
-        ddev exec touch public/FIRST_INSTALL
-        ddev launch
-        ```
-
-=== "OpenMage/Magento 1"
-
-    ## OpenMage/Magento 1
-
-    1. Download OpenMage from [release page](https://github.com/OpenMage/magento-lts/releases).
-    2. Make a directory for it, for example `mkdir ~/workspace/OpenMage` and change to the new directory `cd ~/workspace/OpenMage`.
-    3. Run [`ddev config`](../users/usage/commands.md#config) and accept the defaults.
-    4. Install sample data. (See below.)
-    5. Run [`ddev start`](../users/usage/commands.md#start).
-    6. Follow the URL to the base site.
-
-    You may want the [Magento 1 Sample Data](https://github.com/Vinai/compressed-magento-sample-data) for experimentation:
-
-    * Download Magento [1.9.2.4 Sample Data](https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz).
-    * Extract the download:  
-        `tar -zxf ~/Downloads/compressed-magento-sample-data-1.9.2.4.tgz --strip-components=1`
-    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --src=magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
-
-    OpenMage is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
-
-=== "Magento 2"
-
-    ## Magento 2
-
-    Normal details of a Composer build for Magento 2 are on the [Magento 2 site](https://devdocs.magento.com/guides/v2.4/install-gde/composer.html. You must have a public and private key to install from Magento’s repository. When prompted for “username” and “password” in `composer create`, it’s asking for your public and private keys.
-    
-    ```bash
-    mkdir ddev-magento2 && cd ddev-magento2
-    ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --create-docroot --disable-settings-management
-    ddev get drud/ddev-elasticsearch
-    ddev start
-    ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition -y
-    rm -f app/etc/env.php
-    # Change the base-url below to your project's URL
-    ddev magento setup:install --base-url='https://ddev-magento2.ddev.site/' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
-    ddev magento deploy:mode:set developer
-    ddev magento module:disable Magento_TwoFactorAuth
-    ddev config --disable-settings-management=false
-    ```
-
-    Change the admin name and related information is needed.
-
-    You may want to add the [Magento 2 Sample Data](https://devdocs.magento.com/guides/v2.4/install-gde/install/sample-data-after-composer.html) with `ddev magento sampledata:deploy && ddev magento setup:upgrade`.
-    
-    Magento 2 is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
-
-=== "Moodle"
-
-    ## Moodle
-    
-    ```bash
-    ddev config --composer-root=public --create-docroot --docroot=public --webserver-type=apache-fpm
-    ddev start
-    ddev composer create moodle/moodle -y
-    ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
-    ddev launch /login
-    ```
-    
-    In the web browser, log into your account using `admin` and `password`.
-
-    Visit the [Moodle Admin Quick Guide](https://docs.moodle.org/400/en/Admin_quick_guide) for more information.
-
-    !!!tip
-        Moodle relies on a periodic cron job—don’t forget to set that up! See [drud/ddev-cron](https://github.com/drud/ddev-cron).
-
-=== "Laravel"
-
-    ## Laravel
-
-    Use a new or existing Composer project, or clone a Git repository.
-
-    The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) just as it can for Laravel. DDEV automatically updates or creates the .env file with the database information.
-
-    === "Composer"
-        ```bash
-        mkdir my-laravel-app
-        cd my-laravel-app
-        ddev config --project-type=laravel --docroot=public --create-docroot
-        ddev composer create --prefer-dist --no-install --no-scripts laravel/laravel
-        ddev composer install
-        ddev exec "php artisan key:generate"
-        ddev launch
-        ```
-    === "Git Clone"
-        ```bash
-        git clone <your-laravel-repo>
-        cd <your-laravel-project>
-        ddev config --project-type=laravel --docroot=public --create-docroot
-        ddev start
-        ddev composer install
-        ddev exec "php artisan key:generate"
-        ddev launch
-        ```
-
-=== "Craft CMS"
-
-    ## Craft CMS
-
-    Start a new [Craft CMS](https://craftcms.com) project or retrofit an existing one.
-
-    !!!tip "Compatibility"
-        The `craft` project type was added to DDEV in version [1.21.2](https://github.com/drud/ddev/releases/tag/v1.21.2). Check your current version with the `ddev version` command, and [upgrade](../users/usage/faq.md#how-can-i-updateupgrade-ddev) if necessary!
-
-    Environment variables will be automatically added to your `.env` file to simplify the first boot of a project. For _new_ installations, this means the default URL and database connection settings displayed during installation can be used without modification. If _existing_ projects expect environment variables to be named in a particular way, you are welcome to rename them.
-
-    === "New projects"
-
-        New Craft CMS projects can be created from the official [starter project](https://github.com/craftcms/craft) using DDEV’s [`composer create` command](../users/usage/commands.md#composer):
-
-        ```bash
-        # Create a project directory and move into it:
-        mkdir my-craft-project
-        cd my-craft-project
-
-        # Set up the DDEV environment:
-        ddev config --project-type=craftcms --docroot=web --create-docroot
-
-        # Boot the project and install the starter project:
-        ddev start
-        ddev composer create -y --no-scripts craftcms/craft
-
-        # Run the Craft installer:
-        ddev craft install
-        ddev launch
-        ```
-
-        Third-party starter projects can by used the same way—just substitute the package name when running `ddev composer create`.
-
-    === "Existing projects"
-
-        You can start using DDEV with an existing project, too—just make sure you have a database backup handy!
-
-        ```bash
-        # Clone an existing repository (or navigate to a local project directory):
-        git clone https://github.com/example/example-site my-craft-project
-        cd my-craft-project
-
-        # Set up the DDEV environment:
-        ddev config --project-type=craftcms
-
-        # Boot the project and install Composer packages:
-        ddev start
-        ddev composer install
-
-        # Import a database backup and open the site in your browser:
-        ddev import-db --src=/path/to/db.sql.gz
-        ddev launch
-        ```
-
-    !!!tip "Upgrading or using a generic project type?"
-        If you previously set up DDEV in a Craft project using the generic `php` project type, update the `type:` setting in `.ddev/config.yaml` to `craftcms`, then run [`ddev restart`](../users/usage/commands.md#restart) apply the changes.
-
-    ### Running Craft in a Sub-directory
-
-    In order for `ddev craft` to work when Craft is installed in a sub-directory, you will need to change the location of the `craft` executable by providing the `CRAFT_CMD_ROOT` environment variable to the web container. For example, if the installation lives in `my-craft-project/app`, you would run `ddev config --web-environment-add=CRAFT_CMD_ROOT=./app`. `CRAFT_CMD_ROOT` defaults to `./`, the project root directory. Run `ddev restart` to apply the change.
-
-    More information about customizing the environment and persisting configuration can be found in [Providing Custom Environment Variables to a Container](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-environment-variables-to-a-container).
-
-    !!!tip "Installing Craft"
-        Read more about installing Craft in the [official documentation](https://craftcms.com/docs).
-
-=== "Shopware 6"
-
-    ## Shopware 6
-
-    You can set up a Shopware 6 environment many ways, we recommend the following technique:
-
-    ```bash
-    git clone --branch=6.4 https://github.com/shopware/production my-shopware6
-    cd my-shopware6
-    ddev config --project-type=shopware6 --docroot=public
-    ddev start
-    ddev composer install --no-scripts
-    # During system:setup you may have to enter the Database user (db), Database password (db)
-    # Database host (db) and Database name (db). 
-    ddev exec bin/console system:setup --database-url=mysql://db:db@db:3306/db --app-url='${DDEV_PRIMARY_URL}'
-    ddev exec bin/console system:install --create-database --basic-setup
-    ddev launch /admin
-    ```
-
-    Log into the admin site (`/admin`) using the web browser. The default credentials are username `admin` and password `shopware`. You can use the web UI to install sample data or accomplish many other tasks.
-
-    For more advanced tasks like adding elasticsearch, building and watching storefront and administration, see [susi.dev](https://susi.dev/ddev-shopware-6).
-
-=== "Backdrop"
-
-    ## Backdrop
-
-    To get started with Backdrop, clone the project repository and navigate to the project directory.
-    
-    ```bash
-    git clone https://github.com/example/example-site
-    cd example-site
-    ddev config
-    ddev start
-    ddev launch
-    ```
 
 ## Configuration Files
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2,20 +2,6 @@
 
 While the generic `php` project type is ready to go with any CMS or framework, DDEV offers project types for more easily working with popular platforms and content management systems:
 
-=== "Backdrop"
-
-    ## Backdrop
-
-    To get started with Backdrop, clone the project repository and navigate to the project directory.
-    
-    ```bash
-    git clone https://github.com/example/example-site
-    cd example-site
-    ddev config
-    ddev start
-    ddev launch
-    ```
-
 === "Craft CMS"
 
     ## Craft CMS
@@ -106,7 +92,6 @@ While the generic `php` project type is ready to go with any CMS or framework, D
         ddev launch
         ```
 
-
     === "Drupal 9"
 
         ### Drupal 9 via Composer
@@ -151,6 +136,18 @@ While the generic `php` project type is ready to go with any CMS or framework, D
         ddev launch
         ```
 
+    ### Backdrop
+
+    To get started with [Backdrop](https://www.drupal.org/project/backdrop), clone the project repository and navigate to the project directory.
+    
+    ```bash
+    git clone https://github.com/example/example-site
+    cd example-site
+    ddev config
+    ddev start
+    ddev launch
+    ```
+
 === "Laravel"
 
     ## Laravel
@@ -180,7 +177,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
         ddev launch
         ```
 
-=== "Magento 2"
+=== "Magento"
 
     ## Magento 2
 
@@ -206,6 +203,24 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     
     Magento 2 is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
 
+    ## OpenMage/Magento 1
+
+    1. Download OpenMage from [release page](https://github.com/OpenMage/magento-lts/releases).
+    2. Make a directory for it, for example `mkdir ~/workspace/OpenMage` and change to the new directory `cd ~/workspace/OpenMage`.
+    3. Run [`ddev config`](../users/usage/commands.md#config) and accept the defaults.
+    4. Install sample data. (See below.)
+    5. Run [`ddev start`](../users/usage/commands.md#start).
+    6. Follow the URL to the base site.
+
+    You may want the [Magento 1 Sample Data](https://github.com/Vinai/compressed-magento-sample-data) for experimentation:
+
+    * Download Magento [1.9.2.4 Sample Data](https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz).
+    * Extract the download:  
+        `tar -zxf ~/Downloads/compressed-magento-sample-data-1.9.2.4.tgz --strip-components=1`
+    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --src=magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
+
+    OpenMage is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
+
 === "Moodle"
 
     ## Moodle
@@ -225,28 +240,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     !!!tip
         Moodle relies on a periodic cron job—don’t forget to set that up! See [drud/ddev-cron](https://github.com/drud/ddev-cron).
 
-=== "OpenMage/Magento 1"
-
-    ## OpenMage/Magento 1
-
-    1. Download OpenMage from [release page](https://github.com/OpenMage/magento-lts/releases).
-    2. Make a directory for it, for example `mkdir ~/workspace/OpenMage` and change to the new directory `cd ~/workspace/OpenMage`.
-    3. Run [`ddev config`](../users/usage/commands.md#config) and accept the defaults.
-    4. Install sample data. (See below.)
-    5. Run [`ddev start`](../users/usage/commands.md#start).
-    6. Follow the URL to the base site.
-
-    You may want the [Magento 1 Sample Data](https://github.com/Vinai/compressed-magento-sample-data) for experimentation:
-
-    * Download Magento [1.9.2.4 Sample Data](https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz).
-    * Extract the download:  
-        `tar -zxf ~/Downloads/compressed-magento-sample-data-1.9.2.4.tgz --strip-components=1`
-    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --src=magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
-
-    OpenMage is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
-
-
-=== "Shopware 6"
+=== "Shopware"
 
     ## Shopware 6
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -135,17 +135,19 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         ddev launch
         ```
 
-    ### Backdrop
+    === "Backdrop"
 
-    To get started with [Backdrop](https://www.drupal.org/project/backdrop), clone the project repository and navigate to the project directory.
+        ### Backdrop
 
-    ```bash
-    git clone https://github.com/example/example-site
-    cd example-site
-    ddev config
-    ddev start
-    ddev launch
-    ```
+        To get started with [Backdrop](https://backdropcms.org), clone the project repository and navigate to the project directory.
+
+        ```bash
+        git clone https://github.com/example/example-site
+        cd example-site
+        ddev config
+        ddev start
+        ddev launch
+        ```
 
 === "Laravel"
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1,37 +1,6 @@
 # CMS Quickstarts
 
-Once DDEV is installed, you can quickly spin up new projects:
-
-1. Clone or create the code for your project.
-2. `cd` into the project directory and run [`ddev config`](../users/usage/commands.md#config) to initialize a DDEV project.  
-    It automatically detects your project type and docroot—make sure it’s accurate!
-3. Run [`ddev start`](../users/usage/commands.md#start) to spin up the project.  
-    If your project needs it, don’t forget to run [`ddev composer install`](../users/usage/commands.md#composer).
-4. Import a database with [`ddev import-db`](../users/usage/commands.md#import-db).
-5. Optionally import user-managed files with [`ddev import-files`](../users/usage/commands.md#import-files).
-6. Run [`ddev launch`](../users/usage/commands.md#launch) to open your project in a browser, or visit the URL given by [`ddev start`](../users/usage/commands.md#start).
-
-!!!tip
-    While you’re getting your bearings, use [`ddev describe`](../users/usage/commands.md#describe) to get project details, and [`ddev help`](../users/usage/commands.md#help) to investigate commands.
-
-DDEV comes ready to work with any PHP project, and has deeper support for several common PHP platforms and content management systems.
-
-=== "Generic"
-
-    ## Generic
-
-    The `php` project type is the most general, ready for whatever modern PHP or static HTML/JS project you might be working on. It’s just as full-featured as more specific options, just without any app-specific configuration or presets.
-
-    You may even prefer to stick with this flavor despite using one of the apps DDEV supports, simply because you’d rather configure things to your own liking. Please do!
-    
-    1. Create a directory (`mkdir my-new-project`) or clone your project (`git clone <your_project>`).
-    2. Change to the new directory (`cd my-new-project`).
-    3. Run [`ddev config`](../users/usage/commands.md#config) and set the project type and docroot, which are usually auto-detected, but may not be if there's no code in there yet.
-    4. Run [`ddev start`](../users/usage/commands.md#start).
-    6. If you’re using Composer, run [`ddev composer install`](../users/usage/commands.md#composer).
-    4. Configure any database settings; host='db', user='db', password='db', database='db'
-    5. If needed, import a database with [`ddev import-db --src=/path/to/db.sql.gz`](../users/usage/commands.md#import-db).
-    6. Visit the project in a browser, and then build things.
+While the generic `php` project type is ready to go with any CMS or framework, DDEV offers project types for more easily working with popular platforms and content management systems:
 
 === "WordPress"
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1,6 +1,6 @@
 # CMS Quickstarts
 
-While the generic `php` project type is ready to go with any CMS or framework, DDEV offers project types for more easily working with popular platforms and content management systems:
+While the generic `php` project type is [ready to go](./project.md) with any CMS or framework, DDEV offers project types for more easily working with popular platforms and content management systems:
 
 === "Craft CMS"
 
@@ -76,9 +76,9 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     === "Drupal 10"
 
         ### Drupal 10 via Composer
-    
+
         [Drupal 10](https://www.drupal.org/about/10) is fully supported by DDEV.
-        
+
         ```bash
         mkdir my-drupal10-site
         cd my-drupal10-site
@@ -110,7 +110,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     === "Drupal 6/7"
 
         ### Drupal 6/7
-            
+
         ```bash
         git clone https://github.com/example/my-drupal-site
         cd my-drupal-site
@@ -118,9 +118,9 @@ While the generic `php` project type is ready to go with any CMS or framework, D
         ddev start
         ddev launch /install.php
         ```
-        
+
         Drupal 7 doesn’t know how to redirect from the front page to `/install.php` if the database is not set up but the settings files *are* set up, so launching with `/install.php` gets you started with an installation. You can also `drush site-install`, then `ddev exec drush site-install --yes`.
-        
+
         See [Importing a Database](#importing-a-database).
 
     === "Git Clone"
@@ -138,7 +138,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     ### Backdrop
 
     To get started with [Backdrop](https://www.drupal.org/project/backdrop), clone the project repository and navigate to the project directory.
-    
+
     ```bash
     git clone https://github.com/example/example-site
     cd example-site
@@ -181,7 +181,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     ## Magento 2
 
     Normal details of a Composer build for Magento 2 are on the [Magento 2 site](https://devdocs.magento.com/guides/v2.4/install-gde/composer.html. You must have a public and private key to install from Magento’s repository. When prompted for “username” and “password” in `composer create`, it’s asking for your public and private keys.
-    
+
     ```bash
     mkdir ddev-magento2 && cd ddev-magento2
     ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --create-docroot --disable-settings-management
@@ -199,7 +199,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     Change the admin name and related information is needed.
 
     You may want to add the [Magento 2 Sample Data](https://devdocs.magento.com/guides/v2.4/install-gde/install/sample-data-after-composer.html) with `ddev magento sampledata:deploy && ddev magento setup:upgrade`.
-    
+
     Magento 2 is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
 
     ## OpenMage/Magento 1
@@ -214,7 +214,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     You may want the [Magento 1 Sample Data](https://github.com/Vinai/compressed-magento-sample-data) for experimentation:
 
     * Download Magento [1.9.2.4 Sample Data](https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz).
-    * Extract the download:  
+    * Extract the download:
         `tar -zxf ~/Downloads/compressed-magento-sample-data-1.9.2.4.tgz --strip-components=1`
     * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --src=magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
 
@@ -223,7 +223,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
 === "Moodle"
 
     ## Moodle
-    
+
     ```bash
     ddev config --composer-root=public --create-docroot --docroot=public --webserver-type=apache-fpm
     ddev start
@@ -231,7 +231,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
     ddev launch /login
     ```
-    
+
     In the web browser, log into your account using `admin` and `password`.
 
     Visit the [Moodle Admin Quick Guide](https://docs.moodle.org/400/en/Admin_quick_guide) for more information.
@@ -252,7 +252,7 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     ddev start
     ddev composer install --no-scripts
     # During system:setup you may have to enter the Database user (db), Database password (db)
-    # Database host (db) and Database name (db). 
+    # Database host (db) and Database name (db).
     ddev exec bin/console system:setup --database-url=mysql://db:db@db:3306/db --app-url='${DDEV_PRIMARY_URL}'
     ddev exec bin/console system:install --create-database --basic-setup
     ddev launch /admin
@@ -267,9 +267,9 @@ While the generic `php` project type is ready to go with any CMS or framework, D
     ## TYPO3
 
     === "Composer"
-    
+
         ### Composer
-        
+
         ```bash
         mkdir my-typo3-site
         cd my-typo3-site
@@ -281,9 +281,9 @@ While the generic `php` project type is ready to go with any CMS or framework, D
         ```
 
     === "Git Clone"
-        
+
         ### Git Clone
-    
+
         ```bash
         git clone https://github.com/example/example-site
         cd example-site
@@ -305,32 +305,32 @@ While the generic `php` project type is ready to go with any CMS or framework, D
         ### WP-CLI
 
         DDEV has built-in support for [WP-CLI](https://wp-cli.org/), the command-line interface for WordPress.
-        
+
         ```bash
         mkdir my-wp-site
         cd my-wp-site/
-        
+
         # Create a new DDEV project inside the newly-created folder
         # (Primary URL automatically set to `https://<folder>.ddev.site`)
         ddev config --project-type=wordpress
         ddev start
-        
+
         # Download WordPress
         ddev wp core download
-        
+
         # Launch in browser to finish installation
         ddev launch
-        
+
         # OR use the following installation command
         # (we need to use single quotes to get the primary site URL from `.ddev/config.yaml` as variable)
         ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_email=admin@example.com --prompt=admin_password
-        
+
         # Launch WordPress admin dashboard in your browser
         ddev launch wp-admin/
         ```
 
     === "Bedrock"
-        
+
         ### Bedrock
 
         [Bedrock](https://roots.io/bedrock/) is a modern, Composer-based installation in WordPress:
@@ -354,51 +354,51 @@ While the generic `php` project type is ready to go with any CMS or framework, D
         WP_SITEURL=${WP_HOME}/wp
         WP_ENV=development
         ```
-    
+
         You can then run [`ddev start`](../users/usage/commands.md#start) and [`ddev launch`](../users/usage/commands.md#launch).
-    
+
         For more details, see [Bedrock installation](https://docs.roots.io/bedrock/master/installation/).
 
     === "Git Clone"
-    
+
         ### Git Clone
 
         To get started using DDEV with an existing WordPress project, clone the project’s repository. Note that the git URL shown here is just an example.
-        
+
         ```bash
         git clone https://github.com/example/example-site.git
         cd example-site
         ddev config
         ```
-        
+
         You’ll see a message like:
-        
+
         ```php
         An existing user-managed wp-config.php file has been detected!
         Project DDEV settings have been written to:
-        
+
         /Users/rfay/workspace/bedrock/web/wp-config-ddev.php
-        
+
         Please comment out any database connection settings in your wp-config.php and
         add the following snippet to your wp-config.php, near the bottom of the file
         and before the include of wp-settings.php:
-        
+
         // Include for DDEV-managed settings in wp-config-ddev.php.
         $ddev_settings = dirname(__FILE__) . '/wp-config-ddev.php';
         if (is_readable($ddev_settings) && !defined('DB_USER')) {
           require_once($ddev_settings);
         }
-        
+
         If you don't care about those settings, or config is managed in a .env
         file, etc, then you can eliminate this message by putting a line that says
         // wp-config-ddev.php not needed
         in your wp-config.php
         ```
-        
+
         So just add the suggested include into your `wp-config.php`, or take the workaround shown.
-        
+
         Now start your project with [`ddev start`](../users/usage/commands.md#start).
-        
+
         Quickstart instructions regarding database imports can be found under [Importing a database](#importing-a-database).
 
 ## Configuration Files
@@ -407,9 +407,9 @@ The [`ddev config`](../users/usage/commands.md#config) command attempts to creat
 
 For **Drupal** and **Backdrop**, DDEV settings are written to a DDEV-managed file, `settings.ddev.php`. The `ddev config` command will ensure these settings are included in your `settings.php` through the following steps:
 
-* Write DDEV settings to `settings.ddev.php`.
-* If no `settings.php` file exists, create one that includes `settings.ddev.php`.
-* If a `settings.php` file already exists, ensure that it includes `settings.ddev.php`, modifying `settings.php` to write the include if necessary..
+- Write DDEV settings to `settings.ddev.php`.
+- If no `settings.php` file exists, create one that includes `settings.ddev.php`.
+- If a `settings.php` file already exists, ensure that it includes `settings.ddev.php`, modifying `settings.php` to write the include if necessary..
 
 For **Magento 1**, DDEV settings go into `app/etc/local.xml`
 
@@ -419,10 +419,10 @@ For **TYPO3**, DDEV settings are written to `AdditionalConfiguration.php`. If `A
 
 For **WordPress**, DDEV settings are written to a DDEV-managed file, `wp-config-ddev.php`. The `ddev config` command will attempt to write settings through the following steps:
 
-* Write DDEV settings to `wp-config-ddev.php`.
-* If no `wp-config.php` exists, create one that include `wp-config-ddev.php`.
-* If a DDEV-managed `wp-config.php` exists, create one that includes `wp-config.php`.
-* If a user-managed `wp-config.php` exists, instruct the user on how to modify it to include DDEV settings.
+- Write DDEV settings to `wp-config-ddev.php`.
+- If no `wp-config.php` exists, create one that include `wp-config-ddev.php`.
+- If a DDEV-managed `wp-config.php` exists, create one that includes `wp-config.php`.
+- If a user-managed `wp-config.php` exists, instruct the user on how to modify it to include DDEV settings.
 
 You’ll know DDEV is managing a settings file when you see the comment below. Remove the comment and DDEV will not attempt to overwrite it! If you’re letting DDEV create its settings file, we recommended leaving this comment so DDEV can continue to manage it, and make any needed changes in another settings file.
 
@@ -435,7 +435,7 @@ You’ll know DDEV is managing a settings file when you see the comment below. R
 
 ```
 
-If you’re providing the `settings.php` or `wp-config.php` and DDEV is creating `settings.ddev.php` (or `wp-config-local.php`, `AdditionalConfig.php`, or similar), the main settings file must explicitly include the appropriate DDEV-generated settings file. Any changes you need should be included somewhere that loads after DDEV’s settings file, for example in Drupal’s `settings.php` *after* `settings.ddev.php` is included. (See [Adding Configuration](#adding-configuration) below).
+If you’re providing the `settings.php` or `wp-config.php` and DDEV is creating `settings.ddev.php` (or `wp-config-local.php`, `AdditionalConfig.php`, or similar), the main settings file must explicitly include the appropriate DDEV-generated settings file. Any changes you need should be included somewhere that loads after DDEV’s settings file, for example in Drupal’s `settings.php` _after_ `settings.ddev.php` is included. (See [Adding Configuration](#adding-configuration) below).
 
 !!!note "Completely Disabling Settings Management"
 
@@ -549,12 +549,12 @@ Successfully imported database for drupal8
 
 Database imports can be any of the following file types:
 
-* Raw SQL Dump (`.sql`)
-* Gzipped SQL Dump (`.sql.gz`)
-* Xz’d SQL Dump (`.sql.xz`)
-* (Gzipped) Tarball Archive (`.tar`, `.tar.gz`, `.tgz`)
-* Zip Archive (`.zip`)
-* stdin
+- Raw SQL Dump (`.sql`)
+- Gzipped SQL Dump (`.sql.gz`)
+- Xz’d SQL Dump (`.sql.xz`)
+- (Gzipped) Tarball Archive (`.tar`, `.tar.gz`, `.tgz`)
+- Zip Archive (`.zip`)
+- stdin
 
 If a Tarball Archive or Zip Archive is provided for the import, you’ll be prompted to specify a path within the archive to use for the import asset. The specified path should provide a raw SQL dump (`.sql`). In the following example, the database we want to import is named `data.sql` and resides at the top level of the archive:
 
@@ -584,8 +584,8 @@ ddev import-db <mydb.sql
 
 #### Database Import Notes
 
-* Importing from a dump file via stdin will not show progress because there’s no way the import can know how far along through the import it has progressed.
-* Use `ddev import-db --target-db <some_database>` to import to a non-default database (other than the default `db` database). This will create the database if it doesn’t already exist.
-* Use `ddev import-db --no-drop` to import without first emptying the database.
-* If a database already exists and the import does not specify dropping tables, the contents of the imported dumpfile will be *added* to the database. Most full database dumps do a table drop and create before loading, but if yours does not, you can drop all tables with `ddev stop --remove-data` before importing.
-* If imports are stalling or failing, make sure you have plenty of unused space (see [#3360](https://github.com/drud/ddev/issues/3360)). DDEV has no problems importing large (2G+) databases, but importing requires lots of space. DDEV will show a warning on startup if unused space is getting low.
+- Importing from a dump file via stdin will not show progress because there’s no way the import can know how far along through the import it has progressed.
+- Use `ddev import-db --target-db <some_database>` to import to a non-default database (other than the default `db` database). This will create the database if it doesn’t already exist.
+- Use `ddev import-db --no-drop` to import without first emptying the database.
+- If a database already exists and the import does not specify dropping tables, the contents of the imported dumpfile will be _added_ to the database. Most full database dumps do a table drop and create before loading, but if yours does not, you can drop all tables with `ddev stop --remove-data` before importing.
+- If imports are stalling or failing, make sure you have plenty of unused space (see [#3360](https://github.com/drud/ddev/issues/3360)). DDEV has no problems importing large (2G+) databases, but importing requires lots of space. DDEV will show a warning on startup if unused space is getting low.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,8 +118,9 @@ nav:
       - users/install/docker-installation.md
       - users/install/ddev-installation.md
     - 'Getting Started':
-      - users/install/performance.md
+      - users/project.md
       - users/quickstart.md
+      - users/install/performance.md
       - users/install/shell-completion.md
       - users/install/phpstorm.md
   - 'Usage':


### PR DESCRIPTION
## The Issue

Randy [suggested in Discord](https://discord.com/channels/664580571770388500/1062097685143879801/1062097685143879801) that people get discouraged when their CMS type isn’t explicitly supported, and I suggested that we adjust the “Getting Started” framing to put less emphasis on CMS options and hopefully create a bit more clarity.

## How This PR Solves The Issue

This adds a “Starting a Project” page as the first step under “Getting Started”, now leading into (and followed in the nav by) “CMS Quickstarts”. It also pushes “Performance” out of that first slot, because why did that ever make sense?

I tried to strip everything out of those first steps that didn’t _have_ to be there, and follow with support and jumping-off points below. The mention of generic `php` projects got a callout specifically because that’s the thing we need to do a better job of explaining right up front.

It also removes the “Generic” tab from the “CMS Quickstarts” page and shortens the now-redundant intro—both helping to focus that page on the CMS options it already promises to cover in its title.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the [automatic build](https://ddev--4558.org.readthedocs.build/en/4558/users/project/).

## Automated Testing Overview

n/a

## Related Issue Link(s)

https://discord.com/channels/664580571770388500/1062097685143879801/1062097685143879801

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4558"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

