### PR TITLE
[docs] Fix “TYPO3 Specifics” formatting

### DIFF
--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -48,7 +48,9 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 
 ### TYPO3 Specifics
 
-* **Settings Files**: On [`ddev start`](../usage/commands.md#start), DDEV creates a `public/typo3conf/AdditionalConfiguration.php` with database configuration in it.
+#### Settings Files
+
+On [`ddev start`](../usage/commands.md#start), DDEV creates a `public/typo3conf/AdditionalConfiguration.php` file with database configuration in it.
 
 #### Setup a Base Variant (since TYPO3 9.5)
 


### PR DESCRIPTION
## The Issue

The _Managing CMS Specifics_ page includes an oddly-formatted [TYPO3 Specifics](https://ddev.readthedocs.io/en/latest/users/usage/cms-settings/#typo3-specifics) section, which starts with a single-item bulleted list and continues with a level 4 subheading.

## How This PR Solves The Issue

This swaps the rogue bullet with a level 4 subheading, and adds the word “file” to complete the sentence.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the [automatic build](https://ddev--4687.org.readthedocs.build/en/4687/users/usage/cms-settings/#typo3-specifics).

## Automated Testing Overview

n/a

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a

