### PR TITLE
fix(commands): use /usr/bin/env bash in web console command

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/console
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/console
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Description: Run symfony console inside the web container


### PR DESCRIPTION
## The Issue

- Fixes #8180

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Update the shebang in the web console command to use `/usr/bin/env bash` for better portability across different environments.

At the time of submission, this PR only addresses the global commands folder (`~/.ddev/commands`). DDEV internal scripts are not updated.

## Manual Testing Instructions

1. Create a new DDEV project
2. Check DDEV-managed commands in `~/.ddev/commands` do not contain `#!/bin/bash`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
