### PR TITLE
chore(composer): remove `--snapshot` workaround, for #7864

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1432,11 +1432,6 @@ RUN (timeout %d apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-ge
 			composerSelfUpdateArg = "--" + composerSelfUpdateArg
 		}
 
-		// TODO: Remove this condition when Composer v2.9.2 is out
-		if composerSelfUpdateArg == "--2" {
-			composerSelfUpdateArg = "--snapshot"
-		}
-
 		// Try composer self-update twice because of troubles with Composer downloads
 		// breaking testing.
 		// First of all Composer is updated to latest stable release to ensure


### PR DESCRIPTION
## The Issue

- #7864

Composer 2.9.2 is out https://github.com/composer/composer/releases/tag/2.9.2

## How This PR Solves The Issue

Removes install from snapshot.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
