### PR TITLE
[docs] Fix PHP code block highlighting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,11 @@ markdown_extensions:
     emoji_generator: !!python/name:materialx.emoji.to_svg
 - pymdownx.highlight:
     anchor_linenums: true
+    extend_pygments_lang:
+      - name: php
+        lang: php
+        options:
+          startinline: true
 - pymdownx.inlinehilite
 - pymdownx.keys
 - pymdownx.magiclink:


### PR DESCRIPTION
## The Issue

The few PHP fenced code blocks we’ve got (` ```php `) [don’t appear to be highlighted](https://ddev.readthedocs.io/en/latest/users/usage/cms-settings/#cms-specific-help-and-techniques) like you’d expect:

<img width="762" alt="Screen Shot 2023-02-27 at 02 22 09 PM@2x" src="https://user-images.githubusercontent.com/2488775/221699392-c63f914e-9282-4d0d-84b7-d428a04feaff.png">

## How This PR Solves The Issue

While it’s possible to fix this with a leading `<?php`, that also seems impractical and even distracting in some cases. So this PR uses the `extend_pygments_lang` options to override the `php` highlighter’s default behavior and allow inline highlighting—which means highlighting clumps of PHP that don’t start with an opening `<?php`.

<img width="757" alt="Screen Shot 2023-02-27 at 02 24 41 PM@2x" src="https://user-images.githubusercontent.com/2488775/221699795-d223189d-d1fd-42bf-b47b-4a418914b252.png">

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect [the automatic build](https://ddev--4685.org.readthedocs.build/en/4685/users/usage/cms-settings/#cms-specific-help-and-techniques).

## Automated Testing Overview

n/a

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a
