### PR TITLE
test(buildkite): Make sure to clean up global traefik dir [skip ci]

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 os=$(go env GOOS)
 
-rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml ~/.ddev/project_list.yaml ~/.ddev/homeadditions ~/.ddev/commands ~/.ddev/bin/docker-compose* ~/tmp/ddevtest
+rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml ~/.ddev/project_list.yaml ~/.ddev/homeadditions ~/.ddev/commands ~/.ddev/bin/docker-compose* ~/.ddev/traefik ~/tmp/ddevtest
 
 # Latest git won't let you do much in a non-safe directory
 git config --global --add safe.directory '*' || true


### PR DESCRIPTION

## The Issue

The buildkite tests were being affected dramatically by earlier failures in https://github.com/ddev/ddev/pull/7961, actually demonstrating the problem that was designed to fix. 

## How This PR Solves The Issue

Start out tests with clean ~/.ddev/traefik

