### PR TITLE
Don't allow Let's Encrypt with Traefik router, fixes #4632

### DIFF
--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drud/ddev/pkg/exec"
 	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/globalconfig"
+	"github.com/drud/ddev/pkg/nodeps"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -16,7 +17,9 @@ import (
 
 func TestCmdGlobalConfig(t *testing.T) {
 	assert := asrt.New(t)
-
+	if nodeps.UseTraefikDefault {
+		t.Skip("Skipping with traefik turned on because can't use hardened images")
+	}
 	backupConfig := globalconfig.DdevGlobalConfig
 	// Start with no config file
 	configFile := globalconfig.GetGlobalConfigPath()

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -216,7 +216,7 @@ DDEV must detect whether the internet is working to determine whether to add hos
 
 ## `letsencrypt_email`
 
-Email associated with Let’s Encrypt feature. (Works in conjunction with [`use_letsencrypt`](#use_letsencrypt).)
+Email associated with Let’s Encrypt feature. (Works in conjunction with [`use_letsencrypt`](#use_letsencrypt).) (Not currently compatible with Traefik router.)
 
 | Type | Default | Usage
 | -- | -- | --
@@ -497,7 +497,7 @@ When `true`, more secure hardened images are used for an internet deployment. Th
 
 ## `use_letsencrypt`
 
-Whether to enable Let’s Encrypt integration. (Works in conjunction with [`letsencrypt_email`](#letsencrypt_email).)
+Whether to enable Let’s Encrypt integration. (Works in conjunction with [`letsencrypt_email`](#letsencrypt_email).) (Not currently compatible with Traefik router.)
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/topics/hosting.md
+++ b/docs/content/users/topics/hosting.md
@@ -2,6 +2,8 @@
 
 !!!warning "Experimental Feature!"
     This is not a replacement for scalable, managed hosting. It’s unknown how much traffic it can handle in a given environment.
+!!!warning "Let's Encrypt support not directly compatible with Traefik router"
+    `ddev config global --use-lets-encrypt` is not directly compatible with the Traefik router, but it [can be configured using Traefik docs](https://doc.traefik.io/traefik/https/acme/).
 
 One of DDEV’s experimental features is lightweight hosting with Let’s Encrypt for HTTPS support. You can run DDEV on a public web server, point DNS to it, and use it as a limited hosting environment.
 

--- a/docs/content/users/topics/hosting.md
+++ b/docs/content/users/topics/hosting.md
@@ -3,7 +3,7 @@
 !!!warning "Experimental Feature!"
     This is not a replacement for scalable, managed hosting. It’s unknown how much traffic it can handle in a given environment.
 !!!warning "Let's Encrypt support not directly compatible with Traefik router"
-    `ddev config global --use-lets-encrypt` is not directly compatible with the Traefik router, but it [can be configured using Traefik docs](https://doc.traefik.io/traefik/https/acme/).
+    `ddev config global --use-letsencrypt` is not directly compatible with the Traefik router, but it [can be configured using Traefik docs](https://doc.traefik.io/traefik/https/acme/).
 
 One of DDEV’s experimental features is lightweight hosting with Let’s Encrypt for HTTPS support. You can run DDEV on a public web server, point DNS to it, and use it as a limited hosting environment.
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -135,6 +135,9 @@ func ValidateGlobalConfig() error {
 	if DdevGlobalConfig.DisableHTTP2 && DdevGlobalConfig.UseTraefik {
 		return fmt.Errorf("disable_http2 and use_traefik are mutually incompatible")
 	}
+	if DdevGlobalConfig.UseTraefik && (DdevGlobalConfig.UseLetsEncrypt || DdevGlobalConfig.LetsEncryptEmail != "") {
+		return fmt.Errorf("use-lets-encrypt is not directly supported with traefik. but can be configured with custom config, see https://doc.traefik.io/traefik/https/acme/")
+	}
 	return nil
 }
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -136,7 +136,7 @@ func ValidateGlobalConfig() error {
 		return fmt.Errorf("disable_http2 and use_traefik are mutually incompatible")
 	}
 	if DdevGlobalConfig.UseTraefik && (DdevGlobalConfig.UseLetsEncrypt || DdevGlobalConfig.LetsEncryptEmail != "") {
-		return fmt.Errorf("use-lets-encrypt is not directly supported with traefik. but can be configured with custom config, see https://doc.traefik.io/traefik/https/acme/")
+		return fmt.Errorf("use-letsencrypt is not directly supported with traefik. but can be configured with custom config, see https://doc.traefik.io/traefik/https/acme/")
 	}
 	return nil
 }


### PR DESCRIPTION
## The Issue

* #4632 

## How This PR Solves The Issue

Don't allow this configuration; however, it can be configured with custom traefik config

## Manual Testing Instructions

Try to configure let's encrypt with traefik. Should fail. Read docs.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

