### PR TITLE
If /mnt/ddev_config is not mounted, don't fail, just warn

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1293,7 +1293,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		Cmd: `ls -l /mnt/ddev_config/nginx_full/nginx-site.conf >/dev/null`,
 	})
 	if err != nil {
-		return fmt.Errorf("Something is wrong with docker/colima and /mnt/ddev_config is not mounted from the project .ddev folder")
+		util.Warning("Something is wrong with docker or colima and /mnt/ddev_config is not mounted from the project .ddev folder. This can cause all kinds of problems.")
 	}
 
 	if !IsRouterDisabled(app) {


### PR DESCRIPTION
## The Issue

I noticed that a new check about /mnt/ddev_config being mounted resulted in a failure, but it only needs to be a warning.

This class of failure happens when:

* Colima: Project directory is outside the home dir.

<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4642"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

