### PR TITLE
ci(github-runner): use jlumbroso/free-disk-space action for cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,14 +110,15 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@main
 
       - name: Remove unnecessary items on disk
-        run: |
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/{aws*,julia*}
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/local/lib/node_modules
-          sudo rm -rf /usr/local/bin/minikube,bin/terraform,bin/oc
-          sudo rm -rf /usr/local/share/chromium /usr/local/share/powershell /usr/local/share/vcpkg
-          df -h .
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
 
       - name: Install Docker and deps (Linux)
         run: ./.github/workflows/linux-setup.sh


### PR DESCRIPTION
## The Issue

While working on Podman, I noticed that cleaning up a GitHub runner can take 1-5 minutes, and when it starts there is no output for what is being cleaned.

## How This PR Solves The Issue

I found the [Free Disk Space](https://github.com/jlumbroso/free-disk-space) action for this, which not only cleans up more files, but can also be faster.

Note that I didn't enable cleanup for everything (to make it faster), so if we need more space in the future, it will be easy to add more deletions.

## Manual Testing Instructions

Before cleanup:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   51G   22G  71% /
```

Using `sudo rm`:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   35G   38G  49% /
```

Using action:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   31G   41G  43% /
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
