### PR TITLE
Update service name typo in ddev ssh example

### DIFF
--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -19,7 +19,7 @@ var DdevSSHCmd = &cobra.Command{
 	Short: "Starts a shell session in the container for a service. Uses web service by default.",
 	Long:  `Starts a shell session in the container for a service. Uses web service by default. To start a shell session for another service, run "ddev ssh --service <service>`,
 	Example: `ddev ssh
-ddev ssh -s sb
+ddev ssh -s db
 ddev ssh <projectname>
 ddev ssh -d /var/www/html`,
 	Args: cobra.MaximumNArgs(1),


### PR DESCRIPTION
## The Issue / How This PR Solves The Issue

There is no "sb" service in ddev by default. It was probably just a mistype of the "s" next to the "d" on the keyboard. Just adjust that.

## Manual Testing Instructions

Run `ddev ssh --help`

## Automated Testing Overview

Only info/help/documentation text output

## Release/Deployment Notes

--

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4602"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

