### PR TITLE
docs(ssh): Explain what to do when remote host identification has changed, fixes #7946

### DIFF
--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -157,3 +157,23 @@ To set the `PAGER` variable in the `web` and `db` containers across all projects
 ```bash
 export DDEV_PAGER="less -SFXR"
 ```
+
+## In-container `ssh` or `rsync` failures
+
+If you use `ddev auth ssh` and use `ssh` or `rsync` inside the container and see a message like this:
+
+```bash
+$ ddev exec ssh <hostname>
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+```
+
+It means that the host you are connecting to has actually changed its identification. If you know why that is, and accept the situation, you can clean up the situation with this command:
+
+```bash
+ddev exec ssh-keygen -f '/home/.ssh-agent/known_hosts' -R '<hostname>'
+```
+
+Use the hostname that gave you trouble.


### PR DESCRIPTION
## The Issue

- #7946 

When target hostname has changed, `ssh-keygen` can be used to remove it and allow new access

## How This PR Solves The Issue

Add that to the docs

Review rendered at https://ddev--7956.org.readthedocs.build/en/7956/users/extend/in-container-configuration/#in-container-ssh-or-rsync-failures
