### PR TITLE
fix(test): Force TestDownloadFileRetryLogic to work even if DDEV_DEBUG wasn't set [skip ci]

### DIFF
--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -12,7 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -111,7 +114,14 @@ func TestDownloadFileRetryLogic(t *testing.T) {
 		defer ts.Close()
 
 		dest := filepath.Join(tmpDir, "retry-fail.txt")
-		t.Setenv("DDEV_DEBUG", "true")
+		// Set DdevDebug directly since the package variable is cached at init time
+		origDebug := globalconfig.DdevDebug
+		globalconfig.DdevDebug = true
+		t.Cleanup(func() { globalconfig.DdevDebug = origDebug })
+		// Also set log level since UserOut is initialized at package load time
+		origLevel := output.UserOut.GetLevel()
+		output.UserOut.SetLevel(log.DebugLevel)
+		t.Cleanup(func() { output.UserOut.SetLevel(origLevel) })
 
 		restoreOutput := util.CaptureUserOut()
 		err := util.DownloadFile(dest, ts.URL+"/"+fileName, false, "")
@@ -218,7 +228,14 @@ func TestDownloadFileRetryLogic(t *testing.T) {
 		defer ts.Close()
 
 		dest := filepath.Join(tmpDir, "slow-copy.txt")
-		t.Setenv("DDEV_DEBUG", "true")
+		// Set DdevDebug directly since the package variable is cached at init time
+		origDebug := globalconfig.DdevDebug
+		globalconfig.DdevDebug = true
+		t.Cleanup(func() { globalconfig.DdevDebug = origDebug })
+		// Also set log level since UserOut is initialized at package load time
+		origLevel := output.UserOut.GetLevel()
+		output.UserOut.SetLevel(log.DebugLevel)
+		t.Cleanup(func() { output.UserOut.SetLevel(origLevel) })
 
 		restoreOutput := util.CaptureUserOut()
 		err := util.DownloadFileExtended(dest, ts.URL+"/"+fileName, false, "", 2, 1*time.Second)


### PR DESCRIPTION

## The Issue

I was trying to recreate the problem  in 
* https://github.com/lima-vm/lima/issues/4496

on my local machine. I was successful, but TestDownloadFileRetryLogic failed simply because DDEV_DEBUG wasn't set right

## How This PR Solves The Issue

Handle that case

