### PR TITLE
test: Fix TestConfigValidate for TYPO3 [skip buildkite]

### DIFF
--- a/.github/workflows/test-apache-fpm.yml
+++ b/.github/workflows/test-apache-fpm.yml
@@ -32,5 +32,5 @@ jobs:
     secrets: inherit
     with:
       ddev_test_webserver_type: "apache-fpm"
-      #gotest_short: "5" # means use TYPO3 as the default codebase
+      gotest_short: "5" # means use TYPO3 as the default codebase
       debug_enabled: ${{ inputs.debug_enabled || false }}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -3,6 +3,8 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
+	dockerContainer "github.com/docker/docker/api/types/container"
+	copy2 "github.com/otiai10/copy"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -12,10 +14,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	dockerContainer "github.com/docker/docker/api/types/container"
-
-	copy2 "github.com/otiai10/copy"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ddev/ddev/pkg/ddevapp"


### PR DESCRIPTION

## The Issue

TestConfigValidate was failing on TYPO3 (GOTEST_SHORT=5), see https://github.com/ddev/ddev/pull/7746#issuecomment-3435931193


## How This PR Solves The Issue

The problem was that it was using a static validation URL that requires loading the files tarball

This loads the files tarball, does a little bit of test fixup.

