### PR TITLE
fix(self-upgrade): add docs for updating ddev package only, fixes #7785

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -37,8 +37,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         Use the `-s` argument to specify a specific stable or prerelease version:
 
         ```bash
-        # Download and run the script to install DDEV v1.23.5
-        curl -fsSL https://ddev.com/install.sh | bash -s v1.23.5
+        # Download and run the script to install DDEV v1.24.9
+        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.9
         ```
 
 === "Linux"
@@ -92,7 +92,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     name=ddev
     baseurl=https://pkg.ddev.com/yum/
     gpgcheck=0
-    enabled=1' | perl -p -e 's/^ +//' | sudo tee /etc/yum.repos.d/ddev.repo >/dev/null
+    enabled=1' | sed 's/^ \+//' | sudo tee /etc/yum.repos.d/ddev.repo >/dev/null
 
     # Install DDEV
     sudo sh -c 'echo ""'
@@ -148,8 +148,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         Use the `-s` argument to specify a specific stable or prerelease version:
 
         ```bash
-        # Download and run the script to install DDEV v1.23.5
-        curl -fsSL https://ddev.com/install.sh | bash -s v1.23.5
+        # Download and run the script to install DDEV v1.24.9
+        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.9
         ```
 
     ??? "Do you still have an old version after installing or upgrading?"

--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -13,7 +13,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Upgrade DDEV to the latest version
-    brew upgrade ddev/ddev/ddev
+    brew update && brew upgrade ddev/ddev/ddev
     ```
 
     ### Install Script (Unusual)
@@ -31,8 +31,8 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
         Use the `-s` argument to specify a specific stable or prerelease version:
 
         ```bash
-        # Download and run the script to update to DDEV v1.24.6
-        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.6
+        # Download and run the script to update to DDEV v1.24.9
+        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.9
         ```
 
 === "Linux"
@@ -42,15 +42,18 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     ### Debian/Ubuntu (including WSL2)
 
     ```bash
-    # Update package information and all packages including DDEV
-    sudo apt-get update && sudo apt-get upgrade
+    # Update package information and ddev package
+    sudo apt-get update && sudo apt-get install --only-upgrade ddev
+
+    # If you are using WSL2, also upgrade the ddev-wsl2 package
+    sudo apt-get update && sudo apt-get install --only-upgrade ddev ddev-wsl2
     ```
 
     ### Fedora, Red Hat, etc.
 
     ```bash
     # Upgrade the DDEV package
-    sudo dnf upgrade ddev
+    sudo dnf upgrade --refresh ddev
     ```
 
     ### Arch Linux
@@ -75,8 +78,8 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     Open the WSL2 terminal, for example “Ubuntu” from the Windows start menu, and run the following:
 
     ```bash
-    # Upgrade the DDEV package
-    sudo apt-get update && sudo apt-get upgrade -y
+    # Update package information and ddev packages
+    sudo apt-get update && sudo apt-get install --only-upgrade ddev ddev-wsl2
     ```
 
     You can also download and run the DDEV Windows Installer again, and it will do the upgrade for you. Make sure to choose the type of installation you have (Docker CE or Docker/Rancher Desktop).
@@ -94,8 +97,8 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     ## GitHub Codespaces
 
     ```bash
-    # Update package information and all packages including DDEV
-    sudo apt-get update && sudo apt-get upgrade -y
+    # Update package information and ddev package
+    sudo apt-get update && sudo apt-get install --only-upgrade ddev
     ```
 
 === "Manual"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -13,23 +13,31 @@ for ddev_path in $(which -a ddev | uniq); do
   case $ddev_path in
     "/usr/bin/ddev")
       if [[ ${OSTYPE} = "linux-gnu"* ]]; then
-        if command -v apt-get; then echo "You seem to have an apt-installed DDEV, upgrade with 'sudo apt-get update && sudo apt-get upgrade -y ddev'";
-        elif [ -f /etc/arch-release ] && command -v yay >/dev/null ; then echo "You seem to have yay-installed DDEV (AUR), upgrade with 'yay -Syu ddev-bin'";
-        elif command -v dnf; then echo "You seem to have dnf-installed DDEV, upgrade with 'sudo dnf install --refresh ddev'"; fi
+        packages_to_upgrade="ddev"
+        if [[ -f "/usr/bin/ddev-hostname.exe" ]]; then
+          packages_to_upgrade="$packages_to_upgrade ddev-wsl2"
+        fi
+        if command -v apt-get; then
+          echo "You seem to have an apt-installed DDEV, upgrade with 'sudo apt-get update && sudo apt-get install --only-upgrade ${packages_to_upgrade}'"
+        elif [ -f /etc/arch-release ]; then
+          echo "You seem to have an AUR-installed DDEV, upgrade with your AUR helper, for example, 'yay -Syu ddev-bin'"
+        elif command -v dnf; then
+          echo "You seem to have dnf-installed DDEV, upgrade with 'sudo dnf upgrade --refresh ${packages_to_upgrade}'"
+        fi
       fi
       ;;
 
     "/usr/local/bin/ddev")
       if [ ! -L /usr/local/bin/ddev ]; then
-        printf "DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.\ncurl -fsSL https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh | bash\n"
+        printf "DDEV appears to have been installed with a script, run it again for upgrade.\ncurl -fsSL https://ddev.com/install.sh | bash\n"
       elif command -v brew; then
-        echo "DDEV appears to have been installed with Homebrew, upgrade with 'brew update && brew upgrade ddev'"
+        echo "DDEV appears to have been installed with Homebrew, upgrade with 'brew update && brew upgrade ddev/ddev/ddev'"
       fi
       ;;
 
     "/opt/homebrew/bin/ddev" | "/home/linuxbrew/.linuxbrew/bin/ddev")
       if [ -L "$(which ddev)" ] && command -v brew; then
-        echo "DDEV appears to have been installed with Homebrew, upgrade with 'brew update && brew upgrade ddev'"
+        echo "DDEV appears to have been installed with Homebrew, upgrade with 'brew update && brew upgrade ddev/ddev/ddev'"
       fi
       ;;
 


### PR DESCRIPTION
## The Issue

- #7785

## How This PR Solves The Issue

Updates `apt` and `dnf` instructions to upgrade only `ddev` (and `ddev-wsl2` in case of using WSL2).

## Manual Testing Instructions

```
ddev self-upgrade
```

https://ddev--7787.org.readthedocs.build/en/7787/users/install/ddev-installation/#linux

https://ddev--7787.org.readthedocs.build/en/7787/users/install/ddev-upgrade/#upgrading-ddev-linux

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
