### PR TITLE
test: Stop using old version of memcached to prevent output about docker-compose version tag [skip ci]

### DIFF
--- a/cmd/ddev/cmd/addon_test.go
+++ b/cmd/ddev/cmd/addon_test.go
@@ -53,7 +53,7 @@ func TestCmdAddon(t *testing.T) {
 	// Test with many input styles
 	for _, arg := range []string{
 		"ddev/ddev-memcached",
-		"https://github.com/ddev/ddev-memcached/archive/refs/tags/v1.1.1.tar.gz",
+		"https://github.com/ddev/ddev-memcached/archive/refs/tags/v1.1.8.tar.gz",
 		tarballFile} {
 		out, err := exec.RunHostCommand(DdevBin, "add-on", "get", arg)
 		assert.NoError(err, "failed ddev add-on get %s", arg)


### PR DESCRIPTION


## The Issue

I noticed test output about obsolete `version` tag in a `docker-compose.memcached.yaml` and thought it was odd.

## How This PR Solves The Issue

Use a newer version of ddev-memcached to prevent this output

(I thought we had an invalid test fixture, but that wasn't it)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
