### PR TITLE
docs: update TYPO3 link

### DIFF
--- a/docs/content/users/usage/vite.md
+++ b/docs/content/users/usage/vite.md
@@ -201,7 +201,7 @@ Several tools are available for integrating Vite with TYPO3:
 - **[vite-plugin-typo3](https://github.com/s2b/vite-plugin-typo3)** - Vite plugin for TYPO3
 - **[ddev-vite-sidecar](https://github.com/s2b/ddev-vite-sidecar)** - DDEV add-on for zero-config Vite integration
 
-The vite-asset-collector extension provides detailed [DDEV installation instructions](https://docs.typo3.org/p/praetorius/vite-asset-collector/main/en-us/Installation/Index.html#installation-1). For questions or support, join the Vite channel on [TYPO3 Slack](https://typo3.org/community/meet/chat-slack).
+The vite-asset-collector extension provides detailed [DDEV installation instructions](https://docs.typo3.org/p/praetorius/vite-asset-collector/main/en-us/Installation/Index.html#installation-1). For questions or support, join the Vite channel on [TYPO3 Slack](https://typo3.community/meet/slack).
 
 ## WordPress
 


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/19641268847/job/56245091306

```
Running linkspector with reviewdog 🐶 ...
  message:"Cannot reach https://typo3.org/community/meet/chat-slack Status: 404"
```

## How This PR Solves The Issue

Uses a new link.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
