### PR TITLE
docs(xdebug): Add step-debugging.md endpoint security notes

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -36,6 +36,7 @@ Commands
 Completely
 Create
 CRM
+CrowdStrike
 DBeaver
 DDEV's
 DDEV
@@ -643,6 +644,7 @@ styleguide
 subdirectory
 subdirectories
 subfield
+subnet
 sudo
 superglobal
 supervisord

--- a/docs/content/users/debugging-profiling/step-debugging.md
+++ b/docs/content/users/debugging-profiling/step-debugging.md
@@ -127,7 +127,7 @@ Here are basic steps to take to sort out any difficulty:
 * `ddev logs` may show you something like `Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (fallback through xdebug.client_host/xdebug.client_port) :-(`. If it does, it may mean that your firewall is blocking the connection, or in a small number of cases that `host.docker.internal` is not figured out successfully by DDEV or Docker. If it does:
     * Temporarily disable your firewall. On Windows/WSL this is typically Windows Defender; on macOS you'll find it in settings; on Debian/Ubuntu it's typically `ufw` so `sudo ufw disable`.
     * If disabling the firewall fixes the problem, re-enable the firewall and add an exception for port 9003. Your firewall will have a way to do this; on Debian/Ubuntu run `sudo ufw allow 9003`.
-    * If your machine is managed by corporate endpoint security (Cisco Secure Endpoint, CrowdStrike, etc.), it may block container → host connections even when the OS firewall is “off”.
+    * If your machine is managed by corporate endpoint security (Cisco Secure Endpoint, CrowdStrike, etc.), it may block container → host connections even when the OS firewall is "off":
         * If possible, temporarily disable the endpoint security agent and try again.
         * If you can’t disable it, ask your IT/security team to allow inbound connections to your IDE on port 9003 from the container/VM subnet(s).
         * On macOS/Linux, you can confirm whether traffic is reaching the host by watching for packets while connecting from the container:


### PR DESCRIPTION
## The Issue

https://discord.com/channels/664580571770388500/1451709667096002621

## How This PR Solves The Issue

Added troubleshooting steps for corporate endpoint security affecting Xdebug connections.

## Manual Testing Instructions

Review at: https://ddev--8002.org.readthedocs.build/en/8002/users/debugging-profiling/step-debugging/#troubleshooting-xdebug

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
