### PR TITLE
Switch devcontainer/github codespaces to use apt install

### DIFF
--- a/.github/devcontainers/src/install-ddev/devcontainer-feature.json
+++ b/.github/devcontainers/src/install-ddev/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "name": "Install DDEV for Codespaces",
     "id": "install-ddev",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "DDEV feature for Codespaces/devcontainers"
 }

--- a/.github/devcontainers/src/install-ddev/install.sh
+++ b/.github/devcontainers/src/install-ddev/install.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-sudo apt update >/dev/null && sudo apt install -y xdg-utils >/dev/null
+curl -fsSL https://apt.fury.io/drud/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/drud/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
+sudo apt update >/dev/null && sudo apt install -y ddev xdg-utils >/dev/null
 
-# This will eventually move to a simple apt install
-sudo apt remove ddev >/dev/null 2>&1 || true
-DDEV_URL=https://nightly.link/drud/ddev/workflows/master-build/master/ddev-linux-amd64.zip
-echo "Installing DDEV"
-
-cd /tmp && curl -s -L -O ${DDEV_URL}
-zipball=$(basename ${DDEV_URL})
-unzip ${zipball}
-chmod +x ddev && sudo mv ddev /usr/local/bin
-
-rm -rf ${zipball} /tmp/tempproject


### PR DESCRIPTION

## The Issue

When v1.21.5 comes out, codespaces/devcontainer can use regular apt install

## How This PR Solves The Issue

Prepare to just use apt install


<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4612"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

