### PR TITLE
docs: explicitly mention setting system managed nvm version, for #6013

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1303,7 +1303,9 @@ ddev npx create-next-app@latest
 Run [`nvm`](https://github.com/nvm-sh/nvm#usage) inside the web container (global shell web container command).
 
 !!!tip
-    Use of `ddev nvm` is discouraged because `nodejs_version` is much easier to use, can specify any version, and is more robust than using `nvm`. If your project previously made use of nvm, you will need to revert back to using system defined version by running `ddev nvm alias default system` as per the example below.
+    Use of `ddev nvm` is discouraged because `nodejs_version` is much easier to use, can specify any version, and is more robust than using `nvm`.
+
+    If your project previously made use of `nvm`, you will need to revert back to using system defined version by running `ddev nvm alias default system` as per the example below.
 
 Example:
 


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/issues/6013#issuecomment-3427094678

Whilst the example does contain the command to run to set to default, initially, the tip suggesting using `nodejs_version` should clarify needing to set nvm to use system version.

## How This PR Solves The Issue
Explicitly clearer in the tip mentioning about preferring the use of `nodejs_version`

https://ddev--7733.org.readthedocs.build/en/7733/users/usage/commands/#nvm