### PR TITLE
[docs] Fix copy pasta on webserver_type description

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -562,7 +562,7 @@ Example: `webimage_extra_packages: [php-yaml, php-bcmath]` will add the `php-yam
 
 ## `webserver_type`
 
-Which available [web server type](../extend/customization-extendibility.md/#changing-web-server-type) should be used.
+Which available [web server type](../../extend/customization-extendibility.md/#changing-web-server-type) should be used.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -562,7 +562,7 @@ Example: `webimage_extra_packages: [php-yaml, php-bcmath]` will add the `php-yam
 
 ## `webserver_type`
 
-Which available web server should be used.
+Which available [web server type](../extend/customization-extendibility.md/#changing-web-server-type) should be used.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -562,7 +562,7 @@ Example: `webimage_extra_packages: [php-yaml, php-bcmath]` will add the `php-yam
 
 ## `webserver_type`
 
-Whether Xdebug should be enabled for [step debugging](../debugging-profiling/step-debugging.md) or [profiling](../debugging-profiling/xdebug-profiling.md).
+Which available web server should be used.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -562,7 +562,7 @@ Example: `webimage_extra_packages: [php-yaml, php-bcmath]` will add the `php-yam
 
 ## `webserver_type`
 
-Which available [web server type](../../extend/customization-extendibility.md/#changing-web-server-type) should be used.
+Which available [web server type](../extend/customization-extendibility.md#changing-web-server-type) should be used.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -113,7 +113,7 @@ On Drupal 8+, if you want to use `drush uli` on the host (or other Drush command
 
 ## DDEV and Terminus
 
-[Terminus](https://pantheon.io/docs/guides/terminus) is a command line tool providing advanced interaction with [Pantheon](https://pantheon.io/) services. `terminus` is available inside the project’s container, allowing users to get information from, or issue commands to their Pantheon-hosted sites. This is an especially helpful feature for Windows users since Terminus is only officially supported on Unix-based systems.
+[Terminus](https://pantheon.io/docs/terminus) is a command line tool providing advanced interaction with [Pantheon](https://pantheon.io/) services. `terminus` is available inside the project’s container, allowing users to get information from, or issue commands to their Pantheon-hosted sites. This is an especially helpful feature for Windows users since Terminus is only officially supported on Unix-based systems.
 
 To use Terminus, you’ll first need to:
 

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -113,7 +113,7 @@ On Drupal 8+, if you want to use `drush uli` on the host (or other Drush command
 
 ## DDEV and Terminus
 
-[Terminus](https://pantheon.io/docs/terminus) is a command line tool providing advanced interaction with [Pantheon](https://pantheon.io/) services. `terminus` is available inside the project’s container, allowing users to get information from, or issue commands to their Pantheon-hosted sites. This is an especially helpful feature for Windows users since Terminus is only officially supported on Unix-based systems.
+[Terminus](https://docs.pantheon.io/terminus) is a command line tool providing advanced interaction with [Pantheon](https://pantheon.io/) services. `terminus` is available inside the project’s container, allowing users to get information from, or issue commands to their Pantheon-hosted sites. This is an especially helpful feature for Windows users since Terminus is only officially supported on Unix-based systems.
 
 To use Terminus, you’ll first need to:
 


### PR DESCRIPTION
The webserver_type description here:

https://ddev.readthedocs.io/en/stable/users/configuration/config/#webserver_type

Was the same as xdebug_enabled here:

https://ddev.readthedocs.io/en/stable/users/configuration/config/#xdebug_enabled

This PR fixes that.