### PR TITLE
test(lima): force limactl stop [skip ci]

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -33,7 +33,7 @@ if [ "${os:-}" = "darwin" ]; then
     if [ -f /Applications/Docker.app ]; then echo "Stopping Docker Desktop" && (killall com.docker.backend || true); fi
     command -v colima 2>/dev/null && echo "Stopping colima" && (colima stop || true)
     command -v colima 2>/dev/null && echo "Stopping colima_vz" && (colima stop vz || true)
-    command -v limactl 2>/dev/null && echo "Stopping lima" && (limactl stop lima-vz || true)
+    command -v limactl 2>/dev/null && echo "Stopping lima" && (limactl stop -f lima-vz || true)
     if [ -f ~/.rd/bin/rdctl ]; then echo "Stopping Rancher Desktop" && (~/.rd/bin/rdctl shutdown || true); fi
     docker context use default
     # Leave orbstack running as the most likely to be reliable, otherwise Docker Desktop


### PR DESCRIPTION

## The Issue

We've been seeing useless failures like this one stopping lima: https://buildkite.com/ddev/macos-colima-vz/builds/5421#019b327d-c784-4c46-8e81-644b1b2c2201


```
Stopping lima
FATA[0000] expected status "Running", got "Stopped" (maybe use `limactl stop -f`?)
```
## How This PR Solves The Issue

Force stop

This is irrelevant to anything, but might as well satisfy it.