### PR TITLE
Add dev libraries / function test requirements

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -83,8 +83,11 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         mkdir my-drupal10-site
         cd my-drupal10-site
         ddev config --project-type=drupal10 --docroot=web --create-docroot
+        # If you want to run Functional / FunctionalJavascript Tests include:
+        ddev get ddev/ddev-selenium-standalone-chrome 
         ddev start
         ddev composer create drupal/recommended-project
+        ddev composer require drupal/core-dev --dev --update-with-all-dependencies
         ddev composer require drush/drush
         ddev drush site:install --account-name=admin --account-pass=admin -y
         ddev drush uli
@@ -99,8 +102,11 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         mkdir my-drupal9-site
         cd my-drupal9-site
         ddev config --project-type=drupal9 --docroot=web --create-docroot
+        # If you want to run Functional / FunctionalJavascript Tests include:
+        ddev get ddev/ddev-selenium-standalone-chrome         
         ddev start
         ddev composer create "drupal/recommended-project:^9"
+        ddev composer require drupal/core-dev --dev --update-with-all-dependencies
         ddev composer require drush/drush
         ddev drush site:install --account-name=admin --account-pass=admin -y
         ddev drush uli


### PR DESCRIPTION


## The Issue
Quickstart needs to be updated if we want users to know how to run Functional / FunctionalJavascript tests.  We could do it this way or we could add this knowledge to the phpunit portion of the phpstorm documentation.  

Kind of feels like there should be a phpunit section instead of a phpunit in phpstorm section.

## How This PR Solves The Issue

Adds documentation that I needed in order to understand how to debug functional tests in Drupal 10

