### PR TITLE
test(quickstart): php8.3 for silverstripe and symfony, disable typo3 v13

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2298,7 +2298,7 @@ Use a new or existing Composer project, or clone a Git repository.
 
     ```bash
     mkdir my-silverstripe-site && cd my-silverstripe-site
-    ddev config --project-type=silverstripe --docroot=public
+    ddev config --project-type=silverstripe --docroot=public --php-version=8.3
     ```
 
     Start DDEV (this may take a minute):
@@ -2328,7 +2328,7 @@ Use a new or existing Composer project, or clone a Git repository.
         #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-silverstripe-site && cd my-silverstripe-site
-        ddev config --project-type=silverstripe --docroot=public
+        ddev config --project-type=silverstripe --docroot=public --php-version=8.3
         ddev start -y
         ddev composer create-project --prefer-dist silverstripe/installer
         ddev sake dev/build flush=all
@@ -2343,7 +2343,7 @@ Use a new or existing Composer project, or clone a Git repository.
     ```bash
     git clone <my-silverstripe-repo> my-silverstripe-site
     cd my-silverstripe-site
-    ddev config --project-type=silverstripe --docroot=public
+    ddev config --project-type=silverstripe --docroot=public --php-version=8.3
     ddev start
     ddev composer install
     ddev sake dev/build flush=all
@@ -2520,7 +2520,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
-    ddev config --project-type=symfony --docroot=public
+    ddev config --project-type=symfony --docroot=public --php-version=8.3
     ```
 
     Start DDEV (this may take a minute):
@@ -2551,7 +2551,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
         #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-symfony-site && cd my-symfony-site
-        ddev config --project-type=symfony --docroot=public
+        ddev config --project-type=symfony --docroot=public --php-version=8.3
         ddev start -y
         ddev composer create-project symfony/skeleton
         ddev composer require webapp
@@ -2565,7 +2565,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
-    ddev config --project-type=symfony --docroot=public
+    ddev config --project-type=symfony --docroot=public --php-version=8.3
     ddev start
     ddev exec symfony check:requirements
     ddev exec symfony new temp --webapp
@@ -2580,7 +2580,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```bash
     git clone <my-symfony-repo> my-symfony-site
     cd my-symfony-site
-    ddev config --project-type=symfony --docroot=public
+    ddev config --project-type=symfony --docroot=public --php-version=8.3
     ddev start
     ddev composer install
     ddev launch

--- a/docs/tests/silverstripe.bats
+++ b/docs/tests/silverstripe.bats
@@ -15,7 +15,8 @@ teardown() {
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  run ddev config --project-type=silverstripe --docroot=public
+  # TODO: quickstart, I reported the problem with PHP 8.4 upstream, see https://github.com/silverstripe/silverstripe-framework/issues/11913
+  run ddev config --project-type=silverstripe --docroot=public --php-version=8.3
   assert_success
 
   run ddev start -y

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -15,7 +15,8 @@ teardown() {
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  run ddev config --project-type=symfony --docroot=public
+  # TODO: quickstart, Symfony 8.0 requires PHP 8.4, but there are some issues with dependencies at this time, pin it to 8.3 for now.
+  run ddev config --project-type=symfony --docroot=public --php-version=8.3
   assert_success
 
   run ddev start -y
@@ -47,7 +48,8 @@ teardown() {
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  run ddev config --project-type=symfony --docroot=public
+  # TODO: quickstart, Symfony 8.0 requires PHP 8.4, but there are some issues with dependencies at this time, pin it to 8.3 for now.
+  run ddev config --project-type=symfony --docroot=public --php-version=8.3
   assert_success
 
   run ddev start -y

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "TYPO3 v13 'ddev typo3 setup' composer test with $(ddev --version)" {
+  # TODO: quickstart, waiting for fix from TYPO3
+  skip "re-enable this when typo3 v13 composer build works, see https://forge.typo3.org/issues/108349"
   PROJNAME=my-typo3-site
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -38,7 +40,7 @@ teardown() {
     --force
   assert_success
 
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 
@@ -77,7 +79,7 @@ teardown() {
     --force
   assert_success
 
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 
@@ -102,7 +104,7 @@ teardown() {
   run ddev exec touch public/FIRST_INSTALL
   assert_success
 
-  run bash -c "DDEV_DEBUG=true ddev launch /typo3/install.php"
+  DDEV_DEBUG=true run ddev launch /typo3/install.php
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/typo3/install.php"
   assert_success
 
@@ -111,7 +113,6 @@ teardown() {
   run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/typo3/install.php \| grep "data-init=\"TYPO3/CMS/Install/Installer\""
   assert_success
 }
-
 
 @test "TYPO3 git based quickstart with $(ddev --version)" {
   PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
@@ -128,7 +129,7 @@ teardown() {
   assert_success
   run ddev exec touch public/FIRST_INSTALL
   assert_success
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
@@ -183,6 +184,7 @@ teardown() {
 # This test is for the future, when we have a v14 quickstart.
 # bats test_tags=typo3-setup,t3v14
 @test "TYPO3 v14 'ddev typo3 setup' composer test with $(ddev --version)" {
+  # TODO: quickstart, waiting for fix from TYPO3, this is probably the same issue as v13
   skip "re-enable this when typo3 v14 composer build works, see https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/issues/76"
   PROJNAME=my-typo3-site
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
@@ -210,7 +212,7 @@ teardown() {
     --force
   assert_success
 
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 


### PR DESCRIPTION
## The Issue

We see failures in our quickstart tests https://github.com/ddev/ddev/actions/runs/19737429486/job/56552634960?pr=7907#step:8:142

This is all related to recent updates for Symfony https://symfony.com/blog/preparing-for-symfony-7-4-and-symfony-8-0

## How This PR Solves The Issue

- Uses PHP 8.3 in Silverstripe, upstream issue https://github.com/silverstripe/silverstripe-framework/issues/11913
- Disables testing for TYPO3 v13, upstream issue https://forge.typo3.org/issues/108349
- Uses PHP 8.3 for Symfony, which uses Symfony 7.4, there are some unsorted composer dependencies in Symfony 8.0

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
