### PR TITLE
[docs] Update guidance about Colima/Docker Desktop requirements and Mutagen

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -20,7 +20,7 @@ These environments can be extended, version controlled, and shared, so you can t
     * RAM: 8GB
     * Storage: 256GB
     * [Colima](https://github.com/abiosoft/colima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-    * Docker Desktop requires macOS Catalina (10.15) or higher; Colima runs on older systems
+    * Colima runs on many versions of macOS up through the latest. Docker Desktop requires macOS Big Sur (11) or higher.
 
 === "Windows WSL2"
     ### Windows WSL2

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -20,7 +20,8 @@ These environments can be extended, version controlled, and shared, so you can t
     * RAM: 8GB
     * Storage: 256GB
     * [Colima](https://github.com/abiosoft/colima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-    * Colima runs on many versions of macOS up through the latest. Docker Desktop requires macOS Big Sur (11) or higher.
+    * Colima (preferred by many) runs on many versions of macOS up through the latest. Docker Desktop (fully supported) requires macOS Big Sur (11) or higher.
+    * On macOS with either Colima or Docker Desktop most users will want to enable Mutagen for superb performance, `ddev config global --mutagen-enabled`
 
 === "Windows WSL2"
     ### Windows WSL2

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -20,10 +20,11 @@ These environments can be extended, version controlled, and shared, so you can t
     * RAM: 8GB
     * Storage: 256GB
     * [Colima](https://github.com/abiosoft/colima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-    * Colima (preferred by many) runs on many versions of macOS up through the latest. Docker Desktop (fully supported) requires macOS Big Sur (11) or higher.
-    * On macOS with either Colima or Docker Desktop most users will want to enable Mutagen for superb performance, `ddev config global --mutagen-enabled`
+    * Colima and Docker Desktop both require macOS Big Sur (11) or higher.
+    * On macOS with either Colima or Docker Desktop most users will want to enable Mutagen for best performance, `ddev config global --mutagen-enabled`
 
 === "Windows WSL2"
+
     ### Windows WSL2
 
     * RAM: 8GB
@@ -49,8 +50,8 @@ These environments can be extended, version controlled, and shared, so you can t
     * RAM: 8GB
     * Storage: 256GB
 
-=== "Gitpod"
+=== "Gitpod and GitHub Codespaces"
 
-    ### Gitpod
+    ### Gitpod and GitHub Codespaces
 
-    With [Gitpod](https://www.gitpod.io) you don’t install anything; you only need a browser and an internet connection.
+    With [Gitpod](https://www.gitpod.io) and [GitHub Codespaces](https://github.com/features/codespaces) you don’t install anything; you only need a browser and an internet connection.

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -41,10 +41,10 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     You can include a `-s <version>` argument to install a specific release or a prerelease version:
 
     ```
-    curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.21.5
+    curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.21.4
     ```
 
-    Most macOS users will want to enable Mutagen for superb performance; no installation is required, just `ddev config global --mutagen-enabled`.
+    We recommend [enabling Mutagen](performance.md#mutagen) for the best performance; enable with [`ddev config global --mutagen-enabled`](../usage/commands.md#config).
 
 === "Linux"
 
@@ -175,7 +175,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     You can do these things manually, or you can do most of it with the provided PowerShell (5) script. 
     In all cases:
     
-    1. Install WSL2 with an Ubuntu distro. On a system without WSL2, just run:
+    1. Install WSL2 with an Ubuntu distro. On a system without WSL2, run:
         ```powershell
         wsl --install
         ```
@@ -186,7 +186,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
         If that doesn't work for you, see the [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and linked [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
         
-        If you prefer to use another Ubuntu distro, just install it and set it as default. For example, `wsl --set-default Ubuntu-22.04`.
+        If you prefer to use another Ubuntu distro, install it and set it as default. For example, `wsl --set-default Ubuntu-22.04`.
 
     2. Visit the Microsoft Store and install the updated "Windows Subsystem for Linux", then click *Open*. It will likely prompt you for a username and password for the Ubuntu WSL2 instance it creates.
 
@@ -240,7 +240,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     To upgrade DDEV in WSL2 Ubuntu, run `apt upgrade ddev` as described in the [Linux installation section](#linux).
 
     !!!note "Path to certificates"
-        If you get the prompt `Installing to the system store is not yet supported on this Linux`, you may just need to add `/usr/sbin` to the `$PATH` so that `/usr/sbin/update-ca-certificates` can be found.
+        If you get the prompt `Installing to the system store is not yet supported on this Linux`, you may need to add `/usr/sbin` to the `$PATH` so that `/usr/sbin/update-ca-certificates` can be found.
 
     ### Traditional Windows
 
@@ -249,7 +249,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     * We recommend using [Chocolatey](https://chocolatey.org/). Once installed, you can run `choco install ddev docker-desktop git` from an administrative shell. You can upgrade by running `ddev poweroff && choco upgrade ddev`.
     * Each [DDEV release](https://github.com/drud/ddev/releases) includes a Windows installer (`ddev_windows_installer.<version>.exe`). After running that, you can open a new Git Bash, PowerShell, or cmd.exe window and start using DDEV.
 
-    Most traditional Windows users will want to enable Mutagen for superb performance; no installation is required, just `ddev config global --mutagen-enabled`. It still won't be as fast as one of the WSL2 options.
+    Most traditional Windows users will want to enable Mutagen for superb performance; no installation is required; run `ddev config global --mutagen-enabled`. It still won't be as fast as one of the WSL2 options.
 
     Most people interact with DDEV on Windows using Git Bash, part of the [Windows Git suite](https://git-scm.com/download/win). Although DDEV does work with cmd.exe and PowerShell, it's more at home in Bash. You can install Git Bash with Chocolatey by running `choco install -y git`.
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -41,8 +41,10 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     You can include a `-s <version>` argument to install a specific release or a prerelease version:
 
     ```
-    curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.19.5
+    curl -fsSL https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh | bash -s v1.21.5
     ```
+
+    Most macOS users will want to enable Mutagen for superb performance; no installation is required, just `ddev config global --mutagen-enabled`.
 
 === "Linux"
 
@@ -246,6 +248,8 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     * We recommend using [Chocolatey](https://chocolatey.org/). Once installed, you can run `choco install ddev docker-desktop git` from an administrative shell. You can upgrade by running `ddev poweroff && choco upgrade ddev`.
     * Each [DDEV release](https://github.com/drud/ddev/releases) includes a Windows installer (`ddev_windows_installer.<version>.exe`). After running that, you can open a new Git Bash, PowerShell, or cmd.exe window and start using DDEV.
+
+    Most traditional Windows users will want to enable Mutagen for superb performance; no installation is required, just `ddev config global --mutagen-enabled`. It still won't be as fast as one of the WSL2 options.
 
     Most people interact with DDEV on Windows using Git Bash, part of the [Windows Git suite](https://git-scm.com/download/win). Although DDEV does work with cmd.exe and PowerShell, it's more at home in Bash. You can install Git Bash with Chocolatey by running `choco install -y git`.
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -49,7 +49,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     Docker Desktop for Mac can be installed via Homebrew (`brew install homebrew/cask/docker`) or can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing.
 
-    If you use Docker Desktop for Mac, the `VirtioFS` option, while performant, is *not* recommended at this time and can cause many mysterious problems. Also,, when Mutagen is enabled, the performance implications of `VirtioFS` are not significant.
+    We do not recommend the `VirtioFS` option with Docker Desktop for Mac. While it’s performant, it can cause mysterious problems that are not present with [Mutagen](performance.md#mutagen)—which offers comparable performance when enabled.
 
 === "Windows"
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -49,6 +49,8 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     Docker Desktop for Mac can be installed via Homebrew (`brew install homebrew/cask/docker`) or can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing.
 
+    If you use Docker Desktop for Mac, the `VirtioFS` option, while performant, is *not* recommended at this time and can cause many mysterious problems. Also,, when Mutagen is enabled, the performance implications of `VirtioFS` are not significant.
+
 === "Windows"
 
     ## Windows


### PR DESCRIPTION
## The Issue

* One person reported confusion about the wording of Docker Desktop vs Colima, thinking that Colima was only for older versions of macOS
* Many people don't understand that Mutagen is the normal standard on macOS (and will be default on v1.22)
* VirtioFS is still problematic on filesystem permissions on Docker Desktop.

