### PR TITLE
Fix `ddev import-db` and `ddev import-files` queries for path to artifacts

### DIFF
--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -86,7 +86,7 @@ func promptForFileSource(val *string) {
 	// An empty string isn't acceptable here, keep
 	// prompting until something is entered
 	for {
-		fmt.Print("Pull path: ")
+		fmt.Print("Full path: ")
 		*val = util.GetInput("")
 		if len(*val) > 0 {
 			break

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -86,7 +86,7 @@ func promptForFileSource(val *string) {
 	// An empty string isn't acceptable here, keep
 	// prompting until something is entered
 	for {
-		fmt.Print("Full path: ")
+		fmt.Print("Path to file(s): ")
 		*val = util.GetInput("")
 		if len(*val) > 0 {
 			break

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -4,20 +4,12 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"github.com/drud/ddev/pkg/globalconfig"
-	"github.com/drud/ddev/pkg/nodeps"
-	"github.com/drud/ddev/pkg/versionconstants"
-	"github.com/mattn/go-isatty"
-	"github.com/otiai10/copy"
-	"golang.org/x/term"
-	"gopkg.in/yaml.v3"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
-
-	"path"
 	"time"
 
 	"github.com/drud/ddev/pkg/appimport"
@@ -25,9 +17,16 @@ import (
 	"github.com/drud/ddev/pkg/dockerutil"
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	"github.com/drud/ddev/pkg/output"
 	"github.com/drud/ddev/pkg/util"
+	"github.com/drud/ddev/pkg/versionconstants"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/mattn/go-isatty"
+	"github.com/otiai10/copy"
+	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
 )
 
 // SiteRunning defines the string used to denote running sites.
@@ -485,7 +484,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 			extPathPrompt = true
 		}
 		output.UserOut.Println("Provide the path to the database you want to import.")
-		fmt.Print("Pull path: ")
+		fmt.Print("Full path: ")
 
 		imPath = util.GetInput("")
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -484,7 +484,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 			extPathPrompt = true
 		}
 		output.UserOut.Println("Provide the path to the database you want to import.")
-		fmt.Print("Full path: ")
+		fmt.Print("Path to file: ")
 
 		imPath = util.GetInput("")
 	}


### PR DESCRIPTION
## The Issue

In the two queries for a full path, "pull" is used instead of "full".

## How This PR Solves The Issue

"pull" is replaced by "full".

## Manual Testing Instructions

Run the two commands `import-db` and `import-files` to see if the query for the path is fine.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

