### PR TITLE
[docs] Change edit button to pencil again

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,8 @@ docs_dir: docs/content
 theme:
   name: material
   custom_dir: docs/overrides
+  icon:
+    edit: material/pencil
   palette:
   - scheme: default
     primary: indigo


### PR DESCRIPTION
## The Issue

Icon for editing docs was obscure.

* https://github.com/squidfunk/mkdocs-material/issues/5092#issuecomment-1445152593

## How This PR Solves The Issue

Change the icon.

