### PR TITLE
fix(healthcheck): resolve optional profiles to services, for #7745

### DIFF
--- a/pkg/ddevapp/start_test.go
+++ b/pkg/ddevapp/start_test.go
@@ -41,11 +41,17 @@ func TestDdevApp_StartOptionalProfiles(t *testing.T) {
 	require.Nil(t, container)
 
 	// Now StartOptionalProfiles() and make sure the service is there
-	profiles := []string{"busybox1", "busybox2"}
+	profiles := []string{"busybox-first", "busybox-second"}
 	err = app.StartOptionalProfiles(profiles)
 	require.NoError(t, err)
+	// Map profile names to service names for verification
+	profileToService := map[string]string{
+		"busybox-first":  "busybox1",
+		"busybox-second": "busybox2",
+	}
 	for _, prof := range profiles {
-		container, err = ddevapp.GetContainer(app, prof)
+		serviceName := profileToService[prof]
+		container, err = ddevapp.GetContainer(app, serviceName)
 		require.NoError(t, err)
 		require.NotNil(t, container)
 	}

--- a/pkg/ddevapp/testdata/TestDdevApp_StartOptionalProfiles/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevApp_StartOptionalProfiles/docker-compose.busybox.yaml
@@ -3,7 +3,7 @@ services:
     image: busybox:stable
     command: tail -f /dev/null
     profiles:
-      - busybox1
+      - busybox-first
     container_name: ddev-${DDEV_SITENAME}-busybox1
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -12,7 +12,7 @@ services:
     image: busybox:stable
     command: tail -f /dev/null
     profiles:
-      - busybox2
+      - busybox-second
     container_name: ddev-${DDEV_SITENAME}-busybox2
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
## The Issue

This PR added `app.Wait()` for optional profiles: 

- #7745

But this logic is going to work only for one-to-one relations between services and profiles with the same name:

```go
// Using `profiles` here assumes that profile and container name are the same
output.UserOut.Printf("Waiting for containers to become ready: %v", profiles)
err = app.Wait(profiles)
if err != nil {
	return err
}
```

## How This PR Solves The Issue

- Adds proper code inside `app.StartOptionalProfiles()` to wait for corresponding services, not profiles.
- Updates the related test to check for the new behavior.

## Manual Testing Instructions

```bash
ddev config --auto
ddev add-on get ddev/ddev-memcached
ddev add-on get ddev/ddev-redis

cat <<'EOF' > .ddev/docker-compose.profiles.yaml
services:
  redis:
    profiles:
      - extra
  memcached:
    profiles:
      - extra
EOF

ddev start
ddev start --profiles=extra
```

Before, DDEV HEAD:

```
$ ddev start --profiles=extra
...
 Container ddev-l12-memcached Started
 Container ddev-l12-redis Started
...
Waiting for containers to become ready: [extra]...
Failed to start optional profiles 'extra': extra container failed: log=, err=failed to query container
```

After, this PR:

```
$ ddev start --profiles=extra
...
 Container ddev-l12-memcached Started
 Container ddev-l12-redis Started
...
Waiting for containers to become ready: [memcached redis]... ready in 1.0s
Started optional compose profiles 'extra'
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
