### PR TITLE
docs(macos): bump system requirements

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -150,6 +150,7 @@ Silverstripe
 Snapshotting
 Solr
 SomeExternalDrive
+Sonoma
 SQLite
 StarterKits
 Starts
@@ -171,7 +172,6 @@ Use
 Uses
 Uz
 VCS
-Ventura
 VM
 VNC
 VPN

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -17,7 +17,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
     Runs natively on ARM64 (Apple Silicon) and AMD64 machines.
 
-    * macOS Ventura (13) or higher. This is primarily driven by the available Docker providers.
+    * macOS Sonoma (14) or higher. This is primarily driven by the available Docker providers.
     * RAM: 8GB
     * Storage: 256GB
     * [OrbStack](https://orbstack.dev/) or [Lima](https://github.com/lima-vm/lima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/) or [Rancher Desktop](https://rancherdesktop.io/) or [Colima](https://github.com/abiosoft/colima)


### PR DESCRIPTION
## The Issue

https://docs.docker.com/desktop/release-notes/#4480

> Support for macOS 13 has ended. Installing Docker Desktop will require macOS 14 in the next release.

## How This PR Solves The Issue

Bumps it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
