### PR TITLE
test(typo3): Fix TYPO3 quickstart, failing since TYPO3 v14.0.0 released

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2609,7 +2609,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```bash
     PROJECT_NAME=my-typo3-site
     mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
-    ddev config --project-type=typo3 --docroot=public --php-version=8.3
+    ddev config --project-type=typo3 --docroot=public
     ```
 
     Start DDEV (this may take a minute):
@@ -2621,7 +2621,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     Install TYPO3 via Composer:
 
     ```bash
-    ddev composer create-project "typo3/cms-base-distribution"
+    ddev composer create-project "typo3/cms-base-distribution:^13"
     ```
 
     Run the TYPO3 setup:
@@ -2658,9 +2658,9 @@ DDEV automatically updates or creates the `.env.local` file with the database in
         set -euo pipefail
         PROJECT_NAME=my-typo3-site
         mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
-        ddev config --project-type=typo3 --docroot=public --php-version=8.3
+        ddev config --project-type=typo3 --docroot=public
         ddev start -y
-        ddev composer create-project "typo3/cms-base-distribution"
+        ddev composer create-project "typo3/cms-base-distribution:^13"
         ddev typo3 setup \
             --admin-user-password="Demo123*" \
             --driver=mysqli \
@@ -2691,7 +2691,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     PROJECT_NAME=my-typo3-site
     mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
     git clone ${PROJECT_GIT_REPOSITORY} .
-    ddev config --project-type=typo3 --docroot=public --php-version=8.3
+    ddev config --project-type=typo3 --docroot=public
     ddev start
     ddev composer install
     ddev exec touch public/FIRST_INSTALL


### PR DESCRIPTION
## The Issue

- https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/issues/76

- https://github.com/ddev/ddev/actions/runs/19650186675/job/56275109822

TYPO3 v14.0.0 was released today, and broke a couple of the TYPO3 quickstarts right away.

## How This PR Solves The Issue

* Use default PHP version for most TYPO3 installs (at least newer)
* Don't test v14 yet
* Make the xhgui variant use v13

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
