### PR TITLE
feat: enable non-interactive mode for CI or non-tty environments

### DIFF
--- a/cmd/ddev-hostname/ddev-hostname.go
+++ b/cmd/ddev-hostname/ddev-hostname.go
@@ -43,8 +43,8 @@ because the hosts file never gets manipulated.`,
 		// If requested, remove the provided host name and exit
 		if removeHostnameFlag {
 			if inHostsFile {
-				if os.Getenv("DDEV_NONINTERACTIVE") != "" {
-					printStderr("DDEV_NONINTERACTIVE is set. Not removing the host entry.\n")
+				if os.Getenv("DDEV_NONINTERACTIVE") == "true" || os.Getenv("CI") == "true" {
+					printStderr("DDEV_NONINTERACTIVE or CI is set. Not removing the host entry.\n")
 					os.Exit(0)
 				}
 				elevateIfNeeded()
@@ -70,8 +70,8 @@ because the hosts file never gets manipulated.`,
 		}
 		// By default, add a host name
 		if !inHostsFile {
-			if os.Getenv("DDEV_NONINTERACTIVE") != "" {
-				printStderr("DDEV_NONINTERACTIVE is set. Not adding the host entry.\n")
+			if os.Getenv("DDEV_NONINTERACTIVE") == "true" || os.Getenv("CI") == "true" {
+				printStderr("DDEV_NONINTERACTIVE or CI is set. Not adding the host entry.\n")
 				os.Exit(0)
 			}
 			elevateIfNeeded()

--- a/cmd/ddev/cmd/clean.go
+++ b/cmd/ddev/cmd/clean.go
@@ -88,8 +88,16 @@ Additional commands that can help clean up resources:
 			return
 		}
 
-		if !util.ConfirmTo("Are you sure you want to continue?", false) {
-			os.Exit(1)
+		cleanImagesNoConfirm, _ := cmd.Flags().GetBool("yes")
+
+		if !cleanImagesNoConfirm {
+			if !util.ConfirmTo("Are you sure you want to continue?", false) {
+				if globalconfig.IsInteractive() {
+					util.Failed("User cancelled operation. Terminating without removing items.")
+				} else {
+					util.Failed("DDEV_NONINTERACTIVE or CI is set or terminal is not interactive. Use `--yes` flag to proceed.")
+				}
+			}
 		}
 
 		if needsPoweroffToDeleteImages {
@@ -143,5 +151,6 @@ Additional commands that can help clean up resources:
 func init() {
 	CleanCmd.Flags().BoolP("all", "a", false, "Clean all DDEV projects")
 	CleanCmd.Flags().Bool("dry-run", false, "Run the clean command without deleting")
+	CleanCmd.Flags().BoolP("yes", "y", false, "Yes - skip confirmation prompt")
 	RootCmd.AddCommand(CleanCmd)
 }

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +36,7 @@ ddev pull platform --environment=PLATFORM_ENVIRONMENT=main,PLATFORMSH_CLI_TOKEN=
 // appPull() does the work of pull
 func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDBArg bool, skipFilesArg bool, env string) {
 	// If we're not performing the import step, we won't be deleting the existing db or files.
-	if !skipConfirmation && !skipImportArg && os.Getenv("DDEV_NONINTERACTIVE") == "" {
+	if !skipConfirmation && !skipImportArg && globalconfig.IsInteractive() {
 		// Only warn the user about relevant risks.
 		var message string
 		if skipDBArg && skipFilesArg {

--- a/cmd/ddev/cmd/push.go
+++ b/cmd/ddev/cmd/push.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -32,10 +32,10 @@ ddev push platform --environment=PLATFORM_ENVIRONMENT=main,PLATFORMSH_CLI_TOKEN=
 	},
 }
 
-// apppush() does the work of push
-func apppush(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDBArg bool, skipFilesArg bool, env string) {
+// appPush does the work of push
+func appPush(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDBArg bool, skipFilesArg bool, env string) {
 	// If we're not performing the import step, we won't be deleting the existing db or files.
-	if !skipConfirmation && !skipImportArg && os.Getenv("DDEV_NONINTERACTIVE") == "" {
+	if !skipConfirmation && !skipImportArg && globalconfig.IsInteractive() {
 		// Only warn the user about relevant risks.
 		var message string
 		if skipDBArg && skipFilesArg {
@@ -122,7 +122,7 @@ ddev push %s --skip-files -y`, subCommandName, subCommandName, subCommandName),
 				}
 				environment, _ := cmd.Flags().GetString("environment")
 
-				apppush(providerName, app, flags["skip-confirmation"], flags["skip-import"], flags["skip-db"], flags["skip-files"], environment)
+				appPush(providerName, app, flags["skip-confirmation"], flags["skip-import"], flags["skip-db"], flags["skip-files"], environment)
 			},
 		}
 		// Mark custom command

--- a/cmd/ddev/cmd/testdata/TestCmdAddon/example-repo/tests/test.bats
+++ b/cmd/ddev/cmd/testdata/TestCmdAddon/example-repo/tests/test.bats
@@ -2,7 +2,7 @@ setup() {
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
   export TESTDIR=$(mktemp -d -t testmemcached-XXXXXXXXXX)
   export PROJNAME=testmemcached
-  export DDEV_NON_INTERACTIVE=true
+  export DDEV_NONINTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME} --project-type=drupal9 --docroot=web

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -283,6 +283,7 @@ Flags:
 
 * `--all`, `-a`: Clean all DDEV projects.
 * `--dry-run`: Run the clean command without deleting.
+* `--yes`, `-y`: Skip confirmation prompt.
 
 Example:
 

--- a/pkg/ddevapp/amplitude_project.go
+++ b/pkg/ddevapp/amplitude_project.go
@@ -73,7 +73,7 @@ func (app *DdevApp) TrackProject() {
 		CorepackEnable(app.CorepackEnable).
 		DdevVersionConstraint(app.DdevVersionConstraint).
 		DisableSettingsManagement(app.DisableSettingsManagement).
-		NoProjectMount(app.NoProjectMount).Ci(os.Getenv(`CI`) == `true`)
+		NoProjectMount(app.NoProjectMount).Ci(os.Getenv("CI") == "true")
 
 	if !nodeps.ArrayContainsString(containersOmitted, "db") {
 		builder.

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -5,7 +5,7 @@
 ## Usage: phpmyadmin
 ## Example: "ddev phpmyadmin"
 
-if [ "${DDEV_NONINTERACTIVE:-}" != "" ]; then
+if [ "${DDEV_NONINTERACTIVE:-}" = "true" ]; then
     echo "Nothing has been changed."
     exit 0
 fi

--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/hostname"
 	"github.com/ddev/ddev/pkg/netutil"
 	"github.com/ddev/ddev/pkg/util"
@@ -23,8 +23,8 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 		return fmt.Errorf("could not get Docker IP: %v", err)
 	}
 
-	if os.Getenv("DDEV_NONINTERACTIVE") == "true" {
-		util.Warning("Not trying to add hostnames because DDEV_NONINTERACTIVE=true")
+	if !globalconfig.IsInteractive() {
+		util.Warning("Not trying to add hostnames because DDEV_NONINTERACTIVE=true or CI=true or terminal is not interactive")
 		return nil
 	}
 
@@ -75,8 +75,8 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 // This should be run without administrative privileges and will elevate
 // where needed.
 func (app *DdevApp) RemoveHostsEntriesIfNeeded() error {
-	if os.Getenv("DDEV_NONINTERACTIVE") == "true" {
-		util.Warning("Not trying to remove hostnames because DDEV_NONINTERACTIVE=true")
+	if !globalconfig.IsInteractive() {
+		util.Warning("Not trying to remove hostnames because DDEV_NONINTERACTIVE=true or CI=true or terminal is not interactive")
 		return nil
 	}
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -235,7 +235,7 @@ func CreateOrResumeMutagenSync(app *DdevApp) error {
 	// In tests or other non-interactive environments we don't need to show the
 	// Mutagen sync monitor output (and it fills up the test logs)
 
-	if os.Getenv("DDEV_NONINTERACTIVE") != "true" {
+	if globalconfig.IsInteractive() {
 		go func() {
 			previousStatus := ""
 			curStatus := ""
@@ -541,7 +541,7 @@ func DownloadMutagen() error {
 	if err != nil {
 		return fmt.Errorf("unable to create directory %s: %v", globalMutagenDir, err)
 	}
-	err = util.DownloadFile(destFile, mutagenURL, os.Getenv("DDEV_NONINTERACTIVE") != "true", shasumFileURL)
+	err = util.DownloadFile(destFile, mutagenURL, globalconfig.IsInteractive(), shasumFileURL)
 	if err != nil {
 		_ = fileutil.RemoveFilesMatchingGlob(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen*"))
 		_ = os.Remove(destFile)

--- a/pkg/dockerutil/docker_compose.go
+++ b/pkg/dockerutil/docker_compose.go
@@ -269,7 +269,7 @@ func DownloadDockerCompose() error {
 	_ = os.Remove(destFile)
 
 	_ = os.MkdirAll(globalBinDir, 0777)
-	err = util.DownloadFile(destFile, composeURL, os.Getenv("DDEV_NONINTERACTIVE") != "true", shasumURL)
+	err = util.DownloadFile(destFile, composeURL, globalconfig.IsInteractive(), shasumURL)
 	if err != nil {
 		_ = os.Remove(destFile)
 		return err

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -2,8 +2,10 @@ package globalconfig
 
 import (
 	"os"
+	"testing"
 
 	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/moby/term"
 )
 
 // Container types used with DDEV (duplicated from ddevapp, avoiding cross-package cycles)
@@ -36,6 +38,21 @@ var ValidXdebugIDELocations = []string{XdebugIDELocationContainer, XdebugIDELoca
 
 // GoroutineCount for tests
 var GoroutineCount = 0
+
+// IsInteractive returns true if we are running in an interactive mode
+func IsInteractive() bool {
+	if os.Getenv("DDEV_NONINTERACTIVE") == "true" || os.Getenv("CI") == "true" {
+		return false
+	}
+	// Pretend that terminal is interactive when running tests, because tests may mock input
+	if testing.Testing() {
+		return true
+	}
+	if term.IsTerminal(os.Stdin.Fd()) {
+		return true
+	}
+	return false
+}
 
 // IsValidXdebugIDELocation limits the choices for XdebugIDELocation
 func IsValidXdebugIDELocation(loc string) bool {

--- a/pkg/hostname/hostname.go
+++ b/pkg/hostname/hostname.go
@@ -2,7 +2,6 @@ package hostname
 
 import (
 	"fmt"
-	"os"
 	exec2 "os/exec"
 	"strings"
 
@@ -51,8 +50,8 @@ func GetDdevHostnameBinary() string {
 // elevateHostsManipulation uses elevation (sudo or runas) to manipulate the hosts file.
 func elevateHostsManipulation(args []string) (out string, err error) {
 	// We can't elevate in tests, and they know how to deal with it.
-	if os.Getenv("DDEV_NONINTERACTIVE") != "" {
-		util.Warning("DDEV_NONINTERACTIVE is set. You must manually run '%s'", strings.Join(args, " "))
+	if !globalconfig.IsInteractive() {
+		util.Warning("DDEV_NONINTERACTIVE or CI is set or terminal is not interactive. You must manually run '%s'", strings.Join(args, " "))
 		return "", nil
 	}
 

--- a/pkg/util/prompt.go
+++ b/pkg/util/prompt.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/ddev/ddev/pkg/globalconfig"
 )
 
 var inputScanner = bufio.NewScanner(os.Stdin)
@@ -57,13 +59,13 @@ func Confirm(prompt string) bool {
 }
 
 // ConfirmTo handles the asking and interpreting of a basic yes/no question.
-// If DDEV_NONINTERACTIVE is set, Confirm() returns true.
+// If DDEV_NONINTERACTIVE is set, Confirm() returns defaultTo.
 // If response is blank, the defaultTo value is returned.
 // If response is invalid, the prompt will be presented at most three times
 // before returning false.
 func ConfirmTo(prompt string, defaultTo bool) bool {
-	if len(os.Getenv("DDEV_NONINTERACTIVE")) > 0 {
-		return true
+	if !globalconfig.IsInteractive() {
+		return defaultTo
 	}
 
 	var promptOptions string

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -138,12 +138,8 @@ func TestConfirmTo(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Unset the env var, then reset after the test
-	noninteractiveEnv := "DDEV_NONINTERACTIVE"
-	defer os.Setenv(noninteractiveEnv, os.Getenv(noninteractiveEnv))
-	err := os.Unsetenv(noninteractiveEnv)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	t.Setenv("DDEV_NONINTERACTIVE", "")
+	t.Setenv("CI", "")
 
 	// test a given input against a default value
 	testInput := func(input string, defaultTo bool, expected bool) {


### PR DESCRIPTION
## The Issue

`CI=true` should be enough for non-interactive mode.

## How This PR Solves The Issue

- Sets non-interactive mode for `CI=true`
- Sets non-interactive mode for non-tty (this check is disabled in tests, because we mock stdin there)
- Adds missing `--yes` flag to `ddev clean`

## Manual Testing Instructions

Try:

```
CI=true ddev clean
CI=true ddev clean --yes
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
