### PR TITLE
build: bump docker-compose to v2.40.3, for #7678

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/amplitude/analytics-go v1.2.0
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/cheggaaa/pb/v3 v3.1.7
-	github.com/compose-spec/compose-go/v2 v2.9.0
+	github.com/compose-spec/compose-go/v2 v2.9.1
 	github.com/containerd/errdefs v1.0.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/cli v28.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
-github.com/compose-spec/compose-go/v2 v2.9.0 h1:UHSv/QHlo6QJtrT4igF1rdORgIUhDo1gWuyJUoiNNIM=
-github.com/compose-spec/compose-go/v2 v2.9.0/go.mod h1:Oky9AZGTRB4E+0VbTPZTUu4Kp+oEMMuwZXZtPPVT1iE=
+github.com/compose-spec/compose-go/v2 v2.9.1 h1:8UwI+ujNU+9Ffkf/YgAm/qM9/eU7Jn8nHzWG721W4rs=
+github.com/compose-spec/compose-go/v2 v2.9.1/go.mod h1:Oky9AZGTRB4E+0VbTPZTUu4Kp+oEMMuwZXZtPPVT1iE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -61,7 +61,7 @@ const RequiredMutagenVersion = "0.18.1"
 // RequiredDockerComposeVersionDefault defines the required version of docker-compose
 // Keep this in sync with github.com/compose-spec/compose-go/v2 in go.mod,
 // matching the version used in https://github.com/docker/compose/blob/main/go.mod for the same tag
-const RequiredDockerComposeVersionDefault = "v2.39.3"
+const RequiredDockerComposeVersionDefault = "v2.40.3"
 
 // ---
 // Fallback version derivation for developer builds not using the Makefile

--- a/vendor/github.com/compose-spec/compose-go/v2/loader/extends.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/loader/extends.go
@@ -81,13 +81,12 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 
 	var (
 		base      any
-		processor PostProcessor
+		processor PostProcessor = NoopPostProcessor{}
 	)
 
 	if file != nil {
 		refFilename := file.(string)
 		services, processor, err = getExtendsBaseFromFile(ctx, name, ref, filename, refFilename, opts, tracker)
-		post = append(post, processor)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +104,7 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 	}
 
 	// recursively apply `extends`
-	base, err = applyServiceExtends(ctx, ref, services, opts, tracker, post...)
+	base, err = applyServiceExtends(ctx, ref, services, opts, tracker, processor)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/compose-spec/compose-go/v2/loader/include.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/loader/include.go
@@ -177,6 +177,9 @@ func importResources(source map[string]any, target map[string]any) error {
 	if err := importResource(source, target, "configs"); err != nil {
 		return err
 	}
+	if err := importResource(source, target, "models"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/vendor/github.com/compose-spec/compose-go/v2/loader/loader.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/loader/loader.go
@@ -260,11 +260,13 @@ func WithProfiles(profiles []string) func(*Options) {
 // PostProcessor is used to tweak compose model based on metadata extracted during yaml Unmarshal phase
 // that hardly can be implemented using go-yaml and mapstructure
 type PostProcessor interface {
-	yaml.Unmarshaler
-
 	// Apply changes to compose model based on recorder metadata
 	Apply(interface{}) error
 }
+
+type NoopPostProcessor struct{}
+
+func (NoopPostProcessor) Apply(interface{}) error { return nil }
 
 // LoadConfigFiles ingests config files with ResourceLoader and returns config details with paths to local copies
 func LoadConfigFiles(ctx context.Context, configFiles []string, workingDir string, options ...func(*Options)) (*types.ConfigDetails, error) {

--- a/vendor/github.com/compose-spec/compose-go/v2/schema/compose-spec.json
+++ b/vendor/github.com/compose-spec/compose-go/v2/schema/compose-spec.json
@@ -531,19 +531,24 @@
             {"type": "object",
               "patternProperties": {
                 "^[a-zA-Z0-9._-]+$": {
-                  "type": "object",
-                  "properties": {
-                    "endpoint_var": {
-                      "type": "string",
-                      "description": "Environment variable set to AI model endpoint."
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "endpoint_var": {
+                          "type": "string",
+                          "description": "Environment variable set to AI model endpoint."
+                        },
+                        "model_var": {
+                          "type": "string",
+                          "description": "Environment variable set to AI model name."
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {"^x-": {}}
                     },
-                    "model_var": {
-                      "type": "string",
-                      "description": "Environment variable set to AI model name."
-                    }
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {"^x-": {}}
+                    {"type": "null"}
+                  ]
                 }
               }
             }

--- a/vendor/github.com/compose-spec/compose-go/v2/types/types.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/types/types.go
@@ -145,7 +145,7 @@ type ServiceConfig struct {
 }
 
 type ServiceProviderConfig struct {
-	Type       string       `yaml:"type,omitempty" json:"driver,omitempty"`
+	Type       string       `yaml:"type,omitempty" json:"type,omitempty"`
 	Options    MultiOptions `yaml:"options,omitempty" json:"options,omitempty"`
 	Extensions Extensions   `yaml:"#extensions,inline,omitempty" json:"-"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,7 +51,7 @@ github.com/cheggaaa/pb/v3/termutil
 # github.com/chzyer/readline v1.5.1
 ## explicit; go 1.15
 github.com/chzyer/readline
-# github.com/compose-spec/compose-go/v2 v2.9.0
+# github.com/compose-spec/compose-go/v2 v2.9.1
 ## explicit; go 1.23
 github.com/compose-spec/compose-go/v2/consts
 github.com/compose-spec/compose-go/v2/dotenv


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/issues/7678#issuecomment-3462264611

`docker-compose` v2.40.3 is out.

## How This PR Solves The Issue

- Updates `docker-compose` to v2.40.3
- Updates `github.com/compose-spec/compose-go/v2` to stay in sync with `docker-compose`
- Fixes a bug that caused `ddev start` to hang on macOS (permissions for temp directory)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
