### PR TITLE
fix(commands): make `HostWorkingDir` respect `WebWorkingDir`

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -87,6 +87,7 @@ func init() {
 			postImportDBAction:         backdropPostImportDBAction,
 			postStartAction:            backdropPostStartAction,
 			importFilesAction:          backdropImportFilesAction,
+			defaultWorkingDirMap:       docrootWorkingDir,
 			composerCreateAllowedPaths: getBackdropComposerCreateAllowedPaths,
 		},
 
@@ -113,6 +114,7 @@ func init() {
 			configOverrideAction:       drupalConfigOverrideAction,
 			postStartAction:            drupal6PostStartAction,
 			importFilesAction:          drupalImportFilesAction,
+			defaultWorkingDirMap:       docrootWorkingDir,
 			composerCreateAllowedPaths: getDrupalComposerCreateAllowedPaths,
 		},
 
@@ -125,6 +127,7 @@ func init() {
 			configOverrideAction:       drupal7ConfigOverrideAction,
 			postStartAction:            drupal7PostStartAction,
 			importFilesAction:          drupalImportFilesAction,
+			defaultWorkingDirMap:       docrootWorkingDir,
 			composerCreateAllowedPaths: getDrupalComposerCreateAllowedPaths,
 		},
 


### PR DESCRIPTION
## The Issue

As discussed on slack here: https://drupal.slack.com/archives/C5TQRQZRR/p1764172282991909

There have been issues with using `ddev npm` in "backdrop" projerts whereby the path to package.json is formed incorrectly (with the docroot part repeated) leading to errors - `ddev ssh` also takes you to the docroot rather than the project root. `defaultWorkingDirMap` was found to be the culprit  in [apptypes.go](/ddev/ddev/blob/main/pkg/ddevapp/apptypes.go) and is also found in the Drupal 6 and Drupal 7 config in that same file.  So we'd expect similar issues for custom commands which use HostWorkingDir and in Drupal 6 or Drupal 7 projects.

Before the attached changes, these actions...
```
mkdir x && cd x
ddev config --docroot=mydocroot --project-type=backdrop
ddev start
cd mydocroot
ddev npm init -y
```
...result in this error:
```
OCI runtime exec failed: exec failed: unable to start container process: chdir to cwd ("/var/www/html/mydocroot/mydocroot") set in config.json failed: no such file or directory
```

## How This PR Solves The Issue

Removing defaultWorkingDirMap from app type configurations (appTypeMatrix initialization) for Backdrop, Drupal 6, and Drupal 7 means that the normal project root takes precedence, hence npm commands and others behave as expected.

## Manual Testing Instructions

After the changes...
```
mkdir x && cd x
ddev config --docroot=mydocroot --project-type=backdrop
ddev start
cd mydocroot
ddev npm init -y
```
....rather than an error, this should now result in the expected behavior of creating a new package.json file. 

This should be tested by maintainers.

## Automated Testing Overview

No tests are introduced by this PR.

This change brings the config in-line with other project types so no automated testing is required.

## Release/Deployment Notes

If users of backdrop, or drupal 6 & 7, have implemented workarounds for this behavior and/or have come to expect actions performed at the project root to be erroneously acted upon in the docroot, they should update their scripts and practices to account for this fix.

Backdrop users with the code in a subdirectory will experience a change on `ddev ssh` and `ddev exec`