### PR TITLE
fix: use config values for primary router ports instead of container env

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -699,9 +699,9 @@ func (app *DdevApp) GetWebserverType() string {
 // GetPrimaryRouterHTTPPort returns app's primary router http port
 // It has to choose from (highest to lowest priority):
 // 1. Empty string if webserver type is generic and no web_extra_exposed_ports are defined
-// 2. The actual port configured into running container via DDEV_ROUTER_HTTP_PORT
-// 3. The project router_http_port
-// 4. The global router_http_port
+// 2. The project router_http_port
+// 3. The global router_http_port
+// 4. Default port 80
 func (app *DdevApp) GetPrimaryRouterHTTPPort() string {
 	proposedPrimaryRouterHTTPPort := "80"
 	if globalconfig.DdevGlobalConfig.RouterHTTPPort != "" {
@@ -709,9 +709,6 @@ func (app *DdevApp) GetPrimaryRouterHTTPPort() string {
 	}
 	if app.RouterHTTPPort != "" {
 		proposedPrimaryRouterHTTPPort = app.RouterHTTPPort
-	}
-	if httpPort := app.GetWebEnvVar("DDEV_ROUTER_HTTP_PORT"); httpPort != "" {
-		proposedPrimaryRouterHTTPPort = httpPort
 	}
 	if app.WebserverType == nodeps.WebserverGeneric && len(app.WebExtraExposedPorts) == 0 {
 		proposedPrimaryRouterHTTPPort = ""
@@ -762,9 +759,9 @@ func (app *DdevApp) TargetPortFromExposeVariable(exposeEnvVar string, targetPort
 // GetPrimaryRouterHTTPSPort returns app's primary router https port
 // It has to choose from (highest to lowest priority):
 // 1. Empty string if webserver type is generic and no web_extra_exposed_ports are defined
-// 2. The actual port configured into running container via DDEV_ROUTER_HTTPS_PORT
-// 3. The project router_https_port
-// 4. The global router_https_port
+// 2. The project router_https_port
+// 3. The global router_https_port
+// 4. Default port 443
 func (app *DdevApp) GetPrimaryRouterHTTPSPort() string {
 	proposedPrimaryRouterHTTPSPort := "443"
 	if globalconfig.DdevGlobalConfig.RouterHTTPSPort != "" {
@@ -772,9 +769,6 @@ func (app *DdevApp) GetPrimaryRouterHTTPSPort() string {
 	}
 	if app.RouterHTTPSPort != "" {
 		proposedPrimaryRouterHTTPSPort = app.RouterHTTPSPort
-	}
-	if httpsPort := app.GetWebEnvVar("DDEV_ROUTER_HTTPS_PORT"); httpsPort != "" {
-		proposedPrimaryRouterHTTPSPort = httpsPort
 	}
 	if app.WebserverType == nodeps.WebserverGeneric && len(app.WebExtraExposedPorts) == 0 {
 		proposedPrimaryRouterHTTPSPort = ""


### PR DESCRIPTION
## Summary

When `web_extra_exposed_ports` is configured (e.g., for Vite dev server), the primary router URL incorrectly shows the extra exposed port instead of the actual router port.

For example, with this config:
```yaml
router_https_port: "8443"
web_extra_exposed_ports:
  - name: vite
    container_port: 5173
    http_port: 5173
    https_port: 5174
```

The `ddev describe` and `ddev start` would show:
```
Project: myapp ... https://myapp.ddev.site:5174
```

Instead of the expected:
```
Project: myapp ... https://myapp.ddev.site:8443
```

## Root Cause

`GetPrimaryRouterHTTPPort()` and `GetPrimaryRouterHTTPSPort()` were reading from the container's environment variable (`DDEV_ROUTER_HTTP_PORT`/`DDEV_ROUTER_HTTPS_PORT`) as a higher priority than the config values. This created a circular dependency:

1. First run: compose file generated with extra ports somehow influencing the env vars
2. Next restart: functions read from old compose's env vars, picking up wrong values
3. Values persist incorrectly across restarts

## Fix

Remove the reading from container environment. The config values (`router_http_port` and `router_https_port`) should be the source of truth for primary router ports.

## Test Plan

- [ ] Configure a project with `web_extra_exposed_ports` for Vite
- [ ] Set `router_https_port: "8443"` 
- [ ] Run `ddev restart`
- [ ] Verify `ddev describe` shows correct port (8443, not the extra port)
- [ ] Verify `ddev launch` opens correct URL

Fixes #7462
Related to #7246