### PR TITLE
fix: remove check for no-bind-mounts in remote Docker, for #8139

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1496,10 +1496,6 @@ func (app *DdevApp) Start() error {
 		return fmt.Errorf("bind mounts can't be used with Docker Rootless.\nRun `ddev config global --no-bind-mounts` and try again")
 	}
 
-	if dockerutil.IsRemoteDockerHost() && !globalconfig.DdevGlobalConfig.NoBindMounts {
-		return fmt.Errorf("bind mounts can't be used with a remote Docker host.\nRun `ddev config global --no-bind-mounts` and try again")
-	}
-
 	if err := globalconfig.CheckForMultipleGlobalDdevDirs(); err != nil {
 		util.WarningOnce("Warning: %v", err)
 	}


### PR DESCRIPTION
## The Issue

- #8139

https://github.com/ddev/ddev-gitlab-ci/actions/runs/22178687155/job/64134000827
```
#   Failed to start tryddevproject-6800: bind mounts can't be used with a remote Docker host.
#   Run `ddev config global --no-bind-mounts` and try again
```

This change broke the `ddev-gitlab-ci` test. We used to use `no-bind-mounts` there, but then removed it, because there's a way to bypass bind-mounts:

- https://github.com/ddev/ddev-gitlab-ci/pull/23

## How This PR Solves The Issue

Removes this check.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
