### PR TITLE
docs(drupal-cms): In the Drupal CMS quick-start, call drupal recipe:unpack

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -644,6 +644,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
     ```bash
     ddev composer create-project drupal/cms
+    # Note: recipe-unpack runs automatically in DDEV v1.25.0+
     ddev composer drupal:recipe-unpack
     ```
 
@@ -666,6 +667,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         ddev config --project-type=drupal11 --docroot=web
         ddev start -y
         ddev composer create-project drupal/cms
+        # Note: recipe-unpack runs automatically in DDEV v1.25.0+
         ddev composer drupal:recipe-unpack
         ddev launch
         EOF

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -156,8 +156,10 @@ teardown() {
   assert_success
   assert_output --partial "Congratulations, you’ve installed Drupal CMS!"
 
+  # Note: recipe-unpack runs automatically in DDEV v1.25.0+
   run ddev composer drupal:recipe-unpack
   assert_success
+  assert_output --partial "No recipes to unpack."
 
   # Run Drush site install to set up the site
   run ddev drush si --account-name=admin --account-pass=admin -y


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

Not a GitHub issue, but available on drupal.org: https://www.drupal.org/project/drupal_cms/issues/3556092

DDEV's `composer create-project` wrapper inadvertently skips the recipe unpacking process, which happens automatically on `composer create-project` or `composer require`, but not on `composer install`. (See https://www.drupal.org/node/3522189 for details.)

## How This PR Solves The Issue

This adds the necessary step to the documentation.

## Manual Testing Instructions

Follow the quick-start instructions for Drupal CMS.

## Automated Testing Overview

This is purely a documentation thing, so I don't think we need tests. Adding automatic support for recipe unpacking to `ddev composer create-project` is beyond the scope of this issue, and not necessary for Drupal CMS right now.

The only test change (as requested) is in `docs/tests/drupal.bats`.

## Release/Deployment Notes

This should not affect anything other than a single documentation page.