### PR TITLE
build: add optional notarization skip via DISABLE_NOTARIZATION variable [skip ci]

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -184,6 +184,7 @@ jobs:
       - name: Sign and notarize binaries (amd64 and arm64)
         env:
           TEAM_ID: "9HQ298V2BW"
+          DISABLE_NOTARIZATION: ${{ vars.DISABLE_NOTARIZATION }}
         run: |
           set -o errexit -o pipefail
           if [ -z "${DDEV_MACOS_SIGNING_PASSWORD}" ] ; then echo "DDEV_MACOS_SIGNING_PASSWORD is empty"; exit 1; fi
@@ -192,7 +193,11 @@ jobs:
             echo "Signing and notarizing ${item} ..."
             codesign --remove-signature "${item}" || true
             curl -s https://raw.githubusercontent.com/ddev/signing_tools/master/macos_sign.sh | bash -s -  --signing-password="${DDEV_MACOS_SIGNING_PASSWORD}" --cert-file=certfiles/ddev_developer_id_cert.p12 --cert-name="Developer ID Application: Localdev Foundation (9HQ298V2BW)" --target-binary="${item}"
-            curl -sSL -f https://raw.githubusercontent.com/ddev/signing_tools/master/macos_notarize.sh | bash -s -  --app-specific-password=${DDEV_MACOS_APP_PASSWORD} --apple-id=notarizer@localdev.foundation --primary-bundle-id=com.ddev.ddev --target-binary="${item}"
+            if [ "${DISABLE_NOTARIZATION:-}" != "true" ]; then
+              curl -sSL -f https://raw.githubusercontent.com/ddev/signing_tools/master/macos_notarize.sh | bash -s -  --app-specific-password=${DDEV_MACOS_APP_PASSWORD} --apple-id=notarizer@localdev.foundation --primary-bundle-id=com.ddev.ddev --target-binary="${item}"
+            else
+              echo "Notarization disabled via DISABLE_NOTARIZATION=true environment variable"
+            fi
           done
       - name: Save notarized binaries to cache
         uses: actions/cache@v4


### PR DESCRIPTION
## The Issue

Development builds and testing scenarios sometimes need to skip the macOS notarization step to save time and resources while still maintaining code signing functionality. Currently, Apple seems to be queuing and not responding to our notarization requests. But notarization is not strictly required. We'd prefer to have it for the next release, but it probably doesn't matter until then; it's used only for HEAD builds. But as currently it's blocking nightly build and HEAD build success, we'd be better to just turn off notarization for now.

## How This PR Solves The Issue

Adds a DISABLE_NOTARIZATION repository variable check to the main build workflow. When set to "true", the notarization step is skipped while code signing still occurs.

## Manual Testing Instructions

I tested this on ddev-test, https://github.com/ddev-test/ddev/actions/runs/17042868887/job/48311795063

1. Set DISABLE_NOTARIZATION=true as a repository variable
2. Trigger a build workflow
3. Verify that code signing occurs but notarization is skipped
4. Check that "Notarization disabled" message appears in logs


🤖 Generated with [Claude Code](https://claude.ai/code)
