### PR TITLE
build(curl): use trixie-backports to install newer curl

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -19,12 +19,17 @@ done
 
 RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb /usr/sbin/tar /usr/sbin/rm
 
+# Add backports repository to have ability to install newer packages
+# See https://backports.debian.org/Instructions/
+# This is used to install updated curl, see https://github.com/curl/curl/issues/18336
+RUN printf "Types: deb\nURIs: http://deb.debian.org/debian\nSuites: trixie-backports\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.pgp\n" > /etc/apt/sources.list.d/debian-backports.sources
+
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     apt-transport-https \
     ca-certificates \
     bzip2 \
-    curl \
+    curl/trixie-backports \
     git \
     gnupg \
     lsb-release \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:20251117_apt_sources AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20251124_stasadev_curl AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20251117_apt_sources" // Note that this can be overridden by make
+var WebTag = "20251124_stasadev_curl" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

We see intermittent failures in the quickstart test for CiviCRM https://github.com/ddev/ddev/actions/runs/19634715541/job/56222544521?pr=7889

```
...
ddev composer require civicrm/cli-tools --no-scripts
...
Unhandled promise rejection with Composer\Downloader\TransportException: curl error 95 while downloading https://storage.googleapis.com/civicrm/cv/cv-0.3.67.phar: HTTP/3 stream 0 reset by server in phar:///usr/local/bin/composer/src/Composer/Util/Http/CurlDownloader.php:398
...
```

It's not clear either this is related to some Composer 2.9 changes or using Debian Trixie.

DDEV v1.24.10 doesn't have support for HTTP/3 in curl:

```
# DDEV v1.24.10
$ docker run --rm -it ddev/ddev-webserver:v1.24.10 curl --version
curl 7.88.1 (x86_64-pc-linux-gnu) libcurl/7.88.1 OpenSSL/3.0.17 zlib/1.2.13 brotli/1.0.9 zstd/1.5.4 libidn2/2.3.3 libpsl/0.21.2 (+libidn2/2.3.3) libssh2/1.10.0 nghttp2/1.52.0 librtmp/2.3 OpenLDAP/2.5.13
Release-Date: 2023-02-20, security patched: 7.88.1-10+deb12u14
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB PSL SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd

# DDEV HEAD
$ docker run --rm -it ddev/ddev-webserver:20251117_apt_sources curl --version
curl 8.14.1 (x86_64-pc-linux-gnu) libcurl/8.14.1 OpenSSL/3.5.4 zlib/1.3.1 brotli/1.1.0 zstd/1.5.7 libidn2/2.3.8 libpsl/0.21.2 libssh2/1.11.1 nghttp2/1.64.0 nghttp3/1.8.0 librtmp/2.3 OpenLDAP/2.6.10
Release-Date: 2025-06-04, security patched: 8.14.1-2+deb13u2
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM PSL SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd
```

## How This PR Solves The Issue

Uses [Debian Backports](https://backports.debian.org/Instructions/) repository to install newer `curl`.

There's no guarantee that it's going to help, but according to this issue, there are some new fixes:

- https://github.com/curl/curl/issues/18336

## Manual Testing Instructions

```
$ ddev exec curl --version
curl 8.16.0 (x86_64-pc-linux-gnu) libcurl/8.16.0 OpenSSL/3.5.4 zlib/1.3.1 brotli/1.1.0 zstd/1.5.7 libidn2/2.3.8 libpsl/0.21.2 libssh2/1.11.1 nghttp2/1.64.0 ngtcp2/1.16.0 nghttp3/1.12.0 librtmp/2.3 OpenLDAP/2.6.10
Release-Date: 2025-09-10, security patched: 8.16.0-4~bpo13+1
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM PSL SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd

$ ddev exec apt-cache madison curl      
      curl | 8.16.0-4~bpo13+1 | http://deb.debian.org/debian trixie-backports/main amd64 Packages
      curl | 8.14.1-2+deb13u2 | http://deb.debian.org/debian trixie/main amd64 Packages
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
