### PR TITLE
fix(router): healthcheck after new config must happen as normal user

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -152,7 +152,8 @@ func StartDdevRouter() error {
 			return fmt.Errorf("failed to find router for healthcheck: %v", err)
 		}
 		util.Debug("Forcing router healthcheck to verify new config is loaded")
-		_, _, err = dockerutil.Exec(router.ID, "rm -f /tmp/healthy && /healthcheck.sh", "")
+		uid, _, _ := dockerutil.GetContainerUser()
+		_, _, err = dockerutil.Exec(router.ID, "rm -f /tmp/healthy && /healthcheck.sh", uid)
 		if err != nil {
 			return fmt.Errorf("router healthcheck failed: %v", err)
 		}


### PR DESCRIPTION

## The Issue

In manual testing of 
* https://github.com/ddev/ddev/pull/7961

I discovered that the router push-and-wait-for-healthy feature was being executed as root, so it left /tmp/healthy owned by root, which was causing lots of interesting problems. 

## How This PR Solves The Issue

Run that as the normal user

