### PR TITLE
test(quickstart): disable symfony tests, update Laravel SQLite, for #8058

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -30,6 +30,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DDEV_SKIP_QUICKSTART_TEST: ${{ vars.DDEV_SKIP_QUICKSTART_TEST || 'symfony-composer,symfony-cli' }}
 
 permissions:
   actions: write

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1397,7 +1397,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
     ```bash
     mkdir my-laravel-site && cd my-laravel-site
-    ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+    ddev config --project-type=laravel --docroot=public --omit-containers=db
     ```
 
     Start DDEV (this may take a minute):
@@ -1426,7 +1426,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
         #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-laravel-site && cd my-laravel-site
-        ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+        ddev config --project-type=laravel --docroot=public --omit-containers=db
         ddev start -y
         ddev composer create-project "laravel/laravel:^12"
         ddev launch
@@ -1440,7 +1440,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Configure for SQLite and restart:
 
     ```bash
-    ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+    ddev config --project-type=laravel --docroot=public --omit-containers=db
     ddev restart
     ```
 
@@ -1465,7 +1465,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
         cat > switch-laravel-sqlite.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+        ddev config --project-type=laravel --docroot=public --omit-containers=db
         ddev restart
         ddev composer run-script post-root-package-install
         ddev dotenv set .env --db-connection=sqlite
@@ -1484,7 +1484,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     mkdir my-laravel-site && cd my-laravel-site
     ddev config --project-type=laravel --docroot=public
     # For SQLite instead, use:
-    # ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+    # ddev config --project-type=laravel --docroot=public --omit-containers=db
     ```
 
     Create Dockerfile to add Laravel installer:

--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "backdrop new-project quickstart with $(ddev --version)" {
+  _skip_test_if_needed "backdrop-new"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
@@ -59,6 +61,8 @@ teardown() {
 }
 
 @test "backdrop existing project with $(ddev --version)" {
+  _skip_test_if_needed "backdrop-existing"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 

--- a/docs/tests/cakephp.bats
+++ b/docs/tests/cakephp.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "CakePHP Composer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "cakephp-composer"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -29,7 +31,7 @@ teardown() {
   assert_success
 
   # validate ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project

--- a/docs/tests/civicrm.bats
+++ b/docs/tests/civicrm.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "CiviCRM quickstart with $(ddev --version)" {
+  _skip_test_if_needed "civicrm-standalone"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 

--- a/docs/tests/codeigniter.bats
+++ b/docs/tests/codeigniter.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "CodeIgniter composer based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "codeigniter-composer"
+
   run mkdir my-codeigniter-site && cd my-codeigniter-site
   assert_success
 

--- a/docs/tests/common-setup.bash
+++ b/docs/tests/common-setup.bash
@@ -15,6 +15,27 @@ _common_setup() {
 #    echo "# Starting test at $(date)" >&3
 }
 
+# Check if a test should be skipped based on DDEV_SKIP_QUICKSTART_TEST
+# Set DDEV_SKIP_QUICKSTART_TEST to a comma-separated list of test identifiers to skip
+# Examples:
+#   DDEV_SKIP_QUICKSTART_TEST="symfony-composer" make quickstart-test
+#   DDEV_SKIP_QUICKSTART_TEST="symfony-composer,symfony-cli,drupal10-composer" make quickstart-test
+# Usage in test files: _skip_test_if_needed "test-identifier"
+_skip_test_if_needed() {
+    local test_id="$1"
+    if [ -n "${DDEV_SKIP_QUICKSTART_TEST:-}" ]; then
+        IFS=',' read -ra SKIP_TESTS <<< "${DDEV_SKIP_QUICKSTART_TEST}"
+        local skip_id
+        for skip_id in "${SKIP_TESTS[@]}"; do
+            # Trim whitespace
+            skip_id=$(echo "$skip_id" | xargs)
+            if [ "$skip_id" = "$test_id" ]; then
+                skip "Test skipped via DDEV_SKIP_QUICKSTART_TEST: ${test_id}"
+            fi
+        done
+    fi
+}
+
 _extra_info() {
   HOST_HTTP_URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.web.host_http_url)
   HOST_HTTPS_URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.web.host_https_url)

--- a/docs/tests/contao.bats
+++ b/docs/tests/contao.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Contao Composer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "contao-composer"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -37,7 +39,7 @@ teardown() {
   run ddev exec contao-console contao:user:create --username=admin --name=Administrator --email=admin@example.com --language=en --password=Password123 --admin
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch contao"
+  DDEV_DEBUG=true run ddev launch contao
   assert_output "FULLURL https://${PROJNAME}.ddev.site/contao"
   assert_success
   # validate running project
@@ -47,6 +49,8 @@ teardown() {
 }
 
 @test "Contao Manager quickstart with $(ddev --version)" {
+  _skip_test_if_needed "contao-manager"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -63,7 +67,7 @@ teardown() {
   run ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch contao-manager.phar.php"
+  DDEV_DEBUG=true run ddev launch contao-manager.phar.php
   assert_output "FULLURL https://${PROJNAME}.ddev.site/contao-manager.phar.php"
   assert_success
   # validate running project

--- a/docs/tests/craftcms.bats
+++ b/docs/tests/craftcms.bats
@@ -11,6 +11,8 @@ teardown() {
   _common_teardown
 }
 @test "Craft CMS New Projects quickstart with $(ddev --version)" {
+  _skip_test_if_needed "craftcms-new"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
@@ -54,5 +56,7 @@ teardown() {
 }
 
 @test "Craft CMS Existing Projects quickstart with $(ddev --version)" {
+  _skip_test_if_needed "craftcms-existing"
+
   skip "Does not have a test yet"
 }

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Drupal 11 quickstart with $(ddev --version)" {
+  _skip_test_if_needed "drupal11-composer"
+
   run mkdir my-drupal-site && cd my-drupal-site
   assert_success
 
@@ -42,6 +44,8 @@ teardown() {
 }
 
 @test "Drupal 10 quickstart with $(ddev --version)" {
+  _skip_test_if_needed "drupal10-composer"
+
   run mkdir my-drupal-site && cd my-drupal-site
   assert_success
 
@@ -72,6 +76,8 @@ teardown() {
 }
 
 @test "Drupal 11 git based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "drupal11-git"
+
   PROJECT_GIT_URL=https://github.com/ddev/test-drupal11.git
   run git clone ${PROJECT_GIT_URL} ${PROJNAME}
   assert_success
@@ -103,6 +109,8 @@ teardown() {
 }
 
 @test "Drupal CMS composer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "drupal-cms-composer"
+
   run mkdir my-drupal-site && cd my-drupal-site
   assert_success
 

--- a/docs/tests/ee.bats
+++ b/docs/tests/ee.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Expression Engine Zip File Download quickstart with $(ddev --version)" {
+  _skip_test_if_needed "ee-zip"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -33,7 +35,7 @@ teardown() {
   assert_success
 
   # validate ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch /admin.php"
+  DDEV_DEBUG=true run ddev launch /admin.php
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin.php"
   assert_success
 
@@ -65,6 +67,8 @@ teardown() {
 }
 
 @test "Expression Engine Git Clone quickstart with $(ddev --version)" {
+  _skip_test_if_needed "ee-git"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -96,7 +100,7 @@ teardown() {
   assert_file_exist .env.php
 
   # validate ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch /admin.php"
+  DDEV_DEBUG=true run ddev launch /admin.php
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin.php"
   assert_success
 

--- a/docs/tests/generic.bats
+++ b/docs/tests/generic.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Generic PHP built-in server quickstart with $(ddev --version)" {
+  _skip_test_if_needed "generic-php"
+
   GENERIC_SITENAME=${PROJNAME}
   run mkdir ${GENERIC_SITENAME} && cd ${GENERIC_SITENAME}
   assert_success

--- a/docs/tests/grav.bats
+++ b/docs/tests/grav.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Grav Composer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "grav-composer"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
@@ -41,6 +43,8 @@ teardown() {
 
 
 @test "Grav Git Clone quickstart with $(ddev --version)" {
+  _skip_test_if_needed "grav-git"
+
   run mkdir my-grav-site && cd my-grav-site
   assert_success
 

--- a/docs/tests/ibexa.bats
+++ b/docs/tests/ibexa.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Ibexa DXP quickstart with $(ddev --version)" {
+  _skip_test_if_needed "ibexa-composer"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -28,7 +30,7 @@ teardown() {
   run ddev exec console ibexa:install --no-interaction
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch /admin/login"
+  DDEV_DEBUG=true run ddev launch /admin/login
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin/login"
   assert_success
   # validate running project

--- a/docs/tests/joomla.bats
+++ b/docs/tests/joomla.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Joomla quickstart with $(ddev --version)" {
+  _skip_test_if_needed "joomla-zip"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -31,7 +33,7 @@ teardown() {
   run ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="Administrator" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@example.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch /administrator/"
+  DDEV_DEBUG=true run ddev launch /administrator/
   assert_output "FULLURL https://${PROJNAME}.ddev.site/administrator/"
   assert_success
   # validate running project

--- a/docs/tests/kirby.bats
+++ b/docs/tests/kirby.bats
@@ -12,6 +12,7 @@ teardown() {
 }
 
 @test "Kirby new project quickstart with $(ddev --version)" {
+  _skip_test_if_needed "kirby-composer"
 
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
@@ -30,7 +31,7 @@ teardown() {
   assert_success
 
   # validate ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 

--- a/docs/tests/laravel.bats
+++ b/docs/tests/laravel.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Laravel composer based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "laravel-composer"
+
   run mkdir my-laravel-site && cd my-laravel-site
   assert_success
 
@@ -44,6 +46,8 @@ teardown() {
 }
 
 @test "Laravel composer (SQLite) based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "laravel-composer-sqlite"
+
   run mkdir my-laravel-site && cd my-laravel-site
   assert_success
 
@@ -76,6 +80,8 @@ teardown() {
 }
 
 @test "Laravel installer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "laravel-installer"
+
   run mkdir my-laravel-site && cd my-laravel-site
   assert_success
 

--- a/docs/tests/magento2.bats
+++ b/docs/tests/magento2.bats
@@ -12,6 +12,7 @@ teardown() {
 }
 
 @test "Magento 2 quickstart with $(ddev --version)" {
+  _skip_test_if_needed "magento2-composer"
 
   if [ "${MAGENTO2_PUBLIC_ACCESS_KEY}" = "" ]; then
     skip "MAGENTO2_PUBLIC_ACCESS_KEY not provided (forked PR)"

--- a/docs/tests/moodle.bats
+++ b/docs/tests/moodle.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Moodle quickstart with $(ddev --version)" {
+  _skip_test_if_needed "moodle-composer"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -26,7 +28,7 @@ teardown() {
   run ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch /login"
+  DDEV_DEBUG=true run ddev launch /login
   assert_output "FULLURL https://${PROJNAME}.ddev.site/login"
   assert_success
   # validate running project

--- a/docs/tests/nodejs.bats
+++ b/docs/tests/nodejs.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Node.js quickstart with $(ddev --version)" {
+  _skip_test_if_needed "nodejs-express"
+
   NODEJS_SITENAME=${PROJNAME}
   run mkdir ${NODEJS_SITENAME} && cd ${NODEJS_SITENAME}
   assert_success
@@ -54,7 +56,7 @@ EOF
   echo "# Traefik routers: $output"
 
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_success
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
 

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "OpenMage git based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "openmage-git"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
@@ -31,7 +33,7 @@ teardown() {
   run ddev openmage-install -q
   assert_success
 
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 
@@ -55,6 +57,8 @@ teardown() {
 }
 
 @test "OpenMage composer based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "openmage-composer"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
@@ -110,7 +114,7 @@ teardown() {
   run ddev openmage-install -q
   assert_success
 
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 

--- a/docs/tests/pimcore.bats
+++ b/docs/tests/pimcore.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Pimcore Composer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "pimcore-composer"
+
   skip "Pimcore requires a license key"
 
   # mkdir -p ${PROJNAME} && cd ${PROJNAME}
@@ -41,7 +43,7 @@ teardown() {
   run ddev restart -y
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch /admin"
+  DDEV_DEBUG=true run ddev launch /admin
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin"
   assert_success
   # validate running project

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "processwire zipball with $(ddev --version)" {
+  _skip_test_if_needed "processwire-zip"
+
   run mkdir -p my-processwire-site && cd my-processwire-site
   assert_success
   run _curl_github -LJOf https://github.com/processwire/processwire/archive/master.zip
@@ -22,7 +24,7 @@ teardown() {
   assert_success
   DDEV_DEBUG=true run ddev start -y
   assert_success
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 
@@ -60,6 +62,8 @@ teardown() {
 }
 
 @test "processwire composer with $(ddev --version)" {
+  _skip_test_if_needed "processwire-composer"
+
   # mkdir my-processwire-site && cd my-processwire-site
   run mkdir -p my-processwire-site && cd my-processwire-site
   assert_success
@@ -72,7 +76,7 @@ teardown() {
   # ddev composer create-project "processwire/processwire:^3"
   run ddev composer create-project "processwire/processwire:^3"
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Shopware Composer based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "shopware-composer"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 

--- a/docs/tests/silverstripe.bats
+++ b/docs/tests/silverstripe.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Silverstripe CMS Composer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "silverstripe-composer"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
@@ -46,5 +48,7 @@ teardown() {
 }
 
 @test "Silverstripe CMS Git Clone  quickstart with $(ddev --version)" {
+  _skip_test_if_needed "silverstripe-git"
+
   skip "Does not have a test yet"
 }

--- a/docs/tests/statamic.bats
+++ b/docs/tests/statamic.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Statamic Composer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "statamic-composer"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -31,10 +33,10 @@ teardown() {
 
 
   # validate ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
-  run bash -c "DDEV_DEBUG=true ddev launch /cp"
+  DDEV_DEBUG=true run ddev launch /cp
   assert_output "FULLURL https://${PROJNAME}.ddev.site/cp"
   assert_success
 
@@ -60,5 +62,7 @@ teardown() {
 
 
 @test "Statamic Git Clone quickstart with $(ddev --version)" {
+  _skip_test_if_needed "statamic-git"
+
   skip "Does not have a test yet"
 }

--- a/docs/tests/sulu.bats
+++ b/docs/tests/sulu.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Sulu quickstart with $(ddev --version)" {
+  _skip_test_if_needed "sulu-composer"
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -47,7 +49,7 @@ teardown() {
   run ddev exec bin/adminconsole sulu:build dev --no-interaction
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch /admin"
+  DDEV_DEBUG=true run ddev launch /admin
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/admin"
   assert_success
   # validate running project

--- a/docs/tests/sveltekit.bats
+++ b/docs/tests/sveltekit.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "sveltekit quickstart with $(ddev --version)" {
+  _skip_test_if_needed "sveltekit-demo"
+
   SVELTEKIT_SITENAME=${PROJNAME}
   run mkdir ${SVELTEKIT_SITENAME} && cd ${SVELTEKIT_SITENAME}
   assert_success
@@ -73,7 +75,7 @@ EOF
   echo "# Existing containers: $output" >&3
 
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Symfony Composer quickstart with $(ddev --version)" {
+  _skip_test_if_needed "symfony-composer"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
@@ -44,6 +46,8 @@ teardown() {
 }
 
 @test "Symfony CLI quickstart with $(ddev --version)" {
+  _skip_test_if_needed "symfony-cli"
+
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "TYPO3 v14 'ddev typo3 setup' composer test with $(ddev --version)" {
+  _skip_test_if_needed "typo3-v14-setup"
+
   PROJNAME=my-typo3-site
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -54,6 +56,8 @@ teardown() {
 }
 
 @test "TYPO3 v13 'ddev typo3 setup' composer test with $(ddev --version)" {
+  _skip_test_if_needed "typo3-v13-setup"
+
   PROJNAME=my-typo3-site
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -93,6 +97,8 @@ teardown() {
 }
 
 @test "TYPO3 v12 'ddev typo3 setup' composer test with $(ddev --version)" {
+  _skip_test_if_needed "typo3-v12-setup"
+
   PROJNAME=my-typo3-site
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -132,6 +138,8 @@ teardown() {
 }
 
 @test "TYPO3 v11 'web installer' composer test with $(ddev --version)" {
+  _skip_test_if_needed "typo3-v11-installer"
+
   PROJNAME=my-typo3-site
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -155,6 +163,8 @@ teardown() {
 }
 
 @test "TYPO3 git based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "typo3-git"
+
   PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
   PROJNAME=my-typo3-site
   run git clone ${PROJECT_GIT_URL} ${PROJNAME}
@@ -180,6 +190,8 @@ teardown() {
 }
 
 @test "TYPO3 XHGui composer test with $(ddev --version)" {
+  _skip_test_if_needed "typo3-xhgui"
+
   run mkdir my-typo3-site && cd my-typo3-site
   assert_success
 

--- a/docs/tests/wagtail.bats
+++ b/docs/tests/wagtail.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Wagtail quickstart with $(ddev --version)" {
+  _skip_test_if_needed "wagtail-gunicorn"
+
   WAGTAIL_SITENAME=${PROJNAME}
   run mkdir ${WAGTAIL_SITENAME} && cd ${WAGTAIL_SITENAME}
   assert_success

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "WordPress wp-cli based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "wordpress-cli"
+
   # mkdir my-wp-site && cd my-wp-site
   run mkdir my-wp-site && cd my-wp-site
   assert_success
@@ -27,7 +29,7 @@ teardown() {
   run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
@@ -43,6 +45,8 @@ teardown() {
 }
 
 @test "WordPress wp-cli based quickstart (different docroot) with $(ddev --version)" {
+  _skip_test_if_needed "wordpress-cli-docroot"
+
   # mkdir my-wp-site && cd my-wp-site
   run mkdir my-wp-site && cd my-wp-site
   assert_success
@@ -59,7 +63,7 @@ teardown() {
   run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
@@ -75,6 +79,8 @@ teardown() {
 }
 
 @test "WordPress Bedrock based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "wordpress-bedrock"
+
   # mkdir my-wp-site && cd my-wp-site
   run mkdir my-wp-site && cd my-wp-site
   assert_success
@@ -98,7 +104,7 @@ teardown() {
   run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
@@ -114,6 +120,8 @@ teardown() {
 }
 
 @test "WordPress git based quickstart with $(ddev --version)" {
+  _skip_test_if_needed "wordpress-git"
+
   # PROJECT_GIT_URL=https://github.com/ddev/test-wordpress.git
   PROJECT_GIT_URL=https://github.com/ddev/test-wordpress.git
   # git clone ${PROJECT_GIT_URL} ${PROJNAME}
@@ -132,7 +140,7 @@ teardown() {
   run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
   # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
+  DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project


### PR DESCRIPTION
## The Issue

- #8058

---

- #7108

> Remove `--disable-settings-management=true` from the Laravel SQLite quickstart

## How This PR Solves The Issue

- Skips Symfony quickstarts with `DDEV_SKIP_QUICKSTART_TEST`
- Refactors this check while I'm here:
   ```diff
   -run bash -c "DDEV_DEBUG=true ddev launch"
   +DDEV_DEBUG=true run ddev launch
   ```
- Removes `--disable-settings-management=true` from Laravel quickstart, it's not needed anymore, see https://github.com/ddev/ddev/pull/7584

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
