### PR TITLE
fix(mutagen): use fixed length for `com.ddev.volume-signature` label, fixes #7710

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1340,8 +1340,9 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		// Check again to make sure the Mutagen Docker volume exists. It's compatible if we found it above
 		// so we can keep it in that case.
 		if !dockerutil.VolumeExists(GetMutagenVolumeName(app)) {
-			util.Debug("Creating new docker volume '%s' with signature '%v'", GetMutagenVolumeName(app), GetDefaultMutagenVolumeSignature(app))
-			_, err = dockerutil.CreateVolume(GetMutagenVolumeName(app), "local", nil, map[string]string{mutagenSignatureLabelName: GetDefaultMutagenVolumeSignature(app)})
+			signature, _ := GetDefaultMutagenVolumeSignature(app)
+			util.Debug("Creating new docker volume '%s' with signature '%v'", GetMutagenVolumeName(app), signature)
+			_, err = dockerutil.CreateVolume(GetMutagenVolumeName(app), "local", nil, map[string]string{mutagenSignatureLabelName: signature})
 			if err != nil {
 				return fmt.Errorf("unable to create new Mutagen Docker volume %s: %v", GetMutagenVolumeName(app), err)
 			}

--- a/pkg/dockerutil/docker_manager.go
+++ b/pkg/dockerutil/docker_manager.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"net"
 	"net/url"
-	"regexp"
-	"strings"
 	"sync"
 
 	"github.com/ddev/ddev/pkg/util"
@@ -30,7 +28,6 @@ type dockerManager struct {
 	host              string             // Docker daemon URL (e.g., "unix:///var/run/docker.sock")
 	hostIP            string             // IP address of Docker host
 	hostIPErr         error              // Error from Docker host IP lookup, if any
-	hostSanitized     string             // Docker host with special characters removed
 	info              system.Info        // Docker system information from daemon (version, OS, etc.)
 	serverVersion     types.Version      // Docker server version information
 }
@@ -64,7 +61,6 @@ func getDockerManagerInstance() (*dockerManager, error) {
 		sDockerManager.host = sDockerManager.cli.DockerEndpoint().Host
 		util.Verbose("getDockerManagerInstance(): dockerContextName=%s, host=%s", sDockerManager.dockerContextName, sDockerManager.host)
 		sDockerManager.hostIP, sDockerManager.hostIPErr = getDockerIPFromDockerHost(sDockerManager.host)
-		sDockerManager.hostSanitized = getDockerHostSanitized(sDockerManager.host)
 		sDockerManager.goContext = context.Background()
 		// Set the Docker CLI version for User-Agent header
 		version.Version = "ddev-" + versionconstants.DdevVersion
@@ -116,16 +112,6 @@ func GetDockerContextNameAndHost() (string, string, error) {
 	return dm.dockerContextName, dm.host, nil
 }
 
-// GetDockerHostSanitized returns Docker host but with all special characters removed
-// It stands in for Docker context name, but Docker context name is not a reliable indicator
-func GetDockerHostSanitized() (string, error) {
-	dm, err := getDockerManagerInstance()
-	if err != nil {
-		return "", err
-	}
-	return dm.hostSanitized, nil
-}
-
 // GetDockerIP returns either the default Docker IP address (127.0.0.1)
 // or the value as configured by Docker host (if it is a tcp:// URL)
 func GetDockerIP() (string, error) {
@@ -172,7 +158,6 @@ func ResetDockerHost(host string) error {
 	}
 	dm.host = host
 	dm.hostIP, dm.hostIPErr = getDockerIPFromDockerHost(dm.host)
-	dm.hostSanitized = getDockerHostSanitized(dm.host)
 	return nil
 }
 
@@ -193,16 +178,4 @@ func GetDockerAPIVersion() (string, error) {
 		return "", err
 	}
 	return dm.serverVersion.APIVersion, nil
-}
-
-// getDockerHostSanitized returns Docker host but with all special characters removed
-func getDockerHostSanitized(host string) string {
-	// Make it shorter so we don't hit Mutagen 63-char limit
-	dockerHost := strings.TrimPrefix(host, "unix://")
-	dockerHost = strings.TrimSuffix(dockerHost, "docker.sock")
-	dockerHost = strings.Trim(dockerHost, "/.")
-	// Convert remaining descriptor to alphanumeric
-	reg := regexp.MustCompile("[^a-zA-Z0-9]+")
-	alphaOnly := reg.ReplaceAllString(dockerHost, "-")
-	return alphaOnly
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7710

When `DOCKER_HOST` is in path like `/Users/[username]/.local/share/containers/podman/machine/podman.sock`, its length is more than 63 characters (see https://mutagen.io/documentation/introduction/names-labels-identifiers/), causing Mutagen to fail on startup.

## How This PR Solves The Issue

- Uses `DOCKER_HOST` sha1 (40 chars) + timestamp (10 chars) for `com.ddev.volume-signature`.
- Removes `GetDockerHostSanitized`, as it's no longer needed.

## Manual Testing Instructions

```
ddev config global --performance-mode=mutagen
ddev start

# check com.ddev.volume-signature label
docker volume inspect <project_name>_project_mutagen
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
