### PR TITLE
[docs] update custom nginx configuration docs

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -162,19 +162,17 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 ## Custom nginx Configuration
 
-When you run [`ddev restart`](../usage/commands.md#restart) using `nginx-fpm`, DDEV creates a configuration customized to your project type in `.ddev/nginx_full/nginx-site.conf`. You can edit and override the configuration by removing the `#ddev-generated` line and doing whatever you need with it. After each change, run `ddev restart`.
+When you run [`ddev restart`](../usage/commands.md#restart) using `nginx-fpm`, DDEV creates a configuration customized to your project type in `.ddev/nginx_full/nginx-site.conf`. You can edit and override the configuration by removing the `#ddev-generated` line and doing whatever you need with it. After each change, run `ddev restart`. (For updates without restart see [Troubleshooting nginx Configuration](#troubleshooting-nginx-configuration))
 
 You can also have more than one config file in the `.ddev/nginx_full` directory, and each will be loaded when DDEV starts. This can be used for [serving multiple docroots](#multiple-docroots-in-nginx-advanced) and other techniques.
 
 ### Troubleshooting nginx Configuration
 
 * Any errors in your configuration may cause the `web` container to fail and try to restart. If you see that behavior, use [`ddev logs`](../usage/commands.md#logs) to diagnose.
-* You can run `ddev exec nginx -t` to test whether your configuration is valid. (Or run [`ddev ssh`](../usage/commands.md#ssh) and run `nginx -t`.)
-* You can reload the nginx configuration by running either [`ddev restart`](../usage/commands.md#restart) or `ddev exec nginx -s reload`.
+* The configuration is copied into the container during restart. Therefore it is not possible to simply edit the host file for the changes to take effect. You may want to edit the file directly inside the container at `/etc/nginx/sites-enabled/`. (For example use [`ddev ssh`](../usage/commands.md#ssh) to get into the container)
+* You can run `ddev exec nginx -t` to test whether your configuration inside the container is valid. (Or run [`ddev ssh`](../usage/commands.md#ssh) and run `nginx -t`.)
+* You can reload the nginx configuration by running either [`ddev restart`](../usage/commands.md#restart) or edit the configuration inside the container at `/etc/nginx/sites-enabled/` and run `ddev exec nginx -s reload` on the host system (inside the container just `nginx -s reload`).
 * The alias `Alias "/phpstatus" "/var/www/phpstatus.php"` is required for the health check script to work.
-
-!!!warning "Important!"
-    Changes to configuration take place on a [`ddev restart`](../usage/commands.md#restart), when the container is rebuilt for another reason, or when the nginx server receives the reload signal.
 
 ### Multiple Docroots in nginx (Advanced)
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -169,7 +169,7 @@ You can also have more than one config file in the `.ddev/nginx_full` directory,
 ### Troubleshooting nginx Configuration
 
 * Any errors in your configuration may cause the `web` container to fail and try to restart. If you see that behavior, use [`ddev logs`](../usage/commands.md#logs) to diagnose.
-* The configuration is copied into the container during restart. Therefore it is not possible to simply edit the host file for the changes to take effect. You may want to edit the file directly inside the container at `/etc/nginx/sites-enabled/`. (For example use [`ddev ssh`](../usage/commands.md#ssh) to get into the container)
+* The configuration is copied into the container during restart. Therefore it is not possible to simply edit the host file for the changes to take effect. You may want to edit the file directly inside the container at `/etc/nginx/sites-enabled/`. (For example, run [`ddev ssh`](../usage/commands.md#ssh) to get into the container.)
 * You can run `ddev exec nginx -t` to test whether your configuration inside the container is valid. (Or run [`ddev ssh`](../usage/commands.md#ssh) and run `nginx -t`.)
 * You can reload the nginx configuration by running either [`ddev restart`](../usage/commands.md#restart) or edit the configuration inside the container at `/etc/nginx/sites-enabled/` and run `ddev exec nginx -s reload` on the host system (inside the container just `nginx -s reload`).
 * The alias `Alias "/phpstatus" "/var/www/phpstatus.php"` is required for the health check script to work.

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -171,7 +171,7 @@ You can also have more than one config file in the `.ddev/nginx_full` directory,
 * Any errors in your configuration may cause the `web` container to fail and try to restart. If you see that behavior, use [`ddev logs`](../usage/commands.md#logs) to diagnose.
 * The configuration is copied into the container during restart. Therefore it is not possible to simply edit the host file for the changes to take effect. You may want to edit the file directly inside the container at `/etc/nginx/sites-enabled/`. (For example, run [`ddev ssh`](../usage/commands.md#ssh) to get into the container.)
 * You can run `ddev exec nginx -t` to test whether your configuration inside the container is valid. (Or run [`ddev ssh`](../usage/commands.md#ssh) and run `nginx -t`.)
-* You can reload the nginx configuration by running either [`ddev restart`](../usage/commands.md#restart) or edit the configuration inside the container at `/etc/nginx/sites-enabled/` and run `ddev exec nginx -s reload` on the host system (inside the container just `nginx -s reload`).
+* You can reload the nginx configuration by running either [`ddev restart`](../usage/commands.md#restart) or editing the configuration inside the container at `/etc/nginx/sites-enabled/` and running `ddev exec nginx -s reload` on the host system (inside the container just `nginx -s reload`).
 * The alias `Alias "/phpstatus" "/var/www/phpstatus.php"` is required for the health check script to work.
 
 ### Multiple Docroots in nginx (Advanced)

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -162,7 +162,7 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 ## Custom nginx Configuration
 
-When you run [`ddev restart`](../usage/commands.md#restart) using `nginx-fpm`, DDEV creates a configuration customized to your project type in `.ddev/nginx_full/nginx-site.conf`. You can edit and override the configuration by removing the `#ddev-generated` line and doing whatever you need with it. After each change, run `ddev restart`. (For updates without restart see [Troubleshooting nginx Configuration](#troubleshooting-nginx-configuration))
+When you run [`ddev restart`](../usage/commands.md#restart) using `nginx-fpm`, DDEV creates a configuration customized to your project type in `.ddev/nginx_full/nginx-site.conf`. You can edit and override the configuration by removing the `#ddev-generated` line and doing whatever you need with it. After each change, run `ddev restart`. (For updates without restart, see [Troubleshooting nginx Configuration](#troubleshooting-nginx-configuration).)
 
 You can also have more than one config file in the `.ddev/nginx_full` directory, and each will be loaded when DDEV starts. This can be used for [serving multiple docroots](#multiple-docroots-in-nginx-advanced) and other techniques.
 


### PR DESCRIPTION
## The Issue

Currently the docs states that you can easily edit the custom nginx configuration (on the host system) and run `ddev exec nginx -s reload` to take the changes into effect.
That's currently not possible, because the configuration is copied during restart. (Reference https://discord.com/channels/664580571770388500/1067833800597446698/1067834259815010365)

## How This PR Solves The Issue
I edited the wording to reflect the current possibility to edit and reload the configuration within the container.

## Manual Testing Instructions
Read the docs and try to follow the steps: see if it really works 😄 

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

I don't think that it's possible to have automated testing for the documentation. Else I really need to know how!

## Related Issue Link(s)
https://discord.com/channels/664580571770388500/1067833800597446698/1067834259815010365

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
No actions needed since it's only plain text in the documentation.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4583"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

