### PR TITLE
test(buildkite): Use colima stop -f to force stop [skip ci]

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -31,8 +31,7 @@ if [ "${os:-}" = "darwin" ]; then
     command -v orb 2>/dev/null && echo "Stopping orbstack" && (nohup orb stop &)
     sleep 3 # Since we backgrounded orb stop, make sure it completes
     if [ -f /Applications/Docker.app ]; then echo "Stopping Docker Desktop" && (killall com.docker.backend || true); fi
-    command -v colima 2>/dev/null && echo "Stopping colima" && (colima stop || true)
-    command -v colima 2>/dev/null && echo "Stopping colima_vz" && (colima stop vz || true)
+    command -v colima 2>/dev/null && echo "Stopping colima_vz" && (colima stop -f vz || true)
     command -v limactl 2>/dev/null && echo "Stopping lima" && (limactl stop -f lima-vz || true)
     if [ -f ~/.rd/bin/rdctl ]; then echo "Stopping Rancher Desktop" && (~/.rd/bin/rdctl shutdown || true); fi
     docker context use default


### PR DESCRIPTION

## The Issue

Our arm64 runners for colima/lima/rancher were all hung.

This was actually a result of me installing new buildkite-agent versions (and then re-pinning buildkite-agent)

But the practical outcome was macOS prompting for extra privileges for buildkite-agent.

## How This PR Solves The Issue

I noticed while debugging that colima didn't seem to be stopping. Add `-f` to the stop.

