### PR TITLE
fix: fail on `ddev start` for docker-rootless w/o no-bind-mounts, don't test with latest rootless

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -195,7 +195,14 @@ EOF
 Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_DISABLE_HOST_LOOPBACK=false"
 EOF
   # Install rootless docker
-  curl -fsSL https://get.docker.com/rootless | sh
+  # Download the rootless installer script
+  curl -fsSL https://get.docker.com/rootless -o /tmp/docker-rootless-install.sh
+  # Get Docker version from docker --version (format: "Docker version 29.1.3, build f52814d454")
+  DOCKER_VERSION=$(docker --version | sed -E 's/Docker version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+  # Replace STABLE_LATEST with the current Docker version to match rootful installation
+  sed -i "s/STABLE_LATEST=\"[0-9.]*\"/STABLE_LATEST=\"${DOCKER_VERSION}\"/" /tmp/docker-rootless-install.sh
+  # Execute the modified script
+  sh /tmp/docker-rootless-install.sh
   cat /etc/subuid
   cat /etc/subgid
 fi

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1417,6 +1417,12 @@ func (app *DdevApp) Start() error {
 		return fmt.Errorf("mutagen is not compatible with use-hardened-images")
 	}
 
+	if dockerutil.IsDockerRootless() && !globalconfig.DdevGlobalConfig.NoBindMounts {
+		// See https://github.com/moby/moby/issues/45919
+		// See https://github.com/moby/moby/issues/2259
+		return fmt.Errorf("bind mounts can't be used with Docker Rootless.\nRun `ddev config global --no-bind-mounts` and try again")
+	}
+
 	if err := globalconfig.CheckForMultipleGlobalDdevDirs(); err != nil {
 		util.WarningOnce("Warning: %v", err)
 	}


### PR DESCRIPTION
## The Issue

We see intermittent fails for docker builds in `docker-rootless`

https://github.com/ddev/ddev/actions/runs/20281804435/job/58245516314
https://github.com/ddev/ddev/actions/runs/20283152764/job/58265709576

```
target web: failed to solve: failed to prepare extraction snapshot "extract-723956080-but9 sha256:98aadc33b4c66175f497b2a2afa364ffa6c162909f6a0bc15692ab9691ad2236": parent snapshot sha256:67e8265291254656ea4f112f6d4ebe594b2cd4a73b6b50e50e46640b4fb5f8d4 does not exist: not found
```

It always installs the latest version:
```
+ curl -fsSL https://get.docker.com/rootless
+ sh
# Installing stable version 29.1.3
```
When Rootless was merged:
```
+ curl -fsSL https://get.docker.com/rootless
+ sh
# Installing stable version 29.1.2
```

---

Also, Docker Rootless does not work without `no-bind-mounts`, but I didn't add a check for this because I was thinking about a flexible configuration, but our users will not read the setup instructions very carefully, and we will get support requests why it does not work:

```
$ ddev ssh
stas@l12-web:/var/www/html$ touch test-file
touch: cannot touch 'test-file': Permission denied
```

## How This PR Solves The Issue

- Trying to fix intermittent fails in tests by installing the same rootless docker version as we use in rootful mode.
- Adds an error on `ddev start` if `no-bind-mounts` is not enabled.

## Manual Testing Instructions

Check `docker-rootless` test in GitHub Actions, confirm the installed docker version is not the latest 29.1.3 https://github.com/ddev/ddev/actions/runs/20302539723/job/58311490118?pr=7952#step:8:165

```
$ docker context use rootless

$ ddev start
Starting l12... 
Failed to start l12: bind mounts can't be used with Docker Rootless.
Run `ddev config global --no-bind-mounts` and try again

$ ddev config global --no-bind-mounts

$ ddev start
Starting l12... 
Mutagen is enabled because `no_bind_mounts: true` is set.
`ddev config global --no-bind-mounts=false` if you do not intend that. 
97.44 MiB / 97.44 MiB [-----------------------------] 100.00% 91.89 MiB p/s 1.3s
Download complete. 
 Container ddev-ssh-agent  Created 
 Container ddev-ssh-agent  Started
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
