### PR TITLE
fix: allow usage of wp-cli when docroot has changed in a wordpress project

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -244,6 +244,7 @@ func init() {
 			uploadDirs:           getWordpressUploadDirs,
 			hookDefaultComments:  getWordpressHooks,
 			appTypeSettingsPaths: setWordpressSiteSettingsPaths,
+			postStartAction:      wordpressPostStartAction,
 			appTypeDetect:        isWordpressApp,
 			importFilesAction:    wordpressImportFilesAction,
 		},
@@ -417,7 +418,6 @@ func (app *DdevApp) DetectAppType() string {
 // PostImportDBAction calls each apptype's detector until it finds a match,
 // or returns 'php' as a last resort.
 func (app *DdevApp) PostImportDBAction() error {
-
 	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.postImportDBAction != nil {
 		return appFuncs.postImportDBAction(app)
 	}


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #7039 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue
Adds a wp-cli.yml file to the app root when the application starts up, setting the path to the app.docroot. Allows for overriding it by removing the `#ddev-generated` signature

## Manual Testing Instructions
I suppose you could create a new wordpress project, change the docroot, install wordpress then run something like `ddev wp plugin list` (which wont work without the yml file)

https://ddev.readthedocs.io/en/stable/users/quickstart/#wordpress


## Automated Testing Overview

I didnt add anything. If a test is required, please let me know what and where to add it.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
