### PR TITLE
test(add-on): replace redis-commander with redis-insight

### DIFF
--- a/cmd/ddev/cmd/addon-search.go
+++ b/cmd/ddev/cmd/addon-search.go
@@ -25,8 +25,8 @@ var AddonSearchCmd = &cobra.Command{
 	Long:  `Search available DDEV add-ons by name or description.`,
 	Example: `ddev add-on search redis
 ddev add-on search database
-ddev add-on search redis commander
-ddev add-on search "redis commander"`,
+ddev add-on search redis insight
+ddev add-on search "redis insight"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		searchTerms := strings.Join(args, " ")
 

--- a/cmd/ddev/cmd/addon_test.go
+++ b/cmd/ddev/cmd/addon_test.go
@@ -607,10 +607,10 @@ func TestCmdAddonSearch(t *testing.T) {
 	assert.Contains(out, "repositories found matching 'redis cache'")
 
 	// Test search with quotes
-	out, err = exec.RunHostCommand(DdevBin, "add-on", "search", "redis commander")
-	assert.NoError(err, "failed ddev add-on search 'redis commander': %v (%s)", err, out)
-	assert.Contains(out, "ddev/ddev-redis-commander")
-	assert.Contains(out, "repositories found matching 'redis commander'")
+	out, err = exec.RunHostCommand(DdevBin, "add-on", "search", "redis insight")
+	assert.NoError(err, "failed ddev add-on search 'redis insight': %v (%s)", err, out)
+	assert.Contains(out, "ddev/ddev-redis-insight")
+	assert.Contains(out, "repositories found matching 'redis insight'")
 
 	// Test search with no results
 	out, err = exec.RunHostCommand(DdevBin, "add-on", "search", "nonexistentservice")

--- a/docs/content/users/extend/using-add-ons.md
+++ b/docs/content/users/extend/using-add-ons.md
@@ -46,7 +46,7 @@ ddev add-on search redis
 ddev add-on search redis web
 
 # Search with multiple terms using quotes (currently same behavior)
-ddev add-on search "redis commander"
+ddev add-on search "redis insight"
 ```
 
 ## Installing Add-ons
@@ -214,7 +214,7 @@ This approach:
 
 - **[`ddev/ddev-adminer`](https://github.com/ddev/ddev-adminer)** - Adminer web-based MySQL, MariaDB, PostgreSQL database browser
 - **[`ddev/ddev-phpmyadmin`](https://github.com/ddev/ddev-phpmyadmin)** - Web-based phpMyAdmin interface for MySQL, MariaDB
-- **[`ddev/ddev-redis-commander`](https://github.com/ddev/ddev-redis-commander)** - Redis Commander Web UI for use with Redis service
+- **[`ddev/ddev-redis-insight`](https://github.com/ddev/ddev-redis-insight)** - Redis Insight Web UI for use with Redis service
 - **[`ddev/ddev-browsersync`](https://github.com/ddev/ddev-browsersync)** - Live-reload and HTTPS auto-refresh on file changes
 
 ### Platform and Cloud Integration

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -122,7 +122,7 @@ ddev add-on get /path/to/tarball.tar.gz
 ddev add-on get ddev/ddev-redis --project my-project
 
 # Install an add-on without installing its dependencies
-ddev add-on get ddev/ddev-redis-commander --skip-deps
+ddev add-on get ddev/ddev-redis-insight --skip-deps
 ```
 
 **Automatic Dependency Installation:**
@@ -196,7 +196,7 @@ ddev add-on search database
 ddev add-on search redis web
 
 # Search with multiple terms using quotes (currently same behavior)
-ddev add-on search "redis commander"
+ddev add-on search "redis insight"
 ```
 
 ## `aliases`

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -46,9 +46,9 @@ func TestGetGitHubRelease(t *testing.T) {
 
 	// Test real addon with dependencies
 	t.Run("RealAddonWithDependencies", func(t *testing.T) {
-		// Test ddev-redis-commander which depends on ddev-redis
-		tarballURL, version, err := github.GetGitHubRelease("ddev", "ddev-redis-commander", "")
-		require.NoError(t, err, "Should successfully get ddev-redis-commander release")
+		// Test ddev-redis-insight which depends on ddev-redis
+		tarballURL, version, err := github.GetGitHubRelease("ddev", "ddev-redis-insight", "")
+		require.NoError(t, err, "Should successfully get ddev-redis-insight release")
 		require.NotEmpty(t, tarballURL, "Tarball URL should not be empty")
 		require.NotEmpty(t, version, "Version should not be empty")
 		require.Contains(t, tarballURL, "github.com", "Tarball URL should be from GitHub")


### PR DESCRIPTION
## The Issue

Our tests are failing because I archived this add-on:

- https://github.com/ddev/ddev-redis-commander/issues/29

And now we have https://github.com/ddev/ddev-redis-insight available.

## How This PR Solves The Issue

Replaces `redis-commander` with `redis-insight`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
