### PR TITLE
docs: add commands for preparing DDEV to work offline

### DIFF
--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -63,7 +63,7 @@ ddev utility download-images --all
 				if err != nil {
 					util.Failed("Failed to run `docker-compose config` for '%s': %v", app.Name, err)
 				}
-				appImages, err := app.FindAllImages([]string{"*"})
+				appImages, err := app.FindAllImages()
 				if err != nil {
 					util.Failed("Failed to get images for '%s': %v", app.Name, err)
 				}


### PR DESCRIPTION
## The Issue

We have `ddev utility download-images`, which is not mentioned in the docs for offline usage.

## How This PR Solves The Issue

Updates the docs.

## Manual Testing Instructions

https://ddev--7726.org.readthedocs.build/en/7726/users/usage/offline/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
