### PR TITLE
fix: Allow .DS_Store when doing ddev composer create-project [skip ci]

### DIFF
--- a/cmd/ddev/cmd/composer-create-project.go
+++ b/cmd/ddev/cmd/composer-create-project.go
@@ -330,7 +330,7 @@ ddev composer create-project --prefer-dist --no-interaction --no-dev psr/log .
 func checkForComposerCreateAllowedPaths(app *ddevapp.DdevApp) {
 	appRoot := app.GetAbsAppRoot(false)
 	composerRoot := filepath.Join(app.GetComposerRoot(false, false), composerDirectoryArg)
-	skipDirs := []string{".ddev", ".git", ".idea", ".tarballs", ".vscode"}
+	skipDirs := []string{".ddev", ".DS_Store", ".git", ".idea", ".tarballs", ".vscode"}
 	composerCreateAllowedPaths, _ := app.GetComposerCreateAllowedPaths()
 	err := filepath.Walk(composerRoot,
 		func(walkPath string, walkInfo os.FileInfo, err error) error {


### PR DESCRIPTION

## The Issue

Drupal Slack: https://drupal.slack.com/archives/C5TQRQZRR/p1753093589691309

Somebody had a .DS_Store (probably network drive?) on macOS

We don't need to insist on its removal

## How This PR Solves The Issue

Add .DS_Store to allowed files

