### PR TITLE
chore(provider): remove trailing whitespace in YAML files

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml
@@ -31,13 +31,13 @@ db_import_command:
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     export MARIADB_HOST=db MARIADB_USERNAME=db MARIADB_PASSWORD=db MARIADB_DATABASE=db
-    lagoon-sync sync mariadb -p ${LAGOON_PROJECT} -e ${LAGOON_ENVIRONMENT} --no-interaction 
+    lagoon-sync sync mariadb -p ${LAGOON_PROJECT} -e ${LAGOON_ENVIRONMENT} --no-interaction
 
 files_import_command:
   command: |
     #set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
-    lagoon-sync sync files -p ${LAGOON_PROJECT} -e ${LAGOON_ENVIRONMENT} --no-interaction 
+    lagoon-sync sync files -p ${LAGOON_PROJECT} -e ${LAGOON_ENVIRONMENT} --no-interaction
 
 # push is very useful for non-production environments, but can be
 # very dangerous to production environments. If it is dangerous to your
@@ -47,7 +47,7 @@ db_push_command:
     set -eu -o pipefail
     #set -x   # You can enable bash debugging output by uncommenting
     export MARIADB_HOST=db MARIADB_USERNAME=db MARIADB_PASSWORD=db MARIADB_DATABASE=db
-    lagoon-sync sync mariadb -p ${LAGOON_PROJECT} -t ${LAGOON_ENVIRONMENT} -e local --no-interaction 
+    lagoon-sync sync mariadb -p ${LAGOON_PROJECT} -t ${LAGOON_ENVIRONMENT} -e local --no-interaction
 
 # push is very useful for non-production environments, but can be
 # very dangerous to production environments. If it is dangerous to your
@@ -56,4 +56,4 @@ files_push_command:
   command: |
     set -eu -o pipefail
     #set -x   # You can enable bash debugging output by uncommenting
-    lagoon-sync sync files -p ${LAGOON_PROJECT} -e local -t ${LAGOON_ENVIRONMENT} --no-interaction 
+    lagoon-sync sync files -p ${LAGOON_PROJECT} -e local -t ${LAGOON_ENVIRONMENT} --no-interaction

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
@@ -27,9 +27,9 @@
 #    ```
 #    You can also do this with `ddev config --web-environment-add="PANTHEON_SITE=yourproject,PANTHEON_ENVIRONMENT=dev"`.
 #
-#    You can usually use the site name, but in some environments you may need the site uuid, 
-#    which is the long 3rd component of your site dashboard URL. So if the site dashboard is at 
-#    <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>, 
+#    You can usually use the site name, but in some environments you may need the site uuid,
+#    which is the long 3rd component of your site dashboard URL. So if the site dashboard is at
+#    <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>,
 #    the site ID is 009a2cda-2c22-4eee-8f9d-96f017321555.
 #
 # 3. For `ddev push pantheon` make sure your public ssh key is configured in Pantheon (Account->SSH Keys)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

When building out the DDEV config, the provider .yaml files are saved with ending whitespace. While this is no issue, it does cause a diff to occur in linting with systems that aim to trim the ending whitespace. This would result in a small unneeded diff of removing the ending whitespace.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR removes the ending whitespace from those provider .yaml files so that linting doesn't report it.

## Manual Testing Instructions

No real testing is needed, but if you really wanted to test, do a search for ` \n` in the providers directory.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
No automated tests are needed, it's all just doc changes.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

- Trims ending whitespace in provider `.yaml` files
