### PR TITLE
fix(docker): Revert "fix: skip port check for remote Docker hosts (#8128)"

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -28,16 +28,6 @@ func IsPortActive(port string) bool {
 		return false
 	}
 
-	// Skip port check for remote Docker hosts (non-local IPs)
-	// Remote IPs may cause timeouts and false positives
-	if parsedIP := net.ParseIP(dockerIP); parsedIP != nil && !parsedIP.IsLoopback() {
-		localIPs, _ := GetLocalIPs()
-		if !slices.Contains(localIPs, dockerIP) {
-			util.Verbose("Skipping port check for remote Docker host %s:%s", dockerIP, port)
-			return false
-		}
-	}
-
 	util.Verbose("Checking if port %s is active", port)
 	conn, err := net.DialTimeout("tcp", dockerIP+":"+port, dialTimeout)
 


### PR DESCRIPTION

## The Issue

- https://github.com/ddev/ddev/pull/8128 seems to have introduced hangs in CI on macOS (various providers). 

Experimental revert. For odd reasons we now have persistent hangs on macOS.

This reverts commit d16e244fccd31694061158c5f0f061d9e0cfb8a4.

* Probably this stanza shouldn't even happen on macOS docker providers. Are remote providers always Linux?

Copilot chat analysis at https://github.com/copilot/c/55492e19-30ab-48d2-b19c-7b124da82a87