### PR TITLE
docs: add command for ddevcd

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1453,7 +1453,7 @@ A collection of utility and debugging commands, often useful for [troubleshootin
 
 Uses shell built-in `cd` to change to a project directory. For example, `ddevcd some-project` will change directories to the project root of the project named `some-project`.
 
-Note that this command can't work until you make a small addition to your `.bashrc`, `.zshrc`, or `config.fish` (type: `ddev debug cd`).
+Note that this command can't work until you make a small addition to your `.bashrc`, `.zshrc`, or `config.fish` (type: `ddev utility cd`).
 
 ```shell
 # To see the explanation of what you need to do


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

I recently reset a WSL distro which required me to reinstall DDEV.
When I reached for `ddevcd` command I got an error:

```shell
$ ddevcd senju 
zsh: command not found: ddevcd
$ ddev -v      
ddev version v1.25.0
```

My Google skills found 

- the [blog announce](https://ddev.com/blog/release-v1240-php84/#new-features-and-other-things-were-proud-of) of the feature
- with a link "[tiny bit of one-time configuration](https://docs.ddev.com/en/stable/users/usage/commands/#debug-cd)" that displays the "Commands" page.
- searching on this page for `ddevcd` lead to "Note that this command can’t work until you make a small addition to your .bashrc, .zshrc, or config.fish."

The required "small addition" didn't appear obvious to me though.

## How This PR Solves The Issue

This PR adds a hint to type `ddev debug cd`, which the required commands for bach, zsh, and fish.

## Manual Testing Instructions

Updated doc at https://ddev--8168.org.readthedocs.build/en/8168/users/usage/commands/#utility


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
