### PR TITLE
fix: don't output debug or verbose in middle of doing json

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -113,34 +113,22 @@ func Success(format string, a ...interface{}) {
 
 // Debug Output controlled by DDEV_DEBUG environment variable
 func Debug(format string, a ...interface{}) {
-	if globalconfig.DdevDebug {
-		if output.JSONOutput {
-			return
-		}
-		n := time.Now()
-		s := fmt.Sprintf(format, a...)
-		if !output.JSONOutput {
-			output.UserOut.Debugf("%s %s", n.Format("2006-01-02T15:04:05.000"), s)
-		} else {
-			output.UserOut.Debugf("%s", s)
-		}
+	if !globalconfig.DdevDebug || output.JSONOutput {
+		return
 	}
+	n := time.Now()
+	s := fmt.Sprintf(format, a...)
+	output.UserOut.Debugf("%s %s", n.Format("2006-01-02T15:04:05.000"), s)
 }
 
 // Verbose Output controlled by DDEV_VERBOSE environment variable
 func Verbose(format string, a ...interface{}) {
-	if globalconfig.DdevVerbose {
-		if output.JSONOutput {
-			return
-		}
-		n := time.Now()
-		s := fmt.Sprintf(format, a...)
-		if !output.JSONOutput {
-			output.UserOut.Debugf("%s %s", n.Format("2006-01-02T15:04:05.000"), s)
-		} else {
-			output.UserOut.Debug(s)
-		}
+	if !globalconfig.DdevVerbose || output.JSONOutput {
+		return
 	}
+	n := time.Now()
+	s := fmt.Sprintf(format, a...)
+	output.UserOut.Debugf("%s %s", n.Format("2006-01-02T15:04:05.000"), s)
 }
 
 // ShowDots displays dots one per second until done gets true


### PR DESCRIPTION

## The Issue

util.Debug() and util.Verbose() can corrupt json output if used inappropriately.

For example, with DDEV v1.24.8
```
DDEV_DEBUG=true /opt/homebrew/bin/ddev describe -j | jq -r .raw
**null
{
  "approot": "/Users/rfay/workspace/d11",
  "database_type": "mariadb",
  "database_version": "11.8",
  "dbimg": "ddev/ddev-dbserver-mariadb-11.8:v1.24.8",
  "docroot": "web",
```

Note the `null` value from empty line

## How This PR Solves The Issue

When in `output.JsonOutput`, don't output things to util.Debug() or util.Verbose

## Manual Testing Instructions

`DDEV_DEBUG=true ddev describe -j | jq -r .raw`

Should not show the output described.

Note that there's a workaround for this in
* https://github.com/ddev/ddev/pull/7720

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
