### PR TITLE
docs: platform.sh->upsun name changes, fixes #7654

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Additionally, [https://ddev.com/get-started/](https://ddev.com/get-started/) pro
 * Quickly create local web development environments based on code repositories, with minimal configuration.
 * Import a database to any of your local environments.
 * Import upload files to match the project (e.g. Drupal sites/default/files or WordPress `wp-content/uploads`).
-* Customizable integration with hosting platforms like [Platform.sh](https://platform.sh), [Pantheon](https://pantheon.io), [Acquia](https://www.acquia.com) and others.
+* Customizable integration with hosting platforms like [Upsun (formerly Platform.sh)](https://upsun.com), [Pantheon](https://pantheon.io), [Acquia](https://www.acquia.com) and others.
 * Run commands within the Docker environment using `ddev exec`.
 * View logs from the web and database containers.
 * Use `ddev ssh` to explore the Linux environment inside the container.

--- a/docs/content/developers/maintainers.md
+++ b/docs/content/developers/maintainers.md
@@ -38,7 +38,7 @@ Not all maintainers can do all these things at any given time, but these are the
 
 Most privileges should be granted per-developer as separate accounts. In general, we don't want to share a common login. So for example, instead of sharing a login to [developer.apple.com](https://developer.apple.com) or [buildkite.com](https://buildkite.com/ddev) each maintainer should have their own login.
 
-There are cases like access to hosting provider integrations that have essentially no value upstream where a shared login is acceptable. And of course, tokens listed in 1Password are a type of shared login. Our hosting integrations like Acquia, Platform.sh, etc. should never have any valuable things to attack anyway, so these should be very low risk. However, the bad guys are always trying new things...
+There are cases like access to hosting provider integrations that have essentially no value upstream where a shared login is acceptable. And of course, tokens listed in 1Password are a type of shared login. Our hosting integrations like Acquia, Upsun, etc. should never have any valuable things to attack anyway, so these should be very low risk. However, the bad guys are always trying new things...
 
 * **GitHub**: Maintainers should usually be added to the [DDEV organization](https://github.com/orgs/ddev/people), usually was "owner", but lesser privileges are possible, and some maintainers may want only access to the DDEV project, etc.
 * **Buildkite**: Maintainers should be added to the [DDEV Buildkite organization](https://buildkite.com/organizations/ddev/users) with "maintainer" privileges. This gives access to the Buildkite pipelines and the ability to add new pipelines. Do not require "SSO" or people won't be able to get in.
@@ -61,7 +61,7 @@ There are cases like access to hosting provider integrations that have essential
 * **Zoho CRM** is how we track contacts and send monthly emails or announcements. People involved in marketing will want to have access to this, but it will cost for additional users.
 * **[1Password](https://1password.com/)**. Maintainers should be added to the DDEV team in 1Password. This gives access to the DDEV team vault, which has tokens and passwords that are needed for various things. Please try to maintain things like tokens in there.
 * Acquia Cloud test account
-* Platform.sh test account
+* Upsun test accounts
 * Pantheon test account
 * Lagoon test account
 * [Newmonitor.thefays.us](https://newmonitor.thefays.us/icingaweb2/dashboard) (Test runner monitoring).

--- a/docs/content/users/extend/using-add-ons.md
+++ b/docs/content/users/extend/using-add-ons.md
@@ -212,7 +212,7 @@ This approach:
 
 ### Platform and Cloud Integration
 
-- **[`ddev/ddev-platformsh`](https://github.com/ddev/ddev-platformsh)** - Platform.sh integration for project syncing and workflows
+- **[`ddev/ddev-upsun`](https://github.com/ddev/ddev-upsun)** - Upsun Fixed (formerly Platform.sh) and Flex integration for project syncing and workflows
 - **[`ddev/ddev-ibexa-cloud`](https://github.com/ddev/ddev-ibexa-cloud)** - Pull projects and data from Ibexa Cloud
 - **[`ddev/ddev-minio`](https://github.com/ddev/ddev-minio)** - MinIO S3-compatible object storage solution
 

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -1,10 +1,10 @@
 # Hosting Provider Integration
 
-DDEV offers hosting provider integration and sample integrations for [Pantheon](https://pantheon.io), [Platform.sh](https://platform.sh), [Upsun](https://upsun.com/), [Lagoon](https://lagoon.sh/) and [Acquia](https://www.acquia.com) hosting, along with other examples.
+DDEV offers hosting provider integration and sample integrations for [Pantheon](https://pantheon.io), [Upsun](https://upsun.com/), [Lagoon](https://lagoon.sh/) and [Acquia](https://www.acquia.com) hosting, along with other examples.
 
 Hosting provider integration allows connecting with your upstream hosting. `ddev pull <provider>` downloads and `ddev push <provider>` uploads the **database** and the **user-generated files** to an upstream provider. It does *not* push (deploy) or pull your code. Your code should be under version control in for example Git.
 
-DDEV provides ready-to-go integrations for Platform.sh, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
+DDEV provides ready-to-go integrations for Upsun, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
 
 In addition, each project includes [example recipes](https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers) for Pantheon, Git, local files, and `rsync` in its `.ddev/providers` directory, which you can use and adapt however you’d like.
 
@@ -21,9 +21,9 @@ Each provider recipe is a YAML file that can have whatever name you want. The ex
 - [Lagoon](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml)
 - [Local files](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) (like Dropbox, for example)
 - [Pantheon](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml)
-- [Platform.sh](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/platform.yaml)
+- [Upsun Fixed/Platform.sh](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/platform.yaml)
 - [rsync](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example)
-- [Upsun](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/upsun.yaml)
+- [Upsun Flex](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/upsun.yaml)
 
 We know you’ll find improvements to these examples and will have lots to contribute for other hosting providers, and we look forward to your contributions as pull requests here or as new add-ons.
 

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -1,17 +1,17 @@
-# Platform.sh Integration
+# Upsun Fixed (Platform.sh) Integration
 
-DDEV provides integration with the [Platform.sh Website Management Platform](https://platform.sh/), which allows Platform.sh users to quickly download and provision a project from Platform.sh in a local DDEV-managed environment.
+DDEV provides integration with the [Upsun "Fixed" Website Management Platform (formerly Platform.sh)](https://fixed.docs.upsun.com/), which allows Upsun Fixed users to quickly download and provision a project from Upsun in a local DDEV-managed environment.
 
 !!!tip
-    Consider using `ddev add-on get ddev/ddev-platformsh` ([platformsh/ddev-platformsh](https://github.com/ddev/ddev-platformsh)) for more complete Platform.sh integration.
+    Consider using `ddev add-on get ddev/ddev-upsun` ([platformsh/ddev-upsun](https://github.com/ddev/ddev-upsun)) for more complete Upsun Fixed integration.
 
-DDEV’s Platform.sh integration pulls databases and files from an existing Platform.sh site/environment into your local system so you can develop locally.
+DDEV’s Upsun Fixed integration pulls databases and files from an existing Upsun/Platform.sh-style site/environment into your local system so you can develop locally.
 
-## Platform.sh Global Configuration
+## Upsun Fixed (Platform.sh) Global Configuration
 
 You need to obtain and configure an API token first. This is only needed once.
 
-1. Login to the Platform.sh Dashboard and go to *Account* → *API Tokens*. Create an API token DDEV can use.
+1. Login to the Upsun Dashboard and go to *Account* → *API Tokens*. Create an API token DDEV can use.
 2. Add the API token to the `web_environment` section in your global DDEV configuration at `~/.ddev/global_config.yaml`:
 
     ```yaml
@@ -33,9 +33,9 @@ You need to obtain and configure an API token first. This is only needed once.
             - PLATFORMSH_CLI_TOKEN=abcdeyourtoken
         ```
 
-## Platform.sh Per-Project Configuration
+## Upsun/Platform.sh Per-Project Configuration
 
-1. Check out the site from Platform.sh and configure it with [`ddev config`](../usage/commands.md#config). You’ll want to use [`ddev start`](../usage/commands.md#start) and make sure the basic functionality is working.
+1. Check out the site and configure it with [`ddev config`](../usage/commands.md#config). You’ll want to use [`ddev start`](../usage/commands.md#start) and make sure the basic functionality is working.
 2. Add `PLATFORM_PROJECT` and `PLATFORM_ENVIRONMENT` variables to your project.
 
     * Either in `.ddev/config.yaml` or a `.ddev/config.*.yaml` file:
@@ -54,7 +54,7 @@ You need to obtain and configure an API token first. This is only needed once.
 
 3. Run [`ddev restart`](../usage/commands.md#restart).
 4. Run `ddev pull platform`. After you agree to the prompt, the current upstream databases and files will be downloaded.
-5. Optionally use `ddev push platform` to push local files and database to Platform.sh. The [`ddev push`](../usage/commands.md#push) command can potentially damage your production site, so we don’t recommend using it.
+5. Optionally use `ddev push platform` to push local files and database to Upsun. The [`ddev push`](../usage/commands.md#push) command can potentially damage your production site, so use it against a known environment and not against your production site..
 
 ### Managing Multiple Apps
 
@@ -94,5 +94,5 @@ ddev pull platform --environment="PLATFORM_PRIMARY_RELATIONSHIP=main"
 
 ## Usage
 
-* `ddev pull platform` will connect to Platform.sh to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
-* If you need to change the `platform.yaml` recipe, you can change it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.
+* `ddev pull platform` will connect to Upsun to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* If you need to change the `platform.yaml` recipe, you can change it or copy it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.

--- a/docs/content/users/topics/index.md
+++ b/docs/content/users/topics/index.md
@@ -5,4 +5,4 @@ DDEV does not provide capabilities for deploying your code, as it's focused on b
 * [Sharing your project](sharing.md)
 * [Hosting with DDEV](hosting.md)
 * [Remote Docker environments](remote-docker.md)
-* [Hosting integrations](../providers/index.md) including Acquia, Lagoon, Pantheon, Platform.sh, Upsun, rsync-based solutions, Git-based solutions, local files (like Dropbox), etc.
+* [Hosting integrations](../providers/index.md) including Acquia, Lagoon, Pantheon, Upsun, rsync-based solutions, Git-based solutions, local files (like Dropbox), etc.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1372,20 +1372,20 @@ Example:
 # Pull a backup from the configured Pantheon project to use locally
 ddev pull pantheon
 
-# Pull a backup from the configured Platform.sh project to use locally
-ddev pull platform
+# Pull a backup from the configured Upsun project to use locally
+ddev pull upsun
 
 # Pull a backup from the configured Pantheon project without confirming
 ddev pull pantheon -y
 
-# Pull the Platform.sh database archive *only* without confirming
-ddev pull platform --skip-files -y
+# Pull the Upsun database *only* without confirming
+ddev pull upsun --skip-files -y
 
 # Pull the localfile integration’s files *only* without confirming
 ddev pull localfile --skip-db -y
 
-# Pull from Platform.sh specifying the environment variables PLATFORM_ENVIRONMENT and PLATFORM_CLI_TOKEN on the command line
-ddev pull platform --environment=PLATFORM_ENVIRONMENT=main,PLATFORMSH_CLI_TOKEN=abcdef
+# Pull from Upsun specifying the environment variables UPSUN_ENVIRONMENT and UPSUN_CLI_TOKEN on the command line
+ddev pull upsun --environment=UPSUN_ENVIRONMENT=main,UPSUN_CLI_TOKEN=abcdef
 ```
 
 ## `push`
@@ -1398,14 +1398,14 @@ Example:
 # Push local files and database to the configured Pantheon project
 ddev push pantheon
 
-# Push local files and database to the configured Platform.sh project
-ddev push platform
+# Push local files and database to the configured Upsun project
+ddev push upsun
 
 # Push files and database to Pantheon without confirming
 ddev push pantheon -y
 
-# Push database only to Platform.sh without confirming
-ddev push platform --skip-files -y
+# Push database only to Upsun without confirming
+ddev push upsun --skip-files -y
 
 # Push files only to Acquia without confirming
 ddev push acquia --skip-db -y

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,8 +218,8 @@ nav:
       - 'Acquia': users/providers/acquia.md
       - 'Lagoon': users/providers/lagoon.md
       - 'Pantheon': users/providers/pantheon.md
-      - 'Platform.sh': users/providers/platform.md
-      - 'Upsun': users/providers/upsun.md
+      - 'Upsun Fixed/Platform.sh': users/providers/platform.md
+      - 'Upsun Flex': users/providers/upsun.md
   - 'Development':
     - developers/index.md
     - developers/building-contributing.md

--- a/pkg/ddevapp/dotddev_assets/providers/README.txt
+++ b/pkg/ddevapp/dotddev_assets/providers/README.txt
@@ -5,15 +5,15 @@ Providers README
 
 ## Introduction to Hosting Provider Integration
 
-DDEV offers hosting provider integration and sample integrations for Pantheon, Platform.sh and Acquia hosting, along with other examples.
+DDEV offers hosting provider integrations for Pantheon, Upsun and Acquia hosting, along with a number of examples.
 
 Hosting provider integration allows connecting with your upstream hosting. `ddev pull <provider>` downloads and `ddev push <provider>` uploads the **database** and the **user-generated files** to an upstream provider. It does *not* push (deploy) or pull your code. Your code should be under version control in for example Git.
 
-DDEV provides ready-to-go integrations for Platform.sh, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
+DDEV provides ready-to-go integrations for Upsun, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
 
-In addition, each project includes example recipes https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers for Pantheon, Git, local files, and `rsync` in its `.ddev/providers` directory, which you can use and adapt however you’d like.
+In addition, each project includes example recipes https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers for Git, local files, and `rsync` in its `.ddev/providers` directory, which you can use and adapt however you’d like.
 
-DDEV provides the `pull` command with whatever recipes you have configured. For example, `ddev pull platform` is available by default, and `ddev pull pantheon` is available if you have created `.ddev/providers/pantheon.yaml`.
+DDEV provides the `pull` command with whatever recipes you have configured. For example, `ddev pull upsun` and and `ddev pull pantheon` are available by default.
 
 DDEV also provides the `push` command to push database and files to upstream. This is very useful for non-production environments, but could be quite dangerous to your upstream production site and should only be used when appropriate. If you consider it to be dangerous, you can remove the `push` section of the provider YAML file.
 
@@ -25,11 +25,11 @@ Recipes are provided for:
 - Lagoon .ddev/providers/lagoon.yaml
 - Local files .ddev/providers/localfile.yaml.example (like Dropbox, for example)
 - Pantheon .ddev/providers/pantheon.yaml
-- Platform.sh .ddev/providers/platform.yaml
+- Upsun Fixed/Platform.sh .ddev/providers/platform.yaml
 - rsync .ddev/providers/rsync.yaml.example
-- Upsun .ddev/providers/upsun.yaml
+- Upsun Flex .ddev/providers/upsun.yaml
 
-Recipes are provided for Acquia (see .ddev/providers/acquia.yaml), Local files (see .ddev/providers/localfile.yaml.example) (like Dropbox, for example), Pantheon (see .ddev/providers/pantheon.yaml), Platform.sh (see .ddev/providers/platform.yaml, and rsync (see .ddev/providers/rsync.yaml.example).
+Recipes are provided for Acquia (see .ddev/providers/acquia.yaml), Local files (see .ddev/providers/localfile.yaml.example) (like Dropbox, for example), Pantheon (see .ddev/providers/pantheon.yaml), Upsun Fixed (see .ddev/providers/platform.yaml, and rsync (see .ddev/providers/rsync.yaml.example).
 
 Each provider recipe is a file named `<provider>.yaml` and consists of several mostly-optional stanzas:
 

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -1,16 +1,16 @@
 #ddev-generated
-# Platform.sh provider configuration. This works out of the box, but can be edited to add
+# Upsun Fixed/Platform.sh provider configuration. This works out of the box, but can be edited or copied to add
 # your own preferences. If you edit it, remove the `ddev-generated` line from the top so
 # that it won't be overwritten.
 
-# Consider using `ddev add-on get ddev/ddev-platformsh` (https://github.com/ddev/ddev-platformsh) for more
-# complete platform integration.
+# Consider using `ddev add-on get ddev/ddev-upsun` (https://github.com/ddev/ddev-upsun) for more
+# complete Upsun integration.
 
 # To use this configuration,
 
-# 1. Check out the site from platform.sh and then configure it with `ddev config`. You'll want to use `ddev start` and make sure the basic functionality is working.
+# 1. Check out the site and then configure it with `ddev config`. You'll want to use `ddev start` and make sure the basic functionality is working.
 # 2. Obtain and configure an API token.
-#    a. Login to the Platform.sh Dashboard and go to Account->API Tokens to create an API token for ddev to use.
+#    a. Login to the Upsun (Fixed) Dashboard and go to Account->API Tokens to create an API token for ddev to use.
 #    b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml:
 #    ```yaml
 #    web_environment:
@@ -36,9 +36,9 @@
 #
 # 4. `ddev restart`
 # 5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
-# 6. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
+# 6. Optionally use `ddev push platform` to push local files and database to Upsun. Note that `ddev push` is a command that can potentially damage your production site, so use it against an environment you want to use it against.
 
-# If you have more than one database on your Platform.sh project,
+# If you have more than one database on your Upsun Fixed project,
 # you will likely to choose which one you want to use
 # as the primary database ('db').
 # Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example, `ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=main`
@@ -46,7 +46,7 @@
 # `ddev pull platform -y --environment=PLATFORM_PRIMARY_RELATIONSHIP=main`
 # If you need to change this `platform.yaml` recipe, you can change it to suit your needs, but remember to remove the "ddev-generated" line from the top.
 
-# Debugging: Use `ddev exec platform` to see what platform.sh knows about
+# Debugging: Use `ddev exec platform` to use the `platform` CLI inside the web container to see what Upsun knows about
 # your configuration and whether it's working correctly.
 
 auth_command:

--- a/pkg/ddevapp/providerPlatform_test.go
+++ b/pkg/ddevapp/providerPlatform_test.go
@@ -37,7 +37,7 @@ const platformSiteExpectation = "Super easy vegetarian pasta"
 // This is a security feature, but means that PRs intended to test this
 // must be done in the DDEV repo.
 
-// TestPlatformPull ensures we can pull backups from platform.sh for a configured environment.
+// TestPlatformPull ensures we can pull database/files from Upsun Fixed for a configured environment.
 func TestPlatformPull(t *testing.T) {
 	var token string
 	if token = os.Getenv("DDEV_PLATFORM_API_TOKEN"); token == "" {
@@ -101,7 +101,7 @@ func TestPlatformPull(t *testing.T) {
 	assert.True(strings.HasPrefix(out, "1\n"))
 }
 
-// TestPlatformPush ensures we can push to platform.sh for a configured environment.
+// TestPlatformPush ensures we can push to Upsun Fixed for a configured environment.
 func TestPlatformPush(t *testing.T) {
 	var token string
 	if token = os.Getenv("DDEV_PLATFORM_API_TOKEN"); token == "" {


### PR DESCRIPTION

## The Issue

- #7654 

Platform.sh has changed its branding to "Upsun"

## How This PR Solves The Issue

Use "Upsun" where possible in docs and READMEs etc.

## Manual Testing Instructions

Review changes. 
Look at index/headings in docs.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
