### PR TITLE
[docs] Remove space and backtick from Windows installation instructions.

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -141,9 +141,9 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     
     1. Install WSL2 with an Ubuntu distro.
 
-        * Install WSL with 
+        * Install WSL with
             ```
-            wsl --install`
+            wsl --install
             ```
 
         * Reboot if required. (Usually required.)


### PR DESCRIPTION
## The Issue

The [Windows installation instructions](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/#windows) include an unnecessary backtick.

![Screen Shot 2023-01-19 at 04 23 50 PM@2x](https://user-images.githubusercontent.com/2488775/213591381-42d6ba62-a813-44df-9c30-2ccf211c8258.png)

## How This PR Solves The Issue

This removes said backtick, along with an unnecessary space as a bonus.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the automatic build.

## Automated Testing Overview

n/a

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4567"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

