### PR TITLE
docs: clarify that `mkcert` is a dependency of DDEV

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -14,7 +14,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     # Install DDEV
     brew install ddev/ddev/ddev
 
-    # One-time initialization of mkcert
+    # One-time initialization of mkcert, a dependency of DDEV
     mkcert -install
     ```
 
@@ -65,7 +65,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     sudo sh -c 'echo ""'
     sudo apt-get update && sudo apt-get install -y ddev
 
-    # One-time initialization of mkcert
+    # One-time initialization of mkcert, a dependency of DDEV
     mkcert -install
     ```
 
@@ -98,7 +98,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     sudo sh -c 'echo ""'
     sudo dnf install --refresh ddev
 
-    # One-time initialization of mkcert
+    # One-time initialization of mkcert, a dependency of DDEV
     mkcert -install
     ```
 
@@ -114,7 +114,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     # Install DDEV
     yay -S ddev-bin
 
-    # One-time initialization of mkcert
+    # One-time initialization of mkcert, a dependency of DDEV
     mkcert -install
     ```
 
@@ -126,7 +126,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     # Install DDEV using Homebrew
     brew install ddev/ddev/ddev
 
-    # One-time initialization of mkcert
+    # One-time initialization of mkcert, a dependency of DDEV
     mkcert -install
     ```
 


### PR DESCRIPTION
I wonder if it's worth mentioning this, since I remembered that I used to have to install it myself, and spent some time figuring out how it got installed ...

Or it could be a single tip at the top instead, if this is too much?

<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
