### PR TITLE
feat: display user-defined `router-compose.*.yaml` on `ddev start`

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -631,6 +631,14 @@ func (app *DdevApp) CheckCustomConfig() {
 		customConfig = true
 	}
 
+	routerComposeFiles, err := filepath.Glob(filepath.Join(globalconfig.GetGlobalDdevDir(), "router-compose.*.yaml"))
+	util.CheckErr(err)
+	if len(routerComposeFiles) > 0 {
+		printableFiles, _ := util.ArrayToReadableOutput(routerComposeFiles)
+		util.Warning("Using custom global router-compose configuration (use `docker logs ddev-router` for troubleshooting): %v", printableFiles)
+		customConfig = true
+	}
+
 	traefikGlobalConfigPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "traefik")
 	if _, err := os.Stat(traefikGlobalConfigPath); err == nil {
 		traefikGlobalFiles, err := filepath.Glob(filepath.Join(traefikGlobalConfigPath, "static_config.*.yaml"))


### PR DESCRIPTION
## The Issue

While working on #7350, I noticed that we don't show customizations from the `~/.ddev/router-compose.*.yaml` files.

## How This PR Solves The Issue

Adds a message about it on `ddev start`.

## Manual Testing Instructions

```
$ cat <<'EOF' > ~/.ddev/router-compose.http3.yaml
services:
  ddev-router:
    ports:
      - "127.0.0.1:443:443/udp"
EOF

$ ddev start
...
Using custom global router-compose configuration (use `docker logs ddev-router` for troubleshooting): 
  - /home/stas/.ddev/router-compose.http3.yaml
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
