### PR TITLE
Traefik needs to properly handle $VIRTUAL_HOST, fixes #4537

### DIFF
--- a/pkg/ddevapp/testdata/TestTraefikVirtualHost/docker-compose.extra.yaml
+++ b/pkg/ddevapp/testdata/TestTraefikVirtualHost/docker-compose.extra.yaml
@@ -1,0 +1,14 @@
+
+services:
+  nginx:
+    image: nginx
+    container_name: ddev-${DDEV_SITENAME}-nginx
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    ports:
+      - 80
+    environment:
+      - VIRTUAL_HOST=extra.ddev.site
+      - HTTP_EXPOSE=80:80
+      - HTTPS_EXPOSE=443:80

--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -244,6 +244,8 @@ func configureTraefikForApp(app *DdevApp) error {
 	if err != nil {
 		return err
 	}
+
+	// hostnames here should be used only for creating the cert.
 	hostnames := app.GetHostnames()
 	// There can possibly be VIRTUAL_HOST entries which are not configured hostnames.
 	for _, r := range routingTable {
@@ -358,7 +360,7 @@ func configureTraefikForApp(app *DdevApp) error {
 	} else {
 		f, err := os.Create(traefikYamlFile)
 		if err != nil {
-			util.Failed("failed to create traefik config file: %v", err)
+			return fmt.Errorf("failed to create traefik config file: %v", err)
 		}
 		t, err := template.New("traefik_config_template.yaml").Funcs(sprig.TxtFuncMap()).ParseFS(bundledAssets, "traefik_config_template.yaml")
 		if err != nil {

--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -336,12 +336,14 @@ func configureTraefikForApp(app *DdevApp) error {
 		UseLetsEncrypt:  globalconfig.DdevGlobalConfig.UseLetsEncrypt,
 	}
 
-	// Convert wildcards like `*.<anything>` to `.*\.anything`
-	for _, hostname := range hostnames {
-		if strings.HasPrefix(hostname, `*.`) {
-			hostname = `{subdomain:.+}` + strings.TrimPrefix(hostname, `*`)
+	// Convert externalHostnames wildcards like `*.<anything>` to `{subdomain:.+}.wild.ddev.site`
+	for i, v := range routingTable {
+		for j, h := range v.ExternalHostnames {
+			if strings.HasPrefix(h, `*.`) {
+				h = `{subdomain:.+}` + strings.TrimPrefix(h, `*`)
+				routingTable[i].ExternalHostnames[j] = h
+			}
 		}
-		templateData.Hostnames = append(templateData.Hostnames, hostname)
 	}
 
 	traefikYamlFile := filepath.Join(sourceConfigDir, app.Name+".yaml")

--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -39,6 +39,9 @@ func detectAppRouting(app *DdevApp) ([]TraefikRouting, error) {
 				if virtualHost, ok = env["VIRTUAL_HOST"].(string); ok {
 					util.Debug("VIRTUAL_HOST=%v for %s", virtualHost, serviceName)
 				}
+				if virtualHost == "" {
+					continue
+				}
 				hostnames := strings.Split(virtualHost, ",")
 				if httpExpose, ok := env["HTTP_EXPOSE"].(string); ok {
 					util.Debug("HTTP_EXPOSE=%v for %s", httpExpose, serviceName)

--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -332,7 +332,7 @@ func configureTraefikForApp(app *DdevApp) error {
 	}
 
 	// Convert wildcards like `*.<anything>` to `.*\.anything`
-	for _, hostname := range app.GetHostnames() {
+	for _, hostname := range hostnames {
 		if strings.HasPrefix(hostname, `*.`) {
 			hostname = `{subdomain:.+}` + strings.TrimPrefix(hostname, `*`)
 		}

--- a/pkg/ddevapp/traefik_config_template.yaml
+++ b/pkg/ddevapp/traefik_config_template.yaml
@@ -2,26 +2,25 @@
 
 http:
   routers:
-    {{$appname := .App.Name}}{{$hostnames := .Hostnames}}{{ range $s := .RoutingTable }}
+    {{$appname := .App.Name}}{{ range $s := .RoutingTable }}
     {{ if not $s.HTTPS }}
     {{$appname}}-{{$s.InternalServiceName}}-{{$s.InternalServicePort}}-http:
       {{if not $.UseLetsEncrypt}}{{/* Let's Encrypt only works with Host(), but we need HostRegex() for wildcards*/}}
-      rule: HostRegexp({{ range $i, $h := $hostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
+      rule: HostRegexp({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
       {{else}}
-      rule: Host({{ range $i, $h := $hostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
+      rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
       {{end}}
       service: "{{$appname}}-{{$s.InternalServiceName}}-{{$s.InternalServicePort}}-http"
       tls: false
       entrypoints:
         - http-{{$s.ExternalPort}}
     {{ end }}{{ end }}
-    {{$appname := .App.Name}}{{$hostnames := .Hostnames}}{{ range $s := .RoutingTable }}{{ if $s.HTTPS }}
+    {{$appname := .App.Name}}{{ range $s := .RoutingTable }}{{ if $s.HTTPS }}
     {{$appname}}-{{$s.InternalServiceName}}-{{$s.InternalServicePort}}-https:
-      # UseLetsEncrypt={{$.UseLetsEncrypt}}
       {{if not $.UseLetsEncrypt}}{{/* Let's Encrypt only works with Host(), but we need HostRegex() for wildcards*/}}
-      rule: HostRegexp({{ range $i, $h := $hostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
+      rule: HostRegexp({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
       {{else}}
-      rule: Host({{ range $i, $h := $hostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
+      rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
       {{end}}
       service: "{{$appname}}-{{$s.InternalServiceName}}-{{$s.InternalServicePort}}-https"
       {{ if not $.UseLetsEncrypt }}

--- a/pkg/ddevapp/traefik_test.go
+++ b/pkg/ddevapp/traefik_test.go
@@ -59,7 +59,6 @@ func TestTraefikSimple(t *testing.T) {
 
 	// If no mkcert trusted https, use only the httpURLs
 	// This is especially the case for colima
-	t.Logf("CAROOT='%s'", globalconfig.GetCAROOT())
 	if globalconfig.GetCAROOT() == "" {
 		allURLs = httpURLs
 	}

--- a/pkg/ddevapp/traefik_test.go
+++ b/pkg/ddevapp/traefik_test.go
@@ -2,11 +2,13 @@ package ddevapp_test
 
 import (
 	"github.com/drud/ddev/pkg/ddevapp"
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
 	"github.com/drud/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -73,5 +75,71 @@ func TestTraefikSimple(t *testing.T) {
 	_, _ = testcommon.EnsureLocalHTTPContent(t, httpURLs[0]+":8036", "phpMyAdmin")
 	if globalconfig.DdevGlobalConfig.MkcertCARoot != "" {
 		_, _ = testcommon.EnsureLocalHTTPContent(t, httpsURLs[0]+":8037", "phpMyAdmin")
+	}
+}
+
+// TestTraefikVirtualHost tests traefik with an extra VIRTUAL_HOST
+func TestTraefikVirtualHost(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Make sure this leaves us in the original test directory
+	origDir, _ := os.Getwd()
+
+	site := TestSites[0] // 0 == wordpress
+	app, err := ddevapp.NewApp(site.Dir, true)
+	assert.NoError(err)
+
+	ddevapp.PowerOff()
+	origTraefik := globalconfig.DdevGlobalConfig.UseTraefik
+	globalconfig.DdevGlobalConfig.UseTraefik = true
+	err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+	require.NoError(t, err)
+	origConfig := *app
+
+	t.Cleanup(func() {
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = os.RemoveAll(app.GetConfigPath(`docker-compose.extra.yaml`))
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		ddevapp.PowerOff()
+		err = origConfig.WriteConfig()
+		assert.NoError(err)
+		globalconfig.DdevGlobalConfig.UseTraefik = origTraefik
+		err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+		assert.NoError(err)
+	})
+
+	err = fileutil.CopyFile(filepath.Join(origDir, "testdata", t.Name(), "docker-compose.extra.yaml"), app.GetConfigPath("docker-compose.extra.yaml"))
+	require.NoError(t, err)
+
+	err = app.StartAndWait(5)
+	require.NoError(t, err)
+
+	desc, err := app.Describe(false)
+	assert.True(desc["use_traefik"].(bool))
+
+	// Test reachabiliity in each of the hostnames
+	httpURLs, _, allURLs := app.GetAllURLs()
+
+	// If no mkcert trusted https, use only the httpURLs
+	// This is especially the case for colima
+	t.Logf("CAROOT='%s'", globalconfig.GetCAROOT())
+	if globalconfig.GetCAROOT() == "" {
+		allURLs = httpURLs
+	}
+
+	for _, u := range allURLs {
+		// Use something here for wildcard
+		u = strings.Replace(u, `*`, `somewildcard`, 1)
+		_, err = testcommon.EnsureLocalHTTPContent(t, u+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+		assert.NoError(err, "failed EnsureLocalHTTPContent() %s: %v", u+site.Safe200URIWithExpectation.URI, err)
+	}
+
+	// Test Reachability to nginx special VIRTUAL_HOST
+	_, _ = testcommon.EnsureLocalHTTPContent(t, "http://extra.ddev.site", "Welcome to nginx")
+	if globalconfig.DdevGlobalConfig.MkcertCARoot != "" {
+		_, _ = testcommon.EnsureLocalHTTPContent(t, "https://extra.ddev.site", "Welcome to nginx")
 	}
 }

--- a/pkg/ddevapp/traefik_test.go
+++ b/pkg/ddevapp/traefik_test.go
@@ -124,7 +124,6 @@ func TestTraefikVirtualHost(t *testing.T) {
 
 	// If no mkcert trusted https, use only the httpURLs
 	// This is especially the case for colima
-	t.Logf("CAROOT='%s'", globalconfig.GetCAROOT())
 	if globalconfig.GetCAROOT() == "" {
 		allURLs = httpURLs
 	}


### PR DESCRIPTION
## The Issue

* #4537 

## How This PR Solves The Issue

It was mistakenly using all hostnames for all services, now actually walking the routingTable

## TODO
- [ ] .ddev/.gitignore seems to be ignoring changed items in .ddev/traefik/config, and it should not be doing that if they don't have #ddev-generated in them

## Manual Testing Instructions

- [x] Test as in #4537

## Automated Testing Overview

Added TestTraefikVirtualHost


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4582"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

