### PR TITLE
fix(pause): resolve race condition in app.Pause() causing intermittent test failures

### DIFF
--- a/pkg/dockerutil/containers_test.go
+++ b/pkg/dockerutil/containers_test.go
@@ -235,13 +235,13 @@ func TestGetContainerHealth(t *testing.T) {
 	status, log := dockerutil.GetContainerHealth(c)
 	assert.Equal("healthy", status, "container should be healthy; log=%v", log)
 
-	// Now break the container and make sure it's unhealthy
+	// Now stop the container and make sure it's exited
 	timeout := 10
 	_, err = apiClient.ContainerStop(ctx, c.ID, client.ContainerStopOptions{Timeout: &timeout})
 	assert.NoError(err)
 
 	status, log = dockerutil.GetContainerHealth(c)
-	assert.Equal("unhealthy", status, "container should be unhealthy; log=%v", log)
+	assert.Equal("exited", status, "container should be exited; log=%v", log)
 	assert.NoError(err)
 }
 


### PR DESCRIPTION

## The Issue

router-test.go:942 had intermittent failures where status was sometimes 'unhealthy' after app.Pause() instead of 'paused', as illustrated in https://github.com/ddev/ddev/actions/runs/21170367951/job/60885355614#step:13:11398

This was caused by two interrelated problems:
1. app.Pause() returned immediately after calling docker compose stop without waiting for containers to reach stable "exited" state
2. GetContainerHealth() incorrectly returned "unhealthy" for any non-running container with a healthcheck, even when the container was actually in "exited" or "restarting" state

The race condition occurred when containers were transitioning from running→exited and GetContainerHealth() would override the actual state with "unhealthy" based on stale cached health status.

## How This PR Solves The Issue

1. **Fixed GetContainerHealth() logic** (containers.go:505-514): Now correctly returns actual container state ("exited" or "restarting") for non-running containers instead of always returning "unhealthy"

2. **Made app.Pause() wait for container state stabilization** (ddevapp.go:2914-2936): Added polling loop that waits up to 5 seconds for all app containers to reach "exited" state after docker compose stop, using GetAppContainers() to discover all containers dynamically

3. **Refactored to use Docker API constants**: Replaced string literals with type-safe constants from the Docker API:
   - container.StateExited, container.StateRunning, container.StateRestarting
   - container.Healthy, container.Unhealthy, container.Starting, container.NoHealthcheck

## Manual Testing Instructions

I don't know of a predictable way to manually test this, but if we see stable results in automated testing it should be OK.

## Automated Testing Overview

- Updated TestGetContainerHealth to expect "exited" for stopped containers instead of "unhealthy" (reflects corrected behavior)
- TestPausedProjectsExcludedFromRouter now passes consistently without race conditions
- All container-related tests pass with new Docker API constants

