### PR TITLE
Disable xdebug when running composer

### DIFF
--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -20,7 +20,7 @@ func (app *DdevApp) Composer(args []string) (string, string, error) {
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "web",
 		Dir:     app.GetComposerRoot(true, true),
-		RawCmd:  append([]string{"composer"}, args...),
+		RawCmd:  append([]string{"XDEBUG_MODE=off composer"}, args...),
 		Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 	})
 	if err != nil {


### PR DESCRIPTION
## The Issue
When running `ddev composer` with xdebug enabled it will start debugging.

## How This PR Solves The Issue
Adds `XDEBUG_MODE=off` before the `composer` command. 

## Manual Testing Instructions

## Automated Testing Overview
I'm sure some tests would be good, but I'm not very familiar with Go so I'd need some guidance on where I should put them.

## Related Issue Link(s)
Resolves #4219 

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4578"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

