### PR TITLE
test(quickstart): fix TYPO3 v14 test [skip ci]

### DIFF
--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -46,7 +46,7 @@ teardown() {
   assert_output --partial "HTTP/2 200"
   assert_success
   run curl -sfLv "https://${PROJNAME}.ddev.site/"
-  assert_output --partial "Welcome to a default website made with "
+  assert_output --partial "Welcome to your default website"
   assert_success
   run curl -sfLv "https://${PROJNAME}.ddev.site/typo3/"
   assert_output --partial "TYPO3 CMS Login:"


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/21176281231/job/60905880479

```
not ok 42 TYPO3 v14 'ddev typo3 setup' composer test with ddev version v1.24.10-134-ge2c8b9cb9
# (from function `assert_output' in file /home/linuxbrew/.linuxbrew/lib/bats-assert/src/assert_output.bash, line 186,
#  in test file docs/tests/typo3.bats, line 49)
#   `assert_output --partial "Welcome to a default website made with "' failed
# Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
#
# -- output does not contain substring --
# substring (1 lines):
#   Welcome to a default website made with
```

## How This PR Solves The Issue

Updates the check for text on the website page.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
