### PR TITLE
docs(xdebug): Add details on how to repair WSL2 networking

### DIFF
--- a/docs/content/users/debugging-profiling/step-debugging.md
+++ b/docs/content/users/debugging-profiling/step-debugging.md
@@ -166,9 +166,9 @@ WSL2 is a complicated environment for Xdebug, especially if you're running your 
     **Using Windows UI:**
 
     * Open **Control Panel → Programs → Turn Windows features on or off**.
-    * Uncheck **Windows Subsystem for Linux** and **Virtual Machine Platform**
+    * Uncheck **Windows Subsystem for Linux** and **Virtual Machine Platform**.
     * Click **OK** and reboot when prompted.
-    * Return to the same dialog and re-enable the same two features, **Windows Subsystem for Linux** and **Virtual Machine Platform**
+    * Return to the same dialog and re-enable the same two features, **Windows Subsystem for Linux** and **Virtual Machine Platform**.
     * Click **OK** and reboot again.
 
     **Using PowerShell (Admin):**
@@ -185,5 +185,4 @@ WSL2 is a complicated environment for Xdebug, especially if you're running your 
     Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -NoRestart
     ```
 
-    Reboot once more, and WSL2 networking (including access inside web container
-    to `host.docker.internal`) should be restored.
+    Reboot once more, and WSL2 networking (including access inside web container to `host.docker.internal`) should be restored.


### PR DESCRIPTION
## The Issue

My WIndows system WSL2 networking was broken today, both for mirrored and nat networking modes.

I couldn't `telnet host.docker.internal 9003` to connect to phpstorm from inside the web container

## How This PR Solves The Issue

An extensive ChatGPT session finally suggested resetting WSL2 completely, as shown here.

## Manual Testing Instructions

https://ddev--7879.org.readthedocs.build/en/7879/users/debugging-profiling/step-debugging/#troubleshooting-xdebug

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
