### PR TITLE
[docs] add Statamic setup guide

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -116,6 +116,7 @@ Snapshotting
 Solr
 SomeExternalDrive
 Starts
+Statamic
 Support
 TablePlus
 Traefik
@@ -676,4 +677,3 @@ zcompdump
 zsh
 zshrc
 zxf
-

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -157,7 +157,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
 
         Use a new or existing Composer project, or clone a Git repository.
 
-        The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) just as it can for Laravel. DDEV automatically updates or creates the .env file with the database information.
+        The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) just as it can for Laravel. DDEV automatically updates or creates the `.env` file with the database information.
 
         === "Composer"
             ```bash

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -153,30 +153,59 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
 
     ## Laravel
 
-    Use a new or existing Composer project, or clone a Git repository.
+    === "Laravel"
 
-    The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) just as it can for Laravel. DDEV automatically updates or creates the .env file with the database information.
+        Use a new or existing Composer project, or clone a Git repository.
 
-    === "Composer"
-        ```bash
-        mkdir my-laravel-app
-        cd my-laravel-app
-        ddev config --project-type=laravel --docroot=public --create-docroot
-        ddev composer create --prefer-dist --no-install --no-scripts laravel/laravel
-        ddev composer install
-        ddev exec "php artisan key:generate"
-        ddev launch
-        ```
-    === "Git Clone"
-        ```bash
-        git clone <your-laravel-repo>
-        cd <your-laravel-project>
-        ddev config --project-type=laravel --docroot=public --create-docroot
-        ddev start
-        ddev composer install
-        ddev exec "php artisan key:generate"
-        ddev launch
-        ```
+        The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) just as it can for Laravel. DDEV automatically updates or creates the .env file with the database information.
+
+        === "Composer"
+            ```bash
+            mkdir my-laravel-app
+            cd my-laravel-app
+            ddev config --project-type=laravel --docroot=public --create-docroot
+            ddev composer create --prefer-dist --no-install --no-scripts laravel/laravel
+            ddev composer install
+            ddev exec "php artisan key:generate"
+            ddev launch
+            ```
+        === "Git Clone"
+            ```bash
+            git clone <your-laravel-repo>
+            cd <your-laravel-project>
+            ddev config --project-type=laravel --docroot=public --create-docroot
+            ddev start
+            ddev composer install
+            ddev exec "php artisan key:generate"
+            ddev launch
+            ```
+
+    === "Statamic"
+
+        Use a new or existing Composer project, or clone a Git repository.
+
+        The Laravel project type can be used for [Statamic](https://statamic.com/) just as it can for Laravel. DDEV automatically updates or creates the .env file with the database information.
+
+        === "Composer"
+            ```bash
+            mkdir my-statamic-app
+            cd my-statamic-app
+            ddev config --project-type=laravel --docroot=public --create-docroot
+            ddev composer create --prefer-dist --no-install --no-scripts statamic/statamic
+            ddev composer install
+            ddev exec "php artisan key:generate"
+            ddev launch
+            ```
+        === "Git Clone"
+            ```bash
+            git clone <your-statamic-repo>
+            cd <your-statamic-project>
+            ddev config --project-type=laravel --docroot=public --create-docroot
+            ddev start
+            ddev composer install
+            ddev exec "php artisan key:generate"
+            ddev launch
+            ```
 
 === "Magento"
 
@@ -520,8 +549,8 @@ There are two ways to remove a project from DDEV’s listing.
 
 The first, the [`ddev delete`](../users/usage/commands.md#delete) command, is destructive. It removes the project from DDEV’s list, deletes its database, and removes the hostname entry from the hosts file:
 
-`ddev delete <projectname>`  
-or  
+`ddev delete <projectname>`
+or
 `ddev delete --omit-snapshot <projectname>`
 
 If you simply don’t want the project to show up in [`ddev list`](../users/usage/commands.md#list) anymore, use [`ddev stop`](../users/usage/commands.md#stop)—which is nondestructive—to unlist the project until the next time you run [`ddev start`](../users/usage/commands.md#start) or [`ddev config`](../users/usage/commands.md#config):

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -184,7 +184,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
 
         Use a new or existing Composer project, or clone a Git repository.
 
-        The Laravel project type can be used for [Statamic](https://statamic.com/) just as it can for Laravel. DDEV automatically updates or creates the .env file with the database information.
+        The Laravel project type can be used for [Statamic](https://statamic.com/) just as it can for Laravel. DDEV automatically updates or creates the `.env` file with the database information.
 
         === "Composer"
             ```bash


### PR DESCRIPTION
## The Issue

Recently [Discord issue](https://discord.com/channels/664580571770388500/1072827039415021628/1072827039415021628) highlighted the need for current setup instructions.

There is older article, [Setup Statamic via DDEV](https://dev.to/mandrasch/setup-statamic-via-ddev-39bi) which is outdated and has issues as discussed in Discord thread.

## How This PR Solves The Issue

Statamic is built on top of Laravel, so the instructions are almost identical.

## Manual Testing Instructions

Work through setup instructions.

## Related Issue Link(s)

There is currently an "unoffical" addon [ddev-addon-statamic-please](https://github.com/mandrasch/ddev-addon-statamic-please). 

This does _not_ include the `ddev-get` topic and is therefore not disoverable by DDEV. An [issue](https://github.com/mandrasch/ddev-addon-statamic-please/issues/1) was created to address this. However, the addon is stale and I am unsure if it's being actively developed/maintained. 

Not sure if we want to include addon in documents.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4622"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

