### PR TITLE
build: use special qemu binfmt version for db push [skip ci]

### DIFF
--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   push-tagged-dbimage:
     name: "push tagged dbimage"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         dbtype: [mariadb_5.5, mariadb_10.0, mariadb_10.1, mariadb_10.2, mariadb_10.3, mariadb_10.4, mariadb_10.5, mariadb_10.6, mariadb_10.7, mariadb_10.8, mariadb_10.11, mariadb_11.4, mysql_5.5, mysql_5.6, mysql_5.7, mysql_8.0, mysql_8.4]
@@ -44,8 +44,15 @@ jobs:
         DOCKERHUB_TOKEN: "op://push-secrets/DOCKERHUB_TOKEN/credential"
 
     - uses: actions/checkout@v4
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # special qemu version used due to many
+        # failures with "Cannot allocate memory" in
+        # apt-get install of arm64
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub


### PR DESCRIPTION
## The Issue

qemu failures on building images

Same as https://github.com/ddev/ddev/pull/7070 and should have been done there but didn't see @stasadev comment

- https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2096782/
- https://github.com/tonistiigi/binfmt/issues/240
- https://github.com/docker/setup-qemu-action/issues/198
- https://github.com/actions/runner-images/issues/11561#issuecomment-2678571978