### PR TITLE
chore(github): update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,13 +5,17 @@
 
 ## The Issue
 
-- #<issue number>
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
 
 <!-- Provide a brief description of the issue. -->
 
 ## How This PR Solves The Issue
 
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
 ## Manual Testing Instructions
+
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
 
 ## Automated Testing Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ cat <<'EOF' | git commit -F -
 
 ## The Issue
 
-- #<issue_number>
+- Fixes #<issue_number>
 
 [Issue description]
 


### PR DESCRIPTION
## The Issue

1. The line below doesn't create relation between issue and PR in GitHub (because it doesn't have the word "Fixes").

	```
	- #<issue number>
	```

2. `<issue number>` cannot be selected by double click, I often have to select it with a mouse.

## How This PR Solves The Issue

Uses the same template as in https://github.com/ddev/ddev-addon-template/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
