### PR TITLE
fix: use correct condition for host ports, fixes #7920

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2714,7 +2714,7 @@ func (app *DdevApp) DockerEnv() map[string]string {
 	hostHTTPPort, err := app.GetPublishedPort("web")
 	hostHTTPPortStr := ""
 	// Otherwise we'll use the configured value from app.HostWebserverPort
-	if hostHTTPPort > 0 || err == nil {
+	if hostHTTPPort > 0 && err == nil {
 		hostHTTPPortStr = strconv.Itoa(hostHTTPPort)
 	} else {
 		hostHTTPPortStr = app.HostWebserverPort
@@ -2725,7 +2725,7 @@ func (app *DdevApp) DockerEnv() map[string]string {
 	// for the vast majority of applications
 	hostHTTPSPort, err := app.GetPublishedPortForPrivatePort("web", 443)
 	hostHTTPSPortStr := ""
-	if hostHTTPSPort > 0 || err == nil {
+	if hostHTTPSPort > 0 && err == nil {
 		hostHTTPSPortStr = strconv.Itoa(hostHTTPSPort)
 	} else {
 		hostHTTPSPortStr = app.HostHTTPSPort


### PR DESCRIPTION
## The Issue

- #7920 

## How This PR Solves The Issue

The condition was wrong, because function could return `0` for port and `nil` for error, which satisfied it, but it should have been:

```diff
-if hostHTTPPort > 0 || err == nil {
+if hostHTTPPort > 0 && err == nil {
```

## Manual Testing Instructions

I tested it using instructions from #7920

The error itself is clear from the code, because Docker used random port when `0` was provided.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
