### PR TITLE
test(quickstart): fix frankenphp build

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -918,8 +918,19 @@ Create Dockerfile for FrankenPHP:
 
 ```bash
 cat <<'DOCKERFILEEND' >.ddev/web-build/Dockerfile.frankenphp
-RUN curl -s https://frankenphp.dev/install.sh | sh
-RUN mkdir -p /usr/local/etc && ln -s /etc/php/${DDEV_PHP_VERSION}/fpm /usr/local/etc/php
+RUN curl -fsSL https://key.henderkes.com/static-php.gpg -o /usr/share/keyrings/static-php.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/static-php.gpg] https://deb.henderkes.com/ stable main" > /etc/apt/sources.list.d/static-php.list
+# Install FrankenPHP and extensions, see https://frankenphp.dev/docs/#deb-packages for details.
+# You can find the list of available extensions at https://deb.henderkes.com/pool/main/p/
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests \
+    frankenphp \
+    php-zts-cli \
+    php-zts-gd \
+    php-zts-pdo-mysql
+# Make sure that 'php' command uses the ZTS version of PHP
+# and that the php.ini in use by FrankenPHP is the one from DDEV.
+RUN ln -sf /usr/bin/php-zts /usr/local/bin/php && \
+    ln -sf /etc/php/${DDEV_PHP_VERSION}/fpm/php.ini /etc/php-zts/php.ini
 DOCKERFILEEND
 ```
 
@@ -965,8 +976,19 @@ ddev launch $(ddev drush uli)
     INNEREOF
 
     cat <<'INNEREOF' >.ddev/web-build/Dockerfile.frankenphp
-    RUN curl -s https://frankenphp.dev/install.sh | sh
-    RUN mkdir -p /usr/local/etc && ln -s /etc/php/${DDEV_PHP_VERSION}/fpm /usr/local/etc/php
+    RUN curl -fsSL https://key.henderkes.com/static-php.gpg -o /usr/share/keyrings/static-php.gpg && \
+        echo "deb [signed-by=/usr/share/keyrings/static-php.gpg] https://deb.henderkes.com/ stable main" > /etc/apt/sources.list.d/static-php.list
+    # Install FrankenPHP and extensions, see https://frankenphp.dev/docs/#deb-packages for details.
+    # You can find the list of available extensions at https://deb.henderkes.com/pool/main/p/
+    RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests \
+        frankenphp \
+        php-zts-cli \
+        php-zts-gd \
+        php-zts-pdo-mysql
+    # Make sure that 'php' command uses the ZTS version of PHP
+    # and that the php.ini in use by FrankenPHP is the one from DDEV.
+    RUN ln -sf /usr/bin/php-zts /usr/local/bin/php && \
+        ln -sf /etc/php/${DDEV_PHP_VERSION}/fpm/php.ini /etc/php-zts/php.ini
     INNEREOF
 
     ddev composer create-project drupal/recommended-project

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -352,7 +352,6 @@ var (
 		// 20: frankenphp
 		{
 			Name:                          "TestPkgFrankenPHP",
-			Disable:                       true,
 			SourceURL:                     "https://github.com/ddev/test-frankenphp/archive/refs/tags/11.1.2.tar.gz",
 			ArchiveInternalExtractionPath: "test-frankenphp-11.1.2/",
 			FilesTarballURL:               "https://github.com/ddev/test-frankenphp/releases/download/11.1.2/files.tgz",


### PR DESCRIPTION
## The Issue

We see failures for FrankenPHP:

* https://github.com/ddev/ddev/actions/runs/19575538173/job/56059689072

* https://github.com/php/frankenphp/issues/2014

```
#   #24 13.64 🥳 FrankenPHP installed successfully.
#   #24 13.64
#   #24 13.64 ⭐ If you like FrankenPHP, please give it a star on GitHub: https://github.com/php/frankenphp
#   #24 DONE 13.7s
#
#   #25 [web 12/15] RUN mv frankenphp /usr/local/bin/
#   #25 0.149 mv: cannot stat 'frankenphp': No such file or directory
#   #25 ERROR: process "/bin/bash -c mv frankenphp /usr/local/bin/" did not complete successfully: exit code: 1
#   ------
#    > [web 12/15] RUN mv frankenphp /usr/local/bin/:
#   0.149 mv: cannot stat 'frankenphp': No such file or directory
```

## How This PR Solves The Issue

FrankenPHP started providing it's binaries with deb repo https://deb.henderkes.com/dists/stable/main/binary-amd64/

Which resulted in automatic install:

```bash
$ ddev exec apt-cache madison frankenphp
frankenphp |    1.9.1-1 | https://deb.henderkes.com stable/main amd64 Packages

$ ddev exec dpkg -L frankenphp
/.
/usr
/usr/lib
/usr/lib/systemd
/usr/lib/systemd/system
/usr/lib/systemd/system/frankenphp.service
/usr/bin
/usr/bin/frankenphp
/usr/share
/usr/share/doc
/usr/share/doc/frankenphp
/usr/share/doc/frankenphp/changelog.gz
/usr/share/frankenphp
/usr/share/frankenphp/index.php
/etc
/etc/frankenphp
/etc/frankenphp/Caddyfile
/var
/var/lib
/var/lib/frankenphp
```

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
