### PR TITLE
build(webserver): fix check for MariaDB keyring [skip buildkite]

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -33,8 +33,8 @@ RUN rm -f /etc/apt/sources.list.d/symfony-stable.list && \
 # The key is from https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/gpg#mariadb-community-server-debian-ubuntu-key
 # Search for CHANGE_MARIADB_CLIENT to update related code.
 RUN KEYRING_URL="https://supplychain.mariadb.com/mariadb-keyring-2025.gpg" && \
-    curl -fsSL https://r.mariadb.com/downloads/mariadb_repo_setup | grep -q "${KEYRING_URL}" || \
-        (echo "ERROR: KEYRING_URL does not match mariadb_repo_setup script" >&2 && exit 1) && \
+    SCRIPT=$(curl -fsSL https://r.mariadb.com/downloads/mariadb_repo_setup) && \
+    echo "${SCRIPT}" | grep -q "${KEYRING_URL}" || (echo "ERROR: KEYRING_URL does not match mariadb_repo_setup script" >&2 && exit 1) && \
     KEYRING_FILE="${KEYRING_URL##*/}" && \
     KEYRING_PATH="/usr/share/keyrings/${KEYRING_FILE}" && \
     curl -fsSL -O "${KEYRING_URL}" && \


### PR DESCRIPTION
## The Issue

We see errors when building `ddev-webserver` in tests https://github.com/ddev/ddev/actions/runs/21491591472/job/61915245859

## How This PR Solves The Issue

It happened because there was a `curl -f | grep` pipe.
This PR removes the pipe, this change doesn't require image rebuild.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
