### PR TITLE
test: npmjs.com no longer allows unchallenged curl [skip buildkite]

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -27,6 +27,7 @@ ignorePatterns:
   - pattern: "https://web.archive.org"
   - pattern: "https://specifications.freedesktop.org"
   - pattern: "https://mutagen.io"
+  - pattern: "https://www.npmjs.com"
 aliveStatusCodes:
   - 200
   - 206


### PR DESCRIPTION

## The Issue

- https://github.com/ddev/ddev/actions/runs/18395371800/job/52538535550

npmjs.com seems to have turned on cloudflare challenges, so we can't link-check it (we get 403)

## How This PR Solves The Issue

Stop link-checking npmjs.com

