### PR TITLE
Bump golang to v1.20, fixes #4443

### DIFF
--- a/.ci-scripts/linux_arm64_setup.sh
+++ b/.ci-scripts/linux_arm64_setup.sh
@@ -5,7 +5,7 @@ set -o errexit
 # Basic tools
 
 set -x
-export GO_VERSION=1.19.4
+export GO_VERSION=1.20
 
 if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
   set +x

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.4'
+          go-version: '>=1.20'
 
       - name: Homebrew cache/restore
         uses: actions/cache@v3

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.4'
+          go-version: '>=1.20'
 
       - name: Build and test container ${{ matrix.containers }}
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '>=1.19.4'
+        go-version: '>=1.20'
     - uses: actions/checkout@v3
     - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
     - name: golangci-lint

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -38,8 +38,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.50
+        version: latest
 
         # Optional: working directory, useful for monorepos
         # working-directory: somedir

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.4'
+          go-version: '>=1.20'
 
       - name: Build DDEV executables
         run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 completions mkcert
@@ -120,7 +120,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.4'
+          go-version: '>=1.20'
 
       - name: restore build-most results from cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.4'
+          go-version: '>=1.20'
 
       - name: Build DDEV executables
         run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 windows_amd64 windows_install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
         run: ./.github/workflows/linux-setup.sh
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.4'
+          go-version: '>=1.20'
 
       - name: Override environment variables for push-pull-test-platforms
         run: |

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -14,7 +14,7 @@ RUN pip3 install mkdocs pyspelling pymdown-extensions
 RUN npm install -g markdownlint-cli
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.50.0
 
-RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.19.2.linux-amd64.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz && ln -s /usr/local/go/bin/go /usr/local/bin/go
+RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.20.linux-amd64.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 USER gitpod
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(TARGETS): mkcert $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)";
 	@#echo "LDFLAGS=$(LDFLAGS)";
 	@rm -f $@
-	@export TARGET=$(word 3, $(subst /, ,$@)) && \
+	export TARGET=$(word 3, $(subst /, ,$@)) && \
 	export GOOS="$${TARGET%_*}" GOARCH="$${TARGET#*_}" CGO_ENABLED=0 GOPATH="$(PWD)/$(GOTMP)" GOCACHE="$(PWD)/$(GOTMP)/.cache" && \
 	mkdir -p $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	chmod 777 $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \

--- a/go.mod
+++ b/go.mod
@@ -92,4 +92,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-go 1.19
+go 1.20

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -254,8 +254,6 @@ func Untar(source string, dest string, extractionDir string) error {
 			}
 
 		case tar.TypeReg:
-			fallthrough
-		case tar.TypeRegA:
 			// Always ensure the directory is created before trying to move the file.
 			fullPathDir := filepath.Dir(fullPath)
 			err = os.MkdirAll(fullPathDir, 0755)

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -2,11 +2,11 @@ package fileutil
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -22,10 +22,6 @@ import (
 	"github.com/drud/ddev/pkg/output"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 // Failed will print a red error message and exit with failure.
 func Failed(format string, a ...interface{}) {
 	format = ColorizeText(format, "red")


### PR DESCRIPTION
## The Issue

Go v1.210 is out
This should fix 
* #4443

## Caveat

Several testing environments depend on homebrew to install go 1.20, and it is not yet available, see 
* https://github.com/Homebrew/homebrew-core/pull/122082

golangci-lint (at least the homebrew version) does not yet work with go 1.20

## Manual Testing Instructions

Download the appropriate binary from https://github.com/drud/ddev/pull/4639#issuecomment-1426199485. But it's not signed/notarized, so see "macOS and unsigned binaries" in https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-latest-commits-on-head, `xattr -r -d com.apple.quarantine /path/to/ddev`

See if the networking issue is resolved.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4639"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

