### PR TITLE
fix(upsun): upsun should resume paused environment at start [skip buildkite]

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
@@ -53,8 +53,8 @@ auth_command:
     if [ -z "${UPSUN_CLI_TOKEN:-}" ]; then echo "Please make sure you have set UPSUN_CLI_TOKEN." && exit 1; fi
     if [ -z "${PLATFORM_PROJECT:-}" ]; then echo "Please make sure you have set PLATFORM_PROJECT." && exit 1; fi
     if [ -z "${PLATFORM_ENVIRONMENT:-}" ]; then echo "Please make sure you have set PLATFORM_ENVIRONMENT." && exit 1; fi
-    if [ "$(upsun environment:info status)" != "active" ]; then
-      upsun environment:resume -y
+    if [ "$(upsun environment:info status -e ${PLATFORM_ENVIRONMENT})" != "active" ]; then
+      upsun environment:resume -e ${PLATFORM_ENVIRONMENT} -y
     fi
 
 db_pull_command:


### PR DESCRIPTION

## The Issue

The upsun integration may encounter a paused environment. This happened to us today in TestUpsunPull. I don't see why we shouldn't resume the environment

## How This PR Solves The Issue

Resume the environment in the auth section

## Manual Testing Instructions

`ddev pull upsun` with a paused environment. Or an active environment

## Automated Testing Overview

No changes.


## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
