### PR TITLE
docs: note that "pull acquia" uses latest available backup

### DIFF
--- a/docs/content/users/providers/acquia.md
+++ b/docs/content/users/providers/acquia.md
@@ -51,4 +51,4 @@ DDEV’s Acquia integration pulls database and files from an existing project in
 
 ## Usage
 
-`ddev pull acquia` will connect to the Acquia Cloud Platform to download the database and files; note that it will download the latest available backup, rather than use a fresh copy of the database. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+`ddev pull acquia` will connect to the Acquia Cloud Platform to download the database and files; note that it will download the latest available backup on the requested environment, rather than use a fresh copy of the database. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.


### PR DESCRIPTION
Clarified that 'ddev pull acquia' downloads the latest backup instead of a fresh copy.

## The Issue

It was unexpected that the `ddev pull acquia` command did not create a fresh copy/backup of the database, it instead used the latest available backup for the requested environment.

## How This PR Solves The Issue

Adds a note to the docs about what it does.

## Manual Testing Instructions

It's docs man ;-)

## Automated Testing Overview

n/a

## Release/Deployment Notes

n/a