### PR TITLE
docs(sponsor-banner): add link to sustainability article

### DIFF
--- a/docs/overrides/partials/sponsors-banner.html
+++ b/docs/overrides/partials/sponsors-banner.html
@@ -103,13 +103,28 @@
     text-decoration: none;
   }
 
-  .ddev-sponsor-banner__cta {
+  .ddev-sponsor-banner__cta a,
+  .ddev-sponsor-banner__cta span {
     font-weight: bold;
+    text-decoration: none;
+    color: #ffffff;
   }
 
-  .ddev-sponsor-banner__cta a {
-    text-decoration: none;
-    color: inherit;
+  .ddev-sponsor-banner__cta a:hover {
+    color: #0298cf;
+  }
+
+  .ddev-sponsor-banner__cta a::after {
+    content: '';
+    display: inline-block;
+    width: 0.9em;
+    height: 0.9em;
+    margin-left: 0.25em;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='white'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25'/%3E%3C/svg%3E");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    vertical-align: baseline;
   }
 
   @media (max-width: 700px) {
@@ -145,7 +160,7 @@
         <div class="ddev-sponsor-banner__progress-section">
           <div class="ddev-sponsor-banner__progress-header">
             <span id="percent-desktop">0% of monthly goal</span>
-            <span class="ddev-sponsor-banner__cta"><a href="https://ddev.com/blog/sustainability-for-ddev/">Help us cross the finish line! &UpperRightArrow;</a></span>
+            <span class="ddev-sponsor-banner__cta"><a href="https://ddev.com/blog/sustainability-for-ddev/">Help us cross the finish line!</a></span>
           </div>
           <div class="ddev-sponsor-banner__progress-bar">
             <div class="ddev-sponsor-banner__progress-fill" id="progress-desktop" style="width: 0"></div>
@@ -165,7 +180,7 @@
         </div>
         <div class="ddev-sponsor-banner__meta-row">
           <span id="percent-mobile">0% of monthly goal</span>
-          <span class="ddev-sponsor-banner__cta"><a href="https://ddev.com/blog/sustainability-for-ddev/">Help us cross the finish line! &UpperRightArrow;</a></span>
+          <span class="ddev-sponsor-banner__cta"><a href="https://ddev.com/blog/sustainability-for-ddev/">Help us cross the finish line!</a></span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/sponsorship-data/issues/14

## How This PR Solves The Issue

Adds a link to https://ddev.com/blog/sustainability-for-ddev/

## Manual Testing Instructions

https://ddev--7788.org.readthedocs.build/en/7788/

<img width="215" height="61" alt="image" src="https://github.com/user-attachments/assets/141764a4-bb8e-4f4a-a3d4-7a75c0360b7c" />

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
