### PR TITLE
fix: quote DDEV_PRIMARY_URL expansion in launch script to handle empty values, fixes #7424

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -19,7 +19,7 @@ if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
 fi
 FULLURL=${DDEV_PRIMARY_URL}
 HTTPS=""
-if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then HTTPS=true; fi
+if [ "${DDEV_PRIMARY_URL%://*}" = "https" ]; then HTTPS=true; fi
 IN_CLOUD=""
 if [[ -n "${GITPOD_INSTANCE_ID}" ]] || [[ "${CODESPACES}" == "true" ]]; then IN_CLOUD=true; fi
 


### PR DESCRIPTION

## The Issue

- #7424

When DDEV_PRIMARY_URL is empty or not set (which can happen in certain configurations like FrankenPHP), the parameter expansion in the launch script causes a bash syntax error.

## How This PR Solves The Issue

Added proper quoting around the parameter expansion `${DDEV_PRIMARY_URL%://*}` in line 22 of the launch script. This prevents the bash syntax error `[: =: unary operator expected` when the variable is empty.

## Manual Testing Instructions

1. Create a project where DDEV_PRIMARY_URL might be empty
2. Run `ddev launch`
3. Verify no bash syntax errors occur

## Automated Testing Overview

No automated tests added - this is a simple shell quoting fix that prevents a syntax error.

## Release/Deployment Notes

This is a backward-compatible fix that prevents script failures in edge cases where DDEV_PRIMARY_URL is not set.

🤖 Generated with [Claude Code](https://claude.ai/code)
