### PR TITLE
Document disabling xdebug in RUN commands

### DIFF
--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -241,6 +241,14 @@ The error messages you get will be more informative than messages that come when
 
 You can also see the full Docker build using `~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml build --no-cache --progress=plain`.
 
+### Disable Xdebug When Running PHP Applications like Composer or Terminus
+
+During the `docker build` process Xdebug is enabled and configured. If you have an IDE open and listening for connections, `ddev start` can hang. Always disable Xdebug in each `RUN` command:
+
+```dockerfile
+RUN export XDEBUG_MODE=off; terminus self:plugin:install terminus-build-tools-plugin
+```
+
 ## DDEV Starts but Browser Can’t Access URL
 
 You may see one of two messages in your browser:

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -245,8 +245,17 @@ You can also see the full Docker build using `~/.ddev/bin/docker-compose -f .dde
 
 During the `docker build` process Xdebug is enabled and configured. If you have an IDE open and listening for connections, `ddev start` can hang. Always disable Xdebug in each `RUN` command:
 
+For commands that need to run as root:
+
 ```dockerfile
-RUN export XDEBUG_MODE=off; terminus self:plugin:install terminus-build-tools-plugin
+# Example only - ddev already runs self-update for you.
+RUN export XDEBUG_MODE=off; composer self-update
+```
+
+For commands that need to run as the normal user:
+
+```dockerfile
+RUN sudo -u $username XDEBUG_MODE=off terminus self:plugin:install terminus-build-tools-plugin
 ```
 
 ## DDEV Starts but Browser Can’t Access URL


### PR DESCRIPTION
## The Issue

`ddev start` was hanging for members on our team unexpectedly. The only way I figured this out was when I tried running the container on a completely different computer:

```
docker run --rm -it drud/ddev-webserver:v1.21.4 terminus
```

That showed xdebug failing to connect, and then I could look at `.ddev/.webimageBuild/Dockerfile` to see why xdebug was triggering at all.

## How This PR Solves The Issue

I assume there's good reasons why we keep xdebug on. If not, turning it off during project dockerfile builds could be a better approach.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4597"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

