### PR TITLE
test: Can't do ddev-hostname on WSL2

### DIFF
--- a/pkg/hostname/hostname_test.go
+++ b/pkg/hostname/hostname_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	exec2 "github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,6 +50,12 @@ func TestDdevHostnameWithPasswordlessSudo(t *testing.T) {
 
 	// Get the binary name
 	binary := GetDdevHostnameBinary()
+
+	require.FileExists(t, binary, "ddev-hostname or ddev-hostname.exe binary should exist")
+
+	if nodeps.IsWSL2() || nodeps.IsWindows() {
+		t.Skip("Skip escalation because not passwordless on WSL2/Windows")
+	}
 
 	// Clean up any existing entry first
 	cleanupCmd := exec.Command(binary, "--remove", testHostname, testIP)
@@ -99,6 +106,9 @@ func TestElevateToAddRemoveHostEntry(t *testing.T) {
 	// Skip if not in CI
 	if os.Getenv("CI") != "true" {
 		t.Skip("Skipping because not in CI (CI != true)")
+	}
+	if nodeps.IsWSL2() || nodeps.IsWindows() {
+		t.Skip("Skip escalation because not passwordless on WSL2/Windows")
 	}
 
 	// Check if passwordless sudo is available


### PR DESCRIPTION

## The Issue

- #7855

Introduced testing for `ddev-hostname` functionality, but it didn't account for the fact that on WSL2 we have to use ddev-hostname.exe, which requires regular Windows-side elevation

## How This PR Solves The Issue

Go ahead and check for existence of the file, but then skip if on WSL2.

