### PR TITLE
Make nodejs 18.14.0 installation work, changed npm --unsafe-perm behavior

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     postgresql-client \
     sqlite3
 
-RUN npm config set unsafe-perm true && npm install --global gulp-cli yarn
+RUN npm install --unsafe-perm=true --global gulp-cli yarn
 # Normal user needs to be able to write to php sessions
 RUN chmod 777 /var/lib/php/sessions
 RUN set -eu -o pipefail && LATEST=$(curl -L --fail --silent "https://api.github.com/repos/nvm-sh/nvm/releases/latest" | jq -r .tag_name) && curl --fail -sL https://raw.githubusercontent.com/nvm-sh/nvm/${LATEST}/install.sh -o /usr/local/bin/install_nvm.sh && chmod +x /usr/local/bin/install_nvm.sh


### PR DESCRIPTION
## The Issue

Fixes https://github.com/drud/ddev/issues/4614

## How This PR Solves The Issue

Implements the same change to the npm command in the Dockerfile as https://github.com/drud/ddev/pull/4610 did.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4615"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

