### PR TITLE
[docs] Prepend project-relative path and capitalize Supervisor

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -316,7 +316,7 @@ redirect_stderr=true
 And create a `.ddev/web-build/Dockerfile.<daemonname>` to install the config file:
 
 ```dockerfile
-ADD daemonname.conf /etc/supervisor/conf.d
+ADD .ddev/web-build/daemonname.conf /etc/supervisor/conf.d
 ```
 
-Full details for advanced configuration possibilities are in [supervisor docs](http://supervisord.org/configuration.html#program-x-section-settings).
+Full details for advanced configuration possibilities are in [Supervisor docs](http://supervisord.org/configuration.html#program-x-section-settings).


### PR DESCRIPTION
## The Issue

https://github.com/drud/ddev/issues/4648

## How This PR Solves The Issue

Prepends the missing `.ddev/web-build/` to the `daemonname.conf` example.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the automatic build.

## Automated Testing Overview

n/a

## Related Issue Link(s)

https://github.com/drud/ddev/issues/4648

## Release/Deployment Notes

n/a
