### PR TITLE
fix(heidisql): add default `--databases=db` to postgres, for #7830

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -51,6 +51,7 @@ if [ "$type" = "postgres" ]; then
   nettype=8
   user="db"
   password="db"
+  database="${database:-"db"}"
   
   # When using this database type, we also need to specify the library
   if [ -z "${library}" ]; then


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- No issue, discussed in https://github.com/ddev/ddev/pull/7830#issuecomment-3522201524

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Adds a default `--databases=db` flag to postgres connections if no database is explicitly defined.

## Manual Testing Instructions

- Run `ddev heidisql` in a project with database type `postgres`
- HeidiSQL client shows up with `public` database containing the project tables from `db`
<img width="209" height="100" alt="image" src="https://github.com/user-attachments/assets/9dac9ea5-ff50-4081-9751-31aa9e1c1c5b" />

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
