### PR TITLE
feat(debug): show web/db container logs on error

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2702,6 +2702,14 @@ func (app *DdevApp) Wait(requiredContainers []string) error {
 		waitTime := app.GetMaxContainerWaitTime()
 		logOutput, err := dockerutil.ContainerWait(waitTime, labels)
 		if err != nil {
+			if globalconfig.DdevDebug {
+				out, err := app.CaptureLogs(containerType, false, "")
+				if err != nil {
+					util.Warning("Unable to capture logs from %s container: %v", containerType, err)
+				} else {
+					util.Debug("Logs from failed %s container:\n%s", containerType, out)
+				}
+			}
 			return fmt.Errorf("%s container failed: log=%s, err=%v", containerType, logOutput, err)
 		}
 	}


### PR DESCRIPTION
## The Issue

While working on Podman I got many errors like this:

```
Waiting for containers to become ready: [web db]
2025-10-09T18:03:46.260 Copied /home/runner/.config/ddev/commands:CopyIntoVolume_wrxnsccvbpyb into /mnt/v/global-commands in 41.45296ms
2025-10-09T18:03:46.295 Exec chown -R 0 /mnt/v/global-commands stdout=, stderr=, err=<nil>
Failed waiting for web/db containers to become ready: db container failed: log=initializing, err=ddev-TestPkgDrupal11-db container is unhealthy, log=initializing

Troubleshoot this with these commands:

  - ddev logs -s db
  - docker logs ddev-TestPkgDrupal11-db
  - docker inspect --format "{{ json .State.Health }}" ddev-TestPkgDrupal11-db | docker run -i --rm ddev/ddev-utilities jq -r
```

The lack of details in the tests for this is unacceptable.

## How This PR Solves The Issue

Adds failed container logs output when `DDEV_DEBUG=true`.

## Manual Testing Instructions

I already tested it in Podman PR.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
