### PR TITLE
fix(heidisql): use `--databases` flag only when needed, fixes #7829

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -43,8 +43,8 @@ version="$(echo $DDEV_DATABASE | sed 's/.*://')"
 nettype=0
 user="root"
 password="root"
-database="${1:-db}"
-library="${2}"
+database="${1:-}"
+library="${2:-}"
 
 # Arguments for Postgres
 if [ "$type" = "postgres" ]; then
@@ -92,8 +92,8 @@ arguments=(
   "--port=${DDEV_HOST_DB_PORT}"
   "--user=${user}"
   "--password=${password}"
-  "--databases=${database}"
   "--description=ddev-${DDEV_PROJECT}"
+  "${database:+--databases=${database}}"
   "${library:+--library=${library}}"
 )
 


### PR DESCRIPTION
## The Issue

- #7829

## How This PR Solves The Issue

Adds `--databases` only when the db is specified.

## Manual Testing Instructions

```
ddev heidisql
```

<img width="277" height="282" alt="image" src="https://github.com/user-attachments/assets/ad1cd4ea-5aef-44e0-8639-dcb548eca833" />

```
ddev heidisql db
```

<img width="272" height="195" alt="image" src="https://github.com/user-attachments/assets/b564cb0e-9ce3-43fd-a51b-2c55f1f2d9f3" />


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
