### PR TITLE
fix: add profile.d and BASH_ENV so addons are on PATH in web container, fixes #8110

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/profile.d/ddev-global-commands.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/profile.d/ddev-global-commands.sh
@@ -1,0 +1,8 @@
+# Add DDEV global commands (addons) to PATH for login shells
+if [ -d /mnt/ddev-global-cache/global-commands/web ]; then
+  case ":$PATH:" in
+    *":/mnt/ddev-global-cache/global-commands/web:"*) ;;
+    *) PATH="$PATH:/mnt/ddev-global-cache/global-commands/web" ;;
+  esac
+  export PATH
+fi

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2459,6 +2459,11 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		baseComposeExecCmd = append(baseComposeExecCmd, "-u", opts.User)
 	}
 
+	// Ensure web service exec gets BASH_ENV so non-interactive shells load addon path and vendor/bin
+	if opts.Service == "web" {
+		baseComposeExecCmd = append(baseComposeExecCmd, "-e", "BASH_ENV=/etc/bash.nointeractive.bashrc")
+	}
+
 	if len(opts.Env) > 0 {
 		for _, envVar := range opts.Env {
 			baseComposeExecCmd = append(baseComposeExecCmd, "-e", envVar)


### PR DESCRIPTION
## The Issue

- Fixes #8110

Addons (and global custom commands) are not accessible from inside the web container. Commands installed under `~/.ddev/commands/` and copied into the shared volume at `/mnt/ddev-global-cache/global-commands/web` were not on PATH for login shells (`ddev ssh`), so addon commands could not be found when the user had no `~/.bashrc` or a custom one that did not source `/etc/bashrc/*.bashrc`.

## How This PR Solves The Issue

- **Profile.d script:** Add `etc/profile.d/ddev-global-commands.sh` in the webserver image. It appends `/mnt/ddev-global-cache/global-commands/web` to PATH when that directory exists (idempotent, POSIX-sh safe). `/etc/profile` sources `profile.d/*.sh` for every login shell, so `ddev ssh` always sees addon commands regardless of user dotfiles.
- **BASH_ENV hardening:** When building the exec command for the web service, explicitly pass `-e BASH_ENV=/etc/bash.nointeractive.bashrc` so non-interactive execs (`ddev exec`) always load the same env (addon path and vendor/bin) even if the image or runtime changes.

Existing `commandline-addons.bashrc` is unchanged; non-interactive and interactive non-login shells continue to get the path via BASH_ENV and `/etc/bashrc/*.bashrc`.

## Manual Testing Instructions

1. Rebuild the web image (or use an image that includes the new profile.d script) and restart a project: `ddev restart`.
2. Run `ddev exec 'echo $PATH'` and confirm it contains `/mnt/ddev-global-cache/global-commands/web`.
3. Run `ddev ssh`, then `echo $PATH` and confirm the same path is present.
4. (Optional) Install an addon that adds a global command to `commands/web/`, run `ddev restart`, then from the host run `ddev exec <addon-cmd>` and inside `ddev ssh` run `<addon-cmd>`; both should resolve the command.

## Automated Testing Overview

No new automated tests. Change is in container image (profile.d script) and one Exec() code path (BASH_ENV for web). Existing tests that exec into the web container continue to run; build and static checks (golangci-lint, markdownlint) pass.

## Release/Deployment Notes

Users must use a webserver image that includes the new profile.d script (e.g. rebuild from source or use a release that ships the updated image). No config or data migration; no change to addon install or PopulateGlobalCustomCommandFiles behavior.