### PR TITLE
chore: fix webimage_extra_packages example in config.yaml

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -136,7 +136,7 @@ Extra Debian packages for the project’s database container. (This is rarely us
 | -- | -- | --
 | :octicons-file-directory-16: project | `[]` | &zwnj;
 
-Example: `dbimage_extra_packages: ["less"]` will add the `less` package when the database container is built.
+Example: `dbimage_extra_packages: [netcat, telnet, sudo]` will add the `netcat`, `telnet`, and `sudo` packages when the database container is built.
 
 ## `ddev_version_constraint`
 
@@ -711,7 +711,7 @@ Extra Debian packages for the project’s web container.
 | -- | -- | --
 | :octicons-file-directory-16: project | `[]` | &zwnj;
 
-Example: `webimage_extra_packages: [php${DDEV_PHP_VERSION}-yac, php${DDEV_PHP_VERSION}-bcmath]` will add the `php-yac` and `php-bcmath` packages when the web container is built.
+Example: `webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']` will add the `phpX.Y-tidy` and `phpX.Y-yac` packages when the web container is built.
 
 ## `webserver_type`
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -10,8 +10,8 @@ It’s common to have a requirement for the `web` or `db` images which isn’t b
 You can add extra Debian packages with lines like this in `.ddev/config.yaml`:
 
 ```yaml
-webimage_extra_packages: ["php${DDEV_PHP_VERSION}-tidy", "php${DDEV_PHP_VERSION}-yac"]
-dbimage_extra_packages: [telnet, netcat, sudo]
+webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']
+dbimage_extra_packages: [netcat, telnet, sudo]
 ```
 
 Then the additional packages will be built into the containers during [`ddev start`](../usage/commands.md#start).

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -172,10 +172,10 @@ const ConfigInstructions = `
 # The mailpit port is not normally bound on the host at all, instead being routed
 # through ddev-router, but it can be bound directly to localhost if specified here.
 
-# webimage_extra_packages: [php${DDEV_PHP_VERSION}-tidy, php${DDEV_PHP_VERSION}-bcmath]
+# webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']
 # Extra Debian packages that are needed in the webimage can be added here
 
-# dbimage_extra_packages: [telnet,netcat]
+# dbimage_extra_packages: [netcat, telnet, sudo]
 # Extra Debian packages that are needed in the dbimage can be added here
 
 # use_dns_when_possible: true


### PR DESCRIPTION
 ## The Issue

  - N/A

  The default `config.yaml` example for `webimage_extra_packages` uses a hard-coded PHP version, which conflicts
  with documentation that shows `php${DDEV_PHP_VERSION}`.

  ## How This PR Solves The Issue

  Updates the `webimage_extra_packages` example in the config template to use `php${DDEV_PHP_VERSION}` so it
  matches the documentation and works across PHP versions.

  ## Manual Testing Instructions

  1. (Optional) Generate a new project config and verify the example comment shows `php${DDEV_PHP_VERSION}`.

  ## Automated Testing Overview

  No tests added or required (documentation/example comment change only).

  ## Release/Deployment Notes

  None.