### PR TITLE
Mark ddev stop as deprecated command.

### DIFF
--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -29,6 +29,7 @@ var unlist bool
 var DdevStopCmd = &cobra.Command{
 	Use:     "stop [projectname ...]",
 	Aliases: []string{"rm", "remove"},
+	Deprecated: "Please use ddev delete instead.",
 	Short:   "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data.",
 	Long: `Stop and remove the containers of a project. You can run 'ddev stop'
 from a project directory to stop/remove that project, or you can stop/remove projects in


### PR DESCRIPTION
## The Issue

`ddev stop` command is deprecated, but you're not notified about it.

## How This PR Solves The Issue

User gets a message with replacement command.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4623"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

