### PR TITLE
build: drop direct dependency on `github.com/pkg/errors`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/maruel/natural v1.1.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/otiai10/copy v1.14.1
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
@@ -65,6 +64,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/maruel/natural"
-	"github.com/pkg/errors"
 )
 
 // appTypeFuncs prototypes
@@ -485,7 +484,7 @@ func (app *DdevApp) PostStartAction() error {
 // dispatchImportFilesAction executes the relevant import files workflow for each app type.
 func (app *DdevApp) dispatchImportFilesAction(uploadDir, importPath, extractPath string) error {
 	if strings.TrimSpace(uploadDir) == "" {
-		return errors.Errorf("upload_dirs is not set for this project (%s)", app.Type)
+		return fmt.Errorf("upload_dirs is not set for this project (%s)", app.Type)
 	}
 
 	if appFuncs, ok := appTypeMatrix[app.Type]; ok {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/version"
 	"github.com/ddev/ddev/pkg/versionconstants"
-	"github.com/pkg/errors"
 )
 
 const mutagenSignatureLabelName = `com.ddev.volume-signature`
@@ -465,7 +464,7 @@ func (app *DdevApp) MutagenSyncFlush() error {
 	}
 	syncName := MutagenSyncName(app.Name)
 	if !MutagenSyncExists(app) {
-		return errors.Errorf("Mutagen sync session '%s' does not exist", syncName)
+		return fmt.Errorf("mutagen sync session '%s' does not exist", syncName)
 	}
 	if status, shortResult, session, err := app.MutagenStatus(); err == nil {
 		util.Verbose("Mutagen sync %s status='%s', shortResult='%v', session='%v', err='%v'", syncName, status, shortResult, session, err)
@@ -539,7 +538,7 @@ func DownloadMutagen() error {
 
 	err = os.MkdirAll(globalMutagenDir, 0777)
 	if err != nil {
-		return errors.Errorf("Unable to create directory %s: %v", globalMutagenDir, err)
+		return fmt.Errorf("unable to create directory %s: %v", globalMutagenDir, err)
 	}
 	err = util.DownloadFile(destFile, mutagenURL, os.Getenv("DDEV_NONINTERACTIVE") != "true", shasumFileURL)
 	if err != nil {
@@ -617,7 +616,7 @@ func MutagenReset(app *DdevApp) error {
 		err := app.Stop(false, false)
 		if err != nil {
 			util.Warning("Failed to stop project '%s': %v", app.Name, err)
-			return errors.Errorf("Failed to stop project %s: %v", app.Name, err)
+			return fmt.Errorf("failed to stop project %s: %v", app.Name, err)
 		}
 		err = dockerutil.RemoveVolume(GetMutagenVolumeName(app))
 		if err != nil {

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/fs"
 	"os"
@@ -411,7 +410,7 @@ func RemoveContents(dir string) error {
 func RemoveFilesMatchingGlob(pattern string) error {
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
-		return errors.Errorf("Error finding files matching %s: %v", pattern, err)
+		return fmt.Errorf("error finding files matching %s: %v", pattern, err)
 	}
 
 	// If no matches, just return (e.g., directory might not exist)
@@ -421,7 +420,7 @@ func RemoveFilesMatchingGlob(pattern string) error {
 
 	for _, match := range matches {
 		if err := os.Remove(match); err != nil {
-			return errors.Errorf("Unable to remove file %s: %v", match, err)
+			return fmt.Errorf("unable to remove file %s: %v", match, err)
 		}
 	}
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/docker/docker/pkg/homedir"
 	copy2 "github.com/otiai10/copy"
-	"github.com/pkg/errors"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -137,7 +136,7 @@ func (site *TestSite) Prepare() error {
 	app.WebserverType = site.WebserverType
 	detectedType := app.DetectAppType()
 	if app.Type != detectedType && app.Type != nodeps.AppTypeGeneric {
-		return errors.Errorf("Detected apptype (%s) does not match provided site.Type (%s)", detectedType, site.Type)
+		return fmt.Errorf("detected apptype (%s) does not match provided site.Type (%s)", detectedType, site.Type)
 	}
 
 	app.WebEnvironment = site.WebEnvironment
@@ -148,7 +147,7 @@ func (site *TestSite) Prepare() error {
 		}
 		err = os.WriteFile(app.GetConfigPath("web-entrypoint.d/pretest.sh"), []byte(site.PretestCmd), 0755)
 		if err != nil {
-			return errors.Errorf("Failed to write pretest.sh, err=%v", err)
+			return fmt.Errorf("failed to write pretest.sh, err=%v", err)
 		}
 	}
 	err = app.ConfigFileOverrideAction(false)
@@ -165,7 +164,7 @@ func (site *TestSite) Prepare() error {
 
 	err = app.WriteConfig()
 	if err != nil {
-		return errors.Errorf("Failed to write site config for site %s, dir %s, err: %v", app.Name, app.GetAppRoot(), err)
+		return fmt.Errorf("failed to write site config for site %s, dir %s, err: %v", app.Name, app.GetAppRoot(), err)
 	}
 
 	return nil
@@ -372,13 +371,13 @@ func ContainerCheck(checkName string, checkState string) (bool, error) {
 		output.UserErr.Fatal(err)
 	}
 	if c == nil {
-		return false, errors.New("unable to find container " + checkName)
+		return false, fmt.Errorf("unable to find container %s", checkName)
 	}
 
 	if c.State == checkState {
 		return true, nil
 	}
-	return false, errors.New("container " + checkName + " returned " + c.State)
+	return false, fmt.Errorf("container %s returned %s", checkName, c.State)
 }
 
 // GetCachedArchive returns a directory populated with the contents of the specified archive, either from cache or


### PR DESCRIPTION
## The Issue

https://github.com/pkg/errors is archived and we don't seem to use any additional features from there.

Although it is still used by Docker:

- https://github.com/moby/moby/discussions/46358

## How This PR Solves The Issue

- Removes it from the list of direct dependencies.
- Moves it to the list of indirect dependencies (required by `github.com/docker/docker/client`).

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
