### PR TITLE
fix: make a copy of the bytes array before passing to the channel, fixes #5470

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -664,7 +664,12 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 
 	go func() {
 		for inOut.Scan() {
-			chanOut <- inOut.Bytes()
+			// Bytes() underlying array may be overwritten by the next call to Scan().
+			// Copy it to a new allocation to prevent corruption.
+			token := inOut.Bytes()
+			duplicate := make([]byte, len(token))
+			copy(duplicate, token)
+			chanOut <- duplicate
 		}
 		close(stopOut)
 	}()


### PR DESCRIPTION
## The Issue

* #5470

Docker Compose files can become corrupt. This is due to a race condition in the code that calls docker compose commands. I think this only comes up with ddev start because it's the only code that parses docker compose output - namely `docker compose config`.

## How This PR Solves The Issue

https://github.com/ddev/ddev/pull/5340 added support for showing output while the containers are built. https://github.com/hanoii/ddev/commit/35151743309dfadc29ff9e5add9141a2ac403cdb switched from calling `Text()` to `Bytes()` to assist supporting real time output in debug commands. However, [Bytes() has subtly different behaviour](https://pkg.go.dev/bufio#Scanner.Bytes):

> The underlying array may point to data that will be overwritten by a subsequent call to Scan. It does no allocation.

Unfortunately, this issue can take over 1000 instances to actually occur. That's why it hasn't come up yet on our Linux users locals, and also why retries in CI generally work. It's also why we originally thought it was a 1.22.4 issue, and it was! It was just hard to tell with such rare reoccurrence.

This PR fixes the issue by allocating and copying a new value to return through the channel. I did a search for any other calls to `Bytes()` and didn't find any.

## Manual Testing Instructions

~~So far, I'm unable to reproduce this on colima / arm64~~. One time it only took ~20 loops, the last time it took nearly 1200. We can see an error we've seen before, and that in the case the compose file is completely empty.

Edit: I just reproduced the below on my mac. It took 614 iterations:

```bash
#!/bin/bash

echo "Generating first cases..."
ddev debug compose-config > /tmp/1.ddev.compose.yaml
md5sum /tmp/1.ddev.compose.yaml
ddev debug compose-config > /tmp/2.ddev.compose.yaml
md5sum /tmp/2.ddev.compose.yaml

echo "Looping..."
I=2
while diff -up /tmp/1.ddev.compose.yaml /tmp/2.ddev.compose.yaml; do
  ddev debug compose-config > /tmp/2.ddev.compose.yaml
  echo Try $I....
  ((I++))
  md5sum /tmp/2.ddev.compose.yaml
done
```

<img width="1298" alt="image" src="https://github.com/ddev/ddev/assets/255023/837cbb60-abc1-4d35-bae5-5442e9ca8794">

On macOS:

```console
Try 614....
6ba83c77fda3524b8fdf2898c0c32cdd  /tmp/2.ddev.compose.yaml
--- /tmp/1.ddev.compose.yaml	2024-02-23 16:35:27
+++ /tmp/2.ddev.compose.yaml	2024-02-23 16:39:16
@@ -115,7 +115,7 @@ services:
               target: /mnt/ddev_config
               type: bind
             - bind:
-                create_host_path: true
+                cr-ate_host_path: true
               source: /Users/andrew/workspace/no-arq-backup/REDACTED/REDACTED/.ddev/redis
               target: /usr/local/etc/redis
               type: bind
```

I was also able to reproduce this over at https://github.com/Lullabot/drainpipe/pull/453 (while simply testing the debug output!) and have run many retries with this change, and so far they've all passed.

## Automated Testing Overview

This is hard to test! I'm not sure of a way to force the race condition to occur. Let's say it takes 5-10 minutes to run to reproduce this... do we really want that in all tests? Open to ideas here.

## Related Issue Link(s)

https://github.com/orgs/ddev/discussions/5470

## Release/Deployment Notes

None that I can think of.

