### PR TITLE
[tests only] Attempt to get actions/cache working again [skip ci]

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -101,7 +101,8 @@ jobs:
       - name: Cache signed binaries
         # After 3.0.5 they were using zstdmt which is not available on Windows
         # See https://github.com/actions/cache/issues/891
-        uses: actions/cache@v3.0.11
+        # But trying again with @v3, 2023-02-18
+        uses: actions/cache@v3
         with:
           path: .gotmp/bin/windows_amd64
           key: ${{ github.sha }}-${{ github.ref }}-signed-windows-binaries


### PR DESCRIPTION
There's a long term problem with actions/cache when caching on Windows and then restoring on linux.
Apparently there is new trouble in this area.

But we were using the old actions/cache 3.0.11 on Windows, and that suddenly seems to have stopped working.
They have struggled and struggled with this.

