### PR TITLE
fix(router): ensure Traefik dashboard port is always bound to localhost

### DIFF
--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -28,8 +28,8 @@ services:
     ports: {{ $dockerIP := .dockerIP }}{{ if not .router_bind_all_interfaces }}{{ range $port := .ports }}
       - "{{ $dockerIP }}:{{ $port }}:{{ $port }}"{{ end }}{{ else }}{{ range $port := .ports }}
       - "{{ $port }}:{{ $port }}"{{ end }}{{ end }}
-      # Traefik router; configured in static config as entrypoint
-      - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}{{.TraefikMonitorPort}}:{{.TraefikMonitorPort}}"
+      # Traefik monitor port: Always bind to localhost only for security
+      - "{{ $dockerIP }}:{{.TraefikMonitorPort}}:{{.TraefikMonitorPort}}"
     labels:
       # For cleanup on ddev poweroff
       com.ddev.site-name: ""


### PR DESCRIPTION
Currently, the traefik dashboard is exposed with port 10999 to be publically accessible if `router_bind_all_interfaces=true`. This can leak information when ddev is used for public hosting.

<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## How This PR Solves The Issue
The PR binds the port only to localhost.

## Manual Testing Instructions
- Clone branch
- `make`
- `router_bind_all_interfaces=true` globally
- Make sure ddev hostname is not locally resolved to localhost
- Try accessing http://my-domain.ddev.site:10999

I also installed this dev branch on my public host machine and validated that the port is actually not exposed to the public anymore.

## Automated Testing Overview
The new test checks the port binding in the docker composer and tries if the dashboard can still be accessed locally.

## Release/Deployment Notes
No breaking changes as far as i can tell. The traefik rest api can still be accessed from the host. `curl 127.0.0.1:10999/api/version` would still work. 