### PR TITLE
test(wsl): increase time limit for test [skip ci]

### DIFF
--- a/.github/workflows/test-wsl2.yml
+++ b/.github/workflows/test-wsl2.yml
@@ -61,7 +61,7 @@ env:
 jobs:
   test-wsl2:
     runs-on: windows-2025
-    timeout-minutes: 240
+    timeout-minutes: 300
 
     strategy:
       fail-fast: false


### PR DESCRIPTION

## The Issue

This does nothing but increase the time limit allowed for WSL2 tests in github workflow

