### PR TITLE
[docs] Fix link on “Commands” page, fixes #4541

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -923,7 +923,7 @@ ddev poweroff
 
 ## `pull`
 
-Pull files and database using a configured [provider plugin](../../providers/).
+Pull files and database using a configured [provider plugin](./../providers/index.md).
 
 Flags:
 
@@ -953,7 +953,7 @@ ddev pull localfile --skip-db -y
 
 ## `push`
 
-Push files and database using a configured [provider plugin](../providers/).
+Push files and database using a configured [provider plugin](./../providers/index.md).
 
 Example:
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -923,7 +923,7 @@ ddev poweroff
 
 ## `pull`
 
-Pull files and database using a configured [provider plugin](../providers/).
+Pull files and database using a configured [provider plugin](../../providers/).
 
 Flags:
 


### PR DESCRIPTION
Resolves #4541, where the 404 was the result of an incorrect path after some shuffling around.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4564"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

