### PR TITLE
test: Allow overriding ignore expiring keys [skip buildkite]

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -33,11 +33,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DDEV_IGNORE_EXPIRING_KEYS: "false"
-  # Unfortunately, we can't test forked PRs with the secret that's provided for this
-  # So it has to be hard-wired here. Needs to be switched back to "90" after mysql
-  # key is updated, see https://github.com/docker-library/mysql/issues/801
-  DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION: "90"
+  DDEV_IGNORE_EXPIRING_KEYS: ${{ vars.DDEV_IGNORE_EXPIRING_KEYS || 'false' }}
+  DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION: ${{ vars.DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION || '90' }}
   HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:


### PR DESCRIPTION

## The Issue

The deb.sury.org signing key will expire in less than 90 days, so tests are failing, https://codeberg.org/oerdnj/deb.sury.org/issues/34

But we need to wait for that to be resolved.

Unfortunately we can't currently override with github action environment variables

## How This PR Solves The Issue

Set defaults for variables

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
