### PR TITLE
ci(pull-push-providers): don't load 1Password secrets if env is empty

### DIFF
--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -145,7 +145,7 @@ jobs:
           check-latest: true
 
       - name: Load 1password secret(s) for pull-push-providers
-        if: ${{ inputs.pull_push_providers == 'true' }}
+        if: ${{ inputs.pull_push_providers == 'true' && env.OP_SERVICE_ACCOUNT_TOKEN != '' }}
         uses: 1password/load-secrets-action@v3
         with:
           export-env: true


### PR DESCRIPTION
## The Issue

I noticed a failed `pull-push-providers` test on the `main` branch of my fork when I synced it with the upstream.

I'm going to disable `pull-push-providers` in my fork, but it shouldn't fail because of empty `TESTS_SERVICE_ACCOUNT_TOKEN` secret.

## How This PR Solves The Issue

Adds a check for not empty env.

## Manual Testing Instructions

I tested it in my fork:

1. I have no secret, "Load 1password secret(s) for pull-push-providers" is skipped https://github.com/stasadev/ddev/actions/runs/18774188224/job/53564911378
2. I added a dummy `TESTS_SERVICE_ACCOUNT_TOKEN` secret, "Load 1password secret(s) for pull-push-providers" failed as expected https://github.com/stasadev/ddev/actions/runs/18774188224/job/53565463093#step:10:53

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
