### PR TITLE
fix(add-on): normalize `ddev add-on get` output when there's no version

### DIFF
--- a/cmd/ddev/cmd/addon-get.go
+++ b/cmd/ddev/cmd/addon-get.go
@@ -298,7 +298,11 @@ ddev add-on get /path/to/tarball.tar.gz
 		if argType == "github" {
 			util.Success("Please read instructions for this add-on at the source repo at\nhttps://github.com/%v/%v\nPlease file issues and create pull requests there to improve it.", owner, repo)
 		}
-		output.UserOut.WithField("raw", manifest).Printf("Installed %[1]s:%[2]s from %[3]s\nUse `ddev restart` to enable %[1]s:%[2]s", manifest.Name, manifest.Version, manifest.Repository)
+		addonID := manifest.Name
+		if manifest.Version != "" {
+			addonID = fmt.Sprintf("%s:%s", manifest.Name, manifest.Version)
+		}
+		output.UserOut.WithField("raw", manifest).Printf("Installed %[1]s from %[2]s\nUse `ddev restart` to enable %[1]s", addonID, manifest.Repository)
 	},
 }
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

Extra `:` shouldn't be here:

```text
$ ddev add-on get /home/stas/code/ddev-addons/ddev-mongo
...
Installed mongo: from /home/stas/code/ddev-addons/ddev-mongo
Use `ddev restart` to enable mongo:
```

## How This PR Solves The Issue

Adds a check for add-on version.

## Manual Testing Instructions

```text
$ ddev add-on get /home/stas/code/ddev-addons/ddev-mongo
...
Installed mongo from /home/stas/code/ddev-addons/ddev-mongo
Use `ddev restart` to enable mongo
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
