### PR TITLE
fix(wordpress): disable default WordPress 6.9.1 debug mode in wp-config template

### DIFF
--- a/pkg/ddevapp/wordpress/wp-config.php
+++ b/pkg/ddevapp/wordpress/wp-config.php
@@ -26,6 +26,17 @@ define( 'NONCE_SALT', '{{ $config.NonceSalt }}' );
 /* Add any custom values between this line and the "stop editing" line. */
 
 
+/**
+ * WordPress 6.9.1 enables debug mode by default.
+ * This configuration explicitly disables debugging
+ * to prevent debug output in DDEV environments.
+ *
+ * Remove or modify these lines if debugging is required.
+ */
+define( 'WP_DEBUG_DISPLAY', false );
+@ini_set( 'display_errors', 0 );
+define( 'WP_DEBUG', false );
+define( 'WP_DEBUG_LOG', false );
 
 /* That's all, stop editing! Happy publishing. */
 


### PR DESCRIPTION
## The Issue

WordPress 6.9.1 enables debug mode by default, which may result in unexpected debug output in DDEV-managed environments.

## How This PR Solves The Issue

Explicitly set WP_DEBUG and related debug settings to false in the generated wp-config.php template to preserve expected behavior.

## Manual Testing Instructions

1. Create a new WordPress project using DDEV.
2. Run `ddev start`.
3. Open the generated wp-config.php file.
4. Confirm that WP_DEBUG and related debug settings are set to false.

## Automated Testing Overview

No automated tests were added because this change only updates the configuration template.

## Release/Deployment Notes

No special deployment steps required.
Only affects newly generated wp-config.php files.
