### PR TITLE
Fix regression where it always adds *.ddev.site to hosts

### DIFF
--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -9,6 +9,7 @@ import (
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
 	goodhosts "github.com/goodhosts/hostsfile"
+	"net"
 	"os"
 	exec2 "os/exec"
 	"runtime"
@@ -81,6 +82,24 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 	}
 
 	for _, name := range app.GetHostnames() {
+
+		// If we're able to resolve the hostname via DNS or otherwise we
+		// don't have to worry about this. This will allow resolution
+		// of *.ddev.site for example
+		if app.UseDNSWhenPossible && globalconfig.IsInternetActive() {
+			// If they have provided "*.<name>" then look up the suffix
+			checkName := strings.TrimPrefix(name, "*.")
+			hostIPs, err := net.LookupHost(checkName)
+
+			// If we had successful lookup and dockerIP matches
+			// with adding to hosts file.
+			if err == nil && len(hostIPs) > 0 && hostIPs[0] == dockerIP {
+				continue
+			}
+		}
+
+		// We likely won't hit the hosts.Has() as true because
+		// we already did a lookup. But check anyway.
 		exists, err := IsHostnameInHostsFile(name)
 		if exists {
 			continue


### PR DESCRIPTION

## The Issue

In 
* #4553 at the last minute I introduced a regression where network lookup is no longer used when deciding whether to add a hostname to /etc/hosts, so it happens every time.


## How This PR Solves The Issue

But the old code back in for *add* but not for *remove*.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4563"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

