### PR TITLE
test: use testcommon.CopyGlobalDdevDir to fix intermittent failures in TestCmdXHGui

### DIFF
--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -951,20 +951,12 @@ func TestOmitProjectNameByDefault(t *testing.T) {
 	origDir, _ := os.Getwd()
 
 	// Create temporary XDG_CONFIG_HOME for isolated testing
-	tmpXdgConfigHomeDir := testcommon.CreateTmpDir(t.Name())
-	tmpGlobalDdevDir := filepath.Join(tmpXdgConfigHomeDir, "ddev")
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
 		_ = os.Chdir(origDir)
-		_ = os.RemoveAll(tmpXdgConfigHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 	})
-
-	// Set XDG_CONFIG_HOME to use temporary directory
-	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
-
-	// Create the global DDEV directory structure
-	err := os.MkdirAll(tmpGlobalDdevDir, 0755)
-	require.NoError(t, err)
 
 	tests := []struct {
 		name                     string
@@ -1087,20 +1079,12 @@ func TestOmitProjectNameReconfig(t *testing.T) {
 	origDir, _ := os.Getwd()
 
 	// Create temporary XDG_CONFIG_HOME for isolated testing
-	tmpXdgConfigHomeDir := testcommon.CreateTmpDir(t.Name())
-	tmpGlobalDdevDir := filepath.Join(tmpXdgConfigHomeDir, "ddev")
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
 		_ = os.Chdir(origDir)
-		_ = os.RemoveAll(tmpXdgConfigHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 	})
-
-	// Set XDG_CONFIG_HOME to use temporary directory
-	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
-
-	// Create the global DDEV directory structure
-	err := os.MkdirAll(tmpGlobalDdevDir, 0755)
-	require.NoError(t, err)
 
 	tmpDir := testcommon.CreateTmpDir("reconfig-test")
 	actualDirName := filepath.Base(tmpDir)
@@ -1111,7 +1095,7 @@ func TestOmitProjectNameReconfig(t *testing.T) {
 		_ = os.RemoveAll(tmpDir)
 	})
 
-	err = os.Chdir(tmpDir)
+	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
 	// Enable omit_project_name_by_default
@@ -1156,20 +1140,12 @@ func TestOmitProjectNameWithConfigOverride(t *testing.T) {
 	origDir, _ := os.Getwd()
 
 	// Create temporary XDG_CONFIG_HOME for isolated testing
-	tmpXdgConfigHomeDir := testcommon.CreateTmpDir(t.Name())
-	tmpGlobalDdevDir := filepath.Join(tmpXdgConfigHomeDir, "ddev")
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
 		_ = os.Chdir(origDir)
-		_ = os.RemoveAll(tmpXdgConfigHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 	})
-
-	// Set XDG_CONFIG_HOME to use temporary directory
-	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
-
-	// Create the global DDEV directory structure
-	err := os.MkdirAll(tmpGlobalDdevDir, 0755)
-	require.NoError(t, err)
 
 	tmpDir := testcommon.CreateTmpDir("override-test")
 	t.Cleanup(func() {
@@ -1179,7 +1155,7 @@ func TestOmitProjectNameWithConfigOverride(t *testing.T) {
 		_ = os.RemoveAll(tmpDir)
 	})
 
-	err = os.Chdir(tmpDir)
+	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
 	// Enable omit_project_name_by_default
@@ -1225,26 +1201,18 @@ func TestGlobalConfigOmitProjectNameDefault(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Create temporary XDG_CONFIG_HOME for isolated testing
-	tmpXdgConfigHomeDir := testcommon.CreateTmpDir(t.Name())
-	tmpGlobalDdevDir := filepath.Join(tmpXdgConfigHomeDir, "ddev")
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
-		_ = os.RemoveAll(tmpXdgConfigHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 	})
-
-	// Set XDG_CONFIG_HOME to use temporary directory
-	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
-
-	// Create the global DDEV directory structure
-	err := os.MkdirAll(tmpGlobalDdevDir, 0755)
-	require.NoError(t, err)
 
 	// Ensure global config exists
 	globalconfig.EnsureGlobalConfig()
 
 	// Test setting to true directly (avoids subprocess environment variable issues)
 	globalconfig.DdevGlobalConfig.OmitProjectNameByDefault = true
-	err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+	err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 	require.NoError(t, err)
 
 	err = globalconfig.ReadGlobalConfig()

--- a/cmd/ddev/cmd/debug-remote-data_test.go
+++ b/cmd/ddev/cmd/debug-remote-data_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ddev/ddev/pkg/config/remoteconfig/types"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,10 +96,13 @@ func TestDebugRemoteDataWithStorage(t *testing.T) {
 	// Create a temporary directory for test storage
 	tmpDir, err := os.MkdirTemp("", "ddev-download-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
 
-	// Use t.Setenv to set XDG_CONFIG_HOME to tmpDir so .ddev is created there
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+
+	t.Cleanup(func() {
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
+		_ = os.RemoveAll(tmpDir)
+	})
 
 	// Set up global config with remote config settings
 	globalconfig.EnsureGlobalConfig()
@@ -121,7 +125,7 @@ func TestDebugRemoteDataWithStorage(t *testing.T) {
 
 	t.Run("StorageUpdateDisabled", func(t *testing.T) {
 		storageFile := filepath.Join(globalconfig.GetGlobalDdevDir(), ".remote-config")
-		os.Remove(storageFile)
+		_ = os.Remove(storageFile)
 
 		// Test with storage update disabled
 		out, err := exec.RunHostCommand(DdevBin, "debug", "remote-data", "--type=remote-config", "--update-storage=false")

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -158,29 +158,25 @@ func TestCmdStartShowsMessages(t *testing.T) {
 
 	site := TestSites[0]
 	origDir, _ := os.Getwd()
+	err := os.Chdir(TestSites[0].Dir)
+	require.NoError(t, err)
+
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+
+	_, err = exec.RunCommand(DdevBin, []string{"stop", site.Name})
+	require.NoError(t, err)
 
 	// Create temporary XDG_CONFIG_HOME for isolated testing
-	tmpXdgConfigHomeDir := testcommon.CreateTmpDir(t.Name())
-	tmpGlobalDdevDir := filepath.Join(tmpXdgConfigHomeDir, "ddev")
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+	tmpGlobalDdevDir := globalconfig.GetGlobalDdevDir()
 
 	t.Cleanup(func() {
 		_ = os.Chdir(origDir)
-		_ = os.RemoveAll(tmpXdgConfigHomeDir)
+		_ = app.Stop(true, false)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
+		_ = app.Start()
 	})
-
-	// Set XDG_CONFIG_HOME to use temporary directory
-	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
-
-	// Create the global DDEV directory structure
-	err := os.MkdirAll(tmpGlobalDdevDir, 0755)
-	require.NoError(t, err)
-
-	// Copy necessary binaries from original global config
-	origGlobalDdevDir := globalconfig.GetGlobalDdevDirLocation()
-	if fileutil.IsDirectory(filepath.Join(origGlobalDdevDir, "bin")) {
-		err = fileutil.CopyDir(filepath.Join(origGlobalDdevDir, "bin"), filepath.Join(tmpGlobalDdevDir, "bin"))
-		require.NoError(t, err)
-	}
 
 	// Create a global config with shorter intervals for testing
 	globalconfig.EnsureGlobalConfig()
@@ -205,21 +201,6 @@ func TestCmdStartShowsMessages(t *testing.T) {
 	require.NoError(t, err)
 	err = state.Save()
 	require.NoError(t, err)
-
-	// Go to test site directory
-	err = os.Chdir(site.Dir)
-	require.NoError(t, err)
-
-	app, err := ddevapp.NewApp(site.Dir, false)
-	require.NoError(t, err)
-
-	// Stop the site first to ensure clean start
-	_, err = exec.RunCommand(DdevBin, []string{"stop", site.Name})
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = app.Start() // Restore running state
-	})
 
 	// Start the site and capture output (start without specifying project name to use current directory)
 	out, err := exec.RunCommand(DdevBin, []string{"start", "-y"})
@@ -253,29 +234,25 @@ func TestCmdStartShowsSponsorshipData(t *testing.T) {
 
 	site := TestSites[0]
 	origDir, _ := os.Getwd()
+	err := os.Chdir(TestSites[0].Dir)
+	require.NoError(t, err)
+
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+
+	_, err = exec.RunCommand(DdevBin, []string{"stop", site.Name})
+	require.NoError(t, err)
 
 	// Create temporary XDG_CONFIG_HOME for isolated testing
-	tmpXdgConfigHomeDir := testcommon.CreateTmpDir(t.Name())
-	tmpGlobalDdevDir := filepath.Join(tmpXdgConfigHomeDir, "ddev")
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+	tmpGlobalDdevDir := globalconfig.GetGlobalDdevDir()
 
 	t.Cleanup(func() {
 		_ = os.Chdir(origDir)
-		_ = os.RemoveAll(tmpXdgConfigHomeDir)
+		_ = app.Stop(true, false)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
+		_ = app.Start()
 	})
-
-	// Set XDG_CONFIG_HOME to use temporary directory
-	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
-
-	// Create the global DDEV directory structure
-	err := os.MkdirAll(tmpGlobalDdevDir, 0755)
-	require.NoError(t, err)
-
-	// Copy necessary binaries from original global config
-	origGlobalDdevDir := globalconfig.GetGlobalDdevDirLocation()
-	if fileutil.IsDirectory(filepath.Join(origGlobalDdevDir, "bin")) {
-		err = fileutil.CopyDir(filepath.Join(origGlobalDdevDir, "bin"), filepath.Join(tmpGlobalDdevDir, "bin"))
-		require.NoError(t, err)
-	}
 
 	// Create a global config with custom sponsorship settings
 	globalconfig.EnsureGlobalConfig()
@@ -318,21 +295,6 @@ func TestCmdStartShowsSponsorshipData(t *testing.T) {
 	}`
 	err = os.WriteFile(sponsorshipFile, []byte(mockSponsorshipData), 0644)
 	require.NoError(t, err)
-
-	// Go to test site directory
-	err = os.Chdir(site.Dir)
-	require.NoError(t, err)
-
-	app, err := ddevapp.NewApp(site.Dir, false)
-	require.NoError(t, err)
-
-	// Stop the site first to ensure clean start
-	_, err = exec.RunCommand(DdevBin, []string{"stop", site.Name})
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = app.Start() // Restore running state
-	})
 
 	// Start the site and capture output (start without specifying project name to use current directory)
 	out, err := exec.RunCommand(DdevBin, []string{"start", "-y"})


### PR DESCRIPTION
## The Issue

Related to 
* https://github.com/ddev/ddev/pull/7745

TestCmdXHGui still experiences intermittent 403 errors in CI (e.g., https://buildkite.com/ddev/macos-rancher-desktop/builds/1736#019a1563-9cfc-478c-8008-39e7eee631db/21001-21197) despite PR #7745 adding healthchecks to the xhgui container.

## How This PR Solves The Issue

- Uses `testcommon.CopyGlobalDdevDir(t)` and `testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)`

Running single `TestCmdXHGui` doesn't fail.

I checked the output for the failing test, and it shows that there is no `index.php` on first `ddev restart` in `TestCmdXHGui`:

```
The index.php or index.html does not yet exist at this path:
/home/runner/tmp/ddevtest/TestCmdWordpress730660681/index.*
You may get 403 errors 'permission denied' from the browser until it does.
Ignore if a later action (like `ddev composer create-project`) will create it.
```

Some previous test removes the files from the `TestCmdWordpress` directory.

The first appearance of 403 is in `TestCmdStartShowsMessages`

`TestCmdStartShowsMessages` uses `XDG_CONFIG_HOME`, I suppose it's related to XDG_CONFIG_HOME + Mutagen.

We already have `testcommon.CopyGlobalDdevDir(t)` and `testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)` that handle Mutagen daemon stop/start.

But a bunch of new tests don't use these functions.

Using several `mutagen` binaries leads to intermittent failures. 