### PR TITLE
test: Skip TestComposerCreateProjectCmd on Windows where it hangs

### DIFF
--- a/cmd/ddev/cmd/composer-create-project_test.go
+++ b/cmd/ddev/cmd/composer-create-project_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -17,6 +18,9 @@ import (
 )
 
 func TestComposerCreateProjectCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on windows where it hangs")
+	}
 	composerVersionForThisTest := nodeps.ComposerDefault
 	//composerVersionForThisTest := "2.8.0"
 


### PR DESCRIPTION
## The Issue

TestComposerCreateProjectCmd hangs regularly on Windows, as in [test](https://buildkite.com/ddev/ddev-windows-mutagen/builds/5408) and [other test](https://buildkite.com/ddev/ddev-windows-mutagen/builds/5410#0198e4e5-5ba7-4826-9a6c-559d8ddd3ba4)

I wasn't able to reproduce this on a Windows machine with `make testcmd TESTARGS=”-run TestComposerCreateProjectCmd -count=1” so I'm going to give up and just skip that test on Windows.

It's probably a new Docker Desktop bug.

## How This PR Solves The Issue

Skip TestComposerCreateProjectCmd on Windows.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
