### PR TITLE
fix(xdebug): Use a more sophisticated search for windows host ip address on WSL mirrored mode

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -706,9 +706,6 @@ func TestDdevStartCustomEntrypoint(t *testing.T) {
 
 // TestDdevStartMultipleHostnames tests start with multiple hostnames
 func TestDdevStartMultipleHostnames(t *testing.T) {
-	if nodeps.IsWSL2MirroredMode() {
-		t.Skip("Skipping on WSL2 Mirrored Mode, always fails with 'tls: failed to verify certificate: x509: certificate signed by unknown authority'")
-	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 
@@ -2274,8 +2271,8 @@ func readFileTail(fileName string, maxBytes int64) (string, error) {
 // TestDdevFullSiteSetup tests a full import-db and import-files and then looks to see if
 // we have a spot-test success hit on a URL
 func TestDdevFullSiteSetup(t *testing.T) {
-	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && (nodeps.IsWindows() || dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() || nodeps.IsWSL2MirroredMode()) {
-		t.Skip("Skipping on Windows/Lima/Colima/Rancher/MirroredWSL as this is tested adequately elsewhere")
+	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && (nodeps.IsWindows() || dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop()) {
+		t.Skip("Skipping on Windows/Lima/Colima/Rancher as this is tested adequately elsewhere")
 	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
@@ -3455,8 +3452,8 @@ func TestAppdirAlreadyInUse(t *testing.T) {
 // TestHttpsRedirection tests to make sure that webserver and php redirect to correct
 // scheme (http or https).
 func TestHttpsRedirection(t *testing.T) {
-	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && (nodeps.IsAppleSilicon() || nodeps.IsWSL2MirroredMode()) {
-		t.Skip("Skipping on Apple Silicon/Mirrored mode to ignore problems with 'connection reset by peer'")
+	if nodeps.IsAppleSilicon() && os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" {
+		t.Skip("Skipping on Apple Silicon to ignore problems with 'connection reset by peer'")
 	}
 	if globalconfig.GetCAROOT() == "" {
 		t.Skip("Skipping because MkcertCARoot is not set, no https")
@@ -3929,8 +3926,8 @@ func TestPHPWebserverType(t *testing.T) {
 // from host and from inside container by URL (with port)
 // Related test: TestNetworkAliases
 func TestInternalAndExternalAccessToURL(t *testing.T) {
-	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && (nodeps.IsAppleSilicon() || nodeps.IsWSL2MirroredMode()) {
-		t.Skip("Skipping on mac Apple Silicon/Lima/Colima/Rancher/WSLMirrored to ignore problems with 'connection reset by peer'")
+	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && nodeps.IsAppleSilicon() {
+		t.Skip("Skipping on mac Apple Silicon/Lima/Colima/Rancher to ignore problems with 'connection reset by peer'")
 	}
 
 	assert := asrt.New(t)

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/netutil"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,8 +18,8 @@ import (
 // TestExtraPortExpose tests exposing additional ports with web_extra_exposed_ports.
 // It also tests web_extra_daemons
 func TestExtraPortExpose(t *testing.T) {
-	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() || nodeps.IsWSL2MirroredMode()) {
-		t.Skip("skipping on Lima/Colima/Mirrored because of unpredictable behavior, unable to connect")
+	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop()) {
+		t.Skip("skipping on Lima/Colima because of unpredictable behavior, unable to connect")
 	}
 	assert := asrt.New(t)
 

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -194,7 +194,7 @@ func TestAllocateAvailablePortForRouter(t *testing.T) {
 
 // Test that the app assigns an ephemeral port if the default one is not available.
 func TestUseEphemeralPort(t *testing.T) {
-	if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() || globalconfig.DdevGlobalConfig.MkcertCARoot == "" {
+	if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
 		// Intermittent failures in CI due apparently to https://github.com/lima-vm/lima/issues/2536
 		// Expected port is not available, so it allocates another one.
 		t.Skip("Skipping on Lima/Colima/Rancher as ports don't seem to be released properly in a timely fashion")


### PR DESCRIPTION

## The Issue

The previous technique for finding the windows-side IP address for host.docker.internal when using mirrored networking mode could fail if there were VMWare or Virtualbox interfaces on the machine. It made my machine stop being able to do xdebug because of our experiments with VMWare.

## How This PR Solves The Issue

This replaces the previous PowerShell-based host-IP detection (which simply
selected the first non–link-local IPv4 address on Windows) with a more accurate
approach. Instead of scanning all network adapters, the new implementation
selects the IPv4 address associated with the **best default route
(`0.0.0.0/0`)** on Windows. This is the same logic Windows uses to determine
its primary outbound interface.

By basing detection on the default route instead of interface ordering or
adapter names, this method:

- **Ignores host-only / virtual adapters** such as VMware VMnet, VirtualBox
  Host-Only, and other isolated networks that cannot accept incoming
  connections from WSL2 containers.
- **Avoids choosing incorrect IPs** like `192.168.56.1`, which are reachable
  via ping but cannot carry TCP connections back to IDE listeners (e.g., on
  port 9003).
- **Requires no vendor-specific filtering** and works in typical environments
  without customization.
- **Improves reliability of mirrored-networking mode**, where Windows exposes
  multiple NICs and the old heuristic frequently selected the wrong one.

As a result, `host.docker.internal` now maps to an IP that actually accepts
connections from the DDEV web container in WSL2 mirrored mode, fixing Xdebug
connectivity failures and other host-access problems.


## Manual Testing Instructions

Use Xdebug on mirrored networking mode

## Automated Testing Overview

I think the existing TestDdevXdebugEnabled test should properly test this.

## Release/Deployment Notes

Assisted heavily in debugging and code creation by ChatGPT