### PR TITLE
test(traefik): improve reliability of traefik.bats router API tests

### DIFF
--- a/containers/ddev-traefik-router/test/functions.sh
+++ b/containers/ddev-traefik-router/test/functions.sh
@@ -22,6 +22,24 @@ function wait_for_config_reload {
   sleep 1
 }
 
+# Wait for a specific router to appear in the Traefik API.
+# Args: router_name (without @provider suffix)
+# Returns: 0 if router found, 1 if timeout
+function wait_for_router {
+  local router_name="$1"
+  local max_attempts=20
+  local attempt=0
+
+  while [ $attempt -lt $max_attempts ]; do
+    if docker exec ${CONTAINER_NAME} bash -c "curl -sf http://127.0.0.1:\${TRAEFIK_MONITOR_PORT}/api/http/routers/${router_name}@file" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
 # Wait for container to be ready.
 function containercheck {
   for i in {60..0}; do

--- a/containers/ddev-traefik-router/test/traefik.bats
+++ b/containers/ddev-traefik-router/test/traefik.bats
@@ -169,6 +169,7 @@ http:
 EOF"
   # Wait for traefik to reload config
   wait_for_config_reload
+  wait_for_router "test-missing-svc"
 
   # Verify router is disabled with error
   run docker exec ${CONTAINER_NAME} bash -c 'curl -sf http://127.0.0.1:${TRAEFIK_MONITOR_PORT}/api/http/routers/test-missing-svc@file | jq -r .status'
@@ -209,6 +210,7 @@ http:
         - nonexistent-middleware
 EOF"
   wait_for_config_reload
+  wait_for_router "test-missing-mw"
 
   # Verify router is disabled with error
   run docker exec ${CONTAINER_NAME} bash -c 'curl -sf http://127.0.0.1:${TRAEFIK_MONITOR_PORT}/api/http/routers/test-missing-mw@file | jq -r .status'
@@ -243,6 +245,7 @@ http:
 EOF"
   # Wait for traefik to reload config
   wait_for_config_reload
+  wait_for_router "test-bad-ep"
 
   # Verify router is disabled with error
   run docker exec ${CONTAINER_NAME} bash -c 'curl -sf http://127.0.0.1:${TRAEFIK_MONITOR_PORT}/api/http/routers/test-bad-ep@file | jq -r .status'
@@ -275,6 +278,7 @@ http:
       service: d11-web-80
 EOF"
   wait_for_config_reload
+  wait_for_router "test-bad-rule"
 
   # Verify router is disabled with error
   run docker exec ${CONTAINER_NAME} bash -c 'curl -sf http://127.0.0.1:${TRAEFIK_MONITOR_PORT}/api/http/routers/test-bad-rule@file | jq -r .status'


### PR DESCRIPTION
The traefik.bats test suite was failing intermittently in CI with test 11 (verify API detects router with missing middleware reference) returning empty output instead of 'disabled' status. Tests 10, 12, and 13 had the same vulnerability. (https://github.com/ddev/ddev/actions/runs/20829335545/job/59839121300)

Added a wait_for_router() helper function that polls the Traefik API for up to 10 seconds (20 attempts × 0.5s) until a specific router appears. The race condition occurred because after writing config files and calling wait_for_config_reload(), the router wasn't immediately queryable via the API endpoint, especially under high CI system load.

Applied wait_for_router() to all four tests that query individual router status:
- test-missing-svc (missing service reference)
- test-missing-mw (missing middleware reference)
- test-bad-ep (invalid entrypoint)
- test-bad-rule (invalid rule syntax)

cd containers/ddev-traefik-router && make test

Run multiple times to verify no intermittent failures.

The fix is in the test infrastructure itself. All 13 traefik.bats tests pass reliably with the new wait_for_router() polling mechanism.

Test-only change, no impact on runtime behavior or deployment.
