### PR TITLE
[docs] pantheon.yaml.example comments: changed sequence of items #6 and #7

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -22,9 +22,9 @@
 #
 # 5. Check out project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
 #
-# 6. Verify that drush is installed in your project, `ddev composer require drush/drush`
+# 6. Configure the local checkout for ddev using `ddev config`
 #
-# 7. Configure the local checkout for ddev using `ddev config`
+# 7. Verify that drush is installed in your project, `ddev composer require drush/drush`
 #
 # 8. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the "project" under `environment_variables` (change it from `yourproject.dev`). If you want to use a different environment than "dev", change `dev` to the name of the environment.
 #


### PR DESCRIPTION
## The Issue
At least in my experience you can't run `ddev composer require drush/drush` before having a project configured. You need to run `ddev config` first, then run `ddev...` commands.
