### PR TITLE
refactor(add-ons): exclude archived repositories

### DIFF
--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -686,7 +686,7 @@ func GetAddonDdevWarningExitCode(action string) int {
 // ListAvailableAddons lists the add-ons that are listed on github
 func ListAvailableAddons() ([]*github.Repository, error) {
 	ctx, client := github.GetGitHubClient()
-	q := "topic:ddev-get fork:true"
+	q := "topic:ddev-get fork:true archived:false"
 
 	opts := &github.SearchOptions{Sort: "updated", Order: "desc", ListOptions: github.ListOptions{PerPage: 200}}
 	var allRepos []*github.Repository


### PR DESCRIPTION
## The Issue

This is a follow-up for:

- https://github.com/ddev/addon-registry/issues/52

## How This PR Solves The Issue

- Doesn't show archived add-ons.

## Manual Testing Instructions

This PR:
```
$ ddev add-on list | grep 'thunder/ddev-selenium-chrome' | wc -l 
0
```

DDEV HEAD:
```
$ ddev add-on list | grep 'thunder/ddev-selenium-chrome' | wc -l
1
```


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
