### PR TITLE
fix: db port should be integer in generated TYPO3 AdditionalConfiguration.php, fixes #7892

### DIFF
--- a/pkg/ddevapp/typo3/AdditionalConfiguration.php
+++ b/pkg/ddevapp/typo3/AdditionalConfiguration.php
@@ -17,7 +17,7 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
                         'driver' => '{{ .DBDriver }}',
                         'host' => '{{ .DBHostname }}',
                         'password' => 'db',
-                        'port' => '{{ .DBPort }}',
+                        'port' => {{ .DBPort }},
                         'user' => 'db',
                     ],
                 ],


### PR DESCRIPTION
Resolves: #7892