### PR TITLE
fix: use filepath for calculateHostUploadDirFullPath, fixes #7065

### DIFF
--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -77,7 +78,7 @@ func (app *DdevApp) IsUploadDirsWarningDisabled() bool {
 // on the host or "" if there is none.
 func (app *DdevApp) calculateHostUploadDirFullPath(uploadDir string) string {
 	if uploadDir != "" {
-		return path.Clean(path.Join(app.GetAbsDocroot(false), uploadDir))
+		return filepath.Clean(filepath.Join(app.GetAbsDocroot(false), uploadDir))
 	}
 
 	return ""


### PR DESCRIPTION

## The Issue

- #7065 

This didn't work in DDEV v1.24.3 on traditional Windows

```yaml
upload_dirs:
  - ../private_files
```

## How This PR Solves The Issue

Use the `filepath` functions when calculating root path

## TODO

- [ ] Needs test coverage, which should allow multiple upload_dirs


## Manual Testing Instructions

Use this in config.yaml on traditional Windows

```yaml
upload_dirs:
  - ../private_files
```


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
