### PR TITLE
Make ddev nvm work right again, fixes #4499

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -165,8 +165,9 @@ func TestGetActiveAppRoot(t *testing.T) {
 
 	// And we should be able to stop it and find it as well
 	app, err := ddevapp.GetActiveApp("")
+	require.NoError(t, err)
 	err = app.Stop(false, true)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)

--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -113,8 +113,8 @@ if ! shopt -oq posix; then
 fi
 
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"
 
 for f in /etc/bashrc/*.bashrc; do
   source $f;

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -875,8 +875,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	}
 
 	extraWebContent := "\nRUN mkdir -p /home/$username && chown $username /home/$username && chmod 600 /home/$username/.pgpass"
-	_, _, userName := util.GetContainerUIDGid()
-	extraWebContent = extraWebContent + fmt.Sprintf("\nENV NVM_DIR=/home/%s/.nvm", userName)
+	extraWebContent = extraWebContent + "\nENV NVM_DIR=/home/$username/.nvm"
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + "\nRUN (apt-get remove -y nodejs || true) && (apt purge nodejs || true)"
 		// Download of setup_*.sh seems to fail a LOT, probably a problem on their end. So try it twice

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -875,6 +875,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	}
 
 	extraWebContent := "\nRUN mkdir -p /home/$username && chown $username /home/$username && chmod 600 /home/$username/.pgpass"
+	_, _, userName := util.GetContainerUIDGid()
+	extraWebContent = extraWebContent + fmt.Sprintf("\nENV NVM_DIR=/home/%s/.nvm", userName)
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + "\nRUN (apt-get remove -y nodejs || true) && (apt purge nodejs || true)"
 		// Download of setup_*.sh seems to fail a LOT, probably a problem on their end. So try it twice

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -60,6 +60,16 @@ func TestNodeJSVersions(t *testing.T) {
 	assert.Contains(out, "Now using node v6")
 
 	out, err = exec.RunHostCommand(DdevBin, "nvm", "install", "8")
-	require.NoError(t, err)
+	require.NoError(t, err, "output=%v", out)
 	assert.Contains(out, "Now using node v8")
+	out, err = exec.RunHostCommand(DdevBin, "nvm", "use", "8")
+	require.NoError(t, err, "output=%v", out)
+	out, err = exec.RunHostCommand(DdevBin, "nvm", "alias", "default", "8")
+	require.NoError(t, err, "output=%v", out)
+
+	out, err = exec.RunHostCommand(DdevBin, "exec", "node", "--version")
+	require.NoError(t, err)
+
+	assert.Contains(out, "v8.17")
+
 }

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20230128_xdebug_build_time" // Note that this can be overridden by make
+var WebTag = "20230207_fix_nvm" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* #4499 

NVM regression in DDEV v1.21.4 was caused mostly by dropping the NVM_DIR environment variable in the container.

## How This PR Solves The Issue

* Restore the NVM_DIR globally
* Improve the .bashrc (from /etc/skel) by using `source` instead of `.`
* Add better nvm coverage to TestNodeJSVersions

## Manual Testing Instructions

- [x] From #4499:

```
ddev nvm install 10.16.0 && ddev nvm use 10.16.0 && ddev nvm alias default 10.16.0
ddev exec node --version
```
should show 10.16.0

Manually test the things #4346 was aimed at:

#4346 was trying to fix the issues in 
 - [x] https://github.com/drud/ddev/issues/4313
- [ ] And https://github.com/drud/ddev/issues/4243
- [x] And it was trying to fix WSL2 when the uid was 999


## Automated Testing Overview

Improved TestNodeJSVersions to get coverage for this case.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4620"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

