### PR TITLE
test(pantheon): fix TestPantheonPush, which was broken by composer 2.9 [skip buildkite]

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -296,10 +296,10 @@ var (
 		// 16: drupal11
 		{
 			Name:                          "TestPkgDrupal11",
-			SourceURL:                     "https://github.com/ddev/test-drupal11/archive/refs/tags/11.0.9.tar.gz",
-			ArchiveInternalExtractionPath: "test-drupal11-11.0.9/",
-			FilesTarballURL:               "https://github.com/ddev/test-drupal11/releases/download/11.0.9/files.tgz",
-			DBTarURL:                      "https://github.com/ddev/test-drupal11/releases/download/11.0.9/db.sql.tar.gz",
+			SourceURL:                     "https://github.com/ddev/test-drupal11/archive/refs/tags/11.2.8.tar.gz",
+			ArchiveInternalExtractionPath: "test-drupal11-11.2.8/",
+			FilesTarballURL:               "https://github.com/ddev/test-drupal11/releases/download/11.2.8/files.tgz",
+			DBTarURL:                      "https://github.com/ddev/test-drupal11/releases/download/11.2.8/db.sql.tar.gz",
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeDrupal11,
 			Docroot:                       "web",

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -206,7 +206,7 @@ func TestPantheonPush(t *testing.T) {
 
 	// Make sure we have Drush
 	stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
-		Cmd: "composer require --no-interaction drush/drush >/dev/null 2>/dev/null",
+		Cmd: "composer require --no-interaction drush/drush",
 	})
 	require.NoError(t, err, "failed to composer require drush err=%v stdout='%s', stderr='%s'", err, stdout, stderr)
 	err = app.MutagenSyncFlush()


### PR DESCRIPTION
## The Issue

- composer/composer#12607

* TestPantheonPush does a `composer require drush/drush` and the result was a failure with things like 

- drupal/core-recommended is locked to version 11.0.9 and an update of this package was not requested.
- drupal/core-recommended 11.0.9 requires drupal/core 11.0.9 -> found drupal/core[11.0.9] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("SA-CORE-2025-001", "SA-CORE-2025-002", "SA-CORE-2025-003", "SA-CORE-2025-004", "SA-CORE-2025-007", "SA-CORE-2025-008", "SA-CORE-2025-005", "SA-CORE-2025-006", "PKSA-s1zc-gcfk-ddw5", "PKSA-ctyc-dmct-npkz", "PKSA-42zc-x5ss-z64p", "PKSA-s6zc-mws4-ngh4") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.


## How This PR Solves The Issue

* Updated https://github.com/ddev/test-drupal11 to drupal 11.2.8 (current stable) with current drush
* Pushed new test fixtures in https://github.com/ddev/test-drupal11/releases/tag/11.2.8
* Updated ddevapp_test.go list of fixtures to use the new ones, affecting TestDdevFullSiteSetup and TestPantheonPush

## Manual Testing Instructions

Mostly this should only affect TestPantheonPush and TestDdevFullSiteSetup. Both seem to run OK locally now.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
