### PR TITLE
[docs] Re-enable copy and edit icons

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,8 @@ theme:
     primary: indigo
     accent: indigo
   features:
+  - content.action.edit
+  - content.code.copy
 #  - content.tabs.link
   - navigation.expand
   - navigation.indexes


### PR DESCRIPTION
## The Issue

Upgrading to mkdocs-material 9 lost edit and copy icons that are so useful.

* https://github.com/squidfunk/mkdocs-material/issues/5092#issuecomment-1443927417

## How This PR Solves The Issue

Enable them explicitly

## Reviewing

See https://ddev--4675.org.readthedocs.build/en/4675/ to review this.

