### PR TITLE
chore(traefik): Remove redundant Traefik rule syntax configuration, fixes #7822

### DIFF
--- a/containers/ddev-traefik-router/test/testdata/config/d11.yaml
+++ b/containers/ddev-traefik-router/test/testdata/config/d11.yaml
@@ -5,7 +5,6 @@ http:
         - http-80
       rule: HostRegexp(`^d11\.ddev\.site$`)
       service: "d11-web-80"
-      ruleSyntax: v3
       tls: false
 
   services:

--- a/pkg/ddevapp/testdata/TestTraefikStaticConfig/extraPlugin/expectation.yaml
+++ b/pkg/ddevapp/testdata/TestTraefikStaticConfig/extraPlugin/expectation.yaml
@@ -13,8 +13,6 @@ certificatesResolvers:
       email: ""
       storage: /mnt/ddev-global-cache/traefik/acme.json
       tlsChallenge: {}
-core:
-  defaultRuleSyntax: v2
 entryPoints:
   http-80:
     address: :80

--- a/pkg/ddevapp/testdata/TestTraefikStaticConfig/logChange/expectation.yaml
+++ b/pkg/ddevapp/testdata/TestTraefikStaticConfig/logChange/expectation.yaml
@@ -7,8 +7,6 @@ certificatesResolvers:
       email: ""
       storage: /mnt/ddev-global-cache/traefik/acme.json
       tlsChallenge: {}
-core:
-  defaultRuleSyntax: v2
 entryPoints:
   http-80:
     address: :80

--- a/pkg/ddevapp/traefik_config_template.yaml
+++ b/pkg/ddevapp/traefik_config_template.yaml
@@ -16,7 +16,6 @@ http:
       rule: {{ $length := len $s.ExternalHostnames }}{{ range $i, $h := $s.ExternalHostnames }}Host(`{{$h}}`){{if lt $i (sub $length 1)}} || {{end}}{{end}}
       {{ end }}
       service: "{{$appname}}-{{$s.Service.InternalServiceName}}-{{$s.Service.InternalServicePort}}"
-      ruleSyntax: v3
       tls: false
       # middlewares:
       #   - "{{ $.App.Name }}-redirectHttps"
@@ -32,7 +31,6 @@ http:
       rule: {{ $length := len $s.ExternalHostnames }}{{ range $i, $h := $s.ExternalHostnames }}Host(`{{$h}}`){{if lt $i (sub $length 1)}} || {{end}}{{end}}
       {{ end }}
       service: "{{$appname}}-{{$s.Service.InternalServiceName}}-{{$s.Service.InternalServicePort}}"
-      ruleSyntax: v3
       {{ if not $.UseLetsEncrypt }}
       tls: true
       {{ else }}

--- a/pkg/ddevapp/traefik_static_config_template.yaml
+++ b/pkg/ddevapp/traefik_static_config_template.yaml
@@ -15,9 +15,6 @@ api:
   dashboard: true
   insecure: true
 
-core:
-  defaultRuleSyntax: v2
-
 certificatesResolvers:
   acme-tlsChallenge:
     acme:

--- a/pkg/util/testdata/TestMergeYamlFiles/Overrides/base.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/Overrides/base.yaml
@@ -12,9 +12,6 @@ api:
   dashboard: true
   insecure: true
 
-core:
-  defaultRuleSyntax: v2
-
 certificatesResolvers:
   acme-tlsChallenge:
     acme:

--- a/pkg/util/testdata/TestMergeYamlFiles/Overrides/expectation.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/Overrides/expectation.yaml
@@ -12,9 +12,6 @@ certificatesResolvers:
     acme:
       dnsChallenge:
         provider: cloudflare
-core:
-# defaultRuleSyntax overwritten to v3 in extra_overwrites_1
-  defaultRuleSyntax: v3
 entryPoints:
   http-80:
     address: :80

--- a/pkg/util/testdata/TestMergeYamlFiles/Overrides/extra_overrides_1.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/Overrides/extra_overrides_1.yaml
@@ -1,5 +1,2 @@
 log:
   level: INFO
-
-core:
-  defaultRuleSyntax: v3

--- a/pkg/util/testdata/TestMergeYamlFiles/baseFileOnly/base.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/baseFileOnly/base.yaml
@@ -12,9 +12,6 @@ api:
   dashboard: true
   insecure: true
 
-core:
-  defaultRuleSyntax: v2
-
 certificatesResolvers:
   acme-tlsChallenge:
     acme:

--- a/pkg/util/testdata/TestMergeYamlFiles/baseFileOnly/expectation.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/baseFileOnly/expectation.yaml
@@ -12,9 +12,6 @@ api:
   dashboard: true
   insecure: true
 
-core:
-  defaultRuleSyntax: v2
-
 certificatesResolvers:
   acme-tlsChallenge:
     acme:

--- a/pkg/util/testdata/TestMergeYamlFiles/baseWithCertificatesResolvers/base.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/baseWithCertificatesResolvers/base.yaml
@@ -12,9 +12,6 @@ api:
   dashboard: true
   insecure: true
 
-core:
-  defaultRuleSyntax: v2
-
 certificatesResolvers:
   acme-tlsChallenge:
     acme:

--- a/pkg/util/testdata/TestMergeYamlFiles/baseWithCertificatesResolvers/expectation.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/baseWithCertificatesResolvers/expectation.yaml
@@ -12,8 +12,6 @@ certificatesResolvers:
     acme:
       dnsChallenge:
         provider: cloudflare
-core:
-  defaultRuleSyntax: v2
 entryPoints:
   http-80:
     address: :80

--- a/pkg/util/testdata/TestMergeYamlFiles/baseWithPlugins/base.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/baseWithPlugins/base.yaml
@@ -12,9 +12,6 @@ api:
   dashboard: true
   insecure: true
 
-core:
-  defaultRuleSyntax: v2
-
 certificatesResolvers:
   acme-tlsChallenge:
     acme:

--- a/pkg/util/testdata/TestMergeYamlFiles/baseWithPlugins/expectation.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/baseWithPlugins/expectation.yaml
@@ -8,8 +8,6 @@ certificatesResolvers:
       email: ""
       storage: /mnt/ddev-global-cache/traefik/acme.json
       tlsChallenge: {}
-core:
-  defaultRuleSyntax: v2
 entryPoints:
   http-80:
     address: :80

--- a/pkg/util/testdata/TestMergeYamlFiles/caServerOverride/base.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/caServerOverride/base.yaml
@@ -12,9 +12,6 @@ api:
   dashboard: true
   insecure: true
 
-core:
-  defaultRuleSyntax: v2
-
 certificatesResolvers:
   acme-tlsChallenge:
     acme:

--- a/pkg/util/testdata/TestMergeYamlFiles/caServerOverride/expectation.yaml
+++ b/pkg/util/testdata/TestMergeYamlFiles/caServerOverride/expectation.yaml
@@ -14,8 +14,6 @@ certificatesResolvers:
       caServer: https://acme-staging-v02.api.letsencrypt.org/directory
       dnsChallenge:
         provider: cloudflare
-core:
-  defaultRuleSyntax: v2
 entryPoints:
   http-80:
     address: :80


### PR DESCRIPTION
## The Issue

* #7822

Issue #7822 identified unnecessary configuration duplication in Traefik setup. DDEV was setting `defaultRuleSyntax: v2` in the global Traefik static configuration, then overriding it with `ruleSyntax: v3` in each project's Traefik config.

## How This PR Solves The Issue

This change eliminates the redundant rule syntax configuration by:

1. Removing the `core: defaultRuleSyntax: v2` section from `pkg/ddevapp/traefik_static_config_template.yaml`
2. Removing explicit `ruleSyntax: v3` declarations from `pkg/ddevapp/traefik_config_template.yaml` (both HTTP and HTTPS routers)
3. Updating all test data files to reflect the new configuration structure

With these changes, Traefik uses its native v3 default rule syntax without requiring explicit configuration, simplifying the codebase and reducing maintenance overhead.

## Manual Testing Instructions

1. Start a DDEV project: `ddev start`
2. Verify that Traefik routing works correctly by accessing the project URL
3. Check the generated Traefik config files in `.ddev-global-cache/traefik/` to confirm `defaultRuleSyntax` is absent
4. Test with multiple hostnames and additional_hostnames to ensure routing still works

## Automated Testing Overview

- Updated 14 test data files to reflect the new configuration structure
- All YAML merge tests pass: `go test -v ./pkg/util -run TestMergeYamlFiles`
- golangci-lint passes with 0 issues

## Release/Deployment Notes

This is part of the DDEV v1.25.0 cleanup and deprecation initiative (tracked in #7108). The change is backward compatible as Traefik's default behavior is v3 rule syntax. No user action is required during upgrade.

