### PR TITLE
fix(platform): Resume environment if not running

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -86,6 +86,9 @@ auth_command:
     else
       echo "Using PLATFORM_ENVIRONMENT=${PLATFORM_ENVIRONMENT:-}"
     fi
+    if [ "$(platform environment:info status -e ${PLATFORM_ENVIRONMENT})" != "active" ]; then
+      platform environment:resume -e ${PLATFORM_ENVIRONMENT} -y
+    fi
 
 db_pull_command:
   command: |


### PR DESCRIPTION

## The Issue

TestPlatformPush has been failing if the `push` environment has auto-stopped.

## How This PR Solves The Issue

Make the platform integration work like upsun and resume the environment in the initial section

## Manual Testing Instructions

Pause an environment and run `ddev pull platform` etc.

