### PR TITLE
build: add mkcert to artifacts, for #7794

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -310,6 +310,7 @@ jobs:
           path: |
             .gotmp/bin/darwin_amd64/ddev
             .gotmp/bin/darwin_amd64/ddev-hostname
+            .gotmp/bin/darwin_amd64/mkcert
       - name: Upload macos-arm64 binary
         uses: actions/upload-artifact@v5
         with:
@@ -317,6 +318,7 @@ jobs:
           path: |
             .gotmp/bin/darwin_arm64/ddev
             .gotmp/bin/darwin_arm64/ddev-hostname
+            .gotmp/bin/darwin_arm64/mkcert
       - name: Upload linux-arm64 binary
         uses: actions/upload-artifact@v5
         with:
@@ -324,6 +326,7 @@ jobs:
           path: |
             .gotmp/bin/linux_arm64/ddev
             .gotmp/bin/linux_arm64/ddev-hostname
+            .gotmp/bin/linux_arm64/mkcert
       - name: Upload linux-amd64 binary
         uses: actions/upload-artifact@v5
         with:
@@ -331,6 +334,7 @@ jobs:
           path: |
             .gotmp/bin/linux_amd64/ddev
             .gotmp/bin/linux_amd64/ddev-hostname
+            .gotmp/bin/linux_amd64/mkcert
       - name: Upload windows-amd64 binary
         uses: actions/upload-artifact@v5
         with:
@@ -338,6 +342,7 @@ jobs:
           path: |
             .gotmp/bin/windows_amd64/ddev.exe
             .gotmp/bin/windows_amd64/ddev-hostname.exe
+            .gotmp/bin/windows_amd64/mkcert.exe
 
       - name: Upload windows_amd64 installer
         uses: actions/upload-artifact@v5
@@ -351,6 +356,7 @@ jobs:
           path: |
             .gotmp/bin/windows_arm64/ddev.exe
             .gotmp/bin/windows_arm64/ddev-hostname.exe
+            .gotmp/bin/windows_arm64/mkcert.exe
       - name: Upload windows_arm64 installer
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -78,6 +78,7 @@ jobs:
           path: |
             .gotmp/bin/darwin_amd64/ddev
             .gotmp/bin/darwin_amd64/ddev-hostname
+            .gotmp/bin/darwin_amd64/mkcert
       - name: Upload macos-arm64 binary
         uses: actions/upload-artifact@v5
         with:
@@ -85,6 +86,7 @@ jobs:
           path: |
             .gotmp/bin/darwin_arm64/ddev
             .gotmp/bin/darwin_arm64/ddev-hostname
+            .gotmp/bin/darwin_arm64/mkcert
       - name: Upload linux-arm64 binary
         uses: actions/upload-artifact@v5
         with:
@@ -92,6 +94,7 @@ jobs:
           path: |
             .gotmp/bin/linux_arm64/ddev
             .gotmp/bin/linux_arm64/ddev-hostname
+            .gotmp/bin/linux_arm64/mkcert
       - name: Upload linux-amd64 binary
         uses: actions/upload-artifact@v5
         with:
@@ -99,6 +102,7 @@ jobs:
           path: |
             .gotmp/bin/linux_amd64/ddev
             .gotmp/bin/linux_amd64/ddev-hostname
+            .gotmp/bin/linux_amd64/mkcert
       - name: Upload windows-amd64 binary
         uses: actions/upload-artifact@v5
         with:
@@ -106,6 +110,7 @@ jobs:
           path: |
             .gotmp/bin/windows_amd64/ddev.exe
             .gotmp/bin/windows_amd64/ddev-hostname.exe
+            .gotmp/bin/windows_amd64/mkcert.exe
       - name: Upload windows_amd64 installer
         uses: actions/upload-artifact@v5
         with:
@@ -118,6 +123,7 @@ jobs:
           path: |
             .gotmp/bin/windows_arm64/ddev.exe
             .gotmp/bin/windows_arm64/ddev-hostname.exe
+            .gotmp/bin/windows_arm64/mkcert.exe
       - name: Upload windows_arm64 installer
         uses: actions/upload-artifact@v5
         with:


### PR DESCRIPTION
## The Issue

- #7794

It turned out that we only have `mkcert` in the `all-ddev-executables.zip` artifacts, but not in individual ones.

## How This PR Solves The Issue

Adds `mkcert` binary.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
