### PR TITLE
fix: add blackfire-php reconfiguration for older PHP versions, fixes ddev/ddev-platformsh#142

### DIFF
--- a/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
@@ -3,8 +3,8 @@
 set -eu -o pipefail
 
 if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
-    echo "Usage: $0 <PHP_VERSION> <ARCH>"
-    exit 1
+  echo "Usage: $0 <PHP_VERSION> <ARCH>"
+  exit 1
 fi
 
 if ! command -v yq >/dev/null ; then
@@ -27,3 +27,8 @@ echo "Installing packages for PHP ${PHP_VERSION/php/} on ${ARCH}: $pkgs"
 apt-get update -o Acquire::Retries=5 -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
 apt-get update -o Acquire::Retries=5 -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
 DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?
+
+# Reconfigure blackfire-php if installed, to match the current PHP version
+if dpkg -s blackfire-php >/dev/null 2>&1; then
+  dpkg-reconfigure blackfire-php
+fi

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:20251006_rfay_php8.5 AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20251101_stasadev_blackfire AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20251006_rfay_php8.5" // Note that this can be overridden by make
+var WebTag = "20251101_stasadev_blackfire" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- Fixes ddev/ddev-platformsh#142

## How This PR Solves The Issue

Runs `dpkg-reconfigure blackfire-php`

## Manual Testing Instructions

```
ddev config --php-version=8.1
ddev php --version
ddev blackfire on
ddev php --version
```

```
PHP 8.1.33 (cli) (built: Jul  3 2025 16:25:40) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.33, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.33, Copyright (c), by Zend Technologies
    with blackfire v1.92.48~linux-x64-non_zts81, https://blackfire.io, by Blackfire
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
