### PR TITLE
[docs/tests] Exclude deb.sury.org from link check

### DIFF
--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -7,6 +7,9 @@
       "pattern": "^https://www.drupal.org/(u|project|about|forum|slack)"
     },
     {
+      "pattern": "^https://deb.sury.org"
+    },
+    {
       "pattern": "^https://nssm.cc/"
     },
     {


### PR DESCRIPTION
deb.sury.org is down, see 
* https://github.com/oerdnj/deb.sury.org/issues/1919

So it breaks our docs link checker. Just exclude it.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4592"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

