### PR TITLE
Don't enable xdebug by default in ddev-webserver, fixes #4597

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -90,11 +90,11 @@ RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/la
 RUN mkdir -p /home/blackfire && chown blackfire:blackfire /home/blackfire && usermod -d /home/blackfire blackfire
 
 ADD ddev-webserver-dev-base-files /
-RUN phpdismod blackfire xhprof
+RUN phpdismod blackfire xdebug xhprof
 
 RUN set -x; curl --fail -sSL "https://github.com/drud/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_${TARGETPLATFORM##linux/}" -o /usr/local/bin/mailhog && chmod +x /usr/local/bin/mailhog
 
-RUN phpdismod xdebug && curl -sSL --fail --output /usr/local/bin/phive "https://phar.io/releases/phive.phar" && chmod 777 /usr/local/bin/phive && phpenmod xdebug
+RUN curl -sSL --fail --output /usr/local/bin/phive "https://phar.io/releases/phive.phar" && chmod 777 /usr/local/bin/phive
 RUN set -o pipefail && curl --fail -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl -L --fail --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus
 RUN set -o pipefail && curl --fail -sSL https://github.com/platformsh/platformsh-cli/releases/download/$(curl -L --fail --silent "https://api.github.com/repositories/16695539/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/platform.phar --output /usr/local/bin/platform && chmod 777 /usr/local/bin/platform
 

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -53,8 +53,8 @@
 	fi
 }
 
-@test "verify that xdebug is enabled by default when the image is not run with start.sh" {
-  docker run --rm $DOCKER_IMAGE bash -c 'php --version | grep "with Xdebug"'
+@test "verify that xdebug is not enabled by default" {
+  docker run --rm $DOCKER_IMAGE bash -c 'php --version | grep -v "with Xdebug"'
 }
 
 @test "verify apt keys are not expiring" {

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20230106_container_start_hooks" // Note that this can be overridden by make
+var WebTag = "20230128_xdebug_build_time" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Issue

It doesn't make sense for Xdebug to be enabled by default in ddev-webserver any more:
* #4597 

It was enabled for very different workflows back in the day, see 
* https://github.com/drud/ddev/issues/2245
* https://github.com/drud/ddev/pull/2460

I don't think those workflows are valid any more, but will ping those folks.

## How This PR Solves The Issue

Turn off xdebug after it's installed.

## Manual Testing Instructions

As @deviantintegral did in #4597, `docker run -it --rm drud/ddev-webserver:20230128_xdebug_build_time
php --version` and see if xdebug is shown there.

## TODO

It may be worth trying to fix `ddev composer`,  so they doesn't try to use xdebug as well.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4599"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

