### PR TITLE
feat(debug): show logs on error for all containers, for #7736

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2705,14 +2705,6 @@ func (app *DdevApp) Wait(requiredContainers []string) error {
 		waitTime := app.GetMaxContainerWaitTime()
 		logOutput, err := dockerutil.ContainerWait(waitTime, labels)
 		if err != nil {
-			if globalconfig.DdevDebug {
-				out, captureErr := app.CaptureLogs(containerType, false, "")
-				if captureErr != nil {
-					util.Warning("Unable to capture logs from %s container: %v", containerType, captureErr)
-				} else {
-					util.Debug("Logs from failed %s container:\n%s", containerType, out)
-				}
-			}
 			return fmt.Errorf("%s container failed: log=%s, err=%v", containerType, logOutput, err)
 		}
 	}


### PR DESCRIPTION
## The Issue

- #7736 

## How This PR Solves The Issue

- Shows logs for any failed container on `ddev start` with `DDEV_DEBUG=true` (or `DDEV_VERBOSE=true`), not just web/db.
- Shows health logs.
- It will improve not only the tests, but also the output for `ddev debug test`

## Manual Testing Instructions

Break `ddev-router`:
```
$ echo "http:\n  routers:\n    dummy:\n      entrypoints:\n        - http-12345" > .ddev/traefik/config/dummy.yaml
$ DDEV_DEBUG=true ddev start
...
2025-10-23T16:57:32.011 Waiting for ddev-router to become ready, timeout=60 
2025-10-23T16:58:32.015 Logs from failed ddev-router container:
2025-10-23T16:57:32+03:00 ERR Error while creating certificate store error="failed to load X509 key pair: tls: failed to find any PEM data in certificate input" tlsStoreName=default
2025-10-23T16:57:32+03:00 ERR EntryPoint doesn't exist entryPointName=http-12345 routerName=dummy@file
2025-10-23T16:57:32+03:00 ERR No valid entryPoint for this router routerName=dummy@file
 
2025-10-23T16:58:32.016 Health log from failed ddev-router container:
Traefik healthcheck failed: Detected 1 configuration error(s) in project
 
Failed to start l12: ddev-router failed to become ready; log=, err=health check timed out after 1m0s: labels map[com.docker.compose.oneoff:False com.docker.compose.service:ddev-router] timed out without becoming healthy, status=, detail= ddev-router:starting

Troubleshoot this with these commands:

  - docker logs ddev-router
  - docker inspect --format "{{ json .State.Health }}" ddev-router | docker run -i --rm ddev/ddev-utilities jq -r
```

Break `web`:

```
$ echo "RUN rm -f /usr/local/bin/mailpit" > .ddev/web-build/Dockerfile.mailpit
$ DDEV_DEBUG=true ddev start
...
2025-10-23T17:02:34.491 Logs from failed ddev-l12-web container:
...
2025-10-23 17:00:44,191 INFO spawnerr: can't find command '/usr/local/bin/mailpit'
2025-10-23 17:00:44,191 INFO gave up: mailpit entered FATAL state, too many start retries too quickly
 
2025-10-23T17:02:34.492 Health log from failed ddev-l12-web container:
/var/www/html:OK mailpit:FAILED phpstatus:OK
 
2025-10-23T17:02:35.304 Copied /home/stas/.ddev/commands:CopyIntoVolume_shjhgcebhpkq into /mnt/v/global-commands in 73.970046ms 
2025-10-23T17:02:35.355 Exec chown -R 1000 /mnt/v/global-commands stdout=, stderr=, err=<nil> 
Failed waiting for web/db containers to become ready: web container failed: log=, err=health check timed out after 2m0s: labels map[com.ddev.site-name:l12 com.docker.compose.oneoff:False com.docker.compose.service:web] timed out without becoming healthy, status=, detail= ddev-l12-web:starting

Troubleshoot this with these commands:

  - ddev logs -s web
  - docker logs ddev-l12-web
  - docker inspect --format "{{ json .State.Health }}" ddev-l12-web | docker run -i --rm ddev/ddev-utilities jq -r

If your internet connection is slow, consider increasing the timeout by running this:

  - ddev config --default-container-timeout=240 && ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
