### PR TITLE
[wsl install scripts] Use choco upgrade instead of choco install [skip ci]

### DIFF
--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -38,7 +38,7 @@ if (-not(wsl -e docker ps) ) {
 }
 $ErrorActionPreference = "Stop"
 # Install needed choco items
-choco install -y ddev gsudo mkcert
+choco upgrade -y ddev gsudo mkcert
 
 mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"
@@ -56,5 +56,7 @@ if (-not(wsl -e docker ps)) {
     throw "docker does not seem to be working inside the WSL2 distro yet. Check Resources->WSL Integration in Docker Desktop"
 }
 wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[boot]' /etc/wsl.conf >/dev/null; then printf '\n[boot]\nsystemd=true\n' >>/etc/wsl.conf; fi"
+
+refreshenv
 
 wsl ddev version

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -33,7 +33,7 @@ if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
 }
 $ErrorActionPreference = "Stop"
 # Install needed choco items; ddev/gsudo needed for ddev inside wsl2 to update hosts file on windows
-choco install -y ddev gsudo mkcert
+choco upgrade -y ddev gsudo mkcert
 
 mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"
@@ -61,7 +61,10 @@ if (-not(wsl -e docker ps)) {
 # If docker desktop was previously set up, the .docker can break normal use of docker client.
 wsl rm -rf ~/.docker
 
-wsl ddev version
+refreshenv
 
 wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[boot]' /etc/wsl.conf >/dev/null; then printf '\n[boot]\nsystemd=true\n' >>/etc/wsl.conf; fi"
+
+wsl ddev version
+
 


### PR DESCRIPTION

## The Issue

It turned out people with existing versions of ddev, mkcert, gsudo didn't get upgraded.

## How This PR Solves The Issue

Use `choco upgrade` instead of `choco install`. It installs if not already installed.

## Manual Testing Instructions

Run the script



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4571"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

