### PR TITLE
build(docker): bump images to v1.24.10 for release

### DIFF
--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Base tag for pushed dbimage (v1.24.9 for example)'
+        description: Base tag for pushed dbimage (v1.25.0 for example)'
         required: true
         default: ""
       debug_enabled:

--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -19,7 +19,7 @@ on:
           - ddev-xhgui
           - test-ssh-server
       tag:
-        description: Tag for pushed image (v1.24.9 for example)
+        description: Tag for pushed image (v1.25.0 for example)
         required: true
         default: ""
       debug_enabled:

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:v1.24.9 AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:v1.24.10 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -181,7 +181,7 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
     # Adding external_links allows connections to `https://example.ddev.site`,
     # which then can go through `ddev-router`
-    # Tip: external_links are not needed anymore in DDEV v1.24.9+
+    # Tip: external_links are not needed anymore in DDEV v1.24.10+
     external_links:
       - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
     labels:

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -37,8 +37,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         Use the `-s` argument to specify a specific stable or prerelease version:
 
         ```bash
-        # Download and run the script to install DDEV v1.24.9
-        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.9
+        # Download and run the script to install DDEV v1.24.10
+        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.10
         ```
 
 === "Linux"
@@ -148,8 +148,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         Use the `-s` argument to specify a specific stable or prerelease version:
 
         ```bash
-        # Download and run the script to install DDEV v1.24.9
-        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.9
+        # Download and run the script to install DDEV v1.24.10
+        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.10
         ```
 
     ??? "Do you still have an old version after installing or upgrading?"

--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -31,8 +31,8 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
         Use the `-s` argument to specify a specific stable or prerelease version:
 
         ```bash
-        # Download and run the script to update to DDEV v1.24.9
-        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.9
+        # Download and run the script to update to DDEV v1.24.10
+        curl -fsSL https://ddev.com/install.sh | bash -s v1.24.10
         ```
 
 === "Linux"

--- a/docs/content/users/usage/managing-projects.md
+++ b/docs/content/users/usage/managing-projects.md
@@ -193,7 +193,7 @@ ddev exec mysql -h ddev-backend-db
 
 Example: two projects, `backend` and `frontend`.
 
-From v1.24.9+, DDEV supports direct HTTP/S calls between projects:
+From v1.24.10+, DDEV supports direct HTTP/S calls between projects:
 
 ```bash
 # From frontend web container to backend web container

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,31 +20,31 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.24.9" // Note that this can be overridden by make
+var WebTag = "v1.24.10" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.24.9"
+var BaseDBTag = "v1.24.10"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "v1.24.9"
+var TraefikRouterTag = "v1.24.10"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.24.9"
+var SSHAuthTag = "v1.24.10"
 
 // XhguiImage is image for xhgui
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "v1.24.9"
+var XhguiTag = "v1.24.10"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities:latest"


### PR DESCRIPTION
## The Issue

We need to make a hotfix release, v1.24.9 broke CI environments setup for custom project TLDs:

- #7790

## How This PR Solves The Issue

Replaces all v1.24.9 mentions with v1.24.10

Moves Docker tags to v1.24.10:

```
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-5.5:v1.24.10 ddev/ddev-dbserver-mariadb-5.5:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.0:v1.24.10 ddev/ddev-dbserver-mariadb-10.0:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.1:v1.24.10 ddev/ddev-dbserver-mariadb-10.1:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.2:v1.24.10 ddev/ddev-dbserver-mariadb-10.2:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.3:v1.24.10 ddev/ddev-dbserver-mariadb-10.3:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.4:v1.24.10 ddev/ddev-dbserver-mariadb-10.4:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.5:v1.24.10 ddev/ddev-dbserver-mariadb-10.5:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.6:v1.24.10 ddev/ddev-dbserver-mariadb-10.6:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.7:v1.24.10 ddev/ddev-dbserver-mariadb-10.7:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.8:v1.24.10 ddev/ddev-dbserver-mariadb-10.8:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.11:v1.24.10 ddev/ddev-dbserver-mariadb-10.11:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-11.4:v1.24.10 ddev/ddev-dbserver-mariadb-11.4:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-11.8:v1.24.10 ddev/ddev-dbserver-mariadb-11.8:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-5.5:v1.24.10 ddev/ddev-dbserver-mysql-5.5:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-5.6:v1.24.10 ddev/ddev-dbserver-mysql-5.6:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-5.7:v1.24.10 ddev/ddev-dbserver-mysql-5.7:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-8.0:v1.24.10 ddev/ddev-dbserver-mysql-8.0:v1.24.9
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-8.4:v1.24.10 ddev/ddev-dbserver-mysql-8.4:v1.24.9
docker buildx imagetools create -t ddev/ddev-ssh-agent:v1.24.10 ddev/ddev-ssh-agent:v1.24.9
docker buildx imagetools create -t ddev/ddev-traefik-router:v1.24.10 ddev/ddev-traefik-router:v1.24.9
docker buildx imagetools create -t ddev/ddev-xhgui:v1.24.10 ddev/ddev-xhgui:v1.24.9
docker buildx imagetools create -t ddev/ddev-php-base:v1.24.10 ddev/ddev-php-base:v1.24.9
docker buildx imagetools create -t ddev/ddev-php-prod:v1.24.10 ddev/ddev-php-prod:v1.24.9
docker buildx imagetools create -t ddev/ddev-webserver:v1.24.10 ddev/ddev-webserver:v1.24.9
docker buildx imagetools create -t ddev/ddev-webserver-prod:v1.24.10 ddev/ddev-webserver-prod:v1.24.9
```

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
