### PR TITLE
[docs] Add Drupal Multisite recommendations

### DIFF
--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -78,7 +78,7 @@ require $app_root . '/sites/default/settings.ddev.php';
 $databases['default']['default']['database'] = 'site_name';
 ```
 3. if you are using site aliases add the following to your `config.yaml`
-```php   
+```yaml   
 web_environment:
   # Make ddev drush shell PIDs last for entire life of container. So that `ddev drush site:set @alias` will persist
   # for all drush connections.

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -45,6 +45,47 @@ This environment variable is set `true` by default in DDEV’s environment, and 
 ```php
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
 ```
+* **Multisite**:
+    * See [DDEV-Local Drupal 8 Multisite Recipe] (https://github.com/drud/ddev-contrib/tree/master/recipes/drupal8-multisite) to start
+    * update the following files if you are using an existing site as the code base where installing with `--disable-settings-management` is not an option. 
+1. each `site/{site_name}/settings.php` 
+ ```php
+ /**
+ * ddev local-dev environments will have $databases (and other settings)
+ * set by an auto-generated file. Make alterations here for this site
+ * in a multisite environment.
+ */
+elseif (getenv('IS_DDEV_PROJECT') == 'true') {
+
+  /**
+   * Alter database settings and credentials for ddev-local environment.
+   * This includes loading the ddev-generated default/settings.ddev.php.
+   */
+  include $app_root . '/' . $site_path . '/settings.databases.ddev.inc';
+}
+ ```
+2.  add a `settings.databases.ddev.inc` in each `site/{site_name}/`   
+ ```php
+ /**
+ * Fetch ddev generated database credentials and other settings.
+ */
+require $app_root . '/sites/default/settings.ddev.php';
+
+/*
+ * Alter default database for this site. settings.ddev.php will have "reset"
+ * this to 'db'
+ */
+$databases['default']['default']['database'] = 'site_name';
+```
+3. if you are using site aliases add the following to your `config.yaml`
+```php   
+web_environment:
+  # Make ddev drush shell PIDs last for entire life of container. So that `ddev drush site:set @alias` will persist
+  # for all drush connections.
+  # https://chrisfromredfin.dev/posts/drush-use-ddev/
+  - DRUSH_SHELL_PID=PERMANENT
+```
+
 
 ### TYPO3 Specifics
 

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -47,7 +47,7 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 ```
 * **Multisite**:
     * See [DDEV-Local Drupal 8 Multisite Recipe] (https://github.com/drud/ddev-contrib/tree/master/recipes/drupal8-multisite) to start
-    * update the following files if you are using an existing site as the code base where installing with `--disable-settings-management` is not an option. 
+    * update the following files
 1. each `site/{site_name}/settings.php` 
  ```php
  /**

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -36,56 +36,69 @@ This environment variable is set `true` by default in DDEV’s environment, and 
 
 ### Drupal Specifics
 
-* **Settings Files**: By default, DDEV will create settings files for your project that make it “just work” out of the box. It creates a `sites/default/settings.ddev.php` and adds an include in `sites/default/settings.php` to bring that in. There are guards to prevent the `settings.ddev.php` from being active when the project is not running under DDEV, but it still should not be checked in and is gitignored.
-* **Database requirements for Drupal 9.5+ +**:
-    * Using MySQL or MariaDB, Drupal requires `SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED` and DDEV does this for you on [`ddev start`](../usage/commands.md#start).
-    * Using PostgreSQL, Drupal requires the`pg_trm` extension. DDEV creates this extension automatically for you on `ddev start`.
-* **Twig Debugging**: With the default Drupal configuration, it’s very difficult to debug Twig templates; you need to use `development.services.yml` instead of `services.yml`. Add this line in your `settings.php` or `settings.local.php`. See discussion at [drupal.org](https://www.drupal.org/forum/support/module-development-and-code-questions/2019-09-02/ddev-twig-debugging) and the Drupal documentation.
+#### Settings Files
+
+By default, DDEV will create settings files for your project that make it “just work” out of the box. It creates a `sites/default/settings.ddev.php` and adds an include in `sites/default/settings.php` to bring that in. There are guards to prevent the `settings.ddev.php` from being active when the project is not running under DDEV, but it still should not be checked in and is gitignored.
+
+#### Database requirements for Drupal 9.5+
+
+* Using MySQL or MariaDB, Drupal requires `SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED` and DDEV does this for you on [`ddev start`](../usage/commands.md#start).
+* Using PostgreSQL, Drupal requires the`pg_trm` extension. DDEV creates this extension automatically for you on `ddev start`.
+
+#### Twig Debugging
+
+With the default Drupal configuration, it’s very difficult to debug Twig templates; you need to use `development.services.yml` instead of `services.yml`. Add this line in your `settings.php` or `settings.local.php`. See discussion at [drupal.org](https://www.drupal.org/forum/support/module-development-and-code-questions/2019-09-02/ddev-twig-debugging) and the Drupal documentation.
 
 ```php
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
 ```
-* **Multisite**:
-    * See [DDEV-Local Drupal 8 Multisite Recipe] (https://github.com/drud/ddev-contrib/tree/master/recipes/drupal8-multisite) to start
-    * update the following files
-1. each `site/{site_name}/settings.php` 
- ```php
- /**
- * ddev local-dev environments will have $databases (and other settings)
- * set by an auto-generated file. Make alterations here for this site
- * in a multisite environment.
- */
-elseif (getenv('IS_DDEV_PROJECT') == 'true') {
 
-  /**
-   * Alter database settings and credentials for ddev-local environment.
-   * This includes loading the ddev-generated default/settings.ddev.php.
-   */
-  include $app_root . '/' . $site_path . '/settings.databases.ddev.inc';
-}
- ```
-2.  add a `settings.databases.ddev.inc` in each `site/{site_name}/`   
- ```php
- /**
- * Fetch ddev generated database credentials and other settings.
- */
-require $app_root . '/sites/default/settings.ddev.php';
+#### Multisite
 
-/*
- * Alter default database for this site. settings.ddev.php will have "reset"
- * this to 'db'
- */
-$databases['default']['default']['database'] = 'site_name';
-```
+* See [DDEV-Local Drupal 8 Multisite Recipe] (<https://github.com/drud/ddev-contrib/tree/master/recipes/drupal8-multisite>) to start
+* update the following files
+
+1. each `site/{site_name}/settings.php`
+
+     ```php
+     /**
+     * ddev local-dev environments will have $databases (and other settings)
+     * set by an auto-generated file. Make alterations here for this site
+     * in a multisite environment.
+     */
+    elseif (getenv('IS_DDEV_PROJECT') == 'true') {
+      /**
+       * Alter database settings and credentials for ddev-local environment.
+       * This includes loading the ddev-generated default/settings.ddev.php.
+       */
+      include $app_root . '/' . $site_path . '/settings.databases.ddev.inc';
+    }
+     ```
+
+2. add a `settings.databases.ddev.inc` in each `site/{site_name}/`
+
+     ```php
+     /**
+     * Fetch ddev generated database credentials and other settings.
+     */
+    require $app_root . '/sites/default/settings.ddev.php';
+    
+    /*
+     * Alter default database for this site. settings.ddev.php will have "reset"
+     * this to 'db'
+     */
+    $databases['default']['default']['database'] = 'site_name';
+    ```
+
 3. if you are using site aliases add the following to your `config.yaml`
-```yaml   
-web_environment:
-  # Make ddev drush shell PIDs last for entire life of container. So that `ddev drush site:set @alias` will persist
-  # for all drush connections.
-  # https://chrisfromredfin.dev/posts/drush-use-ddev/
-  - DRUSH_SHELL_PID=PERMANENT
-```
 
+    ```yaml
+    web_environment:
+      # Make ddev drush shell PIDs last for entire life of container. So that 'ddev drush site:set @alias' will persist
+      # for all drush connections.
+      # https://chrisfromredfin.dev/posts/drush-use-ddev/
+      - DRUSH_SHELL_PID=PERMANENT
+    ```
 
 ### TYPO3 Specifics
 

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -36,7 +36,7 @@ This environment variable is set `true` by default in DDEV’s environment, and 
 
 ### Drupal Specifics
 
-#### Settings Files
+#### Drupal Settings Files
 
 By default, DDEV will create settings files for your project that make it “just work” out of the box. It creates a `sites/default/settings.ddev.php` and adds an include in `sites/default/settings.php` to bring that in. There are guards to prevent the `settings.ddev.php` from being active when the project is not running under DDEV, but it still should not be checked in and is gitignored.
 

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -55,7 +55,7 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 
 #### Multisite
 
-* See [DDEV-Local Drupal 8 Multisite Recipe] (<https://github.com/drud/ddev-contrib/tree/master/recipes/drupal8-multisite>) to start
+1. Start with the [DDEV Drupal 8 Multisite Recipe](<https://github.com/drud/ddev-contrib/tree/master/recipes/drupal8-multisite>).
 * update the following files
 
 1. each `site/{site_name}/settings.php`

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -98,6 +98,7 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
           # https://chrisfromredfin.dev/posts/drush-use-ddev/
           - DRUSH_SHELL_PID=PERMANENT
         ```
+
 ### TYPO3 Specifics
 
 #### Settings Files

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -56,50 +56,48 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 #### Multisite
 
 1. Start with the [DDEV Drupal 8 Multisite Recipe](<https://github.com/drud/ddev-contrib/tree/master/recipes/drupal8-multisite>).
-* update the following files
+2. Update configuration files.
+    1. Update each `site/{site_name}/settings.php`:
 
-1. each `site/{site_name}/settings.php`
+        ```php
+        /**
+         * DDEV environments will have $databases (and other settings) set
+         * by an auto-generated file. Make alterations here for this site
+         * in a multisite environment.
+         */
+        elseif (getenv('IS_DDEV_PROJECT') == 'true') {
+          /**
+           * Alter database settings and credentials for DDEV environment.
+           * Includes loading the DDEV-generated `default/settings.ddev.php`.
+           */
+          include $app_root . '/' . $site_path . '/settings.databases.ddev.inc';
+        }
+        ```
 
-     ```php
-     /**
-     * ddev local-dev environments will have $databases (and other settings)
-     * set by an auto-generated file. Make alterations here for this site
-     * in a multisite environment.
-     */
-    elseif (getenv('IS_DDEV_PROJECT') == 'true') {
-      /**
-       * Alter database settings and credentials for ddev-local environment.
-       * This includes loading the ddev-generated default/settings.ddev.php.
-       */
-      include $app_root . '/' . $site_path . '/settings.databases.ddev.inc';
-    }
-     ```
+    2. Add a `settings.databases.ddev.inc` in each `site/{site_name}/`:
 
-2. add a `settings.databases.ddev.inc` in each `site/{site_name}/`
+        ```php
+        /**
+         * Fetch DDEV-generated database credentials and other settings.
+         */
+        require $app_root . '/sites/default/settings.ddev.php';
+        
+        /*
+         * Alter default database for this site. `settings.ddev.php` will have 
+         * “reset” this to 'db'.
+         */
+        $databases['default']['default']['database'] = 'site_name';
+        ```
 
-     ```php
-     /**
-     * Fetch ddev generated database credentials and other settings.
-     */
-    require $app_root . '/sites/default/settings.ddev.php';
-    
-    /*
-     * Alter default database for this site. settings.ddev.php will have "reset"
-     * this to 'db'
-     */
-    $databases['default']['default']['database'] = 'site_name';
-    ```
+    3. Update your [`web_environment`](../configuration/config.md#web_environment) config option if you’re using site aliases:
 
-3. if you are using site aliases add the following to your `config.yaml`
-
-    ```yaml
-    web_environment:
-      # Make ddev drush shell PIDs last for entire life of container. So that 'ddev drush site:set @alias' will persist
-      # for all drush connections.
-      # https://chrisfromredfin.dev/posts/drush-use-ddev/
-      - DRUSH_SHELL_PID=PERMANENT
-    ```
-
+        ```yaml
+        web_environment:
+          # Make DDEV Drush shell PIDs last for entire life of the container
+          # so `ddev drush site:set @alias` persists for all Drush connections.
+          # https://chrisfromredfin.dev/posts/drush-use-ddev/
+          - DRUSH_SHELL_PID=PERMANENT
+        ```
 ### TYPO3 Specifics
 
 #### Settings Files


### PR DESCRIPTION
Changes are from Discord DDEV multisite [forum question posed by KristofferRom](https://discord.com/channels/664580571770388500/1037263797674594334).  File examples are from Jon McLaughlin and tested by myself  with an existing codebase deployed on Acquia Cloud Site Factory.

## The Issue
**Original Question**
Anyone here with experience in converting separate sites to one multisite using ddev as local environment? I'm aware of https://github.com/drud/ddev-contrib/tree/master/recipes/drupal8-multisite but I was thinking to use an existing site as the code base so installing with --disable-settings-management isn't an option. Is there a workaround or should I create a new installation for the code base?

**Additional Requirements**
We run a Drupal Multisite setup where the default DB manages the bulk of configuration for all our sites.  We have three specific MVP's where we will run the config updates locally before committing to our hosting environment but never export config from them.  

## How This PR Solves The Issue
This PR adds additional steps in documentation to assist others that might have a similar setup. 

## Manual Testing Instructions
No tests as this for documentation purposes only.

## Automated Testing Overview
No tests as this for documentation purposes only.

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)
None
## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
N/A


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4600"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

