### PR TITLE
test(windows): make sure we have a  clean install distro

### DIFF
--- a/winpkg/installer_test.go
+++ b/winpkg/installer_test.go
@@ -366,7 +366,7 @@ func testBasicDdevFunctionality(t *testing.T, distroName string) {
 	projectName := "tp"
 
 	// Make sure previous has been deleted
-	_, _ = exec.RunHostCommand("wsl.exe", "-d", tc.distro, "bash", "-c", "ddev delete -Oy tp")
+	_, _ = exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", "ddev delete -Oy tp")
 
 	// Clean up any existing test project
 	_, _ = exec.RunHostCommand("wsl.exe", "-d", distroName, "rm", "-rf", projectDir)


### PR DESCRIPTION
## The Issue

Our Windows installer tests are failing because we test for basic functionality, creating a project. But we have changed the default database type and we're leaving the database behind.

https://buildkite.com/ddev/ddev-windows-mutagen/builds/5740#019aac5e-054b-4e0c-bdff-5c5e51265b46/285-346


## How This PR Solves The Issue

* Delete the project with `ddev delete` before starting the install
* Delete the project (and database) in test cleanup.

