### PR TITLE
fix(heidisql): get basename for postgres library, fixes #8086

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -71,7 +71,7 @@ if [ "$type" = "postgres" ]; then
       done
       # Select latest one if no matching version was found and there are any libraries
       if [ -z "${library}" ] && [ ${#libfiles[@]} -gt 0 ]; then
-        library="${libfiles[-1]}"
+        library="${libfiles[-1]##*/}"
       fi
     else
       # For Linux, check if libpq is installed


### PR DESCRIPTION
## The Issue

- Fixes #8086

## How This PR Solves The Issue

The name of the library file should not be the full path, but only basename.
I don't understand how it worked for me a few months ago.

## Manual Testing Instructions

```bash
ddev config --database=postgres:18
ddev start
ddev heidisql
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
