### PR TITLE
fix(postgres): run as container user instead of uid 999

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -10,7 +10,7 @@ services:
         BASE_IMAGE: $DDEV_DBIMAGE
         username: '{{ .Username }}'
         uid: '{{ .UID }}'
-        gid: {{ if ne .DBType "postgres" }} {{ .GID }} {{ else }} "999" {{ end }}
+        gid: '{{ .GID }}'
     image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
     cap_add:
       - SYS_NICE
@@ -33,8 +33,7 @@ services:
       - ddev-global-cache:/mnt/ddev-global-cache
     restart: "no"
 
-    # The postgres image is set up for user 999, we won't try to change that.
-    user: {{ if ne .DBType "postgres" }} '$DDEV_UID:$DDEV_GID' {{ else }} "999:999" {{end}}
+    user: '$DDEV_UID:$DDEV_GID'
     hostname: {{ .Name }}-db
     ports:
       - "{{ .DockerIP }}:$DDEV_HOST_DB_PORT:{{ .DBPort }}"

--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -3,6 +3,7 @@ package ddevapp
 import (
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
@@ -141,11 +142,10 @@ func (app *DdevApp) GetPostgresDataDir() string {
 	if app.Database.Type != nodeps.Postgres {
 		return ""
 	}
-
-	if slices.Contains([]string{nodeps.Postgres9, nodeps.Postgres10, nodeps.Postgres11, nodeps.Postgres12, nodeps.Postgres13, nodeps.Postgres14, nodeps.Postgres15, nodeps.Postgres16, nodeps.Postgres17}, app.Database.Version) {
+	v, _ := strconv.Atoi(app.Database.Version)
+	if v < 18 {
 		return "/var/lib/postgresql/data"
 	}
-
 	// Postgres 18+ changed the default mount point
 	// See https://github.com/docker-library/postgres/pull/1259
 	return "/var/lib/postgresql"

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -217,10 +217,6 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	// With bind mounts, they'll already be there in the /mnt/ddev_config/db_snapshots folder
 	if globalconfig.DdevGlobalConfig.NoBindMounts {
 		uid, _, _ := dockerutil.GetContainerUser()
-		// For PostgreSQL, must be written with PostgreSQL user
-		if app.Database.Type == nodeps.Postgres {
-			uid = "999"
-		}
 
 		// If the snapshot is an old-style directory-based snapshot, then we have to copy into a subdirectory
 		// named for the snapshot
@@ -240,18 +236,17 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 		postgresDataDir := app.GetPostgresDataDir()
 		postgresDataPath := app.GetPostgresDataPath()
 		confdDir := path.Join(nodeps.PostgresConfigDir, "conf.d")
-		targetConfName := path.Join(confdDir, "recovery.conf")
 		v, _ := strconv.Atoi(app.Database.Version)
-		// Before PostgreSQL v12 the recovery info went into its own file
-		if v < 12 {
-			targetConfName = path.Join(nodeps.PostgresConfigDir, "recovery.conf")
-		}
-
 		// PostgreSQL 18+ requires restore_command parameter, older versions use recovery.conf
 		if v >= 18 {
 			restoreCmd = fmt.Sprintf(`bash -c 'chmod 700 %s && mkdir -p %s && rm -rf %s/* && tar -C %s -zxf /mnt/snapshots/%s && chmod 700 %s && touch %s/recovery.signal && postgres -c config_file=%s/postgresql.conf -c hba_file=%s/pg_hba.conf -c restore_command=true'`, postgresDataDir, confdDir, postgresDataDir, postgresDataDir, snapshotFile, postgresDataPath, postgresDataPath, nodeps.PostgresConfigDir, nodeps.PostgresConfigDir)
 		} else {
-			restoreCmd = fmt.Sprintf(`bash -c 'chmod 700 %s && mkdir -p %s && rm -rf %s/* && tar -C %s -zxf /mnt/snapshots/%s && chmod 700 %s && touch %s/recovery.signal && cat /var/lib/postgresql/recovery.conf >>%s && postgres -c config_file=%s/postgresql.conf -c hba_file=%s/pg_hba.conf'`, postgresDataDir, confdDir, postgresDataDir, postgresDataDir, snapshotFile, postgresDataPath, postgresDataPath, targetConfName, nodeps.PostgresConfigDir, nodeps.PostgresConfigDir)
+			targetConfName := path.Join(confdDir, "recovery.conf")
+			// Before PostgreSQL v12 the recovery info went into its own file
+			if v < 12 {
+				targetConfName = path.Join(nodeps.PostgresConfigDir, "recovery.conf")
+			}
+			restoreCmd = fmt.Sprintf(`bash -c 'chmod 700 %s && mkdir -p %s && rm -rf %s/* && tar -C %s -zxf /mnt/snapshots/%s && chmod 700 %s && touch %s/recovery.signal && echo "restore_command = 'true'" >>%s && postgres -c config_file=%s/postgresql.conf -c hba_file=%s/pg_hba.conf'`, postgresDataDir, confdDir, postgresDataDir, postgresDataDir, snapshotFile, postgresDataPath, postgresDataPath, targetConfName, nodeps.PostgresConfigDir, nodeps.PostgresConfigDir)
 		}
 	}
 	_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", restoreCmd)


### PR DESCRIPTION
## The Issue

Using current artifacts from Podman PR:

- #7702

```
ddev config --project-name=d11 --database=postgres:18
ddev start
```

`.pgpass` and `recovery.conf` are copied from the image to the volume on the first start:

```
# ls -la /home/stas/.local/share/containers/storage/volumes/d11-postgres/_data
total 16
drwxrwxrwt 3 100998 100998 4096 Oct 26 02:24 .
drwx------ 3 stas   stas   4096 Oct 26 13:30 ..
drwxr-xr-x 3 stas   stas   4096 Oct 26 02:24 18
-rw------- 1 100998 100998   13 Oct 26 02:24 .pgpass

# ls -la /home/stas/.local/share/containers/storage/volumes/d11-postgres/_data/18/docker
total 12
drwxr-xr-x 2 stas stas 4096 Oct 26 02:24 .
drwxr-xr-x 3 stas stas 4096 Oct 26 02:24 ..
-rw-r--r-- 1 stas stas   25 Oct 26 02:24 recovery.conf
```

This leads to "chmod: Operation not permitted" and "initdb: error: directory exists but is not empty":

```
$ ddev logs -s db
chmod: changing permissions of '/var/lib/postgresql/18/docker': Operation not permitted
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.utf8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are enabled.

initdb: error: directory "/var/lib/postgresql/18/docker" exists but is not empty
initdb: hint: If you want to create a new database system, either remove or empty the directory "/var/lib/postgresql/18/docker" or run initdb with an argument other than "/var/lib/postgresql/18/docker".
```

This happens because `nocopy` doesn't work in Podman (even though it's passed there), it seems unimplemented:

```yaml
services:
  db:
    volumes:
      - type: volume
        source: database
        target: /var/lib/postgresql
        volume:
          nocopy: true
```

I confirmed this by comparing `docker container inspect ddev-d11-db` output - Podman doesn't have `NoCopy`.

## How This PR Solves The Issue

This PR removes `recovery.conf`, the logic works fine without it.

`/var/lib/postgresql` is `$HOME` for the `postgres` user:

- Starting from `postgres:18`, `/var/lib/postgresql/.pgpass` isn't used because the volume mount point is `/var/lib/postgresql` instead of `/var/lib/postgresql/data` (it's discarded by `nocopy: true` in the usual Docker setup).
- Also, `/var/lib/postgresql/.bash_history` becomes part of the volume, which we don't want.

This PR changes the PostgreSQL container user from `999:999` to a regular host user, simplifying the setup and ensuring that `~/.pgpass` is always available.

It should also fix the Podman + PostgreSQL issue by keeping `/var/lib/postgresql` empty.

## Manual Testing Instructions

```
ddev config --database=postgres:18
ddev start

# confirm your user
ddev exec -s db whoami

# navigate through the files, see correct ownership
ddev ssh -s db
```

Switch the binary to DDEV HEAD, run `ddev restart`, and confirm it still works.

Then switch the binary back to this PR and confirm it works again.

---

Alternatively, start Postgres with DDEV HEAD, switch to this PR binary, run `ddev restart`, and verify it still works.

---

Try the same thing using an alternative version of PostgreSQL.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
