### PR TITLE
fix(cakephp): add new variable APP_FULL_BASE_URL to .env file

### DIFF
--- a/pkg/ddevapp/cakephp.go
+++ b/pkg/ddevapp/cakephp.go
@@ -64,6 +64,7 @@ func cakephpPostStartAction(app *DdevApp) error {
 		"export EMAIL_TRANSPORT_DEFAULT_URL": "smtp://localhost:1025",
 		"export SECURITY_SALT":               util.HashSalt(app.GetName()),
 		"export DEBUG_KIT_SAFE_TLD":          "site",
+		"export APP_FULL_BASE_URL":           app.GetPrimaryURL(),
 	}
 	err = WriteProjectEnvFile(envFilePath, envMap, envText)
 	if err != nil {


### PR DESCRIPTION
## The Issue

CakePHP 5.3 is enforcing the use of the full base url to avoid http host injections (see https://github.com/cakephp/app/commit/d4574fadd8a0b846d55ed4e379c0242538e5dbed) so we want to update this var to use DDEV app url

## How This PR Solves The Issue

This PR solves the issue by adding/updating a new env var APP_FULL_BASE_URL that is read by CakePHP app config file
## Manual Testing Instructions

* Follow instructions here: https://docs.ddev.com/en/stable/users/quickstart/#cakephp
* The .env file generated should contain now `export APP_FULL_BASE_URL="https://YOUR_APP.ddev.site"

## Automated Testing Overview

No tests required because we are just adding/updating a new env variable besides the previous ones

## Release/Deployment Notes

Nothing required
