### PR TITLE
fix: don't use GITHUB_OWNER variable for install_ddev.sh, fixes ddev/github-action-setup-ddev#54

### DIFF
--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -10,7 +10,7 @@ set -o nounset
 
 if [ ! -d /usr/local/bin ]; then echo 'using sudo to mkdir missing /usr/local/bin' && sudo mkdir -p /usr/local/bin; fi
 
-GITHUB_OWNER=${GITHUB_OWNER:-ddev}
+DDEV_GITHUB_OWNER=${DDEV_GITHUB_OWNER:-ddev}
 ARTIFACTS="ddev ddev-hostname mkcert"
 
 TMPDIR=/tmp
@@ -94,7 +94,7 @@ case ${unamearch} in
   ;;
 esac
 
-LATEST_RELEASE=$(curl -fsSL -H 'Accept: application/json' https://github.com/${GITHUB_OWNER}/ddev/releases/latest || (printf "${RED}Failed to get find latest release${RESET}\n" >/dev/stderr && exit 107))
+LATEST_RELEASE=$(curl -fsSL -H 'Accept: application/json' https://github.com/${DDEV_GITHUB_OWNER}/ddev/releases/latest || (printf "${RED}Failed to get find latest release${RESET}\n" >/dev/stderr && exit 107))
 # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
 LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 
@@ -102,7 +102,7 @@ VERSION=$LATEST_VERSION
 if [ $# -ge 1 ]; then
   VERSION=$1
 fi
-RELEASE_BASE_URL="https://github.com/${GITHUB_OWNER}/ddev/releases/download/$VERSION"
+RELEASE_BASE_URL="https://github.com/${DDEV_GITHUB_OWNER}/ddev/releases/download/$VERSION"
 
 if [[ "$OS" == "Darwin" ]]; then
     SHACMD="shasum -a 256 --ignore-missing"

--- a/scripts/install_ddev_head.sh
+++ b/scripts/install_ddev_head.sh
@@ -10,7 +10,7 @@ set -o nounset
 
 if [ ! -d /usr/local/bin ]; then echo 'using sudo to mkdir missing /usr/local/bin' && sudo mkdir -p /usr/local/bin; fi
 
-GITHUB_OWNER=${GITHUB_OWNER:-ddev}
+DDEV_GITHUB_OWNER=${DDEV_GITHUB_OWNER:-ddev}
 TMPDIR=/tmp
 
 RED='\033[31m'
@@ -55,7 +55,7 @@ if ! docker --version >/dev/null 2>&1; then
 fi
 
 # Define artifact URLs based on OS and architecture
-ARTIFACTS_BASE_URL="https://nightly.link/${GITHUB_OWNER}/ddev/workflows/main-build/main"
+ARTIFACTS_BASE_URL="https://nightly.link/${DDEV_GITHUB_OWNER}/ddev/workflows/main-build/main"
 BINARY_ARTIFACT_URL="${ARTIFACTS_BASE_URL}/ddev-${OS}-${ARCH}.zip"
 
 printf "${GREEN}Downloading artifacts for ${OS}_${ARCH}...${RESET}\n"


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/github-action-setup-ddev/issues/54

## How This PR Solves The Issue

We used to use `GITHUB_USERNAME` in the `install_ddev.sh`, which was replaced by `GITHUB_OWNER` in #3939.

`GITHUB_OWNER` is not a standard variable, I don't see it in this list https://docs.github.com/en/actions/reference/workflows-and-actions/variables

But when you search for it on [Google](https://www.google.com/search?q=GITHUB_OWNER), it seems like people are using it.

Let's be more specific by renaming it to `DDEV_GITHUB_OWNER`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
