### PR TITLE
Improve visual balance of README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# DDEV
+![DDEV Logo](images/ddev-logo.svg)
+
+---
 
 [![CircleCI](https://circleci.com/gh/drud/ddev.svg?style=shield)](https://circleci.com/gh/drud/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2023.svg)
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/drud/ddev) [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=20221220_codespaces&repo=80927419&machine=basicLinux32gb&location=WestUs2)
-
-![DDEV Logo](images/ddev-logo.svg)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/drud/ddev) <a href="https://github.com/codespaces/new?hide_repo_select=true&amp;ref=20221220_codespaces&amp;repo=80927419&amp;machine=basicLinux32gb&amp;location=WestUs2"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
 
 DDEV is an open source tool for running local PHP development environments in minutes. Its powerful, flexible per-project environment configurations can be extended, version controlled, and shared. DDEV allows development teams to adopt a consistent Docker workflow without the complexities of bespoke configuration.
 


### PR DESCRIPTION
## The Issue

While exciting, the new “Open in GitHub Codespaces” button visually dominates the row of badges and looks like a mistake:

<img width="1072" alt="Screen Shot 2023-01-19 at 03 56 36 PM@2x" src="https://user-images.githubusercontent.com/2488775/213589293-656370dc-49ea-4b67-8fad-20b6d9ce7694.png">

The “DDEV” heading is also redundant with the logo just beneath it.

## How This PR Solves The Issue

1. Introduces some uncomfortable HTML to fix the visual issue by limiting that badge’s height to 20px.
2. Replaces the DDEV heading with the DDEV logo (maintaining alt text!), where it can proudly lead the page instead of being informationally redundant.

<img width="987" alt="Screen Shot 2023-01-19 at 04 12 04 PM@2x" src="https://user-images.githubusercontent.com/2488775/213590454-84e87fb9-7945-40cb-a144-dced34dd80ae.png">

It’s still not ideal because the badge’s text is significantly smaller than its peers. While GitHub [calls the thing a “badge”](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/setting-up-your-repository/adding-a-codespaces-badge) it looks like it’s intended to be used more like a button. Similar examples:

- [Deploy on Platform.sh button](https://platform.sh/deploy/)
- [Open in Gitpod button](https://www.gitpod.io/docs/introduction/getting-started#open-in-gitpod-button)
- [Vercel deploy button](https://vercel.com/docs/deploy-button)
- [Netlify deploy button](https://www.netlify.com/blog/2021/12/26/deploying-with-the-click-of-a-button/)

Another option could be to move the Codespaces button to the “Getting Started” section:

<img width="984" alt="Screen Shot 2023-01-19 at 04 19 37 PM@2x" src="https://user-images.githubusercontent.com/2488775/213590808-8777d754-9643-49b1-a720-14c9e445a78a.png">

## Manual Testing Instructions

n/a

## Automated Testing Overview

n/a

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4566"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

