### PR TITLE
Bump docker-compose to 2.16.0, which is built with go 1.20, fixing DNS issues on macOS

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -609,7 +609,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.15.1"
+var RequiredDockerComposeVersion = "v2.16.0"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION

## The Issue

docker-compose 2.16.0 is out

It's built with go 1.20, so may impact DNS issues reported in 
* #4443 




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4641"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

