### PR TITLE
fix: write download result to stderr for docker-compose and mutagen [skip ci]

### DIFF
--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -547,7 +547,7 @@ func DownloadMutagen() error {
 		_ = os.Remove(destFile)
 		return err
 	}
-	output.UserOut.Printf("Download complete.")
+	output.UserErr.Printf("Download complete.")
 
 	err = archive.Untar(destFile, globalMutagenDir, "")
 	_ = os.Remove(destFile)

--- a/pkg/dockerutil/docker_compose.go
+++ b/pkg/dockerutil/docker_compose.go
@@ -274,7 +274,7 @@ func DownloadDockerCompose() error {
 		_ = os.Remove(destFile)
 		return err
 	}
-	output.UserOut.Printf("Download complete.")
+	output.UserErr.Printf("Download complete.")
 
 	// Remove the cached DockerComposeVersion
 	globalconfig.DockerComposeVersion = ""


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/github-action-setup-ddev/pull/57

The output has `{"level":"info","msg":"Download complete.","time":"2025-11-04T15:37:53+02:00"}`, which can break `ddev describe -j`:

```
$ rm -f .ddev/.ddev-docker-compose-full.yaml ~/.ddev/bin/docker-compose
$ ddev describe -j 2>/dev/null
{"level":"info","msg":"Download complete.","time":"2025-11-04T15:37:53+02:00"}
{"level":"info","msg":"┌────────────────────────────────────────────────────────────────────────────────────┐\n│ Project..."}
```

This happened after this change:

- #7768

## How This PR Solves The Issue

Moves `Download complete.` to stderr.

## Manual Testing Instructions

```
rm -f .ddev/.ddev-docker-compose-full.yaml ~/.ddev/bin/docker-compose
ddev describe -j 2>/dev/null
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
