### PR TITLE
fix: skip port check for remote Docker hosts

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -29,20 +29,10 @@ func IsPortActive(port string) bool {
 	}
 
 	// Skip port check for remote Docker hosts (non-local IPs)
-	// Remote IPs cause timeouts and false positives
-	parsedIP := net.ParseIP(dockerIP)
-	if parsedIP != nil && !parsedIP.IsLoopback() && dockerIP != "127.0.0.1" {
-		localIPs, localErr := GetLocalIPs()
-		isLocal := false
-		if localErr == nil {
-			for _, lip := range localIPs {
-				if lip == dockerIP {
-					isLocal = true
-					break
-				}
-			}
-		}
-		if !isLocal {
+	// Remote IPs may cause timeouts and false positives
+	if parsedIP := net.ParseIP(dockerIP); parsedIP != nil && !parsedIP.IsLoopback() {
+		localIPs, _ := GetLocalIPs()
+		if !slices.Contains(localIPs, dockerIP) {
 			util.Verbose("Skipping port check for remote Docker host %s:%s", dockerIP, port)
 			return false
 		}


### PR DESCRIPTION
## Summary
- When using a remote Docker context (e.g., via SSH tunnel), `IsPortActive()` attempts TCP dial to the remote IP with 0ms timeout, which always times out
- This produces false "Unable to properly check port status" warnings and can cause router startup failures
- The fix detects when Docker IP is a non-local address and skips the port availability check, returning `false` (port not active)

## Problem
Users running DDEV with a remote Docker context (e.g., `docker context use remote-server`) get repeated timeout warnings:
```
Unable to properly check port status for <remote-ip>:8080: err=dial tcp <remote-ip>:8080: connect: operation timed out
```

The v1.25.0 security-software bypass (#7921) doesn't cover this case because it only triggers when all ephemeral ports appear active.

## Solution
In `IsPortActive()`, check if the Docker IP is a non-local address. If so, skip the TCP dial entirely and return `false`. This is safe because:
- Remote Docker hosts manage their own port allocation
- The TCP dial with 0ms timeout will never succeed for remote IPs anyway
- Docker itself will report real port conflicts when starting containers

## Test plan
- [ ] Verify port check is skipped when Docker context points to remote IP
- [ ] Verify port check still works normally for localhost/local IPs
- [ ] Verify `ddev start` works without warnings on remote Docker context