### PR TITLE
fix(tests): make GitHub release downloads more resilient [skip buildkite]

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -783,7 +783,8 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Download and extract the latest ExpressionEngine release:
 
     ```bash
-    curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
+    DOWNLOAD_URL=$(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
+    curl -o ee.zip -L "${DOWNLOAD_URL}"
     unzip ee.zip && rm -f ee.zip
     ```
 
@@ -812,7 +813,8 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-ee-site && cd my-ee-site
-        curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
+        DOWNLOAD_URL=$(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
+        curl -o ee.zip -L "${DOWNLOAD_URL}"
         unzip ee.zip && rm -f ee.zip
         ddev config --database=mysql:8.0
         ddev start -y
@@ -1188,7 +1190,8 @@ Create the project directory and download Joomla:
 mkdir my-joomla-site && cd my-joomla-site
 # Download the latest version of Joomla! and unzip it.
 # This can be manually downloaded from https://downloads.joomla.org/ or done using curl as here.
-curl -o joomla.zip -L $(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
+DOWNLOAD_URL=$(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
+curl -o joomla.zip -L "${DOWNLOAD_URL}"
 unzip joomla.zip && rm -f joomla.zip
 ```
 
@@ -1219,7 +1222,8 @@ ddev launch /administrator
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir my-joomla-site && cd my-joomla-site
-    curl -o joomla.zip -L $(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
+    DOWNLOAD_URL=$(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
+    curl -o joomla.zip -L "${DOWNLOAD_URL}"
     unzip joomla.zip && rm -f joomla.zip
     ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
     ddev start -y

--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -78,13 +78,13 @@ teardown() {
 #  echo "# DEBUG: ddev start output: " >&3
 #  echo "# $output" >&3
 
-  run curl -fLOv https://github.com/ddev/test-backdrop/releases/download/1.32.1/db.sql.gz
+  run _curl_github -fLOv https://github.com/ddev/test-backdrop/releases/download/1.32.1/db.sql.gz
   assert_success
 
   run ddev import-db --file=db.sql.gz
   assert_success
 
-  run curl -fLO https://github.com/ddev/test-backdrop/releases/download/1.32.1/files.tgz
+  run _curl_github -fLO https://github.com/ddev/test-backdrop/releases/download/1.32.1/files.tgz
   assert_success
 
   run ddev import-files --source=files.tgz

--- a/docs/tests/common-setup.bash
+++ b/docs/tests/common-setup.bash
@@ -27,3 +27,45 @@ _common_teardown() {
   ddev delete -Oy ${PROJNAME} >/dev/null
   rm -rf ${tmpdir}
 }
+
+# Curl wrapper that adds GITHUB_TOKEN auth if available
+# Usage: _curl_github [curl options] <url>
+_curl_github() {
+  local auth_args=()
+  [ -n "${GITHUB_TOKEN:-}" ] && auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  curl --retry 5 --retry-delay 2 "${auth_args[@]}" "$@"
+}
+
+# Download the latest release asset from a GitHub repo
+# Usage: _github_release_download <owner/repo> <asset_regex> <output_file>
+# Example: _github_release_download "ExpressionEngine/ExpressionEngine" "^ExpressionEngine.*\\.zip$" "ee.zip"
+# Uses GITHUB_TOKEN env var if available for authenticated requests
+_github_release_download() {
+  local repo="$1"
+  local asset_pattern="$2"
+  local output_file="$3"
+
+  # Get latest release info with retries
+  local release_json
+  release_json=$(_curl_github -sfL "https://api.github.com/repos/${repo}/releases/latest")
+
+  if [ -z "${release_json}" ]; then
+    echo "# Failed to fetch release info from ${repo}" >&3
+    return 1
+  fi
+
+  # Extract download URL - escape backslashes for jq regex
+  local download_url
+  local escaped_pattern="${asset_pattern//\\/\\\\}"
+  download_url=$(echo "${release_json}" | docker run -i --rm ddev/ddev-utilities jq -r ".assets | map(select(.name | test(\"${escaped_pattern}\")))[0].browser_download_url")
+
+  if [ -z "${download_url}" ] || [ "${download_url}" = "null" ]; then
+    echo "# No asset matching '${asset_pattern}' found in ${repo}" >&3
+    return 1
+  fi
+
+  echo "# Downloading ${download_url}" >&3
+
+  # Download the asset
+  _curl_github -fL -o "${output_file}" "${download_url}"
+}

--- a/docs/tests/ee.bats
+++ b/docs/tests/ee.bats
@@ -17,7 +17,7 @@ teardown() {
   assert_success
 
   # Download the latest version of Expression Engine
-  run curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
+  run _github_release_download "ExpressionEngine/ExpressionEngine" "^ExpressionEngine.*\\.zip$" "ee.zip"
   assert_success
 
   # unzip ee.zip && rm -f ee.zip

--- a/docs/tests/joomla.bats
+++ b/docs/tests/joomla.bats
@@ -16,7 +16,7 @@ teardown() {
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
   # Download the latest version of Joomla
-  run curl -o joomla.zip -L $(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
+  run _github_release_download "joomla/joomla-cms" "^Joomla.*Stable-Full_Package\\.zip$" "joomla.zip"
   assert_success
   # unzip joomla.zip && rm -f joomla.zip
   run unzip joomla.zip && rm -f joomla.zip

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -15,7 +15,7 @@ teardown() {
   # mkdir my-processwire-site && cd my-processwire-site
   run mkdir -p my-processwire-site && cd my-processwire-site
   assert_success
-  run curl -LJOf https://github.com/processwire/processwire/archive/master.zip
+  run _curl_github -LJOf https://github.com/processwire/processwire/archive/master.zip
   assert_success
   run unzip processwire-master.zip && rm -f processwire-master.zip && mv processwire-master/* . && mv processwire-master/.* . 2>/dev/null && rm -rf processwire-master
   assert_success


### PR DESCRIPTION

## The Issue

GitHub API calls in bats tests can fail due to rate limiting or transient errors, or need retry in general. It doesn't make sense to have to retry our quickstart tests just because of transient error or failure to use GITHUB_TOKEN.

## How This PR Solves The Issue

- Add `_curl_github` helper that adds GITHUB_TOKEN auth when available and includes retry logic
- Add `_github_release_download` function for downloading latest release assets
- Update ee.bats and joomla.bats to use the new functions
- Update backdrop.bats and processwire.bats to use `_curl_github`
- Split quickstart.md download commands into separate steps for clarity

## Manual Testing Instructions

```bash
bats docs/tests/ee.bats docs/tests/joomla.bats
```

## Automated Testing Overview

The quickstart workflow already runs these tests and provides GITHUB_TOKEN.

## Release/Deployment Notes

No deployment changes needed.
