### PR TITLE
Make sure that traefik items get properly managed in .gitconfig

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -124,7 +124,7 @@ func init() {
 // provided app is the apptype has a settingsCreator function.
 // It also preps the ddev directory, including setting up the .ddev gitignore
 func (app *DdevApp) CreateSettingsFile() (string, error) {
-	err := PrepDdevDirectory(filepath.Dir(app.ConfigPath))
+	err := PrepDdevDirectory(app)
 	if err != nil {
 		util.Warning("Unable to PrepDdevDirectory: %v", err)
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -201,7 +201,7 @@ func (app *DdevApp) WriteConfig() error {
 		}
 	}
 
-	err = PrepDdevDirectory(filepath.Dir(appcopy.ConfigPath))
+	err = PrepDdevDirectory(&appcopy)
 	if err != nil {
 		return err
 	}
@@ -1252,8 +1252,9 @@ func (app *DdevApp) AppTypePrompt() error {
 }
 
 // PrepDdevDirectory creates a .ddev directory in the current working directory
-func PrepDdevDirectory(dir string) error {
+func PrepDdevDirectory(app *DdevApp) error {
 	var err error
+	dir := app.GetConfigPath("")
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 
 		log.WithFields(log.Fields{
@@ -1271,7 +1272,7 @@ func PrepDdevDirectory(dir string) error {
 		return err
 	}
 
-	err = CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-*.yaml", ".*downloads", ".global_commands", ".homeadditions", ".importdb*", ".sshimageBuild", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/xdebug", "commands/web/live", "config.*.y*ml", "db_snapshots", "import-db", "import.yaml", "mutagen", "mutagen/.start-synced", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "providers/platform.yaml", "sequelpro.spf", "traefik", "xhprof", "**/README.*")
+	err = CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-*.yaml", ".*downloads", ".global_commands", ".homeadditions", ".importdb*", ".sshimageBuild", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/xdebug", "commands/web/live", "config.*.y*ml", "db_snapshots", "import-db", "import.yaml", "mutagen/mutagen.yml", "mutagen/.start-synced", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "providers/platform.yaml", "sequelpro.spf", fmt.Sprintf("traefik/config/%s.yaml", app.Name), fmt.Sprintf("traefik/certs/%s.crt", app.Name), fmt.Sprintf("traefik/certs/%s.key", app.Name), "xhprof/xhprof_prepend.php", "**/README.*")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -151,7 +151,7 @@ func TestPrepDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	// Prep the directory.
-	err = PrepDdevDirectory(filepath.Dir(app.ConfigPath))
+	err = PrepDdevDirectory(app)
 	assert.NoError(err)
 
 	// Read directory info an ensure it exists.
@@ -299,7 +299,7 @@ func TestConfigCommand(t *testing.T) {
 		assert.Equal(testValues[apptypePos], app.Type)
 		assert.Equal("docroot", app.Docroot)
 		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion, "PHP value incorrect for apptype %v (expected %s got %s) (%v)", app.Type, testValues[phpVersionPos], app.PHPVersion, app)
-		err = PrepDdevDirectory(testDir)
+		err = PrepDdevDirectory(app)
 		assert.NoError(err)
 	}
 }
@@ -356,7 +356,7 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 		// Ensure we have expected vales in output.
 		assert.Contains(err.Error(), "docroot must exist to continue configuration")
 
-		err = PrepDdevDirectory(testDir)
+		err = PrepDdevDirectory(app)
 		assert.NoError(err)
 		util.Success("Finished %s", t.Name())
 	}
@@ -421,7 +421,7 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 		assert.Equal(nonexistentDocroot, app.Docroot)
 		assert.Equal(testValues[phpVersionPos], app.PHPVersion, "expected php%v for apptype %s", testValues[phpVersionPos], app.Type)
 
-		err = PrepDdevDirectory(tmpDir)
+		err = PrepDdevDirectory(app)
 		assert.NoError(err)
 	}
 	util.Success("Finished %s", t.Name())
@@ -477,7 +477,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		assert.Equal(name, app.Name)
 		assert.Equal(nodeps.AppTypeDrupal8, app.Type)
 		assert.Equal(testDocrootName, app.Docroot)
-		err = PrepDdevDirectory(tmpDir)
+		err = PrepDdevDirectory(app)
 		assert.NoError(err)
 	}
 }
@@ -536,7 +536,7 @@ func TestConfigCommandDocrootDetectionIndexVerification(t *testing.T) {
 	assert.Equal(name, app.Name)
 	assert.Equal(nodeps.AppTypeDrupal8, app.Type)
 	assert.Equal("docroot", app.Docroot)
-	err = PrepDdevDirectory(testDir)
+	err = PrepDdevDirectory(app)
 	assert.NoError(err)
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1010,7 +1010,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 
 	// This is done early here so users won't see gitignored contents of .ddev for too long
 	// It also gets done by `ddev config`
-	err = PrepDdevDirectory(filepath.Dir(app.ConfigPath))
+	err = PrepDdevDirectory(app)
 	if err != nil {
 		util.Warning("Unable to PrepDdevDirectory: %v", err)
 	}
@@ -1260,11 +1260,10 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		} else {
 			util.Error("Mutagen sync completed with problems in %s.\nFor details on sync status 'ddev mutagen st %s -l'", dur, MutagenSyncName(app.Name))
 		}
-		f, err := os.OpenFile(app.GetConfigPath("mutagen/.start-synced"), os.O_RDWR|os.O_CREATE, 0755)
+		err = fileutil.TemplateStringToFile(`#ddev-generated`, nil, app.GetConfigPath("mutagen/.start-synced"))
 		if err != nil {
 			util.Warning("could not create file %s: %v", app.GetConfigPath("mutagen/.start-synced"), err)
 		}
-		_ = f.Close()
 	}
 
 	// Wait for web/db containers to become healthy

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -324,7 +324,7 @@ func TestMain(m *testing.M) {
 			log.Errorf("TestMain startup: app.Init() failed on site %s in dir %s, err=%v", TestSites[i].Name, TestSites[i].Dir, err)
 			continue
 		}
-		err = ddevapp.PrepDdevDirectory(app.AppRoot)
+		err = ddevapp.PrepDdevDirectory(app)
 		if err != nil {
 			testRun = -1
 			log.Errorf("TestMain startup: ddevapp.PrepDdevDirectory() failed on site %s in dir %s, err=%v", TestSites[i].Name, TestSites[i].Dir, err)


### PR DESCRIPTION
## The Issue

In
* #4582

I noticed that manually edited traefik config was not being handled correctly; it should have been left out of the .ddev/.gitconfig, and instead the whole directory was gitignored.

## How This PR Solves The Issue

* Gitignore the specific files
* Fix mutagen config, which had the same problem
* Fix mutagen/.start-synced, which did not contain #ddev-generated


## Manual Testing Instructions

* Check in your project
* Manually edit .ddev/traefik/<project>.conf, remove the #ddev-generated from top
* `ddev start`
* You should see .ddev/traefik/<project>project.conf as changed in `git status`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4604"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

