### PR TITLE
docs: Add "tested on" badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Works with Mac | Windows | Linux | Cloud](https://img.shields.io/badge/works%20with-Mac%20%7C%20Windows%20%7C%20Linux%20%7C%20Cloud-blue.svg)](https://docs.ddev.com/en/stable/users/install/ddev-installation/)
 [![Supported PHP 5.6 to 8.5](https://img.shields.io/badge/supported-PHP%208.5%20%7C%208.4%20%7C%208.3%20%7C%208.2%20%7C%208.1%20%7C%208.0%20%7C%207.4%20%7C%207.3%20%7C%207.2%20%7C%207.1%20%7C%207.0%20%7C%205.6-blue.svg)](https://docs.ddev.com/en/stable/users/configuration/config/#php_version)
 [![Supported nginx & apache](https://img.shields.io/badge/supported-Nginx%20%7C%20Apache-blue)](https://docs.ddev.com/en/stable/users/configuration/config/#webserver_type)
-[![Supported MySQL, MariaDB, PostgreSQL](https://img.shields.io/badge/supported-MySQL%20%7C%20MariaDB%20%7C%20PostgreSQL-blue)](https://docs.ddev.com/en/stable/users/extend/database-types/)
+[![Supported MariaDB, MySQL, PostgreSQL](https://img.shields.io/badge/supported-MariaDB%20%7C%20MySQL%20%7C%20PostgreSQL-blue)](https://docs.ddev.com/en/stable/users/extend/database-types/)
 
 DDEV is an open-source tool for running local web development environments for PHP and Node.js, ready in minutes. Its powerful, flexible per-project environment configurations can be extended, version controlled, and shared. DDEV allows development teams to adopt a consistent Docker workflow without the complexities of bespoke configuration.
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

I was browsing 
https://github.com/PHPCSStandards/PHP_CodeSniffer/ and noticed the "tested on" badge. This really highlights all the supported PHP versions. 

DDEV does extensive testing and including something like this would highlight supported PHP versions more.

I considered a "PHP 5.6 | 7.x | 8.x" badge but it felt too weak.

## How This PR Solves The Issue

Include a badge in the README to indicate compatibility with PHP versions 5.6 through 8.5, enhancing clarity for users regarding supported PHP versions.

I considered adding badges for "tested on Mysql/Postgres ...x" but worried the badges might become too noisy. Happy to take suggestions and feedback.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

** Amended:

Original inspiration

<img width="643" height="136" alt="image" src="https://github.com/user-attachments/assets/a7bcee6b-eec1-43ce-a321-566cf242e514" />

