### PR TITLE
docs: align Craft CMS quickstart with official documentation

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -172,7 +172,7 @@ DDEV injects a number of special environment variables into the container (via `
     # Create a project directory and move into it:
     mkdir my-craft-site && cd my-craft-site
 
-    # Set up the DDEV environment:
+    # Set up the DDEV environment and boot the project:
     ddev config --project-type=craftcms --docroot=web
     ddev start
 
@@ -197,6 +197,7 @@ DDEV injects a number of special environment variables into the container (via `
     ddev config --project-type=craftcms --docroot=web
 
     # Boot the project and install Composer packages:
+    ddev start
     ddev composer install
 
     # Import a database backup and open the site in your browser:

--- a/docs/tests/craftcms.bats
+++ b/docs/tests/craftcms.bats
@@ -20,24 +20,21 @@ teardown() {
   run ddev start -y
   assert_success
 
-  # Suppress Composer post-create-project-cmd hooks...
-  run ddev composer create-project --no-scripts craftcms/craft
-  assert_success
-
-  # ...so we can perform installation non-interactively:
-  run ddev craft install/craft \
-    --username=admin \
-    --password=Password123 \
-    --email=admin@example.com \
-    --site-name='My Craft Site' \
-    --language=en
+  # Username: [admin] admin
+  # Email: admin@example.com
+  # Password: Password123
+  # Confirm: Password123
+  # Site name: CraftCMS
+  # Site URL: [https://my-craft-site.ddev.site]
+  # Site language: [en]
+  run bats_pipe printf "admin\nadmin@example.com\nPassword123\nPassword123\nCraftCMS\n\n\n" \| ddev composer create-project craftcms/craft
   assert_success
 
   # validate ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
-  run bash -c "DDEV_DEBUG=true ddev launch /admin/login"
+  DDEV_DEBUG=true run ddev launch /admin/login
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin/login"
   assert_success
 
@@ -53,7 +50,7 @@ teardown() {
   assert_output --partial "<h2>Popular Resources</h2>"
   run curl -sf https://${PROJNAME}.ddev.site/admin/login
   assert_success
-  assert_output --partial "<title>Sign In - My Craft Site</title>"
+  assert_output --partial "<title>Sign In - CraftCMS</title>"
 }
 
 @test "Craft CMS Existing Projects quickstart with $(ddev --version)" {


### PR DESCRIPTION
## The Issue

Follow-up from #7233! The Craft team has implemented a small change in our starter project so that it is more resilient when special variables are set by DDEV. We saw reports of new projects failing, but only when developers used _our_ first-time setup guide; we then realized the DDEV quick-start had [drifted](https://github.com/ddev/ddev/pull/7107) from our recommendations, but was still working correctly!

## How This PR Solves The Issue

I have revised the installation steps to more closely match our official guide, and updated surrounding descriptions of Craft and DDEV features or behaviors as they relate to first-time setup.

The current DDEV quick-start guide can be found [here](https://ddev.readthedocs.io/en/stable/users/quickstart/#craft-cms-new-projects). Our official installation instructions are [here](https://craftcms.com/docs/5.x/install.html).

## Manual Testing Instructions

Quickstart review at https://ddev--7323.org.readthedocs.build/en/7323/users/quickstart/#craft-cms

## Automated Testing Overview

- [x] Wants related quickstart test.

## Release/Deployment Notes

These changes describe features that are already publicly released!