### PR TITLE
Make `ddev ssh` exit more predictable, not outputting useless info, fixes #3738

### DIFF
--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -43,12 +43,6 @@ ddev ssh -d /var/www/html`,
 
 		app.DockerEnv()
 
-		// Determine if values were piped into the command.
-		pipe, err := os.Stdin.Stat()
-		if err != nil {
-			panic(err)
-		}
-		isPiped := pipe.Size() > 0
 
 		// Use bash for our containers, sh for 3rd-party containers
 		// that may not have bash.

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -55,7 +55,7 @@ ddev ssh -d /var/www/html`,
 			Cmd:     shell + " -l",
 			Dir:     sshDirArg,
 		})
-		if err != nil && isPiped {
+		if err != nil  {
 			if exiterr, ok := err.(*exec.ExitError); ok {
 				os.Exit(exiterr.ExitCode())
 			} else {

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bufio"
+
 	"github.com/drud/ddev/pkg/ddevapp"
 	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/util"
@@ -35,6 +37,11 @@ ddev ssh -d /var/www/html`,
 
 		app.DockerEnv()
 
+		// Determine if values were piped into the command.
+		var reader = bufio.NewReader(cmd.InOrStdin())
+		pipedValues, _ := reader.ReadString('\n')
+		isPiped := len(pipedValues) > 0
+
 		// Use bash for our containers, sh for 3rd-party containers
 		// that may not have bash.
 		shell := "bash"
@@ -46,7 +53,7 @@ ddev ssh -d /var/www/html`,
 			Cmd:     shell + " -l",
 			Dir:     sshDirArg,
 		})
-		if err != nil {
+		if err != nil && isPiped {
 			util.Failed("Failed to ddev ssh %s: %v", serviceType, err)
 		}
 	},

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -43,7 +43,6 @@ ddev ssh -d /var/www/html`,
 
 		app.DockerEnv()
 
-
 		// Use bash for our containers, sh for 3rd-party containers
 		// that may not have bash.
 		shell := "bash"
@@ -55,7 +54,7 @@ ddev ssh -d /var/www/html`,
 			Cmd:     shell + " -l",
 			Dir:     sshDirArg,
 		})
-		if err != nil  {
+		if err != nil {
 			if exiterr, ok := err.(*exec.ExitError); ok {
 				os.Exit(exiterr.ExitCode())
 			} else {

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -31,11 +31,6 @@ ddev ssh -d /var/www/html`,
 		app := projects[0]
 		instrumentationApp = app
 
-		status, _ := app.SiteStatus()
-		if status != ddevapp.SiteRunning {
-			util.Failed("Project is not currently running. Try 'ddev start'.")
-		}
-
 		err = app.Wait([]string{serviceType})
 		if err != nil {
 			util.Failed("Service %s doesn't seem to be running: %v", serviceType, err)


### PR DESCRIPTION
Attempt to check if values were piped in before deciding to return additional error output from ssh.go.  Issue 

* #3738.

## The Issue
`ddev ssh` returns output when not needed.  It should only do so when a command was piped in.

Lots of confusion on this... 
*  #1697 was in 2019... but that code isn't there any more. 

The change reversion happened in 
* https://github.com/drud/ddev/pull/2830

Which was fixing 
* #1858

## How This PR Solves The Issue
It doesn't.  It's a direction that needs work.  Reading the stdin/piped-in values removes them from evaluation later down the chain.

## Manual Testing Instructions
Should NOT produce additional output and should exit with code 0:
```
ddev ssh
ls /non-existent
exit
echo $?
```

SHOULD produce error output from the piped in command:
`echo "ls /non-existent" | ddev ssh`

## Automated Testing Overview
No automated tests at this time.

## Related Issue Link(s)
#3738 

## Release/Deployment Notes
In addition to not solving the problem, `ddev ssh` "hangs" because it appears to be waiting for stdin input read.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4569"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

