### PR TITLE
docs: add missing dot in `.ddev/.env.*`

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -58,7 +58,7 @@ You can set custom environment variables in several places:
     MY_OTHER_ENV_VAR="someotherval"
     ```
 
-2. With DDEV v1.23.5+, an optional, project-level `.ddev/env.*` file (where `*` is a service name, like `web`, `db`, `redis`, etc.) provides environment variables to specific services or add-ons. For example, `.ddev/.env.redis` file can look something like this:
+2. With DDEV v1.23.5+, an optional, project-level `.ddev/.env.*` file (where `*` is a service name, like `web`, `db`, `redis`, etc.) provides environment variables to specific services or add-ons. For example, `.ddev/.env.redis` file can look something like this:
 
     ```dotenv
     REDIS_TAG="7-bookworm"


### PR DESCRIPTION
Added missing `.` prefix in service env file name.

<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

Does this need an issue? 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Updates docs

## Manual Testing Instructions

No manual test

## Automated Testing Overview

No automated test

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
