### PR TITLE
fix(lagoon): bug in lagoon-sync means it fails if ~/.ssh/known_hosts doesn't exist [skip buildkite]

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml
@@ -26,7 +26,10 @@ auth_command:
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     if [ -z "${LAGOON_PROJECT:-}" ]; then echo "Please make sure you have set the LAGOON_PROJECT environment variable in your 'web_environment' or .ddev/.env." && exit 1; fi
     if [ -z "${LAGOON_ENVIRONMENT}" ]; then echo "Please make sure you have set the LAGOON_ENVIRONMENT environment variable in your 'web_environment' or .ddev/.env." && exit 1; fi
-
+    # Defensive fix for missing known_hosts, see odd output in
+    # https://github.com/uselagoon/lagoon-sync/issues/135
+    # https://github.com/uselagoon/lagoon-cli/pull/488
+    mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && chmod -R go-rw ~/.ssh
 
 db_import_command:
   command: |


### PR DESCRIPTION
## The Issue

- https://github.com/uselagoon/lagoon-sync/issues/135

Lots of strange output; saying lagoon-sync not available, etc.

It seems to be just that ~/.ssh/known_hosts didn't exist

Should be fixed upstream in
* https://github.com/uselagoon/lagoon-cli/pull/488

## How This PR Solves The Issue

Just make sure we have that file.

I was tempted to add it it to the startup code for ddev-webserver, but it's a bad time for that.

## Manual Testing Instructions

`ddev pull lagoon` and see output


Occasional previous output on failure:
```
        	            	[INFO]  2026/01/27 22:02:31 Running the following prerequisite command /usr/local/bin/lagoon-sync config || true
        	            	[WARN]  2026/01/27 22:02:31 ssh: no key found &{0xc000078120}
        	            	[WARN]  2026/01/27 22:02:40 'lagoon-sync' is not available on pull
        	            	[INFO]  2026/01/27 22:02:40 Beginning export on source environment pull
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
