### PR TITLE
fix(router): bypass CheckRouterPorts when all ports appear busy, fixes #7921

### DIFF
--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -172,7 +172,18 @@ The resulting output displays which command is running and its PID. Choose the a
 
 You may also be able to find what’s using a port using `curl`. On Linux, macOS, or in Git Bash on Windows, `curl -I localhost` or `curl -I -k https://localhost:443`. The result may give you a hint about which application is at fault.
 
-We welcome your [suggestions](https://github.com/ddev/ddev/issues/new) based on other issues you’ve run into and your troubleshooting technique.
+We welcome your [suggestions](https://github.com/ddev/ddev/issues/new) based on other issues you've run into and your troubleshooting technique.
+
+### Security Software Interfering with Port Detection
+
+If you see messages like:
+
+```
+Unable to check port availability
+Assuming ports are available, see https://ddev.com/s/port-conflict
+```
+
+DDEV will rely on Docker to report actual port conflicts. This can happen when security software intercepts localhost traffic.
 
 ### Debugging Port Issues on WSL2
 


### PR DESCRIPTION
## The Issue

- #7921

[ESET Web access protection](https://help.eset.com/ees/10.1/en-US/idh_config_web_basic.html) intercepts connections to all locahost ports. and DDEV uses `net.DialTimeout`, which shows that something is running:

```
# Nothing running
$ sudo netstat -tulpn | grep LISTEN
tcp        0      0 127.0.0.53:53           0.0.0.0:*               LISTEN      757/systemd-resolve 
tcp        0      0 127.0.0.1:45769         0.0.0.0:*               LISTEN      1500/startd         
tcp        0      0 127.0.0.1:631           0.0.0.0:*               LISTEN      1457/cupsd          
tcp        0      0 127.0.0.54:53           0.0.0.0:*               LISTEN      757/systemd-resolve 
tcp6       0      0 ::1:36123               :::*                    LISTEN      1500/startd         
tcp6       0      0 ::1:631                 :::*                    LISTEN      1457/cupsd

# ESET interception
$ nc -zv 127.0.0.1 443
Connection to 127.0.0.1 443 port [tcp/https] succeeded!

$ nc -zv 127.0.0.1 444
Connection to 127.0.0.1 444 port [tcp/snpp] succeeded!

$ nc -zv 127.0.0.1 445
Connection to 127.0.0.1 445 port [tcp/microsoft-ds] succeeded!

$ nc -zv 127.0.0.1 12345
Connection to 127.0.0.1 12345 port [tcp/*] succeeded!

# Dumping TCP
# (run 'nc -zv 127.0.0.1 443' in another window)
$ sudo tcpdump -i lo port 443 -nn -vv
tcpdump: listening on lo, link-type EN10MB (Ethernet), snapshot length 262144 bytes
13:17:01.772126 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 60)
    127.0.0.1.443 > 127.0.0.1.53808: Flags [S.], cksum 0xfe30 (incorrect -> 0x7898), seq 1396971548, ack 2647314800, win 65483, options [mss 65495,sackOK,TS val 2278231204 ecr 2278231203,nop,wscale 7], length 0
13:17:01.772276 IP (tos 0x0, ttl 64, id 43055, offset 0, flags [DF], proto TCP (6), length 60)
    127.0.0.1.53822 > 127.0.0.1.443: Flags [S], cksum 0xfe30 (incorrect -> 0x2175), seq 2368813298, win 65495, options [mss 65495,sackOK,TS val 2278231204 ecr 0,nop,wscale 7], length 0
13:17:01.772287 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 40)
    127.0.0.1.443 > 127.0.0.1.53822: Flags [R.], cksum 0x17b0 (correct), seq 0, ack 2368813299, win 0, length 0
13:17:01.772373 IP (tos 0x0, ttl 64, id 62771, offset 0, flags [DF], proto TCP (6), length 52)
    127.0.0.1.443 > 127.0.0.1.53808: Flags [F.], cksum 0xfe28 (incorrect -> 0x9f52), seq 1, ack 1, win 512, options [nop,nop,TS val 2278231204 ecr 2278231204], length 0
13:17:01.772537 IP (tos 0x0, ttl 64, id 62772, offset 0, flags [DF], proto TCP (6), length 52)
```

- `Flags [S.]` = SYN-ACK (connection accepted)
- `Flags [S]` = SYN (connection request)
- `Flags [R.]` = RST-ACK (connection reset/refused)
- `Flags [F.]` = FIN-ACK (graceful close)

## How This PR Solves The Issue

We have `ddevapp.CheckRouterPorts()`, which returns an error if a router port cannot be allocated.

If all ephemeral ports appear busy, there is a very high chance this is caused by software interference.

This PR adds an extra check for ephemeral ports availability inside `ddevapp.CheckRouterPorts()`.

It runs only when the error indicates a busy port, so it doesn't add any extra complexity.

## Manual Testing Instructions

Docs change https://ddev--7927.org.readthedocs.build/en/7927/users/usage/troubleshooting/#security-software-interfering-with-port-detection

---

Dummy approach, this PR, edit `pkg/ddevapp/router.go`:

```diff
-MaxEphemeralPort         = 35000
+MaxEphemeralPort         = 33001
```

```bash
# build the binary
$ make

# make all ports busy to emulate busy behavior
$ docker run --rm -p 80:80 -p 443:443 -p 8025:8025 -p 8026:8026 -p 8142:8142 -p 8143:8143 -p 33000:33000 -p 33001:33001 nginx

# in this case `ddev start` should fail on `docker-compose up` step, not inside `ddev` codebase:
$ DDEV_DEBUG=true ddev start
Network ddev_default created 
2026-01-26T17:40:36.981 Downloading sponsorship data from remote source. 
Starting d11... 
2026-01-26T17:40:37.368 GetAvailableRouterPort(): proposedPort 80 is not available, no ephemeral ports in range 33000-33001 are available 
Unable to check port availability 
Assuming ports are available, see https://ddev.com/s/port-conflict 
2026-01-26T17:40:37.368 GetAvailableRouterPort(): proposedPort 443 is available, use proposedPort=443 
2026-01-26T17:40:37.368 GetAvailableRouterPort(): proposedPort 8025 is available, use proposedPort=8025 
2026-01-26T17:40:37.369 GetAvailableRouterPort(): proposedPort 8026 is available, use proposedPort=8026 
2026-01-26T17:40:37.369 GetAvailableRouterPort(): proposedPort 8143 is available, use proposedPort=8143 
2026-01-26T17:40:37.369 GetAvailableRouterPort(): proposedPort 8142 is available, use proposedPort=8142 
2026-01-26T17:40:37.404 host.docker.internal='172.17.0.1' because IsLinux uses 'host-gateway' in extra_hosts 
2026-01-26T17:40:37.405 Using automatically detected timezone: TZ=Europe/Kyiv 
2026-01-26T17:40:37.874 All images already exist locally, no pull needed 
2026-01-26T17:40:38.679 creating docker volume ddev-global-cache 
2026-01-26T17:40:38.680 creating docker volume ddev-d11-snapshots 
2026-01-26T17:40:38.682 creating docker volume d11-mariadb 
2026-01-26T17:40:39.147 Exec chown -R 1000:1000 /mnt/ddev-global-cache /var/lib/mysql 
2026-01-26T17:40:40.838 Done chown -R 1000:1000 /mnt/ddev-global-cache /var/lib/mysql: output= 
2026-01-26T17:40:40.944 All images already exist locally, no pull needed 
 Container ddev-ssh-agent Started  
2026-01-26T17:40:41.645 Waiting for ddev-ssh-agent to become ready, timeout=60 
2026-01-26T17:40:42.159 ContainerWait: ddev-ssh-agent status change: 'starting' after 514ms 
2026-01-26T17:40:47.165 ContainerWait: ddev-ssh-agent status change: 'healthy' after 5.519s 
ssh-agent container is running: If you want to add authentication to the ssh-agent container, run 'ddev auth ssh' to enable your keys. 
2026-01-26T17:40:47.168 Ensuring write permissions for d11 
2026-01-26T17:40:47.175 Existing settings.php file includes settings.ddev.php 
2026-01-26T17:40:47.176 host.docker.internal='172.17.0.1' because IsLinux uses 'host-gateway' in extra_hosts 
2026-01-26T17:40:47.176 Using automatically detected timezone: TZ=Europe/Kyiv 
Building project images... 
2026-01-26T17:40:47.276 Executing docker-compose -f /home/stas/code/ddev-quickstarts/d11/.ddev/.ddev-docker-compose-full.yaml --progress=plain build 
..
Project images built in 3s. 
2026-01-26T17:40:49.971 Removing dangling images for the project ddev-d11 
2026-01-26T17:40:50.104 Executing docker-compose -f /home/stas/code/ddev-quickstarts/d11/.ddev/.ddev-docker-compose-full.yaml up -d 
 Network ddev-d11_default Created  
 Container ddev-d11-web Started  
 Container ddev-d11-db Started  
2026-01-26T17:40:51.379 Copied /home/stas/.local/share/mkcert:CopyIntoVolume_ycqcmetefrha into /mnt/v/mkcert in 79.344963ms 
2026-01-26T17:40:51.433 Exec chown -R 1000 /mnt/v/mkcert stdout=, stderr=, err=<nil> 
2026-01-26T17:40:51.599 Pushed mkcert rootca certs to ddev-global-cache/mkcert 
2026-01-26T17:40:51.599 VIRTUAL_HOST=d11.ddev.site for web 
2026-01-26T17:40:51.599 HTTP_EXPOSE=80:80,8025:8025 for web 
2026-01-26T17:40:51.599 HTTPS_EXPOSE=443:80,8026:8025 for web 
2026-01-26T17:40:51.599 VIRTUAL_HOST=d11.ddev.site for xhgui 
2026-01-26T17:40:51.599 HTTP_EXPOSE=8143:80 for xhgui 
2026-01-26T17:40:51.599 HTTPS_EXPOSE=8142:80 for xhgui 
2026-01-26T17:40:51.745 Running /start.sh in ddev-webserver 
Waiting for containers to become ready: [web db]...
2026-01-26T17:40:52.452 ContainerWait: ddev-d11-web status change: 'starting' after 514ms 
2026-01-26T17:40:57.455 ContainerWait: still waiting for ddev-d11-web, status='starting' after 5.517s 
2026-01-26T17:40:59.949 ContainerWait: ddev-d11-web status change: 'healthy' after 8.011s 
2026-01-26T17:41:00.467 ContainerWait: ddev-d11-db status change: 'healthy' after 518ms 
 ready in 8.5s
2026-01-26T17:41:01.356 Copied /home/stas/.ddev/commands:CopyIntoVolume_petusxofylso into /mnt/v/global-commands in 61.745384ms 
2026-01-26T17:41:01.403 Exec chown -R 1000 /mnt/v/global-commands stdout=, stderr=, err=<nil> 
2026-01-26T17:41:02.173 Testing to see if /mnt/ddev_config is properly mounted 
2026-01-26T17:41:02.369 Getting stderr output from 'log-stderr.sh --show' 
Starting ddev-router, pushing config... 
2026-01-26T17:41:02.647 VIRTUAL_HOST=d11.ddev.site for web 
2026-01-26T17:41:02.647 HTTP_EXPOSE=80:80,8025:8025 for web 
2026-01-26T17:41:02.647 HTTPS_EXPOSE=443:80,8026:8025 for web 
2026-01-26T17:41:02.647 VIRTUAL_HOST=d11.ddev.site for xhgui 
2026-01-26T17:41:02.647 HTTP_EXPOSE=8143:80 for xhgui 
2026-01-26T17:41:02.647 HTTPS_EXPOSE=8142:80 for xhgui 
2026-01-26T17:41:03.513 Copied /home/stas/.ddev/traefik:CopyIntoVolume_fovqqzbrqcaj into /mnt/v/traefik in 64.852413ms 
2026-01-26T17:41:03.567 Exec chown -R 1000 /mnt/v/traefik stdout=, stderr=, err=<nil> 
2026-01-26T17:41:04.041 Copied global Traefik config in /home/stas/.ddev/traefik to ddev-global-cache/traefik 
Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint ddev-router (cc6a0f8310d3dea9b40a5e3499322e5f34fb79cf709281b8637f9178a61b75a7): Bind for 0.0.0.0:80 failed: port is already allocated 
Failed to start d11: failed to start ddev-router: composeCmd failed to run 'COMPOSE_PROJECT_NAME=ddev-d11 docker-compose -f /home/stas/.ddev/.router-compose-full.yaml -p ddev-router up --build -d', action='[-p ddev-router up --build -d]', err='exit status 1', stdout='', stderr=' Container ddev-router Creating 
 Container ddev-router Created 
 Container ddev-router Starting 
Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint ddev-router (cc6a0f8310d3dea9b40a5e3499322e5f34fb79cf709281b8637f9178a61b75a7): Bind for 0.0.0.0:80 failed: port is already allocated'
```

After this, all ports "become" available, which means that we rely on Docker here:

```
2026-01-26T17:40:37.368 GetAvailableRouterPort(): proposedPort 80 is not available, no ephemeral ports in range 33000-33001 are available 
Unable to check port availability 
Assuming ports are available, see https://ddev.com/s/port-conflict 
2026-01-26T17:40:37.368 GetAvailableRouterPort(): proposedPort 443 is available, use proposedPort=443 
```

---


Real approach, using Ubuntu 24.04 and [Download, install and activate ESET Endpoint Antivirus for Linux](https://support.eset.com/en/kb8759-download-install-and-activate-eset-endpoint-antivirus-for-linux), install ESET, activate it, reboot, update modules inside ESET, and run `ddev start`.

```bash
wget https://download.eset.com/com/eset/apps/business/eea/linux/g2/latest/eeau_x86_64.bin
chmod +x ./eeau_x86_64.bin
sudo ./eeau_x86_64.bin --accept-license
sudo /opt/eset/eea/sbin/lic -k XXXX-XXXX-XXXX-XXXX-XXXX
# run ESET
ddev start
```

Before, v1.24.10:

```bash
$ DDEV_DEBUG=true ddev start
Network ddev_default created 
2025-12-08T13:12:19.353 Downloading sponsorship data from remote source. 
You seem to have a new DDEV version (new=v1.24.10, old=v1.24.10-71-gf3aef9614-dirty) 
During an upgrade it's important to `ddev poweroff`.
May I do `ddev poweroff` before continuing?
This does no harm and loses no data. [Y/n] (yes): 
2025-12-08T13:12:22.801 Attempted to stop Mutagen daemon for MUTAGEN_DATA_DIRECTORY=/home/stas/.ddev_mutagen_data_directory 
The ddev-ssh-agent container has been removed. When you start it again you will have to use 'ddev auth ssh' to provide key authentication again. 
Network ddev_default removed 
Starting my-laravel-site... 
2025-12-08T13:12:23.076 GetAvailableRouterPort(): unable to AllocateAvailablePortForRouter() 
2025-12-08T13:12:23.245 GetAvailableRouterPort(): unable to AllocateAvailablePortForRouter() 
2025-12-08T13:12:23.410 GetAvailableRouterPort(): unable to AllocateAvailablePortForRouter() 
2025-12-08T13:12:23.573 GetAvailableRouterPort(): unable to AllocateAvailablePortForRouter() 
2025-12-08T13:12:23.746 GetAvailableRouterPort(): unable to AllocateAvailablePortForRouter() 
2025-12-08T13:12:23.929 GetAvailableRouterPort(): unable to AllocateAvailablePortForRouter() 
Network ddev_default created 
2025-12-08T13:12:24.025 All images already exist locally, no pull needed 
2025-12-08T13:12:24.510 creating docker volume ddev-global-cache 
2025-12-08T13:12:24.511 creating docker volume ddev-my-laravel-site-snapshots 
2025-12-08T13:12:25.018 Exec chown -R 1000:1000 /mnt/ddev-global-cache /var/lib/mysql 
2025-12-08T13:12:25.497 Done chown -R 1000:1000 /mnt/ddev-global-cache /var/lib/mysql: output= 
2025-12-08T13:12:25.557 All images already exist locally, no pull needed 
 Container ddev-ssh-agent  Created 
 Container ddev-ssh-agent  Started 
2025-12-08T13:12:26.451 Waiting for ddev-ssh-agent to become ready, timeout=60 
ssh-agent container is running: If you want to add authentication to the ssh-agent container, run 'ddev auth ssh' to enable your keys. 
Using custom config.*.yaml configuration: 
  - /home/stas/workspace/my-laravel-site/.ddev/config.custom.yaml
 
Custom configuration is updated on restart.
If you don't see your custom configuration taking effect, run 'ddev restart'. 
2025-12-08T13:12:31.968 host.docker.internal='172.17.0.1' because IsLinux uses 'host-gateway' in extra_hosts 
2025-12-08T13:12:31.971 Using automatically detected timezone: TZ=Etc/UTC 
2025-12-08T13:12:32.129 All images already exist locally, no pull needed 
Building project images... 
2025-12-08T13:12:32.132 Executing docker-compose -f /home/stas/workspace/my-laravel-site/.ddev/.ddev-docker-compose-full.yaml build --progress=plain 
.
Project images built in 2s. 
2025-12-08T13:12:33.919 Removing dangling images for the project ddev-my-laravel-site 
2025-12-08T13:12:33.926 Executing docker-compose -f /home/stas/workspace/my-laravel-site/.ddev/.ddev-docker-compose-full.yaml up -d 
 Network ddev-my-laravel-site_default  Created 
 Container ddev-my-laravel-site-web  Created 
 Container ddev-my-laravel-site-db  Created 
 Container ddev-my-laravel-site-web  Started 
 Container ddev-my-laravel-site-db  Started 
2025-12-08T13:12:35.682 Copied /home/stas/.local/share/mkcert:CopyIntoVolume_jtkbcjnklpnt into /mnt/v/mkcert in 63.533487ms 
2025-12-08T13:12:35.737 Exec chown -R 1000 /mnt/v/mkcert stdout=, stderr=, err=<nil> 
2025-12-08T13:12:35.923 Pushed mkcert rootca certs to ddev-global-cache/mkcert 
2025-12-08T13:12:35.923 VIRTUAL_HOST=my-laravel-site.ddev.site for web 
2025-12-08T13:12:35.923 HTTP_EXPOSE=80:80,8025:8025 for web 
2025-12-08T13:12:35.923 HTTPS_EXPOSE=443:80,8026:8025 for web 
2025-12-08T13:12:35.923 VIRTUAL_HOST=my-laravel-site.ddev.site for xhgui 
2025-12-08T13:12:35.923 HTTP_EXPOSE=8143:80 for xhgui 
2025-12-08T13:12:35.923 HTTPS_EXPOSE=8142:80 for xhgui 
2025-12-08T13:12:36.569 Copied /home/stas/workspace/my-laravel-site/.ddev/traefik:CopyIntoVolume_ejgesvylnhfm into /mnt/v/traefik in 76.430952ms 
2025-12-08T13:12:36.623 Exec chown -R 1000 /mnt/v/traefik stdout=, stderr=, err=<nil> 
2025-12-08T13:12:36.806 Copied Traefik certs in /home/stas/workspace/my-laravel-site/.ddev/traefik/certs to ddev-global-cache/traefik 
2025-12-08T13:12:36.806 Running /start.sh in ddev-webserver 
Waiting for containers to become ready: [web db] 
2025-12-08T13:12:44.218 Copied /home/stas/.ddev/commands:CopyIntoVolume_lytrpeidjgkp into /mnt/v/global-commands in 133.799419ms 
2025-12-08T13:12:44.298 Exec chown -R 1000 /mnt/v/global-commands stdout=, stderr=, err=<nil> 
2025-12-08T13:12:44.775 Testing to see if /mnt/ddev_config is properly mounted 
2025-12-08T13:12:45.028 Getting stderr output from 'log-stderr.sh --show' 
Starting ddev-router if necessary... 
2025-12-08T13:12:45.407 VIRTUAL_HOST=my-laravel-site.ddev.site for xhgui 
2025-12-08T13:12:45.407 HTTP_EXPOSE=8143:80 for xhgui 
2025-12-08T13:12:45.407 HTTPS_EXPOSE=8142:80 for xhgui 
2025-12-08T13:12:45.407 VIRTUAL_HOST=my-laravel-site.ddev.site for web 
2025-12-08T13:12:45.407 HTTP_EXPOSE=80:80,8025:8025 for web 
2025-12-08T13:12:45.407 HTTPS_EXPOSE=443:80,8026:8025 for web 
2025-12-08T13:12:46.437 Copied /home/stas/.ddev/traefik:CopyIntoVolume_gsvgisavlgnc into /mnt/v/traefik in 97.741138ms 
2025-12-08T13:12:46.520 Exec chown -R 1000 /mnt/v/traefik stdout=, stderr=, err=<nil> 
2025-12-08T13:12:46.819 Copied global Traefik config in /home/stas/.ddev/traefik/certs to ddev-global-cache/traefik 
Failed to start my-laravel-site: unable to listen on required ports, port 443 is already in use,
Troubleshooting suggestions at https://docs.ddev.com/en/stable/users/usage/troubleshooting/#unable-listen
```

After, this PR:

```bash
$ DDEV_DEBUG=true ddev start
Network ddev_default created 
2026-01-26T16:45:57.137 Downloading sponsorship data from remote source. 
Starting my-laravel-site... 
2026-01-26T16:45:58.018 GetAvailableRouterPort(): proposedPort 80 is not available, no ephemeral ports in range 33000-35000 are available 
Unable to check port availability 
Assuming ports are available, see https://ddev.com/s/port-conflict 
2026-01-26T16:45:58.019 GetAvailableRouterPort(): proposedPort 443 is available, use proposedPort=443 
2026-01-26T16:45:58.019 GetAvailableRouterPort(): proposedPort 8025 is available, use proposedPort=8025 
2026-01-26T16:45:58.020 GetAvailableRouterPort(): proposedPort 8026 is available, use proposedPort=8026 
2026-01-26T16:45:58.020 GetAvailableRouterPort(): proposedPort 8143 is available, use proposedPort=8143 
2026-01-26T16:45:58.021 GetAvailableRouterPort(): proposedPort 8142 is available, use proposedPort=8142 
2026-01-26T16:45:58.073 Downloading 'https://github.com/docker/compose/releases/download/v5.0.2/docker-compose-linux-x86_64' to '/home/stas/.ddev/bin/docker-compose' ... 
2026-01-26T16:45:58.093 Attempting to download SHASUM URL=https://github.com/docker/compose/releases/download/v5.0.2/checksums.txt (attempt 1/3) with timeout 20s 
2026-01-26T16:45:58.732 Downloading https://github.com/docker/compose/releases/download/v5.0.2/docker-compose-linux-x86_64 to '/home/stas/.ddev/bin/docker-compose' (attempt 1/3) with timeout 20m0s 
29.88 MiB / 29.88 MiB [-------------------------------------------------------------------] 100.00% 23.51 MiB p/s 1.5s
Download complete. 
The index.php or index.html does not yet exist at this path:
/home/stas/workspace/my-laravel-site/public/index.*
You may get 403 errors 'permission denied' from the browser until it does.
Ignore if a later action (like `ddev composer create-project`) will create it.
 
2026-01-26T16:46:01.672 host.docker.internal='172.17.0.1' because IsLinux uses 'host-gateway' in extra_hosts 
2026-01-26T16:46:01.672 Using automatically detected timezone: TZ=Etc/UTC 
2026-01-26T16:46:01.760 All images already exist locally, no pull needed 
2026-01-26T16:46:02.161 creating docker volume ddev-global-cache 
2026-01-26T16:46:02.162 creating docker volume ddev-my-laravel-site-snapshots 
2026-01-26T16:46:02.163 creating docker volume my-laravel-site-mariadb 
2026-01-26T16:46:02.562 Exec chown -R 1000:1000 /mnt/ddev-global-cache /var/lib/mysql 
2026-01-26T16:46:02.925 Done chown -R 1000:1000 /mnt/ddev-global-cache /var/lib/mysql: output= 
2026-01-26T16:46:03.016 All images already exist locally, no pull needed 
 Container ddev-ssh-agent Started  
2026-01-26T16:46:03.817 Waiting for ddev-ssh-agent to become ready, timeout=60 
2026-01-26T16:46:04.322 ContainerWait: ddev-ssh-agent status change: 'starting' after 504ms 
2026-01-26T16:46:09.321 ContainerWait: ddev-ssh-agent status change: 'healthy' after 5.504s 
ssh-agent container is running: If you want to add authentication to the ssh-agent container, run 'ddev auth ssh' to enable your keys. 
2026-01-26T16:46:09.331 host.docker.internal='172.17.0.1' because IsLinux uses 'host-gateway' in extra_hosts 
2026-01-26T16:46:09.331 Using automatically detected timezone: TZ=Etc/UTC 
Building project images... 
2026-01-26T16:46:09.454 Executing docker-compose -f /home/stas/workspace/my-laravel-site/.ddev/.ddev-docker-compose-full.yaml --progress=plain build 
.
Project images built in 2s. 
2026-01-26T16:46:11.107 Removing dangling images for the project ddev-my-laravel-site 
2026-01-26T16:46:11.119 Executing docker-compose -f /home/stas/workspace/my-laravel-site/.ddev/.ddev-docker-compose-full.yaml up -d 
 Network ddev-my-laravel-site_default Created  
 Container ddev-my-laravel-site-web Started  
 Container ddev-my-laravel-site-db Started  
2026-01-26T16:46:13.340 Copied /home/stas/.local/share/mkcert:CopyIntoVolume_jmchtudgknmq into /mnt/v/mkcert in 115.449658ms 
2026-01-26T16:46:13.449 Exec chown -R 1000 /mnt/v/mkcert stdout=, stderr=, err=<nil> 
2026-01-26T16:46:13.684 Pushed mkcert rootca certs to ddev-global-cache/mkcert 
2026-01-26T16:46:13.684 VIRTUAL_HOST=my-laravel-site.ddev.site for web 
2026-01-26T16:46:13.684 HTTP_EXPOSE=80:80,8025:8025 for web 
2026-01-26T16:46:13.684 HTTPS_EXPOSE=443:80,8026:8025 for web 
2026-01-26T16:46:13.684 VIRTUAL_HOST=my-laravel-site.ddev.site for xhgui 
2026-01-26T16:46:13.684 HTTP_EXPOSE=8143:80 for xhgui 
2026-01-26T16:46:13.684 HTTPS_EXPOSE=8142:80 for xhgui 
2026-01-26T16:46:14.414 Running /start.sh in ddev-webserver 
Waiting for containers to become ready: [web db]...
2026-01-26T16:46:15.002 ContainerWait: ddev-my-laravel-site-web status change: 'starting' after 503ms 
2026-01-26T16:46:18.002 ContainerWait: ddev-my-laravel-site-web status change: 'healthy' after 3.503s 
2026-01-26T16:46:18.506 ContainerWait: ddev-my-laravel-site-db status change: 'healthy' after 504ms 
 ready in 4.0s
2026-01-26T16:46:19.120 Copied /home/stas/.ddev/commands:CopyIntoVolume_bcvfptpwczau into /mnt/v/global-commands in 175.478947ms 
2026-01-26T16:46:19.227 Exec chown -R 1000 /mnt/v/global-commands stdout=, stderr=, err=<nil> 
2026-01-26T16:46:19.645 Testing to see if /mnt/ddev_config is properly mounted 
2026-01-26T16:46:19.801 Getting stderr output from 'log-stderr.sh --show' 
Starting ddev-router, pushing config... 
2026-01-26T16:46:20.022 VIRTUAL_HOST=my-laravel-site.ddev.site for web 
2026-01-26T16:46:20.022 HTTP_EXPOSE=80:80,8025:8025 for web 
2026-01-26T16:46:20.022 HTTPS_EXPOSE=443:80,8026:8025 for web 
2026-01-26T16:46:20.022 VIRTUAL_HOST=my-laravel-site.ddev.site for xhgui 
2026-01-26T16:46:20.022 HTTP_EXPOSE=8143:80 for xhgui 
2026-01-26T16:46:20.022 HTTPS_EXPOSE=8142:80 for xhgui 
2026-01-26T16:46:20.952 Copied /home/stas/.ddev/traefik:CopyIntoVolume_qjzbvbkvvwbu into /mnt/v/traefik in 138.625657ms 
2026-01-26T16:46:21.044 Exec chown -R 1000 /mnt/v/traefik stdout=, stderr=, err=<nil> 
2026-01-26T16:46:21.269 Copied global Traefik config in /home/stas/.ddev/traefik to ddev-global-cache/traefik 
 Container ddev-router Started  
Waiting for ddev-router to become ready...
2026-01-26T16:46:23.199 Router wait: checking for container with labels map[com.docker.compose.oneoff:False com.docker.compose.service:ddev-router], polling every 500ms for healthy status 
2026-01-26T16:46:23.702 ContainerWait: ddev-router status change: 'starting' after 503ms 
2026-01-26T16:46:28.703 ContainerWait: ddev-router status change: 'healthy' after 5.504s 
 ready in 5.5s
2026-01-26T16:46:28.703 Getting traefik error output 
2026-01-26T16:46:29.314 ContainersWait: status changed to '2/2 healthy' after 506ms 
2026-01-26T16:46:29.322 Laravel: .env.example does not exist yet, not trying to process it 
Successfully started my-laravel-site 
Your project can be reached at https://my-laravel-site.ddev.site
See 'ddev describe' for alternate URLs.
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
