### PR TITLE
feat: use gitlab CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX variable if available

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -72,12 +72,19 @@ Support: https://docs.ddev.com/en/stable/users/support/`,
 			amplitude.TrackCommand(&cmdCopy, argsCopy)
 		}
 
+		imagePrefixVar, err := cmd.Flags().GetString("image-prefix-env")
+		if err != nil {
+			util.Warning("Failed parsing image-prefix-env flag")
+		} else {
+			versionconstants.SetImagePrefixVar(imagePrefixVar)
+		}
+
 		// Skip Docker and other validation for most commands
 		if command != "start" && command != "restart" {
 			return
 		}
 
-		err := dockerutil.CheckDockerVersion(dockerutil.DockerRequirements)
+		err = dockerutil.CheckDockerVersion(dockerutil.DockerRequirements)
 		if err != nil {
 			if err.Error() == "no docker" {
 				util.Failed("Could not connect to Docker. Please ensure Docker is installed and running.")
@@ -147,6 +154,7 @@ func init() {
 	// This flag represents the output.JSONOutput variable, and parsed very early in pkg/output/output_setup.go
 	RootCmd.PersistentFlags().BoolP("json-output", "j", false, "If true, user-oriented output will be in JSON format.")
 	RootCmd.PersistentFlags().BoolVarP(&ddevapp.SkipHooks, "skip-hooks", "", false, "If true, any hook normally run by the command will be skipped.")
+	RootCmd.PersistentFlags().String("image-prefix-env", "CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX", "Environment variable which contains the docker image prefix.")
 
 	// Override Cobra version template for JSON output
 	if output.JSONOutput {

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -1,6 +1,7 @@
 package versionconstants
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime/debug"
@@ -86,6 +87,20 @@ func init() {
 		}
 		// 4) Last resort - use build info without VCS or unknown version
 		DdevVersion = "v0.0.0-overridden-by-make"
+	}
+}
+
+func SetImagePrefixVar(imagePrefixVar string) {
+	// use gitlab dependency proxy if available; this helps to avoid docker hub ratelimt issues in ci
+	// https://docs.gitlab.com/user/packages/dependency_proxy/
+	dependencyProxy := os.Getenv(imagePrefixVar)
+	if dependencyProxy != "" {
+		WebImg = fmt.Sprintf("%s/%s", dependencyProxy, WebImg)
+		DBImg = fmt.Sprintf("%s/%s", dependencyProxy, DBImg)
+		TraefikRouterImage = fmt.Sprintf("%s/%s", dependencyProxy, TraefikRouterImage)
+		SSHAuthImage = fmt.Sprintf("%s/%s", dependencyProxy, SSHAuthImage)
+		XhguiImage = fmt.Sprintf("%s/%s", dependencyProxy, XhguiImage)
+		UtilitiesImage = fmt.Sprintf("%s/%s", dependencyProxy, UtilitiesImage)
 	}
 }
 


### PR DESCRIPTION
use gitlab dependency proxy if available; this helps to avoid docker hub ratelimt issues in ci
https://docs.gitlab.com/user/packages/dependency_proxy/
The variable is automatically set by gitlab ci.

<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## Manual Testing Instructions

```bash
export CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX=gitlab.example.com/example-project/dependency_proxy/containers
ddev start
```
inspect generated .ddev/.ddev-docker-compose-full.yaml
