### PR TITLE
Use 'ddev' for official add-ons, fix test, fixes #4608

### DIFF
--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -45,14 +45,14 @@ func TestCmdGet(t *testing.T) {
 	// Make sure get --list works first
 	out, err := exec.RunHostCommand(DdevBin, "get", "--list")
 	assert.NoError(err, "failed ddev get --list: %v (%s)", err, out)
-	assert.Contains(out, "drud/ddev-memcached")
+	assert.Contains(out, "ddev/ddev-memcached")
 
 	tarballFile := filepath.Join(origDir, "testdata", t.Name(), "ddev-memcached.tar.gz")
 
 	// Test with many input styles
 	for _, arg := range []string{
-		"drud/ddev-memcached",
-		"https://github.com/drud/ddev-memcached/archive/refs/tags/v1.1.1.tar.gz",
+		"ddev/ddev-memcached",
+		"https://github.com/ddev/ddev-memcached/archive/refs/tags/v1.1.1.tar.gz",
 		tarballFile} {
 		out, err := exec.RunHostCommand(DdevBin, "get", arg)
 		assert.NoError(err, "failed ddev get %s", arg)

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -14,7 +14,7 @@ const (
 	XdebugIDELocationWSL2      = "wsl2"
 )
 
-const DdevGithubOrg = "drud"
+const DdevGithubOrg = "ddev"
 
 // ValidOmitContainers is the valid omit's that can be done in for a project
 var ValidOmitContainers = map[string]bool{


### PR DESCRIPTION
## The Issue

* #4608

We moved all the official add-ons to github.com/ddev, and now none are found.

## How This PR Solves The Issue

* change org to ddev
* Fix test to use correct URLs

## Manual Testing Instructions

`ddev get --list` should show all 14 official add-ons

## Automated Testing Overview

Existing test already covered this and would be failing without this.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4609"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

