### PR TITLE
feat(tui): Added ddev project path to TUI project browser, for #8184

### DIFF
--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -113,7 +114,8 @@ func (m AppModel) filteredProjects() []ProjectInfo {
 	for _, p := range m.projects {
 		if strings.Contains(strings.ToLower(p.Name), filter) ||
 			strings.Contains(strings.ToLower(p.Type), filter) ||
-			strings.Contains(strings.ToLower(p.Status), filter) {
+			strings.Contains(strings.ToLower(p.Status), filter) ||
+			strings.Contains(strings.ToLower(p.AppRoot), filter) {
 			result = append(result, p)
 		}
 	}
@@ -778,9 +780,17 @@ func (m AppModel) buildDashboardContent() string {
 
 	// Calculate name width: fit the longest project name, with limits
 	nameWidth := 16
+	pathWidth := 24
+	pathDisplay := make([]string, len(filtered))
 	for _, fp := range filtered {
 		if len(fp.Name) > nameWidth {
 			nameWidth = len(fp.Name)
+		}
+	}
+	for i, fp := range filtered {
+		pathDisplay[i] = formatProjectPath(fp.AppRoot)
+		if len(pathDisplay[i]) > pathWidth {
+			pathWidth = len(pathDisplay[i])
 		}
 	}
 	// Cap: leave room for cursor(2) + status(12) + type(12) + spacing(7) + URL
@@ -793,8 +803,16 @@ func (m AppModel) buildDashboardContent() string {
 	}
 	typeWidth := 12
 	narrow := m.width > 0 && m.width < 60
+	maxPathWidth := 40
+	if m.width > 0 {
+		maxPathWidth = max(18, m.width/2)
+	}
+	if pathWidth > maxPathWidth {
+		pathWidth = maxPathWidth
+	}
 	if narrow {
 		nameWidth = min(nameWidth, max(8, m.width/4))
+		pathWidth = min(pathWidth, max(10, m.width/2))
 	}
 
 	for i, p := range filtered {
@@ -807,11 +825,12 @@ func (m AppModel) buildDashboardContent() string {
 		name := m.styles.ProjectName.Render(fmt.Sprintf("%-*s", nameWidth, displayName))
 		status := m.renderStatus(p.Status)
 		pType := m.styles.ProjectType.Render(fmt.Sprintf("%-*s", typeWidth, p.Type))
+		path := m.styles.URL.Render(fmt.Sprintf("%-*s", pathWidth, truncate(pathDisplay[i], pathWidth)))
 
 		url := ""
 		if !narrow && p.URL != "" && p.Status == ddevapp.SiteRunning {
 			// Truncate URL if it would overflow
-			maxURL := m.width - nameWidth - 10 - typeWidth - 8
+			maxURL := m.width - nameWidth - 10 - typeWidth - pathWidth - 10
 			if m.width > 0 && maxURL > 10 {
 				url = m.styles.URL.Render(truncate(p.URL, maxURL))
 			} else if m.width <= 0 {
@@ -819,7 +838,7 @@ func (m AppModel) buildDashboardContent() string {
 			}
 		}
 
-		fmt.Fprintf(&b, "%s%s %s  %s  %s\n", cursor, name, status, pType, url)
+		fmt.Fprintf(&b, "%s%s %s  %s  %s  %s\n", cursor, name, status, pType, path, url)
 	}
 
 	return b.String()
@@ -1256,6 +1275,28 @@ func truncate(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return s[:maxLen-3] + "..."
+}
+
+func formatProjectPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	formatted := filepath.ToSlash(path)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return formatted
+	}
+
+	home = filepath.ToSlash(home)
+	if formatted == home {
+		return "~"
+	}
+	if strings.HasPrefix(formatted, home+"/") {
+		return "~" + strings.TrimPrefix(formatted, home)
+	}
+
+	return formatted
 }
 
 func (m AppModel) renderStatus(status string) string {

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -129,6 +131,15 @@ func TestFilteredProjects(t *testing.T) {
 	m.filterText = "DRUPAL"
 	filtered = m.filteredProjects()
 	require.Len(t, filtered, 1)
+
+	// Filter by project path
+	m.projects[0].AppRoot = "/tmp/drupal-site"
+	m.projects[1].AppRoot = "/tmp/wp-blog"
+	m.projects[2].AppRoot = "/tmp/laravel-app"
+	m.filterText = "wp-blog"
+	filtered = m.filteredProjects()
+	require.Len(t, filtered, 1)
+	require.Equal(t, "wp-blog", filtered[0].Name)
 }
 
 func TestSelectedProject(t *testing.T) {
@@ -915,7 +926,7 @@ func TestWideTerminalDashboard(t *testing.T) {
 	m.loading = false
 	updated, _ = m.Update(projectsLoadedMsg{
 		projects: []ProjectInfo{
-			{Name: "mysite", Status: ddevapp.SiteRunning, Type: "drupal", URL: "https://mysite.ddev.site"},
+			{Name: "mysite", Status: ddevapp.SiteRunning, Type: "drupal", URL: "https://mysite.ddev.site", AppRoot: "/tmp/mysite"},
 		},
 	})
 	m = updated.(AppModel)
@@ -923,6 +934,16 @@ func TestWideTerminalDashboard(t *testing.T) {
 	view := m.View()
 
 	require.Contains(t, view, "https://mysite.ddev.site", "URL should be visible in wide terminal")
+	require.Contains(t, view, "/tmp/mysite", "project path should be visible in wide terminal")
+}
+
+func TestFormatProjectPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	homePath := filepath.Join(home, "workspace", "site")
+	require.Equal(t, "~/workspace/site", formatProjectPath(homePath))
+	require.Equal(t, "/tmp/site", formatProjectPath("/tmp/site"))
 }
 
 func TestSpinnerInLoadingView(t *testing.T) {


### PR DESCRIPTION
## The Issue

- Fixes #8184

Cannot see which path a project lives in so hard to identify similarly named projects.

## How This PR Solves The Issue

Adds the path to the overview in a new column

## Manual Testing Instructions

- Run `ddev`
- Verify new column with project path

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

## Disclaimer!!

I did not write this PR. I asked GPT 5.3 to code this for me. It may not work, but I plan to test the PR build. It can be used by another developer as inspiration if required. I will do my best to check it, but I have no `go` experience.

