### PR TITLE
fix(diagnose): Remove the hard-coded IP "127.0.0.1" from the DNS check, since it may be incorrect, fixes #7871

### DIFF
--- a/cmd/ddev/cmd/scripts/diagnose_ddev.sh
+++ b/cmd/ddev/cmd/scripts/diagnose_ddev.sh
@@ -3,7 +3,7 @@
 #ddev-generated
 # diagnose_ddev.sh - User-friendly DDEV diagnostics
 # This script provides concise, actionable diagnostics for DDEV issues
-# For more extensive output for issue reports, use 'ddev debug test'
+# For more extensive output for issue reports, use 'ddev utility test'
 
 set -o pipefail
 
@@ -435,7 +435,7 @@ else
   printf "${BOLD}Next steps:${NC}\n"
   suggestion "Review the issues and suggestions above"
   suggestion "Check troubleshooting docs: https://docs.ddev.com/en/stable/users/usage/troubleshooting/"
-  suggestion "For more extensive diagnostics: ddev debug test"
+  suggestion "For more extensive diagnostics: ddev utility test"
   suggestion "Get help on Discord: https://ddev.com/s/discord"
   echo
   exit 1


### PR DESCRIPTION
## The Issue

- #7871

## How This PR Solves The Issue

The IP is extracted from the `ping`, stored to the variable `IP`, which is used in the output

- Suppress the error output.
- Catch the IP with regex.
- Store the IP to the variable `IP`.
- Check that the length of `$IP` is not zero (`-n`). 
- Use `$IP` in the output to show the actual IP of `*.ddev.site`.

## Manual Testing Instructions

Create this bash script (`check-dns.sh`).

```bash
#!/bin/bash

# run script "./check-dns.sh HOST"

# Helper functions
success() {
  printf "${GREEN}✓${NC} %s\n" "$1"
}

warn() {
  printf "${YELLOW}⚠${NC} %s\n" "$1"
  ((WARNINGS_FOUND++))
}

suggestion() {
  printf "  ${BLUE}→${NC} %s\n" "$1"
}

HOST=${1:-"test.ddev.site"}

echo -e "\nCheck DNS resolution for \"$HOST\"\n---------------"
# Check DNS resolution for *.ddev.site
if command -v ping >/dev/null; then
  # git-bash
  if [[ "$OSTYPE" == "msys" ]]; then
    # git-bash No output redirection necessary
    # IP=$(ping -n 1 -w 2 "$HOST" | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' | head -n 1)
    OUTPUT=$(ping -n 1 -w 2 "$HOST")

    # with awk
    # IP=$(ping -n 1 -w 2 "$HOST" | awk -F'[][]' '/\[/{print $2}')

  else
    # IP=$(ping -c 1 -W 2 "$HOST" 2>/dev/null | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' | head -n 1)
    OUTPUT=$(ping -c 1 -W 2 "$HOST" 2>/dev/null)

    # with awk
    # IP=$(ping -c 1 -W 2 "$HOST" 2>/dev/null | awk -F'[()]' '/PING/{print $2}')
  fi

   # grep/head share the same switches in git-bash and linux.
  IP=$(echo "$OUTPUT" | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' | head -n 1)

  if [ -n "$IP" ]; then
    success "DNS resolves $HOST to $IP"
  else
    warn "Cannot resolve $HOST"
    suggestion "See: https://docs.ddev.com/en/stable/users/usage/networking/#restrictive-dns-servers"
  fi
else
  warn "ping command not found; skipping DNS resolution check"
fi
```

Tested under `git-bash` and `linux`

Positive result:

```shell
./check-dns.sh google.com

Check DNS resolution for "google.com"
---------------
✓ DNS resolves google.com to 142.250.186.110
```

```shell
./check-dns.sh test.ddev.site

Check DNS resolution for "test.ddev.site"
---------------
✓ DNS resolves test.ddev.site to 192.168.0.1
```


Negative result: 

```
./check-dns.sh not-reachable-host
```

No extra (error) output, only: 

```
Check DNS resolution for "not-reachable-host"
---------------
⚠ Cannot resolve not-reachable-host
  → See: https://docs.ddev.com/en/stable/users/usage/networking/#restrictive-dns-servers
```


## Automated Testing Overview

I do not know about automated tests for this part.

