### PR TITLE
build(webserver): bump v1.24.10 for expired deb.sury key, php8.5 packages update

### DIFF
--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -167,9 +167,9 @@ jobs:
           # Create and push multi-arch manifests
           for ORG_IMAGE in ${MULTI_ARCH_IMAGES}; do
             docker buildx imagetools create -t ${ORG_IMAGE}:${TAG} ${ORG_IMAGE}:${TAG}-amd64 ${ORG_IMAGE}:${TAG}-arm64
-            if [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              docker buildx imagetools create -t ${ORG_IMAGE}:latest ${ORG_IMAGE}:${TAG}
-            fi
+            # if [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            #   docker buildx imagetools create -t ${ORG_IMAGE}:latest ${ORG_IMAGE}:${TAG}
+            # fi
           done
 
           # Clean up intermediary single-arch tags from remote registry

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -42,26 +42,7 @@ php84:
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
 
-# TODO: php8.5: These are the standard packages carried forward from php8.4 to php8.5
-# https://codeberg.org/oerdnj/deb.sury.org/issues/13#issuecomment-7573144
-# However, opcache is now enabled by default, so we need to add it to the list of extensions.
-# https://wiki.php.net/rfc/make_opcache_required
-# These extensions that DDEV uses are currently missing in php8.5 on Debian bookworm (arm64)
-#apcu
-#imagick
-#memcached
-#redis
-#uploadprogress
-#xdebug
-#xhprof
-#xmlrpc
-#yaml
-
-php85-todo:
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
-
-# TODO: php8.5 temp workaround until php8.5 packages are available
+# php8.5: memcached not yet available in Debian Bookworm Sury arm64
 php85:
-  amd64: ["bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
-  arm64: ["bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]


### PR DESCRIPTION
## The Issue

- #8106

DO NOT merge this PR.

---

Using DDEV v1.24.10:

- https://github.com/ddev/ddev-gitlab-ci/issues/29

If you have custom `.ddev/web-build/Dockerfile.*`:

```
#18 2.535 W: GPG error: https://packages.sury.org/php bookworm InRelease: The following signatures were invalid: EXPKEYSIG B188E2B695BD4743 DEB.SURY.ORG Automatic Signing Key <deb@sury.org>
#18 2.535 E: The repository 'https://packages.sury.org/php bookworm InRelease' is not signed.
```

## How This PR Solves The Issue

Before pushing new images, I created backups for existing v1.24.10 images:

```bash
docker buildx imagetools create -t ddev/ddev-php-base:v1.24.10-old ddev/ddev-php-base:v1.24.10
docker buildx imagetools create -t ddev/ddev-php-prod:v1.24.10-old ddev/ddev-php-prod:v1.24.10
docker buildx imagetools create -t ddev/ddev-webserver:v1.24.10-old ddev/ddev-webserver:v1.24.10
docker buildx imagetools create -t ddev/ddev-webserver-prod:v1.24.10-old ddev/ddev-webserver-prod:v1.24.10
```

If anything goes wrong, revert with:

```diff
-docker buildx imagetools create -t ddev/ddev-php-base:v1.24.10-old ddev/ddev-php-base:v1.24.10
+docker buildx imagetools create -t ddev/ddev-php-base:v1.24.10 ddev/ddev-php-base:v1.24.10-old
```

This technique was tested in:

- https://github.com/ddev-test/ddev/pull/23

## Manual Testing Instructions

```bash
# Using DDEV v1.24.10:
ddev utility download-images # see pull for ddev-webserver
ddev start
ddev php8.2 -v
ddev php8.3 -v
ddev php8.4 -v
ddev php8.5 -v
```

---

Check new PHP versions:

- PHP 8.2.29 -> 8.2.30
- PHP 8.3.27 -> 8.3.30
- PHP 8.4.14 -> 8.4.17
- PHP 8.5.0RC3 -> 8.5.2 (with Xdebug and other PHP extensions that were previously missing)

## Automated Testing Overview

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
