### PR TITLE
test: Disable long-running tests when GOTEST_SHORT is set, fixes #8026

### DIFF
--- a/cmd/ddev/cmd/composer-create-project_test.go
+++ b/cmd/ddev/cmd/composer-create-project_test.go
@@ -17,8 +17,12 @@ import (
 )
 
 func TestComposerCreateProjectCmd(t *testing.T) {
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
 	if nodeps.IsWindows() {
-		t.Skip("Skipping on windows where it hangs")
+		t.Skip("Skipping on traditional windows where it hangs")
 	}
 	composerVersionForThisTest := nodeps.ComposerDefault
 	//composerVersionForThisTest := "2.8.0"

--- a/cmd/ddev/cmd/debug-rebuild_test.go
+++ b/cmd/ddev/cmd/debug-rebuild_test.go
@@ -14,6 +14,11 @@ import (
 
 // TestDebugRebuildCmd tests that ddev utility rebuild actually clears Docker cache
 func TestDebugRebuildCmd(t *testing.T) {
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
+
 	assert := asrt.New(t)
 
 	// Create a temporary directory and switch to it.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1300,9 +1300,11 @@ func TestTimezoneConfig(t *testing.T) {
 
 // TestComposerVersionConfig tests to make sure setting Composer version takes effect in the container.
 func TestComposerVersionConfig(t *testing.T) {
-	if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
-		t.Skip("Skipping on Lima/Colima/Rancher, lots of network connections failed")
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
 	}
+
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1263,6 +1263,10 @@ func TestGetApps(t *testing.T) {
 
 // TestDdevImportDB tests the functionality that is called when "ddev import-db" is executed
 func TestDdevImportDB(t *testing.T) {
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 	origDir, _ := os.Getwd()
@@ -1657,8 +1661,9 @@ func checkImportDBImports(t *testing.T, app *ddevapp.DdevApp) {
 
 // TestDdevAllDatabases tests db import/export/snapshot/restore/start with supported database versions
 func TestDdevAllDatabases(t *testing.T) {
-	if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
-		t.Skip("Skipping on Lima/Colima/Rancher")
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skipping when GOTEST_SHORT unset")
 	}
 	assert := asrt.New(t)
 
@@ -2085,6 +2090,11 @@ func TestDdevExportDB(t *testing.T) {
 // TestWebserverMariaMySQLDBClient tests functionality of mysql/mariadb
 // database clients in the ddev-webserver
 func TestWebserverMariaMySQLDBClient(t *testing.T) {
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
+
 	assert := asrt.New(t)
 
 	serverVersions := []string{"mysql:5.7", "mysql:8.0", "mysql:8.4", "mariadb:10.11", "mariadb:10.6", "mariadb:11.4", "mariadb:11.8"}

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -15,8 +15,13 @@ import (
 
 // TestProcessHooks tests execution of commands defined in config.yaml
 func TestProcessHooks(t *testing.T) {
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
+
 	if nodeps.IsWindows() {
-		t.Skip("Skipping on Windows, as it always hangs")
+		t.Skip("Skipping on traditional Windows, as it always hangs")
 	}
 	assert := asrt.New(t)
 

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -155,6 +155,11 @@ func TestGetLatestSnapshot(t *testing.T) {
 
 // TestDdevRestoreSnapshot tests creating a snapshot and reverting to it.
 func TestDdevRestoreSnapshot(t *testing.T) {
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
+
 	assert := assert2.New(t)
 
 	runTime := util.TimeTrackC(t.Name())


### PR DESCRIPTION
## The Issue

- #8026 

We spend a lot of time on all platforms in tests, but TestDdevAllDatabases takes the cake. 

Stop running so many on some platforms.

There are more that could be done, but this gets some of the really, really long ones.

See comment in https://github.com/ddev/ddev/issues/8026#issuecomment-3751460766

## Manual test

Review the test output; all the buildkite runs should exclude these tests.