### PR TITLE
docs: Update postgres:18 in configuration documentation

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -113,7 +113,7 @@ The type and version of the database engine the project should use.
 
 | Type | Default       | Usage
 | -- |---------------| --
-| :octicons-file-directory-16: project | MariaDB 10.11 | Can be MariaDB 5.5–10.8, 10.11, 11.4, 11.8 and MySQL 5.5–8.0, 8.4, or PostgreSQL 9–17.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats. For very old database types see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/).
+| :octicons-file-directory-16: project | MariaDB 10.11 | Can be MariaDB 5.5–10.8, 10.11, 11.4, 11.8 and MySQL 5.5–8.0, 8.4, or PostgreSQL 9–18.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats. For very old database types see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/).
 
 ## `dbimage_extra_packages`
 


### PR DESCRIPTION
## The Issue

I happened to notice in docs that postgres 18 is not listed in configuration.md Add it.

Rendered: https://ddev--7748.org.readthedocs.build/en/7748/users/configuration/config/#database

<img width="742" height="280" alt="image" src="https://github.com/user-attachments/assets/60d9d349-9759-4f14-8cbc-94227de19b38" />


