### PR TITLE
docs: Fix link to globalsign safenet drivers

### DIFF
--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -178,7 +178,7 @@ This is done automatically by the release build on a dedicated Windows test runn
 
 1. Install the suggested [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/). Only the signing component is required.
 2. Add the path of the kit binaries to the Windows system PATH, `C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64/`.
-3. The keyfob and Safenet Authentication Client must be installed. The best documentation for the Safenet software is at <https://support.globalsign.com/ssl/ssl-certificates-installation/safenet-drivers>. You must configure the advanced client settings to “Enable single logon” or it will require the password on each run.
+3. The keyfob and Safenet Authentication Client must be installed. The best documentation for the Safenet software is at <https://support.globalsign.com/digital-certificates/manage-safeNet-eToken/safenet-drivers>. You must configure the advanced client settings to “Enable single logon” or it will require the password on each run.
 4. After `make windows_amd64_install` the `ddev_windows_amd64_installer.exe` will be in `.ddev/bin/windows_amd64/ddev_windows_amd64_installer.exe` and you can sign it with `signtool sign ddev_windows_amd64_installer.exe`.
 5. If you need to install the GitHub self-hosted Windows runner, do it with the instructions in project settings → Actions → Runners.
 6. Currently the `actions/cache` runner does not work out of the box on Windows, so you have to install tar and zstd as described in [this issue](https://github.com/actions/cache/issues/580#issuecomment-1165839728).


### PR DESCRIPTION

## The Issue

Today's builds are failing link check.

Globalsign changed their website around.

## How This PR Solves The Issue

Use new link

