### PR TITLE
feat: Add ExpressionEngine project type

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -191,7 +191,7 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err, "Failed to run ddev %s --version", c)
 	}
 	// The various CMS commands should not be available here
-	for _, c := range []string{"artisan", "art", "cake", "drush", "magento", "typo3", "wp"} {
+	for _, c := range []string{"artisan", "art", "cake", "drush", "eecli", "magento", "typo3", "wp"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.Error(err, "found command %s when it should not have been there (no error) app.Type=%s", c, app.Type)
 	}
@@ -262,6 +262,17 @@ func TestCustomCommands(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 	for _, c := range []string{"cake"} {
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
+		assert.NoError(err)
+	}
+
+	// ExpressionEngine commands should only be available for type expressionengine
+	app.Type = nodeps.AppTypeExpressionEngine
+	_ = app.WriteConfig()
+	_, _ = exec.RunHostCommand(DdevBin)
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
+	for _, c := range []string{"eecli"} {
 		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -94,7 +94,7 @@ for PHP_VERSION in 8.2 8.3 8.4 8.5; do
     done
 done
 
-for project_type in backdrop craftcms drupal drupal7 drupal10 drupal11 laravel magento magento2 symfony typo3 wordpress default; do
+for project_type in backdrop craftcms drupal drupal7 drupal10 drupal11 expressionengine laravel magento magento2 symfony typo3 wordpress default; do
     export PHP_VERSION="8.4"
     export project_type
     docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DOCROOT=docroot" -e "DDEV_PHP_VERSION=$PHP_VERSION" -e "DDEV_PROJECT_TYPE=$project_type" --name $CONTAINER_NAME -v ddev-global-cache:/mnt/ddev-global-cache -d $DOCKER_IMAGE >/dev/null

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -179,6 +179,12 @@ func init() {
 			composerCreateAllowedPaths: getDrupalComposerCreateAllowedPaths,
 		},
 
+		nodeps.AppTypeExpressionEngine: {
+			settingsCreator:      updateExpressionEngineDotEnv,
+			appTypeDetect:        isExpressionEngineApp,
+			appTypeSettingsPaths: setExpressionEngineSettingsPaths,
+		},
+
 		nodeps.AppTypeGeneric: {
 			postStartAction: nil,
 		},
@@ -248,6 +254,7 @@ func init() {
 			appTypeDetect:        isWordpressApp,
 			importFilesAction:    wordpressImportFilesAction,
 		},
+
 	}
 
 	// Now add "drupal" type as a copy of latest stable, but don't allow it to be detected as a type

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -70,12 +70,14 @@ func TestConfigOverrideAction(t *testing.T) {
 		nodeps.AppTypeDrupal6:      nodeps.PHP56,
 		nodeps.AppTypeDrupal7:      nodeps.PHP82,
 		nodeps.AppTypeDrupal11:     nodeps.PHPDefault,
+		nodeps.AppTypeExpressionEngine: nodeps.PHPDefault,
 		nodeps.AppTypeLaravel:      nodeps.PHPDefault,
 		nodeps.AppTypeMagento:      nodeps.PHPDefault,
 		nodeps.AppTypeMagento2:     nodeps.PHPDefault,
 		nodeps.AppTypeSilverstripe: nodeps.PHPDefault,
 		nodeps.AppTypeSymfony:      nodeps.PHPDefault,
 		nodeps.AppTypeWordPress:    nodeps.PHPDefault,
+		
 	}
 
 	for appType, expectedPHPVersion := range appTypes {

--- a/pkg/ddevapp/expressionengine.go
+++ b/pkg/ddevapp/expressionengine.go
@@ -1,0 +1,113 @@
+package ddevapp
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
+)
+
+// isExpressionEngineApp returns true if the app is of type expressionengine
+func isExpressionEngineApp(app *DdevApp) bool {
+	// Check for ExpressionEngine core file in the system directory
+	systemPath := findExpressionEngineSystemPath(app)
+	if systemPath == "" {
+		return false
+	}
+	return fileutil.FileExists(filepath.Join(systemPath, "ee/ExpressionEngine.php"))
+}
+
+// setExpressionEngineSettingsPaths sets the path to the ExpressionEngine .env.php file
+func setExpressionEngineSettingsPaths(app *DdevApp) {
+	// Find the system directory path from index.php
+	systemPath := findExpressionEngineSystemPath(app)
+	if systemPath == "" {
+		// Fallback to default location if we can't parse index.php
+		app.SiteSettingsPath = filepath.Join(app.AppRoot, ".env.php")
+		return
+	}
+
+	// .env.php lives at the same level as the system directory
+	envPath := filepath.Join(filepath.Dir(systemPath), ".env.php")
+	app.SiteSettingsPath = envPath
+}
+
+// findExpressionEngineSystemPath parses index.php to find the system directory path
+func findExpressionEngineSystemPath(app *DdevApp) string {
+	// Look for index.php in the docroot
+	indexPath := filepath.Join(app.AppRoot, app.Docroot, "index.php")
+	if !fileutil.FileExists(indexPath) {
+		// Try alternate location in project root
+		indexPath = filepath.Join(app.AppRoot, "index.php")
+		if !fileutil.FileExists(indexPath) {
+			return ""
+		}
+	}
+
+	// Read index.php content
+	indexContent, err := fileutil.ReadFileIntoString(indexPath)
+	if err != nil {
+		return ""
+	}
+
+	// Parse for $system_path = '...' or $system_path = "..."
+	re := regexp.MustCompile(`\$system_path\s*=\s*['"]([^'"]+)['"]`)
+	matches := re.FindStringSubmatch(indexContent)
+	if len(matches) < 2 {
+		return ""
+	}
+
+	systemPathRel := matches[1]
+
+	// Resolve the path relative to the directory containing index.php
+	indexDir := filepath.Dir(indexPath)
+	systemPath := filepath.Join(indexDir, systemPathRel)
+
+	// Clean the path
+	systemPath = filepath.Clean(systemPath)
+
+	return systemPath
+}
+
+// updateExpressionEngineDotEnv creates or updates the .env.php file for ExpressionEngine
+func updateExpressionEngineDotEnv(app *DdevApp) (string, error) {
+	// If settings management is disabled, do nothing
+	if app.DisableSettingsManagement {
+		return "", nil
+	}
+
+	envFilePath := app.SiteSettingsPath
+
+	// Warn if we couldn't determine the proper path
+	if envFilePath == "" {
+		util.Warning("Could not determine ExpressionEngine .env.php location")
+		return "", nil
+	}
+
+	// ExpressionEngine database configuration
+	newEnvMap := map[string]string{
+		"BASE_URL": app.GetPrimaryURL(),
+		"DB_HOST":  "db",
+		"DB_NAME":  "db",
+		"DB_USER":  "db",
+		"DB_PASS":  "db",
+	}
+
+	// Read existing .env.php file (preserves comments/structure)
+	_, existingEnvText, err := ReadProjectEnvFile(envFilePath)
+	// If envFilePath doesn't exist, that's not really an error, continue
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+
+	// Write merged configuration
+	err = WriteProjectEnvFile(envFilePath, newEnvMap, existingEnvText)
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/eecli
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/eecli
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run ExpressionEngine CLI command inside the web container
+## Usage: eecli [flags] [args]
+## Example: "ddev eecli cache:clear" or "ddev eecli make:addon" (see https://docs.expressionengine.com/latest/cli/intro.html)
+## ProjectTypes: expressionengine
+## ExecRaw: true
+## MutagenSync: true
+
+cd "${EECLI_CMD_ROOT:-"${DDEV_DOCROOT:-/var/www/html}"}" || exit 1
+
+# Find eecli.php by parsing index.php for the system path
+if [ -n "$EECLI_PATH" ]; then
+  # User specified custom path
+  EECLI="$EECLI_PATH"
+elif [ -f "index.php" ]; then
+  # Parse index.php to find $system_path variable
+  SYSTEM_PATH=$(grep -oP '\$system_path\s*=\s*[\x27"]([^\x27"]+)[\x27"]' index.php | sed -E 's/.*[\x27"]([^\x27"]+)[\x27"].*/\1/')
+
+  if [ -n "$SYSTEM_PATH" ]; then
+    EECLI="${SYSTEM_PATH}/ee/eecli.php"
+    if [ ! -f "$EECLI" ]; then
+      echo "Error: Found system path '$SYSTEM_PATH' in index.php, but $EECLI does not exist." >&2
+      exit 1
+    fi
+  else
+    echo "Error: Could not parse system path from index.php. Please set EECLI_PATH environment variable." >&2
+    exit 1
+  fi
+else
+  echo "Error: index.php not found in $(pwd). Please set EECLI_CMD_ROOT or EECLI_PATH." >&2
+  exit 1
+fi
+
+php "$EECLI" "$@"

--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -501,6 +501,7 @@
         "drupal9",
         "drupal10",
         "drupal11",
+        "expressionengine",
         "generic",
         "laravel",
         "magento",

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -9,7 +9,7 @@ const ConfigInstructions = `
 # If the name is omitted, the project will take the name of the enclosing directory,
 # which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, expressionengine, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
 # See https://docs.ddev.com/en/stable/users/quickstart/ for more
 # information on the different project types
 

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -99,6 +99,7 @@ const (
 	AppTypeDrupal11 = "drupal11"
 	// AppTypeDrupal is an alias for "most recent Drupal version"
 	AppTypeDrupal       = "drupal"
+	AppTypeExpressionEngine = "expressionengine"
 	AppTypeGeneric      = "generic"
 	AppTypeLaravel      = "laravel"
 	AppTypeSilverstripe = "silverstripe"


### PR DESCRIPTION
## The Issue

- No explicit project type for ExpressionEngine.

## How This PR Solves The Issue

- Adds ExpressionEngine project type, auto detects ExpressionEngine application during config, adds URL and DB variables to .env.php, and adds eecli command alias (`ddev eecli [command]`).