### PR TITLE
Make 'ddev composer create' respect composer_root, fixes #4475

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -72,6 +72,11 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 			}
 		}
 
+		err = os.MkdirAll(composerRoot, 0755)
+		if err != nil {
+			util.Failed("failed to create composerRoot: %v", err)
+		}
+
 		// Remove most contents of composer root
 		util.Warning("Removing any existing files in composer root")
 		objs, err := fileutil.ListFilesInDir(composerRoot)
@@ -193,7 +198,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 			stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
 				Service: "web",
 				RawCmd:  composerCmd,
-				Dir:     "/var/www/html",
+				Dir:     app.GetComposerRoot(true, false),
 				Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 			})
 			if err != nil {


### PR DESCRIPTION
## The Issue

* #4475 

## How This PR Solves The Issue

* Create the directory in advance
* Do the composer create-project into the named composer_root

## Manual Testing Instructions

See #4475 

## Automated Testing Overview

* Did not add test
* 
## Related Issue Link(s)



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4611"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

