### PR TITLE
test(quickstart): add disk cleanup before running tests

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -46,6 +46,17 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
 
+      - name: Remove unnecessary items on disk
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - name: Install Docker and deps (Linux)
         run: ./.github/workflows/linux-setup.sh
 


### PR DESCRIPTION
## The Issue

Magento 2 test fails https://github.com/ddev/ddev/actions/runs/18999217705/job/54268160871:

```
...
#   Module 'Magento_ConfigurableSampleData':
#   Running data recurring...{"error":{"root_cause":[{"type":"index_create_block_exception","reason":"blocked by: [FORBIDDEN/10/cluster create-index blocked (api)];"}],"type":"index_create_block_exception","reason":"blocked by: [FORBIDDEN/10/cluster create-index blocked (api)];"},"status":403}
#   Failed to run magento setup:upgrade: exit status 1
```

One of the reasons for this may be the lack of disk space on GitHub runner.

https://repost.aws/knowledge-center/opensearch-403-clusterblockexception

> If one or more nodes in your cluster has storage space less than the minimum value of 1) 20% of available storage space, or 2) 20 GiB of storage space, basic write operations like adding documents and creating indexes can start to fail.

## How This PR Solves The Issue

Adds disk cleanup step.

## Manual Testing Instructions

https://github.com/stasadev/ddev/actions/runs/19005762874/job/54278963164

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
