### PR TITLE
[docs] “Database Management” touch-up

### DIFF
--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -3,7 +3,7 @@
 DDEV provides lots of flexibility for managing your databases between your local, staging and production environments. You may commonly use the [`ddev import-db`](../usage/commands.md#import-db) and [`ddev export-db`](../usage/commands.md#export-db) commands, but there are plenty of other adaptable ways to work with your databases.
 
 !!!tip
-    Remember, you can run `ddev [command] --help` for more info on many of the topics below.
+    You can run `ddev [command] --help` for more info on many of the topics below.
 
 ## Database Imports
 
@@ -21,36 +21,46 @@ You can also:
 * Use [`ddev mysql`](../usage/commands.md#mysql) or `ddev psql` or the `mysql` and `psql` commands inside the `web` and `db` containers.
 * Use phpMyAdmin for database imports—just be aware it’s much slower.
 
-## Discussion
+## Database Backends and Defaults
 
-**Many database backends**: You can use a vast array of different database types, including MariaDB (5.5–10.8) and MySQL (5.5–8.0) PostgreSQL (9–14), see ([docs](../extend/database-types.md#database-server-types)). Note that if you want to _change_ database type, you need to export your database and then [`ddev delete`](../usage/commands.md#delete) the project (to kill off the existing database), make the change to a new database type, start again, and import.
+You can use a [variety of different database types](../extend/database-types.md#database-server-types), including MariaDB (5.5–10.8), MySQL (5.5–8.0), and PostgreSQL (9–14). If you want to _change_ database type, you need to export your database, run [`ddev delete`](../usage/commands.md#delete) to remove the project (and its existing database), change to a new database type, run [`ddev start`](../usage/commands.md#start) again, and [import your data](../usage/commands.md#import-db).
 
-**Default database**: DDEV creates a default database named `db` and default permissions for the `db` user with password `db`, and it’s on the (inside Docker) hostname `db`.
+DDEV creates a default database named `db` and default permissions for the `db` user with password `db`, and it’s on the (inside Docker) hostname `db`.
 
-**Extra databases**: You can easily create and populate additional databases. For example, `ddev import-db --target-db=backend --src=backend.sql.gz` will create the database named `backend` with permissions for that same `db` user and import from the `backend.sql.gz dumpfile`.
+## Extra Databases
 
-**Exporting extra databases**: You can export in the same way: `ddev export-db -f mysite.sql.gz` will export your default database (`db`). `ddev export-db --target-db=backend -f backend-export.sql.gz` will dump the database named `backend`.
+You can easily create and populate additional databases. For example, `ddev import-db --target-db=backend --src=backend.sql.gz` will create the database named `backend` with permissions for that same `db` user and import from the `backend.sql.gz dumpfile`.
 
-**Database snapshots**: Snapshots let you easily save the entire status of all of your databases, which can be great when you’re working incrementally on migrations or updates and want to save state so you can start right back where you were.
+You can export in the same way: `ddev export-db -f mysite.sql.gz` will export your default database (`db`). `ddev export-db --target-db=backend -f backend-export.sql.gz` will dump the database named `backend`.
+
+## Snapshots
+
+Snapshots let you easily save the entire status of all of your databases, which can be great when you’re working incrementally on migrations or updates and want to save state so you can start right back where you were.
 
 Snapshots can be named for easier reference later on. For example, [`ddev snapshot --name=two-dbs`](../usage/commands.md#snapshot) would make a snapshot named `two-dbs` in the `.ddev/db_snapshots` directory. It includes the entire state of the db server, so in the case of our two databases above, both databases and the system level `mysql` or `postgres` database will all be snapshotted. Then if you want to delete everything with `ddev delete -O` (omitting the snapshot since we have one already), and then [`ddev start`](../usage/commands.md#start) again, we can `ddev snapshot restore two-dbs` and we’ll be right back where we were.
 
 Use the [`ddev snapshot restore`](../usage/commands.md#snapshot-restore) command to interactively choose among snapshots, or append `--latest` to restore the most recent snapshot: `ddev snapshot restore --latest`.
 
-**ddev mysql** and **ddev psql**:  These commands give you direct access to the `mysql` and `psql` clients in the database container, which can be useful for quickly running commands while you work. You might run `ddev mysql` to use interactive commands like `DROP DATABASE backend;` or `SHOW TABLES;`, or do things like `echo "SHOW TABLES;" | ddev mysql` or `ddev mysql -uroot -proot` to get root privileges.
+## Database Clients
 
-**mysql/psql clients in containers**: The `web` and `db` containers are each ready with MySQL/PostgreSQL clients, so you can [`ddev ssh`](../usage/commands.md#ssh) or `ddev ssh -s db` and use `mysql` or `psql`.
+The `ddev mysql` and `ddev psql` commands give you direct access to the `mysql` and `psql` clients in the database container, which can be useful for quickly running commands while you work. You might run `ddev mysql` to use interactive commands like `DROP DATABASE backend;` or `SHOW TABLES;`, or do things like `echo "SHOW TABLES;" | ddev mysql` or `ddev mysql -uroot -proot` to get root privileges.
 
-**mysqldump**: The `web` and `db` containers also come with `mysqldump`. You could [`ddev ssh`](../usage/commands.md#ssh) into the web container, for example, then `mkdir /var/www/html/.tarballs` and `mysqldump db >/var/www/html/.tarballs/db.sql` or `mysqldump db | gzip >/var/www/html/.tarballs/db.sql.gz` to create database dumps. Because `/var/www/html` is mounted into the container from your project root, the `.tarballs` directory will also show up in the root of the project on your host machine.
+The `web` and `db` containers are each ready with MySQL/PostgreSQL clients, so you can [`ddev ssh`](../usage/commands.md#ssh) or `ddev ssh -s db` and use `mysql` or `psql`.
 
-**pgdump and related commands**: The PostgreSQL database container includes normal `pg` commands like `pgdump`.
+## `mysqldump` and `pgdump`
 
-**Other database explorers**: There are lots of alternatives for GUI database explorers:
+The `web` and `db` containers come with `mysqldump`. You could run [`ddev ssh`](../usage/commands.md#ssh) to enter the web container, for example, then `mkdir /var/www/html/.tarballs` and run `mysqldump db >/var/www/html/.tarballs/db.sql` or run `mysqldump db | gzip >/var/www/html/.tarballs/db.sql.gz` to create database dumps. Because `/var/www/html` is mounted into the container from your project root, the `.tarballs` directory will also show up in the root of the project on your host machine.
 
+The PostgreSQL database container includes normal `pg` commands like `pgdump`.
+
+## Database GUIs
+
+If you’d like to use a GUI database client, you’ll need the right connection details and there may even be a command to launch it for you:
+
+* The [`ddev describe`](../usage/commands.md#describe) command displays the URL for the built-in phpMyAdmin GUI. (Something like `https://<yourproject>.ddev.site:8037`.) It also includes the `Host:` details you’ll need to connect to the `db` container externally.
 * macOS users can use `ddev sequelace` to launch the free [Sequel Ace](https://sequel-ace.com/) database browser, [`ddev tableplus`](../usage/commands.md#tableplus) to launch [TablePlus](https://tableplus.com), [`ddev querious`] for [Querious](https://www.araelium.com/querious), and the obsolete [Sequel Pro](https://sequelpro.com/) is also supported with `ddev sequelpro`. (Each must be installed for the command to exist.)
-* `ddev describe` displays the URL for the built-in phpMyAdmin GUI. (Something like `https://<yourproject>.ddev.site:8037`.)
 * PhpStorm (and all JetBrains tools) have a nice database browser. (If you use the [DDEV Integration plugin](https://plugins.jetbrains.com/plugin/18813-ddev-integration) this is all done for you.)
-    * Choose a static `host_db_port` for your project. For example `host_db_port: 59002` (each project’s database port should be different if you’re running more than one project at a time). Use [`ddev start`](../usage/commands.md#start) for it to take effect.
+    * Choose a static [`host_db_port`](../configuration/config.md#host_db_port) setting for your project. For example `host_db_port: 59002` (each project’s database port should be different if you’re running more than one project at a time). Use [`ddev start`](../usage/commands.md#start) for it to take effect.
     * Use the “database” tool to create a source from “localhost”, with the proper type “mysql” or “postgresql” and the port you chose, username `db` + password `db`.
     * Explore away!
 * There’s a sample custom command that will run the free MySQL Workbench on macOS, Windows or Linux. To use it, run:


### PR DESCRIPTION
## The Issue

The [Database Management](https://ddev.readthedocs.io/en/stable/users/basics/database-management/) page uses a heading called “Discussion” that consists not of a discussion, but a massive bulleted list.

## How This PR Solves The Issue

This liberates the useful nuggets of information from their list and groups them into more useful headings, with linking and minor language nitpicks we must expect from me at this point.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the [automatic build](https://ddev--4559.org.readthedocs.build/en/4559/users/usage/database-management/).

## Automated Testing Overview

n/a

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4559"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

