### PR TITLE
docs: update ddev.readthedocs.io URLs to docs.ddev.com [skip ci]

### DIFF
--- a/containers/ddev-php-base/ddev-php-files/README_UPDATE_PHP_MAJOR.md
+++ b/containers/ddev-php-base/ddev-php-files/README_UPDATE_PHP_MAJOR.md
@@ -312,4 +312,4 @@ When adding a new PHP version, ensure you:
 - [PHP Configuration Directives](https://www.php.net/manual/en/ini.php)
 - [PHP-FPM Configuration](https://www.php.net/manual/en/install.fpm.configuration.php)
 - [deb.sury.org PHP packages](https://packages.sury.org/php/)
-- [DDEV PHP Documentation](https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-php-configuration-phpini)
+- [DDEV PHP Documentation](https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#providing-custom-php-configuration-phpini)

--- a/pkg/ddevapp/dotddev_assets/share-providers/README.txt
+++ b/pkg/ddevapp/dotddev_assets/share-providers/README.txt
@@ -256,6 +256,6 @@ Provider scripts should use `bash` (not `sh`) and avoid platform-specific comman
 
 ## More Information
 
-- [DDEV Sharing Documentation](https://ddev.readthedocs.io/en/stable/users/topics/sharing/)
+- [DDEV Sharing Documentation](https://docs.ddev.com/en/stable/users/topics/sharing/)
 - [ngrok Documentation](https://ngrok.com/docs)
 - [Cloudflare Tunnel Documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/)

--- a/pkg/ddevapp/dotddev_assets/share-providers/cloudflared.sh
+++ b/pkg/ddevapp/dotddev_assets/share-providers/cloudflared.sh
@@ -2,7 +2,7 @@
 #ddev-generated
 
 # cloudflared share provider for DDEV
-# Documentation: https://ddev.readthedocs.io/en/stable/users/topics/sharing/
+# Documentation: https://docs.ddev.com/en/stable/users/topics/sharing/
 #
 # To customize: remove the '#ddev-generated' line above and edit as needed.
 #

--- a/pkg/ddevapp/dotddev_assets/share-providers/ngrok.sh
+++ b/pkg/ddevapp/dotddev_assets/share-providers/ngrok.sh
@@ -2,7 +2,7 @@
 #ddev-generated
 
 # ngrok share provider for DDEV
-# Documentation: https://ddev.readthedocs.io/en/stable/users/topics/sharing/
+# Documentation: https://docs.ddev.com/en/stable/users/topics/sharing/
 #
 # To customize: remove the '#ddev-generated' line above and edit as needed.
 # To create a variant: copy to a new file like my-ngrok.sh


### PR DESCRIPTION
## The Issue

Remaining references to the old `ddev.readthedocs.io` URL exist in four files across the codebase.

## How This PR Solves The Issue

Replaces all `ddev.readthedocs.io` URLs with `docs.ddev.com` in:

- `containers/ddev-php-base/ddev-php-files/README_UPDATE_PHP_MAJOR.md`
- `pkg/ddevapp/dotddev_assets/share-providers/ngrok.sh`
- `pkg/ddevapp/dotddev_assets/share-providers/README.txt`
- `pkg/ddevapp/dotddev_assets/share-providers/cloudflared.sh`

## Manual Testing Instructions

- Verify each updated URL resolves correctly (e.g., `https://docs.ddev.com/en/stable/users/topics/sharing/`)
- Run `grep -r ddev.readthedocs *` from the repo root and confirm no remaining references (aside from the binary PDF match)

## Automated Testing Overview

No tests needed — documentation URL changes only.

## Release/Deployment Notes

The `#ddev-generated` share provider scripts (`ngrok.sh`, `cloudflared.sh`, `README.txt`) will be updated in users' projects on the next `ddev start` or `ddev config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)