### PR TITLE
feat: improve `ddev debug test`

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -41,15 +41,12 @@ fi
 header "Output file will be in $1"
 if ! ddev describe >/dev/null 2>&1; then printf "Please try running this in an existing DDEV project directory, preferably the problem project.\nIt doesn't work in other directories.\n"; exit 2; fi
 
-
-header "Existing project config"
-
 header "ddev installation alternate locations:"
 which -a ddev
 echo
 
 header "project configuration via ddev debug configyaml"
-ddev debug configyaml --full-yaml --omit-keys=web_environment
+ddev debug configyaml --full-yaml --omit-keys=web_environment 2>/dev/null || { ddev debug configyaml | (grep -v "^web_environment" || true); }
 
 header "existing project customizations"
 grep -r -L "#ddev-generated" .ddev/docker-compose.*.yaml .ddev/php .ddev/mutagen .ddev/apache .ddev/nginx* .ddev/*-build .ddev/mysql .ddev/postgres .ddev/traefik/config .ddev/.env .ddev/.env.* 2>/dev/null | grep -v '\.example$' 2>/dev/null
@@ -61,7 +58,7 @@ fi
 
 header "installed DDEV add-ons"
 
-ddev add-on list --installed
+ddev add-on list --installed || ddev get --installed
 
 if [ -f /proc/version ] && grep -qEi "(microsoft|wsl)" /proc/version; then
   header "WSL2 information"
@@ -105,23 +102,25 @@ set +eu
 
 trap cleanup SIGINT SIGTERM SIGQUIT EXIT
 
-header "OS Information"
+header "OS Information (uname -a)"
 uname -a
 command -v sw_vers >/dev/null && sw_vers
 
-header "User information"
+header "User information (id -a)"
 id -a
 
 header "DDEV version"
-ddev version
-docker_platform=$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r  '.raw."docker-platform"' 2>/dev/null)
+DDEV_DEBUG=true ddev version
+docker_platform=$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw."docker-platform"' 2>/dev/null)
 
 header "proxy settings"
 echo "
- HTTP_PROXY='${HTTP_PROXY:-}'
- HTTPS_PROXY='${HTTPS_PROXY:-}'
- http_proxy='${http_proxy:-}'
- NO_PROXY='${NO_PROXY:-}'
+  HTTP_PROXY='${HTTP_PROXY:-}'
+  http_proxy='${http_proxy:-}'
+  HTTPS_PROXY='${HTTPS_PROXY:-}'
+  https_proxy='${https_proxy:-}'
+  NO_PROXY='${NO_PROXY:-}'
+  no_proxy='${no_proxy:-}'
 "
 
 header "DDEV global info"
@@ -136,9 +135,6 @@ which -a docker
 echo
 
 printf "Docker provider: %s\n" "${docker_platform}"
-if [ "${WSL_DISTRO_NAME}" = "" ] && [ "${OSTYPE%-*}" = "linux" ] && [ "$docker_platform" = "docker-desktop" ]; then
-  printf "Warning: Docker Desktop for Linux is not explicitly supported and does not have automated test coverage.\n"
-fi
 
 if [ "${OSTYPE%-*}" != "linux" ] && [ "$docker_platform" = "docker-desktop" ]; then
   echo -n "Docker Desktop Version: " && docker_desktop_version && echo
@@ -150,7 +146,7 @@ docker version
 header "docker context ls"
 DOCKER_HOST="" docker context ls
 
-printf "\nDOCKER_HOST=%s\nDOCKER_DEFAULT_PLATFORM=%s\n" "${DOCKER_HOST:-notset}" "${DOCKER_DEFAULT_PLATFORM:-notset}"
+printf "\nDOCKER_HOST=%s\nDOCKER_CONTEXT=%s\nDOCKER_DEFAULT_PLATFORM=%s\n" "${DOCKER_HOST:-notset}" "${DOCKER_CONTEXT:-notset}" "${DOCKER_DEFAULT_PLATFORM:-notset}"
 
 case $docker_platform in
 colima)
@@ -195,6 +191,7 @@ echo "
 if command -v mkcert >/dev/null; then
   header "mkcert information"
   which -a mkcert
+  mkcert -version
   echo "CAROOT=${CAROOT:-} WSLENV=${WSLENV:-} JAVA_HOME=${JAVA_HOME:-}"
   mkcert -CAROOT
   ls -l "$(mkcert -CAROOT)"
@@ -202,12 +199,13 @@ fi
 
 if command -v ping >/dev/null; then
   header "ping attempt on ddev.site"
-  ping -c 1 dkdkd.ddev.site
+  ping -c 1 dkdkd.ddev.site || printf "\n  Unable to reach *.ddev.site, troubleshoot with:\n  %s\n\n" "https://docs.ddev.com/en/stable/users/usage/networking/#restrictive-dns-servers-especially-fritzbox-routers"
 fi
 
 if command -v curl >/dev/null; then
   header "curl information"
   which -a curl
+  curl --version
 fi
 
 cat <<END >web/index.php
@@ -227,24 +225,25 @@ else
 fi
 
 header "Project startup"
-DDEV_DEBUG=true ddev start -y || ( \
-  set +x && \
-  ddev list && \
-  ddev describe && \
-  printf "============= ddev-%s-web healthcheck run =========\n" "${PROJECT_NAME}" && \
-  docker exec ddev-${PROJECT_NAME}-web bash -xc 'rm -f /tmp/healthy && /healthcheck.sh' && \
-  printf "========= web container healthcheck ======\n" && \
-  docker inspect --format "{{json .State.Health }}" ddev-${PROJECT_NAME}-web && \
-  printf "============= ddev-router healthcheck =========\n" && \
-  ( docker inspect --format "{{json .State.Health }}" ddev-router || true ) && \
-  printf "============= Global ddev homeadditions =========\n" && \
+if ! DDEV_DEBUG=true ddev start -y; then
+  set +x
+  ddev list
+  ddev describe
+  printf "============= ddev-%s-web healthcheck run =========\n" "${PROJECT_NAME}"
+  docker exec ddev-${PROJECT_NAME}-web bash -xc 'rm -f /tmp/healthy && /healthcheck.sh' || true
+  printf "========= web container healthcheck ======\n"
+  docker inspect --format "{{json .State.Health }}" ddev-${PROJECT_NAME}-web || true
+  printf "============= ddev-router healthcheck =========\n"
+  docker inspect --format "{{json .State.Health }}" ddev-router || true
+  printf "============= Global ddev homeadditions =========\n"
   ls -lR ~/.ddev/homeadditions/
-  printf "============= ddev logs =========\n" && \
-  ddev logs | tail -20l && \
-  printf "============= contents of /mnt/ddev_config  =========\n" && \
-  docker exec -it ddev-${PROJECT_NAME}-db ls -l /mnt/ddev_config && \
-  printf "Start failed.\n" && \
-  exit 1 )
+  printf "============= ddev logs =========\n"
+  ddev logs | tail -20l
+  printf "============= contents of /mnt/ddev_config  =========\n"
+  docker exec -it ddev-${PROJECT_NAME}-db ls -l /mnt/ddev_config || true
+  printf "Start failed.\n"
+  exit 1
+fi
 
 host_http_url=$(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.services.web.host_http_url' 2>/dev/null)
 http_url=$(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.httpURLs[0]' 2>/dev/null)


### PR DESCRIPTION
## The Issue

Some commands in `ddev debug test` can't be used with older DDEV versions, which doesn't align with this recommendation:

https://github.com/ddev/ddev/blob/fef6e067d24f5f1674ca0fde3aab078c0556bcef/cmd/ddev/cmd/debug-test.go#L87-L89

## How This PR Solves The Issue

- Adds fallback for `ddev debug configyaml`
- Adds fallback for `ddev get`
- Adds `DDEV_DEBUG=true ddev version` to see more info about possible downloads for docker-compose and mutagen
- Shows more PROXY_ variables
- Shows `DOCKER_CONTEXT` variable
- Shows `mkcert -version`
- Shows `curl --version`
- Adds link to troubleshoot DNS rebinding issues

## Manual Testing Instructions

Run with artifacts from this PR:

```
ddev debug test
```

Run with v1.24.7:

```
curl -sL -O https://raw.githubusercontent.com/stasadev/ddev/refs/heads/20250917_stasadev_debug_test/cmd/ddev/cmd/scripts/test_ddev.sh && bash test_ddev.sh
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
