### PR TITLE
ci(golangci-lint): add import-shadowing check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters:
             - []
             - []
             - - skip-package-name-checks: true
+        - name: import-shadowing
   exclusions:
     presets:
       - comments

--- a/cmd/ddev/cmd/debug-config-yaml_test.go
+++ b/cmd/ddev/cmd/debug-config-yaml_test.go
@@ -5,14 +5,11 @@ import (
 
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/testcommon"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestDebugConfigYamlCmd tests that ddev utility configyaml works
 func TestDebugConfigYamlCmd(t *testing.T) {
-	assert := assert.New(t)
-
 	// Create a temporary directory and switch to it.
 	tmpdir := testcommon.CreateTmpDir(t.Name())
 	defer testcommon.CleanupDir(tmpdir)
@@ -36,44 +33,44 @@ func TestDebugConfigYamlCmd(t *testing.T) {
 	// Test basic configyaml output (field-by-field mode)
 	t.Run("basic configyaml output", func(t *testing.T) {
 		out, err := exec.RunCommand(DdevBin, []string{"debug", "configyaml"})
-		assert.NoError(err)
+		require.NoError(t, err)
 		// Note: "These config files were loaded" now goes to stderr, not stdout
-		assert.Contains(out, "name: config-yaml-test")
-		assert.Contains(out, "type: php")
-		assert.Contains(out, "docroot: .")
+		require.Contains(t, out, "name: config-yaml-test")
+		require.Contains(t, out, "type: php")
+		require.Contains(t, out, "docroot: .")
 	})
 
 	// Test --full-yaml mode
 	t.Run("full-yaml mode", func(t *testing.T) {
 		out, err := exec.RunCommand(DdevBin, []string{"debug", "configyaml", "--full-yaml"})
-		assert.NoError(err)
+		require.NoError(t, err)
 		// Note: "These config files were loaded" now goes to stderr, not stdout
-		assert.Contains(out, "# Complete processed project configuration:")
-		assert.Contains(out, "name: config-yaml-test")
-		assert.Contains(out, "type: php")
-		assert.Contains(out, "docroot: .")
+		require.Contains(t, out, "# Complete processed project configuration:")
+		require.Contains(t, out, "name: config-yaml-test")
+		require.Contains(t, out, "type: php")
+		require.Contains(t, out, "docroot: .")
 		// Should be valid YAML format
-		assert.Contains(out, "webserver_type:")
-		assert.Contains(out, "php_version:")
+		require.Contains(t, out, "webserver_type:")
+		require.Contains(t, out, "php_version:")
 	})
 
 	// Test --omit-keys functionality in regular mode
 	t.Run("omit-keys in regular mode", func(t *testing.T) {
 		out, err := exec.RunCommand(DdevBin, []string{"debug", "configyaml", "--omit-keys=name,type"})
-		assert.NoError(err)
-		assert.NotContains(out, "name: config-yaml-test")
-		assert.NotContains(out, "type: php")
-		assert.Contains(out, "docroot: .") // This should still be present
+		require.NoError(t, err)
+		require.NotContains(t, out, "name: config-yaml-test")
+		require.NotContains(t, out, "type: php")
+		require.Contains(t, out, "docroot: .") // This should still be present
 	})
 
 	// Test --omit-keys functionality in full-yaml mode
 	t.Run("omit-keys in full-yaml mode", func(t *testing.T) {
 		out, err := exec.RunCommand(DdevBin, []string{"debug", "configyaml", "--full-yaml", "--omit-keys=name,type"})
-		assert.NoError(err)
-		assert.Contains(out, "# Complete processed project configuration:")
-		assert.NotContains(out, "name: config-yaml-test")
-		assert.NotContains(out, "type: php")
-		assert.Contains(out, "docroot: .") // This should still be present
+		require.NoError(t, err)
+		require.Contains(t, out, "# Complete processed project configuration:")
+		require.NotContains(t, out, "name: config-yaml-test")
+		require.NotContains(t, out, "type: php")
+		require.Contains(t, out, "docroot: .") // This should still be present
 	})
 
 	// Test omitting environment variables (the main security use case)
@@ -87,30 +84,30 @@ func TestDebugConfigYamlCmd(t *testing.T) {
 
 		// Test that environment variables appear by default
 		out, err := exec.RunCommand(DdevBin, []string{"debug", "configyaml", "--full-yaml"})
-		assert.NoError(err)
-		assert.Contains(out, "SECRET_KEY=supersecret")
-		assert.Contains(out, "API_TOKEN=sensitive")
+		require.NoError(t, err)
+		require.Contains(t, out, "SECRET_KEY=supersecret")
+		require.Contains(t, out, "API_TOKEN=sensitive")
 
 		// Test that they're hidden with --omit-keys
 		out, err = exec.RunCommand(DdevBin, []string{"debug", "configyaml", "--full-yaml", "--omit-keys=web_environment"})
-		assert.NoError(err)
-		assert.NotContains(out, "SECRET_KEY=supersecret")
-		assert.NotContains(out, "API_TOKEN=sensitive")
-		assert.Contains(out, "name: config-yaml-test") // Other fields should still be present
+		require.NoError(t, err)
+		require.NotContains(t, out, "SECRET_KEY=supersecret")
+		require.NotContains(t, out, "API_TOKEN=sensitive")
+		require.Contains(t, out, "name: config-yaml-test") // Other fields should still be present
 	})
 
 	// Test with spaces in omit-keys (should handle trimming)
 	t.Run("omit-keys with spaces", func(t *testing.T) {
 		out, err := exec.RunCommand(DdevBin, []string{"debug", "configyaml", "--omit-keys= name , type "})
-		assert.NoError(err)
-		assert.NotContains(out, "name: config-yaml-test")
-		assert.NotContains(out, "type: php")
-		assert.Contains(out, "docroot: .") // This should still be present
+		require.NoError(t, err)
+		require.NotContains(t, out, "name: config-yaml-test")
+		require.NotContains(t, out, "type: php")
+		require.Contains(t, out, "docroot: .") // This should still be present
 	})
 
 	// Test that non-existent project name fails gracefully
 	t.Run("non-existent project", func(t *testing.T) {
 		_, err := exec.RunCommand(DdevBin, []string{"debug", "configyaml", "non-existent-project"})
-		assert.Error(err)
+		require.Error(t, err)
 	})
 }

--- a/pkg/config/state/state_manager_test.go
+++ b/pkg/config/state/state_manager_test.go
@@ -39,7 +39,7 @@ type StateTestSuite struct {
 	suite.Suite
 }
 
-func (suite *StateTestSuite) TestGetReturnsCorrectState() {
+func (stateTestSuite *StateTestSuite) TestGetReturnsCorrectState() {
 	var tests = []struct {
 		Key      types.StateEntryKey
 		Expected TestStateEntry
@@ -105,16 +105,16 @@ func (suite *StateTestSuite) TestGetReturnsCorrectState() {
 	stateEntry := TestStateEntry{}
 
 	for _, tt := range tests {
-		suite.Run(tt.Key, func() {
-			suite.NoError(state.Get(tt.Key, &stateEntry))
-			suite.EqualValues(tt.Expected, stateEntry)
+		stateTestSuite.Run(tt.Key, func() {
+			stateTestSuite.NoError(state.Get(tt.Key, &stateEntry))
+			stateTestSuite.EqualValues(tt.Expected, stateEntry)
 		})
 	}
 }
 
-func (suite *StateTestSuite) TestSetUpdatesState() {
+func (stateTestSuite *StateTestSuite) TestSetUpdatesState() {
 	// Use a non existing state file from the temp dir.
-	state := yaml.NewState(filepath.Join(suite.T().TempDir(), "state.yml"))
+	state := yaml.NewState(filepath.Join(stateTestSuite.T().TempDir(), "state.yml"))
 
 	stateEntryOut := TestStateEntry{
 		BoolField1:   true,
@@ -137,12 +137,12 @@ func (suite *StateTestSuite) TestSetUpdatesState() {
 	}
 	stateEntryIn := TestStateEntry{}
 
-	suite.NoError(state.Set("test_state_entry", stateEntryOut))
-	suite.NoError(state.Get("test_state_entry", &stateEntryIn))
-	suite.EqualValues(stateEntryOut, stateEntryIn)
+	stateTestSuite.NoError(state.Set("test_state_entry", stateEntryOut))
+	stateTestSuite.NoError(state.Get("test_state_entry", &stateEntryIn))
+	stateTestSuite.EqualValues(stateEntryOut, stateEntryIn)
 }
 
-func (suite *StateTestSuite) TestSetPreservesExistingStates() {
+func (stateTestSuite *StateTestSuite) TestSetPreservesExistingStates() {
 	var tests = []struct {
 		Key   types.StateEntryKey
 		Entry TestStateEntry
@@ -195,57 +195,57 @@ func (suite *StateTestSuite) TestSetPreservesExistingStates() {
 	}
 
 	// Use a non existing state file from the temp dir.
-	state := yaml.NewState(filepath.Join(suite.T().TempDir(), "state.yml"))
+	state := yaml.NewState(filepath.Join(stateTestSuite.T().TempDir(), "state.yml"))
 
 	for _, tt := range tests {
-		suite.NoError(state.Set(tt.Key, tt.Entry))
+		stateTestSuite.NoError(state.Set(tt.Key, tt.Entry))
 	}
 
 	// Save and reload states.
-	suite.NoError(state.Save())
-	suite.NoError(state.Load())
+	stateTestSuite.NoError(state.Save())
+	stateTestSuite.NoError(state.Load())
 
 	// Add test state.
 	testState := TestStateEntry{
 		BoolField1: true,
 		BoolField2: true,
 	}
-	suite.NoError(state.Set("test", testState))
+	stateTestSuite.NoError(state.Set("test", testState))
 
 	// Verify previous states.
 	stateEntry := TestStateEntry{}
 
 	for _, tt := range tests {
-		suite.Run(tt.Key, func() {
-			suite.NoError(state.Get(tt.Key, &stateEntry))
-			suite.EqualValues(tt.Entry, stateEntry)
+		stateTestSuite.Run(tt.Key, func() {
+			stateTestSuite.NoError(state.Get(tt.Key, &stateEntry))
+			stateTestSuite.EqualValues(tt.Entry, stateEntry)
 		})
 	}
 
 	// Verify test state.
-	suite.NoError(state.Get("test", &stateEntry))
-	suite.EqualValues(testState, stateEntry)
+	stateTestSuite.NoError(state.Get("test", &stateEntry))
+	stateTestSuite.EqualValues(testState, stateEntry)
 }
 
-func (suite *StateTestSuite) TestGetExpectsPointer() {
+func (stateTestSuite *StateTestSuite) TestGetExpectsPointer() {
 	// Use a non existing state file from the temp dir.
-	state := yaml.NewState(filepath.Join(suite.T().TempDir(), "state.yml"))
+	state := yaml.NewState(filepath.Join(stateTestSuite.T().TempDir(), "state.yml"))
 
 	stateEntry := TestStateEntry{}
 
-	suite.ErrorContains(state.Get("test_state_entry", stateEntry), "stateEntry must be a pointer")
+	stateTestSuite.ErrorContains(state.Get("test_state_entry", stateEntry), "stateEntry must be a pointer")
 }
 
-func (suite *StateTestSuite) TestSetExpectsNonPointer() {
+func (stateTestSuite *StateTestSuite) TestSetExpectsNonPointer() {
 	// Use a non existing state file from the temp dir.
-	state := yaml.NewState(filepath.Join(suite.T().TempDir(), "state.yml"))
+	state := yaml.NewState(filepath.Join(stateTestSuite.T().TempDir(), "state.yml"))
 
 	stateEntry := TestStateEntry{}
 
-	suite.ErrorContains(state.Set("test_state_entry", &stateEntry), "stateEntry must not be a pointer")
+	stateTestSuite.ErrorContains(state.Set("test_state_entry", &stateEntry), "stateEntry must not be a pointer")
 }
 
-func (suite *StateTestSuite) TestLoadedIsProperlySet() {
+func (stateTestSuite *StateTestSuite) TestLoadedIsProperlySet() {
 	var tests = []struct {
 		Name string
 		File string
@@ -256,31 +256,31 @@ func (suite *StateTestSuite) TestLoadedIsProperlySet() {
 		},
 		{
 			Name: "StateNotExists",
-			File: filepath.Join(suite.T().TempDir(), "state.yml"),
+			File: filepath.Join(stateTestSuite.T().TempDir(), "state.yml"),
 		},
 	}
 
 	for _, tt := range tests {
-		suite.Run(tt.Name, func() {
+		stateTestSuite.Run(tt.Name, func() {
 			state := yaml.NewState(tt.File)
 
-			suite.False(state.Loaded())
-			suite.NoError(state.Load())
-			suite.True(state.Loaded())
-			suite.NoError(state.Save())
-			suite.True(state.Loaded())
+			stateTestSuite.False(state.Loaded())
+			stateTestSuite.NoError(state.Load())
+			stateTestSuite.True(state.Loaded())
+			stateTestSuite.NoError(state.Save())
+			stateTestSuite.True(state.Loaded())
 		})
 	}
 }
 
-func (suite *StateTestSuite) TestChangedIsProperlySet() {
-	state := yaml.NewState(filepath.Join(suite.T().TempDir(), "state.yml"))
+func (stateTestSuite *StateTestSuite) TestChangedIsProperlySet() {
+	state := yaml.NewState(filepath.Join(stateTestSuite.T().TempDir(), "state.yml"))
 
-	suite.False(state.Changed())
-	suite.NoError(state.Load())
-	suite.False(state.Changed())
-	suite.NoError(state.Set("test_state_entry", TestStateEntry{}))
-	suite.True(state.Changed())
-	suite.NoError(state.Save())
-	suite.False(state.Changed())
+	stateTestSuite.False(state.Changed())
+	stateTestSuite.NoError(state.Load())
+	stateTestSuite.False(state.Changed())
+	stateTestSuite.NoError(state.Set("test_state_entry", TestStateEntry{}))
+	stateTestSuite.True(state.Changed())
+	stateTestSuite.NoError(state.Save())
+	stateTestSuite.False(state.Changed())
 }

--- a/pkg/config/state/storage/yaml/yaml_storage_test.go
+++ b/pkg/config/state/storage/yaml/yaml_storage_test.go
@@ -18,7 +18,7 @@ type YamlStorageTestSuite struct {
 	suite.Suite
 }
 
-func (suite *YamlStorageTestSuite) TestReadProperlyLoadsState() {
+func (yamlStorageTestSuite *YamlStorageTestSuite) TestReadProperlyLoadsState() {
 	var tests = []struct {
 		Key   types.StateEntryKey
 		Value string
@@ -41,35 +41,35 @@ func (suite *YamlStorageTestSuite) TestReadProperlyLoadsState() {
 	storage := yaml.New(filepath.Join("testdata", "state.yml"))
 	data, err := storage.Read()
 
-	suite.NoError(err)
-	suite.NotNil(data)
+	yamlStorageTestSuite.NoError(err)
+	yamlStorageTestSuite.NotNil(data)
 
 	for _, tt := range tests {
-		suite.Run(tt.Key, func() {
-			suite.EqualValues(tt.Value, data[tt.Key].(map[string]interface{})["value"])
+		yamlStorageTestSuite.Run(tt.Key, func() {
+			yamlStorageTestSuite.EqualValues(tt.Value, data[tt.Key].(map[string]interface{})["value"])
 		})
 	}
 }
 
-func (suite *YamlStorageTestSuite) TestReadReturnsStateWithoutStateFile() {
+func (yamlStorageTestSuite *YamlStorageTestSuite) TestReadReturnsStateWithoutStateFile() {
 	storage := yaml.New(filepath.Join("testdata", "not_existing.yml"))
 	data, err := storage.Read()
 
-	suite.NoError(err)
-	suite.NotNil(data)
-	suite.EqualValues(types.RawState{}, data)
+	yamlStorageTestSuite.NoError(err)
+	yamlStorageTestSuite.NotNil(data)
+	yamlStorageTestSuite.EqualValues(types.RawState{}, data)
 }
 
-func (suite *YamlStorageTestSuite) TestReadReturnsErrorForInvalidStateFile() {
+func (yamlStorageTestSuite *YamlStorageTestSuite) TestReadReturnsErrorForInvalidStateFile() {
 	storage := yaml.New(filepath.Join("testdata", "invalid.yml"))
 	data, err := storage.Read()
 
-	suite.ErrorContains(err, "yaml: unmarshal errors")
-	suite.Nil(data)
+	yamlStorageTestSuite.ErrorContains(err, "yaml: unmarshal errors")
+	yamlStorageTestSuite.Nil(data)
 }
 
-func (suite *YamlStorageTestSuite) TestWriteProperlyWritesState() {
-	stateFile := filepath.Join(suite.T().TempDir(), "state.yml")
+func (yamlStorageTestSuite *YamlStorageTestSuite) TestWriteProperlyWritesState() {
+	stateFile := filepath.Join(yamlStorageTestSuite.T().TempDir(), "state.yml")
 	storage := yaml.New(stateFile)
 
 	// Simulation of the state.yml.
@@ -85,20 +85,20 @@ func (suite *YamlStorageTestSuite) TestWriteProperlyWritesState() {
 		},
 	})
 
-	suite.NoError(err)
-	suite.FileExists(stateFile)
+	yamlStorageTestSuite.NoError(err)
+	yamlStorageTestSuite.FileExists(stateFile)
 
 	want, err := os.ReadFile(filepath.Join("testdata", "state.yml"))
 	if err != nil {
-		suite.FailNow("error reading state file:", err)
+		yamlStorageTestSuite.FailNow("error reading state file:", err)
 	}
 
 	has, err := os.ReadFile(stateFile)
 	if err != nil {
-		suite.FailNow("error reading written state file:", err)
+		yamlStorageTestSuite.FailNow("error reading written state file:", err)
 	}
 
-	suite.Equal(want, has)
+	yamlStorageTestSuite.Equal(want, has)
 }
 
 func BenchmarkRead(b *testing.B) {

--- a/pkg/ddevapp/addons_test.go
+++ b/pkg/ddevapp/addons_test.go
@@ -264,8 +264,6 @@ func TestCircularDependencyDetection(t *testing.T) {
 
 // TestParseRuntimeDependencies tests runtime dependency file parsing
 func TestParseRuntimeDependencies(t *testing.T) {
-	assert := assert.New(t)
-
 	// Create a temporary .runtime-deps file
 	tmpDir, err := os.MkdirTemp("", "test-runtime-deps")
 	require.NoError(t, err)
@@ -286,13 +284,13 @@ https://example.com/addon.tar.gz
 
 	// Test parsing
 	deps, err := ddevapp.ParseRuntimeDependencies(runtimeDepsFile)
-	assert.NoError(err)
-	assert.Equal([]string{"ddev/ddev-redis", "ddev/ddev-local-addon", "https://example.com/addon.tar.gz"}, deps)
+	require.NoError(t, err)
+	require.Equal(t, []string{"ddev/ddev-redis", "ddev/ddev-local-addon", "https://example.com/addon.tar.gz"}, deps)
 
 	// Test non-existent file
 	deps, err = ddevapp.ParseRuntimeDependencies(filepath.Join(tmpDir, "nonexistent"))
-	assert.NoError(err)
-	assert.Nil(deps)
+	require.NoError(t, err)
+	require.Nil(t, deps)
 }
 
 // TestMixedDependencyScenarios tests comprehensive mixed dependency scenarios

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -380,8 +380,8 @@ func (app *DdevApp) GetComposerCreateAllowedPaths() ([]string, error) {
 		if err != nil {
 			return []string{""}, err
 		}
-		for _, path := range paths {
-			allowed = append(allowed, nodeps.PathWithSlashesToArray(app.GetRelativeDirectory(path))...)
+		for _, composerPath := range paths {
+			allowed = append(allowed, nodeps.PathWithSlashesToArray(app.GetRelativeDirectory(composerPath))...)
 		}
 	}
 	allowed = util.SliceToUniqueSlice(&allowed)

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -293,10 +293,10 @@ func CreateGitIgnore(targetDir string, ignores ...string) error {
 }
 
 // isTar determines whether the object at the filepath is a .tar archive.
-func isTar(filepath string) bool {
+func isTar(filePath string) bool {
 	tarSuffixes := []string{".tar", ".tar.gz", ".tar.bz2", ".tar.xz", ".tgz"}
 	for _, suffix := range tarSuffixes {
-		if strings.HasSuffix(filepath, suffix) {
+		if strings.HasSuffix(filePath, suffix) {
 			return true
 		}
 	}
@@ -305,8 +305,8 @@ func isTar(filepath string) bool {
 }
 
 // isZip determines if the object at hte filepath is a .zip.
-func isZip(filepath string) bool {
-	return strings.HasSuffix(filepath, ".zip")
+func isZip(filePath string) bool {
+	return strings.HasSuffix(filePath, ".zip")
 }
 
 // GetErrLogsFromApp is used to do app.Logs on an app after an error has
@@ -516,9 +516,9 @@ func GetServiceNamesFunc(existingOnly bool) func(*cobra.Command, []string, strin
 
 // GetRelativeDirectory returns the directory relative to project root
 // Note that the relative dir is returned as unix-style forward-slashes
-func (app *DdevApp) GetRelativeDirectory(path string) string {
+func (app *DdevApp) GetRelativeDirectory(targetPath string) string {
 	// Find the relative dir
-	relativeWorkingDir := strings.TrimPrefix(path, app.AppRoot)
+	relativeWorkingDir := strings.TrimPrefix(targetPath, app.AppRoot)
 	// Convert to slash/linux/macos notation, should work everywhere
 	relativeWorkingDir = filepath.ToSlash(relativeWorkingDir)
 	// Remove any leading /

--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -528,7 +528,7 @@ func GetPublishedPort(privatePort uint16, c container.Summary) int {
 // or it can replace it or have other behaviors, see
 // https://pkg.go.dev/github.com/moby/docker-image-spec/specs-go/v1#HealthcheckConfig
 // Returns containerID, output, error
-func RunSimpleContainer(image string, name string, cmd []string, entrypoint []string, env []string, binds []string, uid string, removeContainerAfterRun bool, detach bool, labels map[string]string, portBindings network.PortMap, healthConfig *container.HealthConfig) (containerID string, output string, returnErr error) {
+func RunSimpleContainer(image string, name string, cmd []string, entrypoint []string, env []string, binds []string, uid string, removeContainerAfterRun bool, detach bool, labels map[string]string, portBindings network.PortMap, healthConfig *container.HealthConfig) (containerID string, out string, returnErr error) {
 	config := &container.Config{
 		Image:       image,
 		Cmd:         cmd,

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -95,7 +95,7 @@ func RunInteractiveCommand(command string, args []string) error {
 
 // RunInteractiveCommandWithOutput writes to the host and
 // also to the passed io.Writer
-func RunInteractiveCommandWithOutput(command string, args []string, output io.Writer) error {
+func RunInteractiveCommandWithOutput(command string, args []string, out io.Writer) error {
 	cmd := HostCommand(command, args...)
 	cmd.Stdin = os.Stdin
 
@@ -112,7 +112,7 @@ func RunInteractiveCommandWithOutput(command string, args []string, output io.Wr
 	}
 
 	go func() {
-		_ = CleanAndCopy(output, pr)
+		_ = CleanAndCopy(out, pr)
 		_ = pr.Close()
 	}()
 

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -242,10 +242,10 @@ func ReplaceStringInFile(searchString string, replaceString string, origPath str
 		return err
 	}
 
-	output := bytes.ReplaceAll(input, []byte(searchString), []byte(replaceString))
+	modifiedContent := bytes.ReplaceAll(input, []byte(searchString), []byte(replaceString))
 
 	// nolint: revive
-	if err = os.WriteFile(destPath, output, 0666); err != nil {
+	if err = os.WriteFile(destPath, modifiedContent, 0666); err != nil {
 		return err
 	}
 	return nil
@@ -266,11 +266,11 @@ func IsSameFile(path1 string, path2 string) (bool, error) {
 
 // ReadFileIntoString gets the contents of file into string
 func ReadFileIntoString(path string) (string, error) {
-	bytes, err := os.ReadFile(path)
+	bytesFile, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-	return string(bytes), err
+	return string(bytesFile), err
 }
 
 // AppendStringToFile takes a path to a file and a string to append

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -316,11 +316,11 @@ func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 
 // Chdir will change to the directory for the site specified by TestSite.
 // It returns an anonymous function which will return to the original working directory when called.
-func Chdir(path string) func() {
+func Chdir(dirPath string) func() {
 	curDir, _ := os.Getwd()
-	err := os.Chdir(path)
+	err := os.Chdir(dirPath)
 	if err != nil {
-		output.UserErr.Errorf("Could not change to directory %s: %v\n", path, err)
+		output.UserErr.Errorf("Could not change to directory %s: %v\n", dirPath, err)
 	}
 
 	return func() {


### PR DESCRIPTION
## The Issue

Some variables collide with imported packages. But we don't have any checks for that.

## How This PR Solves The Issue

Adds `import-shadowing` rule from `revive`.

```
$ make golangci-lint
golangci-lint: 
cmd/ddev/cmd/debug-config-yaml_test.go:14:2: import-shadowing: The name 'assert' shadows an import name (revive)
        assert := assert.New(t)
...
```

This also fixes some existing hidden bugs for `t.Run`, where `t` comes from parent test, not this one.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
