### PR TITLE
Fix chatty docker-compose output, fixes #4655

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(TARGETS): mkcert $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)";
 	@#echo "LDFLAGS=$(LDFLAGS)";
 	@rm -f $@
-	export TARGET=$(word 3, $(subst /, ,$@)) && \
+	@export TARGET=$(word 3, $(subst /, ,$@)) && \
 	export GOOS="$${TARGET%_*}" GOARCH="$${TARGET#*_}" CGO_ENABLED=0 GOPATH="$(PWD)/$(GOTMP)" GOCACHE="$(PWD)/$(GOTMP)/.cache" && \
 	mkdir -p $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	chmod 777 $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -552,7 +552,7 @@ func ComposeCmd(composeFiles []string, action ...string) (string, string, error)
 	// Container (or Volume) ... Creating or Created or Stopping or Starting or Removing
 	// Container Stopped or Created
 	// No resource found to remove (when doing a stop and no project exists)
-	ignoreRegex := "(^(Network|Container|Volume) .* (Creat|Start|Stopp|Remov)ing$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove$|Pulling fs layer|Waiting|Downloading|Extracting|Verifying Checksum|Download complete|Pull complete)"
+	ignoreRegex := "(^ *(Network|Container|Volume) .* (Creat|Start|Stopp|Remov)ing$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove$|Pulling fs layer|Waiting|Downloading|Extracting|Verifying Checksum|Download complete|Pull complete)"
 	downRE, err := regexp.Compile(ignoreRegex)
 	if err != nil {
 		util.Warning("failed to compile regex %v: %v", ignoreRegex, err)


### PR DESCRIPTION
## The Issue

* #4655

## How This PR Solves The Issue

Change regex that controls output to adjust to latest docker-compose output.

## Manual Testing Instructions

`ddev start` should only show a few lines of output, like

```
$ ddev start
Starting d9...
 Container ddev-d9-dba  Running
 Container ddev-d9-db  Recreate
 Container ddev-d9-web  Running
 Container ddev-d9-db  Recreated
 Container ddev-d9-db  Started
Starting mutagen sync process... This can take some time.
Mutagen sync flush completed in 1s.
For details on sync status 'ddev mutagen st d9 -l'
 Container ddev-router  Running
```

