### PR TITLE
fix: make ddev describe work correctly with new Docker Desktop, for docker/for-mac#7742

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -329,12 +329,19 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 
 		var exposedPrivatePorts []int
 		exposedPublicPorts := make(map[int]int)
+
+		// Get all exposed ports from container config (works regardless of Docker Desktop changes)
+		for portSpec := range c.Config.ExposedPorts {
+			port := portSpec.Int()
+			if !slices.Contains(exposedPrivatePorts, port) {
+				exposedPrivatePorts = append(exposedPrivatePorts, port)
+			}
+		}
+
+		// Get public port mappings from container summary
 		for _, pv := range k.Ports {
 			if pv.PublicPort != 0 {
 				exposedPublicPorts[int(pv.PublicPort)] = int(pv.PrivatePort)
-			}
-			if !slices.Contains(exposedPrivatePorts, int(pv.PrivatePort)) {
-				exposedPrivatePorts = append(exposedPrivatePorts, int(pv.PrivatePort))
 			}
 		}
 


### PR DESCRIPTION
## The Issue

- docker/for-mac#7742

Docker Desktop changed their internal inspect format, breaking `ddev describe` and TestCmdDescribe

## How This PR Solves The Issue

Use the (appropriate) ExposedPorts to get the full set of exposed ports, instead of inferring it from Ports.

This affects only `ddev describe` and any other usages of app.Describe(), probably unlikely. It works on all the other Docker providers without problems.

We probably can't update our Docker Desktop runners (macOS and Windows) until this goes in, so manual testing is required with DD.

## Manual Testing Instructions

With Docker Desktop 4.44.0:

1. Use `docker-compose.extra.yaml` like this and `ddev describe` should show the 11111 ports etc.
```
services:
  web:
    expose:
      - 11111/tcp
      - 11112/tcp
      - 11113
```
2. run `TestCmdDescribe` and it should succeed 

## Automated Testing Overview

No changes required as the original tests caught this problem in the first place.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
