### PR TITLE
docs: enhance CLAUDE.md development workflow documentation [skip ci]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ When creating pull requests for DDEV, follow the PR template structure from `.gi
    make staticrequired
    ```
 
-   This command runs golangci-lint, markdownlint, mkdocs, and pyspelling. All must pass before committing.
+   This command runs golangci-lint, markdownlint, and mkdocs. All must pass before committing.
 
 **Complete Pre-Commit Checklist:**
 


### PR DESCRIPTION
## The Issue

I noted that claude code failed to do some very basic things consistently, so I wanted to get it to do a `gofmt -w` after editing go code, and a `markdownlint` check after editing markdown. The [hooks docs](https://docs.anthropic.com/en/docs/claude-code/hooks-guide) seemed very promising but maybe they're buggy or something, but neither I nor claude could get it to apply `gofmt` only to go files and `markdownlint` only to markdown files. 

So instead of that, minor edits and simplification and insistence in the CLAUDE.md.

The CLAUDE.md file needed improvements to better guide Claude Code when working with the DDEV codebase, particularly around:
- Pre-commit workflow requirements
- Code formatting rules for different file types
- Streamlined PR creation guidance

- Added mandatory `make staticrequired` requirement with clear emphasis
- Added specific code formatting rules for markdown and Go files
- Enhanced pre-commit workflow section with detailed explanations
- Simplified and clarified PR creation documentation
- Removed redundant conventional commits and GitHub issue sections to focus on core workflow

1. Verify CLAUDE.md renders correctly in markdown viewers
2. Check that formatting follows project markdownlint rules
3. Confirm all links and references are valid

- markdownlint validation ensures proper markdown formatting
- mkdocs build verification confirms documentation structure
- pyspelling check validates spelling and grammar

This documentation update improves Claude Code's ability to follow DDEV development workflows correctly, with no impact on runtime functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)
