### PR TITLE
test: jq is not available on Windows, use docker run -i ddev/ddev-utilities

### DIFF
--- a/cmd/ddev/cmd/addon_test.go
+++ b/cmd/ddev/cmd/addon_test.go
@@ -234,7 +234,7 @@ func TestCmdAddonPHP(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		addonList, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf("%s add-on list --installed -j | docker run -i ddev/ddev-utilities jq -r .raw.[].Name", DdevBin))
+		addonList, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf("%s add-on list --installed -j | docker run -i --rm ddev/ddev-utilities jq -r .raw.[].Name", DdevBin))
 		require.NoError(t, err)
 		addonList = strings.TrimSpace(addonList)
 		addons := strings.Split(addonList, "\n")


### PR DESCRIPTION

## The Issue

A new test in the PHP add-on stuff used `jq` on the host, but it's not available on the Windows test runners, so TestCmdAddonPHP was failing in t.Cleanup()

## How This PR Solves The Issue

Use `docker run -i ddev/ddev-utilities jq` instead

## Manual Testing Instructions

If tests pass it's good enough

