### PR TITLE
docs: fix a little custom command annotations code example

### DIFF
--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -205,14 +205,14 @@ Usage: `## Flags: <json-definition>`
 
 This is the minimal usage of a `Flags` definition:
 
-Example: `## Flags: [{"Name":"flag","Shorthand":"f","Usage":"sets the flag option"}]`
+Example: `## Flags: [{"Name":"flag","Usage":"sets the flag option"}]`
 
 Output:
 
 ```bash
 Flags:
   -h, --help          help for ddev
-  -f, --flag          sets the flag option
+      --flag          sets the flag option
 ```
 
 Multiple flags are separated by a comma:


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

There's a tiny mistake in the [custom command annotation docs](https://docs.ddev.com/en/stable/users/extend/custom-commands/#flags-annotation) where the example doesn't match the output:

> Example: `## Flags: [{"Name":"flag","Usage":"sets the flag option"}]`
>
>Output:
>
> ```
> Flags:
>   -h, --help          help for ddev
>   -f, --flag          sets the flag option
> ```

As you can see, the example is just missing the shorthand that's depicted in the output: `"Shorthand":"f"`.