### PR TITLE
test(openmage): add --no-security-blocking to openmage.bats for Composer 2.9 compatibility [skip buildkite]

### DIFF
--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -26,7 +26,8 @@ teardown() {
   run ddev start -y
   assert_success
 
-  run ddev composer install
+  # Use --no-security-blocking for now, 2026-02-02
+  run ddev composer install --no-security-blocking
   assert_success
 
   # Silent OpenMage install with sample data
@@ -100,7 +101,8 @@ teardown() {
   assert_success
 
   # composer install
-  run ddev composer install
+  # Use --no-security-blocking for now, 2026-02-02
+  run ddev composer install --no-security-blocking
   assert_success
 
   # download OpenMage install command


### PR DESCRIPTION
## The Issue

OpenMage tests are failing in CI due to Composer 2.9's automatic security blocking feature. Composer 2.9 blocks installation of packages with known security advisories by default. OpenMage has 19 security advisories on Packagist, causing the composer install commands to fail.

## How this PR solves the Issue

Added the `--no-security-blocking` flag (introduced in Composer 2.9.2) to both `ddev composer install` commands in openmage.bats.

This allows the tests to bypass Composer 2.9's security blocking and continue testing OpenMage installation functionality.

1. Run the openmage tests with Composer 2.9+: ```bash cd docs/tests bats openmage.bats ```
2. Verify both test cases pass:
   - "OpenMage git based quickstart"
   - "OpenMage composer based quickstart"


This is a test-only change with no impact on DDEV functionality. OpenMage is a legacy platform with known security advisories that are unlikely to be resolved due to backward compatibility requirements. Users installing OpenMage will need to use similar workarounds with Composer 2.9+.

