### PR TITLE
build(deps): install tzdata-legacy for Debian 13 Trixie

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -47,8 +47,17 @@ RUN set -x; if ( command -v mariadbd && ! command -v mysqld ); then \
 USER root
 RUN rm -f /etc/apt/sources.list.d/mariadb.list /etc/apt/sources.list.d/percona.list
 RUN mkdir -p /var/lib/apt/lists/partial
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" bzip2 curl gnupg2 gpgv less lsb-release pv tzdata vim-tiny wget
-RUN update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
+RUN <<EOF
+    set -eu -o pipefail
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" bzip2 curl gnupg2 gpgv less lsb-release pv tzdata vim-tiny wget
+    update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
+
+    # Install tzdata-legacy to avoid issues with deprecated timezones
+    if apt-cache show tzdata-legacy >/dev/null 2>&1; then
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" tzdata-legacy
+    fi
+EOF
 
 # Configure APT to use gpgv for signature verification to avoid SHA1 deprecation issues
 RUN echo 'APT::Key::gpgvcommand "/usr/bin/gpgv";' > /etc/apt/apt.conf.d/99-use-gpgv

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -24,8 +24,9 @@ RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb /usr/sbin/tar /usr/sbin/rm
 # This is used to install updated curl, see https://github.com/curl/curl/issues/18336
 RUN printf "Types: deb\nURIs: http://deb.debian.org/debian\nSuites: trixie-backports\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.pgp\n" > /etc/apt/sources.list.d/debian-backports.sources
 
-RUN apt-get -qq update
-RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
+# curl/trixie-backports - newer curl version from backports
+# tzdata-legacy - to avoid issues with deprecated timezones
+RUN apt-get -qq update && apt-get -qq install --no-install-recommends --no-install-suggests -y \
     apt-transport-https \
     ca-certificates \
     bzip2 \
@@ -34,6 +35,7 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     gnupg \
     lsb-release \
     procps \
+    tzdata-legacy \
     wget
 RUN url="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETPLATFORM#linux/}"; wget ${url} -q -O /usr/bin/yq && chmod +x /usr/bin/yq
 ADD generic-files /
@@ -78,8 +80,7 @@ ENV COMPOSER_PROCESS_TIMEOUT=2000
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-RUN apt-get -qq update
-RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
+RUN apt-get -qq update && apt-get -qq install --no-install-recommends --no-install-suggests -y \
     apache2 \
     file \
     ghostscript \

--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -3,7 +3,8 @@
 
 FROM debian:trixie-slim AS ddev-ssh-agent
 
-RUN apt-get update && apt-get install -y bash expect file gpg openssh-client socat psmisc && apt-get autoclean
+# tzdata-legacy - to avoid issues with deprecated timezones
+RUN apt-get update && apt-get install -y bash expect file gpg openssh-client socat psmisc tzdata-legacy && apt-get autoclean
 
 # Copy container files
 COPY files /

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:20251208_stasadev_php85 AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20251222_stasadev_tzdata_legacy AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -1,6 +1,6 @@
 FROM xhgui/xhgui:0.23 AS ddev-xhgui
 
-RUN apk add --no-cache bash curl
+RUN apk add --no-cache bash curl tzdata
 ADD /var /var
 ADD /etc /etc
 RUN echo 'memory_limit=512M' >> $PHP_INI_DIR/conf.d/99-memory-limit.ini

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1259,6 +1259,11 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     apt-transport-https bzip2 ca-certificates less procps pv vim-tiny zstd
 update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
 
+# Install tzdata-legacy to avoid issues with deprecated timezones
+if apt-cache show tzdata-legacy >/dev/null 2>&1; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" tzdata-legacy
+fi
+
 # Change directories owned by postgres (and everything inside them)
 find / -type d \( -user postgres -o -group postgres \) -exec chown -Rh %[2]s:%[3]s {} + 2>/dev/null || true
 # Change any remaining individual files owned by postgres

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1275,7 +1275,8 @@ func TestTimezoneConfig(t *testing.T) {
 	require.Regexp(t, regexp.MustCompile("timezone=CES?T"), inDBContainerTZData)
 
 	// With timezone set, TZ env should be used if app.Timezone is empty
-	t.Setenv("TZ", "Europe/Rome")
+	// US/Eastern is a legacy name for America/New_York but should still work
+	t.Setenv("TZ", "US/Eastern")
 	app.Timezone = ""
 	err = app.Start()
 	require.NoError(t, err)
@@ -1284,15 +1285,15 @@ func TestTimezoneConfig(t *testing.T) {
 		Cmd:     "printf \"timezone=$(date +%Z)\n\" && php -r 'print \"phptz=\" . date_default_timezone_get();'",
 	})
 	require.NoError(t, err)
-	require.Regexp(t, regexp.MustCompile("timezone=CES?T\nphptz=Europe/Rome"), inWebContainerTZData)
+	require.Regexp(t, regexp.MustCompile("timezone=E[SD]T\nphptz=US/Eastern"), inWebContainerTZData)
 
-	// Make sure db container is also working with CET
+	// Make sure db container is also working with US/Eastern
 	inDBContainerTZData, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
 		Cmd:     "echo -n timezone=$(date +%Z)",
 	})
 	require.NoError(t, err)
-	require.Regexp(t, regexp.MustCompile("timezone=CES?T"), inDBContainerTZData)
+	require.Regexp(t, regexp.MustCompile("timezone=E[SD]T"), inDBContainerTZData)
 
 	runTime()
 }

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -114,6 +114,7 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 	}
 
 	uid, gid, username := dockerutil.GetContainerUser()
+	timezone, _ := util.GetLocalTimezone()
 
 	_ = app.DockerEnv()
 
@@ -123,6 +124,7 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 		"Username":         username,
 		"UID":              uid,
 		"GID":              gid,
+		"Timezone":         timezone,
 		"BuildContext":     context,
 		"IsPodmanRootless": dockerutil.IsPodmanRootless(),
 	}

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -28,6 +28,7 @@ services:
       - "socket_dir:/tmp/.ssh-agent"
     environment:
       - SSH_AUTH_SOCK=/tmp/.ssh-agent/socket
+      - TZ={{ .Timezone }}
     healthcheck:
       test: "/healthcheck.sh"
       interval: 1s

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,13 +20,13 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20251215_stasadev_php_ext" // Note that this can be overridden by make
+var WebTag = "20251222_stasadev_tzdata_legacy" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20251112_deviantintegral_snapshot_zstd"
+var BaseDBTag = "20251222_stasadev_tzdata_legacy"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"
@@ -38,13 +38,13 @@ var TraefikRouterTag = "v1.24.10"
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "20251210_ssh_agent_trixie"
+var SSHAuthTag = "20251222_stasadev_tzdata_legacy"
 
 // XhguiImage is image for xhgui
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "v1.24.10"
+var XhguiTag = "20251222_stasadev_tzdata_legacy"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities:latest"


### PR DESCRIPTION
## The Issue

I started testing DDEV HEAD on a few projects (which I don't work on anymore) and found that all the deprecated time zones had been removed, resulting in PHP notices.

See https://www.debian.org/releases/trixie/release-notes/issues.html#timezones-split-off-into-tzdata-legacy-package

## How This PR Solves The Issue

Installs `tzdata-legacy` in:

- ddev-webserver
- ddev-dbserver (if available)
- postgres (if available)
- ddev-ssh-agent

Installs `tzdata` in `ddev-xhgui` (alpine images have everything inside `tzdata`)

I didn't touch `ddev-traefik-router` - it already has `tzdata` installed

## Manual Testing Instructions

DDEV HEAD:

```bash
$ ddev php -r 'date_default_timezone_set("US/Eastern"); echo PHP_EOL, date_default_timezone_get(), PHP_EOL;'
PHP Notice:  date_default_timezone_set(): Timezone ID 'US/Eastern' is invalid in Command line code on line 1

Notice: date_default_timezone_set(): Timezone ID 'US/Eastern' is invalid in Command line code on line 1

Europe/Kyiv
```

This PR:

```bash
$ ddev php -r 'date_default_timezone_set("US/Eastern"); echo PHP_EOL, date_default_timezone_get(), PHP_EOL;'

US/Eastern
```

---

DDEV HEAD:

```bash
$ ddev config --database=mariadb:11.8 --timezone="US/Eastern"
$ ddev start

$ ddev exec echo 'timezone=$(date +%Z)'
timezone=

$ ddev exec -s db echo 'timezone=$(date +%Z)'
timezone=
```

This PR:

```bash
$ ddev config --database=mariadb:11.8 --timezone="US/Eastern"
$ ddev start

$ ddev exec echo 'timezone=$(date +%Z)'
timezone=EST

$ ddev exec -s db echo 'timezone=$(date +%Z)'
timezone=EST
```

---

DDEV HEAD:

```bash
$ ddev config --database=postgres:18 --timezone="US/Eastern"
$ ddev start

$ ddev exec echo 'timezone=$(date +%Z)'
timezone=

$ ddev exec -s db echo 'timezone=$(date +%Z)'
timezone=
```

This PR:

```bash
$ ddev config --database=postgres:18 --timezone="US/Eastern"
$ ddev start

$ ddev exec echo 'timezone=$(date +%Z)'
timezone=EST

$ ddev exec -s db echo 'timezone=$(date +%Z)'
timezone=EST
```

---

DDEV HEAD:

```bash
$ ddev auth ssh
$ docker exec -it ddev-ssh-agent bash -c 'echo timezone=$(date +%Z)'
timezone=UTC
```

This PR:

```bash
$ ddev auth ssh
$ docker exec -it ddev-ssh-agent bash -c 'echo timezone=$(date +%Z)'
timezone=EET  # your local timezone
```

---

DDEV HEAD:

```bash
$ ddev config --timezone="US/Eastern"
$ ddev start
$ ddev xhgui
PHP Warning:  PHP Startup: Invalid date.timezone value 'US/Eastern', using 'UTC' instead in Unknown on line 0 
PHP Warning:  PHP Startup: Invalid date.timezone value 'US/Eastern', using 'UTC' instead in Unknown on line 0
$ ddev exec -s xhgui echo 'timezone=$(date +%Z)'
timezone=UTC
```

This PR:

```bash
$ ddev config --timezone="US/Eastern"
$ ddev start
$ ddev xhgui
$ ddev exec -s xhgui echo 'timezone=$(date +%Z)'
timezone=EST
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
