### PR TITLE
refactor: move `ddevapp.RenderHomeRootedDir` to `fileutil.ShortHomeJoin`

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -330,7 +330,7 @@ func init() {
 	_ = configGlobalCommand.Flags().MarkHidden("required-docker-compose-version")
 	configGlobalCommand.Flags().String("project-tld", nodeps.DdevDefaultTLD, "Set the default top-level domain to be used for all projects, can be overridden by project configuration")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("project-tld", configCompletionFunc([]string{nodeps.DdevDefaultTLD}))
-	configGlobalCommand.Flags().Bool("use-docker-compose-from-path", false, fmt.Sprintf("If true, use docker-compose from path instead of private %s (used only in development testing)", fileutil.RenderHomeRootedDir(globalconfig.GetDDEVBinDir(), "docker-compose")))
+	configGlobalCommand.Flags().Bool("use-docker-compose-from-path", false, fmt.Sprintf("If true, use docker-compose from path instead of private %s (used only in development testing)", fileutil.ShortHomeJoin(globalconfig.GetDDEVBinDir(), "docker-compose")))
 	_ = configGlobalCommand.Flags().MarkHidden("use-docker-compose-from-path")
 	configGlobalCommand.Flags().Bool("no-bind-mounts", false, "If true, don't use bind-mounts. Useful for environments like remote Docker where bind-mounts are impossible")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("no-bind-mounts", configCompletionFunc([]string{"true", "false"}))

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -165,7 +165,7 @@ func TestCmdDescribe(t *testing.T) {
 		require.EqualValues(t, "running", raw["status"])
 		require.EqualValues(t, "running", raw["status_desc"])
 		require.EqualValues(t, v.Name, raw["name"])
-		require.Equal(t, fileutil.RenderHomeRootedDir(v.Dir), raw["shortroot"].(string))
+		require.Equal(t, fileutil.ShortHomeJoin(v.Dir), raw["shortroot"].(string))
 		require.EqualValues(t, v.Dir, raw["approot"].(string))
 
 		// exposed and host ports
@@ -302,7 +302,7 @@ func TestCmdDescribeAppFunction(t *testing.T) {
 		require.EqualValues(t, ddevapp.SiteRunning, desc["status"])
 		require.EqualValues(t, ddevapp.SiteRunning, desc["status_desc"])
 		require.EqualValues(t, app.GetName(), desc["name"])
-		require.EqualValues(t, fileutil.RenderHomeRootedDir(v.Dir), desc["shortroot"].(string))
+		require.EqualValues(t, fileutil.ShortHomeJoin(v.Dir), desc["shortroot"].(string))
 		require.EqualValues(t, v.Dir, desc["approot"].(string))
 		require.Equal(t, app.GetHTTPURL(), desc["httpurl"])
 		require.Equal(t, app.GetName(), desc["name"])
@@ -335,13 +335,13 @@ func TestCmdDescribeAppUsingSitename(t *testing.T) {
 		assert.EqualValues(ddevapp.SiteRunning, desc["status"])
 		assert.EqualValues(ddevapp.SiteRunning, desc["status_desc"])
 		assert.EqualValues(app.GetName(), desc["name"])
-		assert.EqualValues(fileutil.RenderHomeRootedDir(v.Dir), desc["shortroot"].(string))
+		assert.EqualValues(fileutil.ShortHomeJoin(v.Dir), desc["shortroot"].(string))
 		assert.EqualValues(v.Dir, desc["approot"].(string))
 
 		out, _ := json.Marshal(desc)
 		assert.NoError(err)
 		assert.Contains(string(out), "running")
-		assert.Contains(string(out), fileutil.RenderHomeRootedDir(v.Dir))
+		assert.Contains(string(out), fileutil.ShortHomeJoin(v.Dir))
 	}
 }
 

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -66,7 +66,7 @@ func TestCmdList(t *testing.T) {
 		}
 		assert.Contains(string(out), testURL)
 		assert.Contains(string(out), app.GetType())
-		assert.Contains(string(out), fileutil.RenderHomeRootedDir(app.GetAppRoot()))
+		assert.Contains(string(out), fileutil.ShortHomeJoin(app.GetAppRoot()))
 
 		// Look through list results in json for this site.
 		found := false
@@ -80,7 +80,7 @@ func TestCmdList(t *testing.T) {
 				assert.Equal(app.GetHTTPSURL(), item["httpsurl"])
 				assert.Equal(app.Name, item["name"])
 				assert.Equal(app.GetType(), item["type"])
-				assert.EqualValues(fileutil.RenderHomeRootedDir(app.GetAppRoot()), item["shortroot"])
+				assert.EqualValues(fileutil.ShortHomeJoin(app.GetAppRoot()), item["shortroot"])
 				assert.EqualValues(app.GetAppRoot(), item["approot"])
 				break
 			}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -215,7 +215,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("failed to process pre-describe hooks: %v", err)
 	}
 
-	shortRoot := fileutil.RenderHomeRootedDir(app.GetAppRoot())
+	shortRoot := fileutil.ShortHomeJoin(app.GetAppRoot())
 	appDesc := make(map[string]interface{})
 	status, statusDesc := app.SiteStatus()
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3202,7 +3202,7 @@ func TestDdevDescribe(t *testing.T) {
 	assert.NoError(err)
 	assert.EqualValues(ddevapp.SiteRunning, desc["status"], "")
 	assert.EqualValues(app.GetName(), desc["name"])
-	assert.EqualValues(fileutil.RenderHomeRootedDir(app.GetAppRoot()), desc["shortroot"])
+	assert.EqualValues(fileutil.ShortHomeJoin(app.GetAppRoot()), desc["shortroot"])
 	assert.EqualValues(app.GetAppRoot(), desc["approot"])
 	assert.EqualValues(app.GetPhpVersion(), desc["php_version"])
 

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -74,7 +74,7 @@ func List(settings ListCommandSettings) {
 			if routerStatus == SiteStopped {
 				routerURL = ""
 			}
-			location := fileutil.RenderHomeRootedDir(globalconfig.GetGlobalDdevDirLocation())
+			location := fileutil.ShortHomeJoin(globalconfig.GetGlobalDdevDirLocation())
 			extendedRouterStatus, errorInfo := RenderRouterStatus()
 			if errorInfo != "" {
 				location = text.WrapSoft(errorInfo, 35)

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -573,8 +573,8 @@ func ExpandFilesAndDirectories(dir string, paths []string) ([]string, error) {
 	return expanded, nil
 }
 
-// RenderHomeRootedDir shortens a directory name to replace homedir with ~
-func RenderHomeRootedDir(path ...string) string {
+// ShortHomeJoin returns the same result as filepath.Join() path with $HOME/ replaced by ~/
+func ShortHomeJoin(path ...string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		util.Failed("Could not get home directory for current user. Is it set? err=%v", err)


### PR DESCRIPTION
## The Issue

While testing DDEV setup on traditional Windows, I noticed `~\.ddev`

```
PS C:\Users\stas> ddev ls
┌─────────────────┬─────────┬─────────────────────────────┬─────┬─────────┐
│ NAME            │ STATUS  │ LOCATION                    │ URL │ TYPE    │
├─────────────────┼─────────┼─────────────────────────────┼─────┼─────────┤
│ my-laravel-site │ stopped │ ~/workspace/my-laravel-site │     │ laravel │
├─────────────────┼─────────┼─────────────────────────────┼─────┼─────────┤
│ Router          │ stopped │ ~\.ddev                     │     │         │
└─────────────────┴─────────┴─────────────────────────────┴─────┴─────────┘
```

This is caused by removing `util.WindowsPathToCygwinPath` from `fileutil.ShortHomeJoin` in:

- #7375

## How This PR Solves The Issue

I checked why the location didn't break for `~/workspace/my-laravel-site` (it used `ddevapp.RenderHomeRootedDir`)

In result, `fileutil.ShortHomeJoin` and `ddevapp.RenderHomeRootedDir` did the same thing, so I just moved `ddevapp.RenderHomeRootedDir` to `fileutil.ShortHomeJoin` with small refactoring.

(`ddevapp.RenderHomeRootedDir` couldn't be used everywhere because of import cycles.)

## Manual Testing Instructions

Run `ddev ls` on traditional Windows, the router location should be `~/.ddev`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
