### PR TITLE
docs: add crosslink for shortened DDEV env variables to full list, fixes #7781

### DIFF
--- a/docs/content/users/extend/custom-docker-services.md
+++ b/docs/content/users/extend/custom-docker-services.md
@@ -249,15 +249,18 @@ services:
 
 ### Available DDEV Variables
 
-Use these variables in your service definitions:
+Here is a compressed list of commonly used variables in your service definitions:
 
 - `${DDEV_SITENAME}` - Project name
-- `${DDEV_HOSTNAME}` - Primary hostname
+- `${DDEV_HOSTNAME}` - Comma-separated list of FQDN hostnames
+- `${DDEV_TLD}` - Default top-level domain (`ddev.site`)
 - `${DDEV_APPROOT}` - Full path to project root
 - `${DDEV_DOCROOT}` - Document root (relative to project root)
 - `${DDEV_PHP_VERSION}` - PHP version
 - `${DDEV_WEBSERVER_TYPE}` - Web server type
 - `${DDEV_DATABASE_FAMILY}` - Database family (`mysql`, `postgres`)
+
+For a full list, please see [Environment Variables Provided](custom-commands.md#environment-variables-provided).
 
 ### Custom Environment Variables
 


### PR DESCRIPTION
## The Issue

- #7781

The list on https://docs.ddev.com/en/stable/users/extend/custom-docker-services/#environment-variables-and-configuration does only contain an excerpt of existing variables, and gives the impression this list could be exhaustive.

## How This PR Solves The Issue

A link to https://docs.ddev.com/en/stable/users/extend/custom-commands/#environment-variables-provided  is added, and the introduction reworded to hint at this being a shortened list.

## Manual Testing Instructions

Build docs, read docs.

## Automated Testing Overview

Docs, I think no tests are needed

## Release/Deployment Notes

It's only words and words are all I have
To take your heart away