### PR TITLE
test: Ignore existing golangci-lint/revive package complaints

### DIFF
--- a/pkg/config/remoteconfig/state.go
+++ b/pkg/config/remoteconfig/state.go
@@ -1,4 +1,4 @@
-package remoteconfig
+package remoteconfig //nolint:revive
 
 import (
 	"time"

--- a/pkg/config/remoteconfig/types/remote_config_storage.go
+++ b/pkg/config/remoteconfig/types/remote_config_storage.go
@@ -1,4 +1,4 @@
-package types
+package types //nolint:revive
 
 import (
 	"github.com/ddev/ddev/pkg/config/remoteconfig/internal"

--- a/pkg/config/state/types/state.go
+++ b/pkg/config/state/types/state.go
@@ -1,4 +1,4 @@
-package types
+package types //nolint:revive
 
 type StateEntry = interface{}
 type StateEntryKey = string

--- a/pkg/config/state/types/state_storage.go
+++ b/pkg/config/state/types/state_storage.go
@@ -1,4 +1,4 @@
-package types
+package types //nolint:revive
 
 // RawState is used to hold a weak type in-memory representation of the state.
 type RawState = map[string]any

--- a/pkg/config/types/xhprof_mode.go
+++ b/pkg/config/types/xhprof_mode.go
@@ -1,4 +1,4 @@
-package types
+package types //nolint:revive
 
 import (
 	"fmt"

--- a/pkg/globalconfig/types/types.go
+++ b/pkg/globalconfig/types/types.go
@@ -1,4 +1,4 @@
-package types
+package types //nolint:revive
 
 import "github.com/ddev/ddev/pkg/nodeps"
 

--- a/pkg/globalconfig/xhprof_mode.go
+++ b/pkg/globalconfig/xhprof_mode.go
@@ -1,4 +1,4 @@
-package globalconfig
+package globalconfig //nolint:revive
 
 import (
 	"github.com/ddev/ddev/pkg/config/types"

--- a/pkg/util/errcheck.go
+++ b/pkg/util/errcheck.go
@@ -1,4 +1,4 @@
-package util
+package util //nolint:revive
 
 import (
 	"io"


### PR DESCRIPTION

## The Issue

A golangci-lint/revive upgrade brings new warnings on something it's not worth changing (too disruptive). 

https://github.com/ddev/ddev/actions/runs/15973505093/job/45049930978

> Error: pkg/config/remoteconfig/types/remote_config_storage.go:1:9: var-naming: avoid meaningless package names (revive)
  package types

This new check was added in 
* https://github.com/mgechev/revive/pull/1312

Coaching on how to ignore it is in
* https://github.com/mgechev/revive/pull/1312#discussion_r2044165709

## How This PR Solves The Issue

Ignore this on existing "violations", but the next time we create something like this we'll get warned. 

