### PR TITLE
docs: update `vendor/bin/composer` examples, for #6772

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -94,13 +94,8 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
-!!!tip "How to run Composer from `vendor/bin/composer`?"
-
-    ```shell
-    ddev exec vendor/bin/composer --version
-    # If you have a custom composer_root:
-    ddev exec '$DDEV_COMPOSER_ROOT/vendor/bin/composer --version'
-    ```
+!!!tip "Using `vendor/bin/composer`"
+    See the example in [Composer from `vendor/bin/composer`](../usage/developer-tools.md#composer-from-vendorbincomposer).
 
 ## `corepack_enable`
 

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -62,8 +62,19 @@ To execute a fully-featured `composer create-project` command, you can execute t
 
     You may want to synchronize created Composer configuration and installed packages with the DDEV’s [`homeadditions` directory](../extend/in-container-configuration.md) on your host machine.
 
-!!!tip "If you require `composer/composer` the version you require will be used"
-    If your `composer.json` specifies `composer/composer`, that version of composer will most likely be used by `ddev composer` and `ddev exec composer`, since it will be first in the `$PATH` inside the container. The `.ddev/config.yaml` `composer_version` will be ignored.
+### Composer from `vendor/bin/composer`
+
+If your `composer.json` specifies `composer/composer`, the version in `vendor/bin/composer` can be run with:
+
+```bash
+ddev exec vendor/bin/composer --version
+```
+
+If a custom [`composer_root`](../configuration/config.md#composer_root) is set, use:
+
+```bash
+ddev exec '$DDEV_COMPOSER_ROOT/vendor/bin/composer --version'
+```
 
 <a name="windows-os-and-ddev-composer"></a>
 


### PR DESCRIPTION
## The Issue

- #6772

- From https://github.com/ddev/ddev/issues/6602#issuecomment-2919909375

	Please repair it in documentation https://ddev.readthedocs.io/en/stable/users/usage/developer-tools/#ddev-and-composer
	
	If you require composer/composer the version you require will be used
	
	If your composer.json specifies composer/composer, that version of composer will most likely be used by ddev composer and ddev exec composer, since it will be first in the $PATH inside the container. The .ddev/config.yaml composer_version will be ignored.

## How This PR Solves The Issue

Updates the documentation for `vendor/bin/composer`.

## Manual Testing Instructions

- https://ddev--7344.org.readthedocs.build/en/7344/users/usage/developer-tools/#composer-from-vendorbincomposer
- https://ddev--7344.org.readthedocs.build/en/7344/users/configuration/config/#composer_version

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
