### PR TITLE
build: fix getopt detection on macOS

### DIFF
--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -13,7 +13,7 @@ if [ ${OS} = "Darwin" ]; then
   if ! command -v brew >/dev/null; then
     echo "On macOS, homebrew is required to get gnu-getopt" && exit 1
   fi
-  if ! brew info gnu-getopt >/dev/null; then
+  if ! brew list gnu-getopt 2>&1 >/dev/null; then
     echo "On macOS, brew install gnu-getopt"
     exit 1
   fi


### PR DESCRIPTION
## The Issue

We incorrectly detect gnu-getopt as installed, and a later line fails out because of it.

## How This PR Solves The Issue

`info` now always returns zero, even if a package isn't installed. Use list instead!

## Manual Testing Instructions

`brew uninstall gnu-getopt && cd containers/ddev-dbserver && make` should error, and then after installing getopt it should pass.

## Automated Testing Overview

None needed, CI makes sure packages are installed during builds.

## Release/Deployment Notes

None, just affects new contributors updating database images.