### PR TITLE
Wrap diagnostic output into collapsed <details> block

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,6 @@ body:
         ```
         [COPY-PASTE HERE THE OUTPUT OF `ddev debug test`]
         ```
-        
         </details>         
       description: |
         Whether you’re having trouble or not, help us with context that will skip a bunch of questions we'd have to ask afterwards:


### PR DESCRIPTION
## The Issue
We need to create a gist now to paste diagnostic information, that is too many actions for a regular user.

## How This PR Solves The Issue
This fix should add the pre-filled text to the diagnostic field.

## Manual Testing Instructions
Create a new issue and fill the diagnostic data.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)
Fixes #4244

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4865"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

