### PR TITLE
build(dbserver): switch to `bitnamilegacy/mysql` for MySQL 8.0 and 8.4, for #7470

### DIFF
--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -114,7 +114,7 @@ if [ ${DB_TYPE} = "mysql" ]; then
     if [ ${DB_MAJOR_VERSION} = "5.7" ] && [[ "$ARCHS" == *"linux/arm64"* ]]; then
       BASE_IMAGE=ddev/mysql
     elif [ "${DB_MAJOR_VERSION:-}" = "8.0" ] || [ "${DB_MAJOR_VERSION}" = "8.4" ]; then
-      BASE_IMAGE=bitnami/mysql
+      BASE_IMAGE=bitnamilegacy/mysql
     fi
 fi
 printf "\n\n========== Building ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG} from ${BASE_IMAGE} for ${ARCHS} with pinned version ${DB_PINNED_VERSION} ==========\n"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20250826_stasadev_magerun" // Note that this can be overridden by 
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "2050813_rfay_mariadb_fail"
+var BaseDBTag = "20250827_stasadev_bitnamilegacy"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
## The Issue

- #7470

## How This PR Solves The Issue

This doesn't really solve the main problem of missing updates for MySQL 8.0 and 8.4:

```diff
-BASE_IMAGE=bitnami/mysql
+BASE_IMAGE=bitnamilegacy/mysql
```

## Manual Testing Instructions

https://github.com/stasadev/ddev/actions/runs/17272341100/job/49020208880#step:8:87

> `#10 [linux/amd64  1/25] FROM docker.io/bitnamilegacy/mysql:8.0@sha256:ec1e8d95b06e7f78c7f4ee0ed91f835dd39afff7c58e36ba1a4878732b60fcf9`

https://github.com/stasadev/ddev/actions/runs/17272341100/job/49020208836#step:8:92

> `#10 [linux/amd64  1/25] FROM docker.io/bitnamilegacy/mysql:8.4@sha256:7089d796fc9b4629a628bd445e4afabe607351ee665444c3197bdeaed812ea65`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
