### PR TITLE
fix(ddevapp): check file existence in isCustomConfigFile

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -594,6 +594,9 @@ func ValidateDocroot(docroot string) error {
 // isCustomConfigFile returns true if the file exists and is not marked with
 // either the standard DDEV signature or the silent-no-warn marker.
 func isCustomConfigFile(filePath string) bool {
+	if !fileutil.FileExists(filePath) {
+		return false
+	}
 	sigFound, _ := fileutil.FgrepStringInFile(filePath, nodeps.DdevFileSignature)
 	silentNoWarnFound, _ := fileutil.FgrepStringInFile(filePath, nodeps.DdevSilentNoWarn)
 	return !sigFound && !silentNoWarnFound


### PR DESCRIPTION
## The Issue

```
$ rm -f .ddev/traefik/config/*.yaml
$ ddev start
...
Using custom Traefik configuration (use `docker logs ddev-router` for troubleshooting): /home/stas/code/ddev/d11/.ddev/traefik/config/d11.yaml 
Custom configuration is updated on restart.
...
```

This can be reproduced with any quickstart, where Traefik config doesn't exist yet.

## How This PR Solves The Issue

Adds check for file existence.

## Manual Testing Instructions

```bash
rm -f .ddev/traefik/config/*.yaml
ddev start
# don't see a warning about custom Traefik config
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
