### PR TITLE
docs: remove duplicate TYPO3 quickstart tab, fixes #7763 [skip buildkite]

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1120,33 +1120,6 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev launch /typo3/install.php
     ```
 
-=== "ddev typo3 setup"
-
-    ```bash
-    PROJECT_NAME=my-typo3-site
-    mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
-    ddev config --project-type=typo3 --docroot=public --php-version=8.3
-    ddev start
-    ddev composer create-project typo3/cms-base-distribution
-    ddev typo3 setup \
-        --admin-user-password="Demo123*" \
-        --driver=mysqli \
-        --create-site=https://${PROJECT_NAME}.ddev.site \
-        --server-type=other \
-        --dbname=db \
-        --username=db \
-        --password=db \
-        --port=3306 \
-        --host=db \
-        --admin-username=admin \
-        --admin-email=admin@example.com \
-        --project-name="demo TYPO3 site" \
-        --force
-
-    ddev launch /typo3/
-    # Log in with credentials above, admin/Demo123*
-    ```
-
 ## WordPress
 
 There are several easy ways to use DDEV with WordPress:


### PR DESCRIPTION
## The Issue

- #7763

The TYPO3 quickstart documentation had three tabs but the first "Composer" tab and third "ddev typo3 setup" tab were nearly identical, providing no meaningful distinction to users.

This duplication was introduced unintentionally when PR #7302 refactored the first "Composer" tab to use `ddev typo3 setup` CLI, making it functionally identical to the third tab which already used the same approach.

Removes the redundant third "ddev typo3 setup" tab from the TYPO3 quickstart section, leaving only the composer and git clone approaches.

This aligns with the pattern used by most other CMS quickstarts in the documentation.

Rendered at https://ddev--7764.org.readthedocs.build/en/7764/users/quickstart/#typo3

No test changes needed. The existing typo3.bats tests validate the underlying setup methods (automated vs manual) across different TYPO3 versions and are not affected by the documentation tab structure.

Documentation-only change. No code or functionality changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
