### PR TITLE
docs: move composer usage tip to composer_root section

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -86,6 +86,9 @@ The relative path, from the project root, to the directory containing `composer.
 | -- | -- | --
 | :octicons-file-directory-16: project | &zwnj; | &zwnj;
 
+!!!tip "Using `vendor/bin/composer`"
+    See the example in [Composer from `vendor/bin/composer`](../usage/developer-tools.md#composer-from-vendorbincomposer).
+
 ## `composer_version`
 
 Composer version for the web container and the [`ddev composer`](../usage/commands.md#composer) command.
@@ -93,9 +96,6 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | Type | Default | Usage
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
-
-!!!tip "Using `vendor/bin/composer`"
-    See the example in [Composer from `vendor/bin/composer`](../usage/developer-tools.md#composer-from-vendorbincomposer).
 
 ## `corepack_enable`
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

None

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

The tip is more related to the composer_root setting than to the composer_version. Therefore I moved the tip to the other section.

## Manual Testing Instructions

https://ddev--7436.org.readthedocs.build/en/7436/users/configuration/config/#composer_root

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
