### PR TITLE
feat: restart supervisor for generic webserver and blackfire, xdebug, xhprof, fixes #7941, for ddev/ddev-frankenphp#44

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/disable_xdebug
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/disable_xdebug
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 export PATH=$PATH:/usr/sbin:/sbin
 phpdismod xdebug
-killall -USR2 php-fpm 2>/dev/null || true
+if [ "${DDEV_WEBSERVER_TYPE:-}" = "generic" ]; then
+  # we don't know what process is running php, restart all web_extra_daemons
+  supervisorctl restart 'webextradaemons:*' || true
+else
+  killall -USR2 php-fpm 2>/dev/null || true
+fi
 echo "Disabled xdebug"

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/disable_xhprof
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/disable_xhprof
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 export PATH=$PATH:/usr/sbin:/sbin
 phpdismod xhprof
-killall -USR2 php-fpm 2>/dev/null || true
+if [ "${DDEV_WEBSERVER_TYPE:-}" = "generic" ]; then
+  # we don't know what process is running php, restart all web_extra_daemons
+  supervisorctl restart 'webextradaemons:*' || true
+else
+  killall -USR2 php-fpm 2>/dev/null || true
+fi
 echo "Disabled xhprof"

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/enable_xdebug
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/enable_xdebug
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 export PATH=$PATH:/usr/sbin:/sbin
 phpenmod xdebug
-killall -USR2 php-fpm 2>/dev/null || true
+if [ "${DDEV_WEBSERVER_TYPE:-}" = "generic" ]; then
+  # we don't know what process is running php, restart all web_extra_daemons
+  supervisorctl restart 'webextradaemons:*' || true
+else
+  killall -USR2 php-fpm 2>/dev/null || true
+fi
+# if xdebug is not enabled, there will be a visible warning in stderr
+php -m >/dev/null || true
 echo "Enabled xdebug"

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/enable_xhprof
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/enable_xhprof
@@ -3,7 +3,14 @@ export PATH=$PATH:/usr/sbin:/sbin
 phpdismod blackfire xdebug
 mkdir -p ${XHPROF_OUTPUT_DIR}
 phpenmod xhprof
-killall -USR2 php-fpm 2>/dev/null || true
+if [ "${DDEV_WEBSERVER_TYPE:-}" = "generic" ]; then
+  # we don't know what process is running php, restart all web_extra_daemons
+  supervisorctl restart 'webextradaemons:*' || true
+else
+  killall -USR2 php-fpm 2>/dev/null || true
+fi
+# if xhprof is not enabled, there will be a visible warning in stderr
+php -m >/dev/null || true
 echo "Enabled xhprof with xhprof_mode=${DDEV_XHPROF_MODE}"
 case "${DDEV_XHPROF_MODE}" in
   xhgui)

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -219,7 +219,7 @@ web_extra_daemons:
 - `web_extra_daemons` is a shortcut for adding a configuration to `supervisord`, which organizes daemons inside the web container. If the default settings are inadequate for your use, you can write a [complete config file for your daemon](#explicit-supervisord-configuration-for-additional-daemons).
 - Your daemon is expected to run in the foreground, not to daemonize itself, `supervisord` will take care of that.
 - To debug and/or get your daemon running to begin with, experiment with running it manually inside `ddev ssh`. Then when it works perfectly implement auto-start with `web_extra_daemons`.
-- You can manually restart all daemons with `ddev exec supervisorctl restart webextradaemons:*` or `ddev exec supervisorctl restart webextradaemons:<yourdaemon>`. (`supervisorctl stop` and `supervisorctl start` are available as you would expect.)
+- You can manually restart all daemons with `ddev exec supervisorctl restart 'webextradaemons:*'` or `ddev exec supervisorctl restart webextradaemons:<yourdaemon>`. (`supervisorctl stop` and `supervisorctl start` are available as you would expect.)
 
 ## Exposing Extra Ports via `ddev-router`
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
@@ -17,7 +17,14 @@ function enable {
   fi
   phpdismod xhprof xdebug
   phpenmod blackfire
-  killall -USR2 php-fpm && killall -HUP nginx
+  if [ "${DDEV_WEBSERVER_TYPE:-}" = "generic" ]; then
+    # we don't know what process is running php, restart all web_extra_daemons
+    supervisorctl restart 'webextradaemons:*' || true
+  else
+    killall -USR2 php-fpm && killall -HUP nginx
+  fi
+  # if blackfire is not enabled, there will be a visible warning in stderr
+  php -m >/dev/null || true
   # Can't use killall here because it kills this process!
   pid=$(ps -ef | awk '$8~/^blackfire.*/ { print $2 }' 2>/dev/null)
   if [ "${pid}" != "" ]; then kill $pid; fi
@@ -28,7 +35,12 @@ function enable {
 }
 function disable {
   phpdismod blackfire
-  killall -USR2 php-fpm
+  if [ "${DDEV_WEBSERVER_TYPE:-}" = "generic" ]; then
+    # we don't know what process is running php, restart all web_extra_daemons
+    supervisorctl restart 'webextradaemons:*' || true
+  else
+    killall -USR2 php-fpm
+  fi
   # Can't use killall here because it kills this process!
   pid=$(ps -ef | awk '$8~/^blackfire.*/ { print $2 }' 2>/dev/null)
   if [ "${pid}" != "" ]; then kill ${pid}; fi

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20251208_stasadev_php85" // Note that this can be overridden by make
+var WebTag = "20251215_stasadev_php_ext" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

-  #7941
- ddev/ddev-frankenphp#44

## How This PR Solves The Issue

- Adds consistent warnings about not loaded PHP extensions on enabling blackfire, xdebug, xhprof
  (This doesn't help much, but it does give users the info that activating xdebug wasn't actually successful.)
- Restarts `web_extra_daemons` (`webextradaemons:*`) for blackfire, xdebug, xhprof when using generic webserver.

## Manual Testing Instructions

Before, v1.24.10:

```bash
$ ddev blackfire
Enabled blackfire PHP extension and started blackfire agent

$ ddev php -v >/dev/null
PHP Warning:  PHP Startup: Unable to load dynamic library 'blackfire.so' (tried: /usr/lib/php/20230831/blackfire.so (/usr/lib/php/20230831/blackfire.so: cannot open shared object file: No such file or directory), /usr/lib/php/20230831/blackfire.so.so (/usr/lib/php/20230831/blackfire.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0

$ ddev xdebug
Enabled xdebug

$ ddev php -v >/dev/null
PHP Warning:  Failed loading Zend extension 'xdebug.so' (tried: /usr/lib/php/20230831/xdebug.so (/usr/lib/php/20230831/xdebug.so: cannot open shared object file: No such file or directory), /usr/lib/php/20230831/xdebug.so.so (/usr/lib/php/20230831/xdebug.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0

$ ddev xhprof           
Enabled xhprof with xhprof_mode=xhgui
Use 'ddev xhgui' to launch browser for xhprof results.

$ ddev php -v >/dev/null
PHP Warning:  PHP Startup: Unable to load dynamic library 'xhprof.so' (tried: /usr/lib/php/20230831/xhprof.so (/usr/lib/php/20230831/xhprof.so: cannot open shared object file: No such file or directory), /usr/lib/php/20230831/xhprof.so.so (/usr/lib/php/20230831/xhprof.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
```

After, this PR, show a clear warning from PHP when extension wasn't loaded. I didn't add any checks to verify whether it is actually enabled. I don't think this is necessary, because it's an edge case limited to newly released PHP versions:

```bash
$ ddev exec 'sudo apt-get remove -y blackfire-php php${DDEV_PHP_VERSION}-xdebug php${DDEV_PHP_VERSION}-xhprof'

$ ddev blackfire    
PHP Warning:  PHP Startup: Unable to load dynamic library 'blackfire.so' (tried: /usr/lib/php/20230831/blackfire.so (/usr/lib/php/20230831/blackfire.so: cannot open shared object file: No such file or directory), /usr/lib/php/20230831/blackfire.so.so (/usr/lib/php/20230831/blackfire.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
Enabled blackfire PHP extension and started blackfire agent

$ ddev xdebug
PHP Warning:  Failed loading Zend extension 'xdebug.so' (tried: /usr/lib/php/20230831/xdebug.so (/usr/lib/php/20230831/xdebug.so: cannot open shared object file: No such file or directory), /usr/lib/php/20230831/xdebug.so.so (/usr/lib/php/20230831/xdebug.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
Enabled xdebug

$ ddev xhprof
PHP Warning:  PHP Startup: Unable to load dynamic library 'xhprof.so' (tried: /usr/lib/php/20230831/xhprof.so (/usr/lib/php/20230831/xhprof.so: cannot open shared object file: No such file or directory), /usr/lib/php/20230831/xhprof.so.so (/usr/lib/php/20230831/xhprof.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
Enabled xhprof with xhprof_mode=xhgui
Use 'ddev xhgui' to launch browser for xhprof results.
```

---

Before, v1.24.10 (it shouldn't try to kill `php-fpm`):

```bash
$ ddev config --webserver-type=generic
$ ddev restart

$ ddev blackfire
php-fpm: no process found
Enabled blackfire PHP extension and started blackfire agent

$ ddev xdebug
Enabled xdebug

$ ddev xhprof
Enabled xhprof with xhprof_mode=xhgui
Use 'ddev xhgui' to launch browser for xhprof results.
```

After, this PR (expected "errors", i.e. warnings):

```bash
$ ddev config --webserver-type=generic
$ ddev restart

$ ddev blackfire
webextradaemons: ERROR (no such group)
webextradaemons: ERROR (no such group)
Enabled blackfire PHP extension and started blackfire agent

$ ddev xdebug
webextradaemons: ERROR (no such group)
webextradaemons: ERROR (no such group)
Enabled xdebug

$ ddev xhprof
webextradaemons: ERROR (no such group)
webextradaemons: ERROR (no such group)
Enabled xhprof with xhprof_mode=xhgui
Use 'ddev xhgui' to launch browser for xhprof results.
```

After, this PR, with `ddev/ddev-frankenphp`, enabling blackfire doesn't work yet because it needs changes on the add-on side:

```bash
$ ddev add-on get ddev/ddev-frankenphp
$ ddev restart

$ ddev blackfire
webextradaemons:frankenphp: stopped
webextradaemons:frankenphp: started
Enabled blackfire PHP extension and started blackfire agent

$ ddev xdebug
Enabled xdebug

$ ddev xhprof
Enabled xdebug
```

The output for restarting `webextradaemons:frankenphp` in xdebug and xhprof is hidden on the add-on side. I'm going to remove custom overrides from the add-on after v1.25.0 to make it straightforward.

I'm not going to suppress this output:

```
webextradaemons:frankenphp: stopped
webextradaemons:frankenphp: started
```

Because it may contain something useful for generic webserver type, it's a custom type, and users should understand what's going on under the hood, so they can debug it.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
