### PR TITLE
fix: suppress files_pull warning when provider has files_import_command, fixes #8103

### DIFF
--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -309,7 +309,9 @@ func (p *Provider) doFilesPullCommand() ([]string, error) {
 	_ = os.MkdirAll(destDir, 0755)
 
 	if p.FilesPullCommand.Command == "" {
-		util.Warning("No files_pull_command provided, so skipping files pull")
+		if p.FilesImportCommand.Command == "" {
+			util.Warning("No files_pull_command provided, so skipping files pull")
+		}
 		return nil, nil
 	}
 	s := p.FilesPullCommand.Service


### PR DESCRIPTION
## The Issue

- Fixes #8103

When a provider defines only `files_import_command` (no `files_pull_command`), such as Acquia, `ddev pull` still prints "No files_pull_command provided, so skipping files pull" and then runs the custom import. That message is misleading because files are being handled via the import command.

## How This PR Solves The Issue

In `doFilesPullCommand()` we only emit the warning when the provider has neither `files_pull_command` nor `files_import_command`. If the provider has `files_import_command`, we skip the pull step without warning; the existing "Importing files via custom files_import_command..." message is sufficient.

## Manual Testing Instructions

1. Configure a project for a provider that has only `files_import_command` (e.g. Acquia: `.ddev/providers/acquia.yaml` with `files_import_command` and no `files_pull_command`).
2. Run `ddev pull acquia` (or that provider) without `--skip-files`.
3. Confirm the "No files_pull_command provided..." message no longer appears.
4. Confirm "Importing files via custom files_import_command..." still appears and files are imported.
5. Optional: Test a provider with neither command to confirm the warning still appears; and a provider with both to confirm no regression.

## Automated Testing Overview

No new tests. Single conditional change in provider logic; existing provider behavior (pull-only, both, or neither) unchanged. `go build` and golangci-lint pass.

## Release/Deployment Notes

No config or API changes. Only the message shown when a provider uses `files_import_command` only is changed (warning suppressed). No deployment impact.