### PR TITLE
feat(clone): add `ddev clone` command

### DIFF
--- a/cmd/ddev/cmd/clone.go
+++ b/cmd/ddev/cmd/clone.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// CloneCmd is the top-level "ddev clone" command container for managing project clones.
+var CloneCmd = &cobra.Command{
+	Use:   "clone [command]",
+	Short: "A collection of commands for managing project clones",
+	Long:  "Create, list, remove, and prune cloned DDEV project environments using git worktrees and Docker volume duplication.",
+	Example: `ddev clone create feature-x
+ddev clone list
+ddev clone remove feature-x
+ddev clone prune`,
+}
+
+func init() {
+	RootCmd.AddCommand(CloneCmd)
+}

--- a/cmd/ddev/cmd/clone_create.go
+++ b/cmd/ddev/cmd/clone_create.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// CloneCreateCmd implements the "ddev clone create" command.
+var CloneCreateCmd = &cobra.Command{
+	Use:   "create <clone-name>",
+	Short: "Create a clone of the current DDEV project",
+	Long: `Create a clone of the current DDEV project using git worktree and Docker volume duplication.
+
+Creates a git worktree at ../<project>-clone-<name>, copies all Docker volumes,
+configures a new DDEV project, and starts it.`,
+	Example: `ddev clone create feature-x
+ddev clone create feature-x --branch existing-branch
+ddev clone create feature-x --no-start`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cloneName := args[0]
+
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Unable to get active project: %v", err)
+		}
+
+		branch, _ := cmd.Flags().GetString("branch")
+		noStart, _ := cmd.Flags().GetBool("no-start")
+
+		if err := ddevapp.CloneCreate(app, cloneName, branch, noStart); err != nil {
+			util.Failed("Failed to create clone: %v", err)
+		}
+	},
+}
+
+func init() {
+	CloneCmd.AddCommand(CloneCreateCmd)
+	CloneCreateCmd.Flags().StringP("branch", "b", "", "Check out an existing branch instead of creating a new one")
+	CloneCreateCmd.Flags().Bool("no-start", false, "Configure the clone but do not start it")
+}

--- a/cmd/ddev/cmd/clone_list.go
+++ b/cmd/ddev/cmd/clone_list.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/styles"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+// CloneListCmd implements the "ddev clone list" command.
+var CloneListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all clones of the current project",
+	Long: `List all clones associated with the current project.
+
+Can be run from the source project or any of its clones.`,
+	Example: `ddev clone list`,
+	Run: func(_ *cobra.Command, _ []string) {
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Unable to get active project: %v", err)
+		}
+
+		clones, err := ddevapp.CloneList(app)
+		if err != nil {
+			util.Failed("Failed to list clones: %v", err)
+		}
+
+		sourceProjectName := ddevapp.GetSourceProjectNameExported(app)
+
+		if len(clones) == 0 {
+			output.UserOut.Printf("No clones found for project '%s'.", sourceProjectName)
+			output.UserOut.Printf("Create one with: ddev clone create <clone-name>")
+			return
+		}
+
+		var out bytes.Buffer
+		t := table.NewWriter()
+		t.SetOutputMirror(&out)
+		styles.SetGlobalTableStyle(t, false)
+
+		columns := table.Row{"Clone Name", "Path", "Branch", "Status"}
+		if !globalconfig.DdevGlobalConfig.SimpleFormatting {
+			var colConfig []table.ColumnConfig
+			for _, col := range columns {
+				colConfig = append(colConfig, table.ColumnConfig{
+					Name: fmt.Sprint(col),
+				})
+			}
+			t.SetColumnConfigs(colConfig)
+		}
+		t.AppendHeader(columns)
+
+		for _, clone := range clones {
+			displayName := clone.CloneName
+			if clone.Current {
+				displayName = "* " + displayName
+			}
+			t.AppendRow(table.Row{displayName, clone.WorktreePath, clone.Branch, clone.Status})
+		}
+
+		t.Render()
+		output.UserOut.WithField("raw", clones).Println(out.String())
+	},
+}
+
+func init() {
+	CloneCmd.AddCommand(CloneListCmd)
+}

--- a/cmd/ddev/cmd/clone_prune.go
+++ b/cmd/ddev/cmd/clone_prune.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// ClonePruneCmd implements the "ddev clone prune" command.
+var ClonePruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Clean up stale clone references",
+	Long:  "Clean up clones whose worktree directories no longer exist.",
+	Example: `ddev clone prune
+ddev clone prune --dry-run`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Unable to get active project: %v", err)
+		}
+
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		pruned, err := ddevapp.ClonePrune(app, dryRun)
+		if err != nil {
+			util.Failed("Failed to prune clones: %v", err)
+		}
+
+		sourceProjectName := ddevapp.GetSourceProjectNameExported(app)
+
+		if len(pruned) == 0 {
+			util.Success("No stale clones found for project '%s'.", sourceProjectName)
+			return
+		}
+
+		if dryRun {
+			util.Success("%d stale clone(s) would be pruned.", len(pruned))
+		} else {
+			util.Success(fmt.Sprintf("Pruned %d stale clone(s).", len(pruned)))
+		}
+	},
+}
+
+func init() {
+	CloneCmd.AddCommand(ClonePruneCmd)
+	ClonePruneCmd.Flags().Bool("dry-run", false, "Show what would be cleaned up without taking action")
+}

--- a/cmd/ddev/cmd/clone_remove.go
+++ b/cmd/ddev/cmd/clone_remove.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// CloneRemoveCmd implements the "ddev clone remove" command.
+var CloneRemoveCmd = &cobra.Command{
+	Use:               "remove <clone-name>",
+	Short:             "Remove a clone and clean up all its resources",
+	Long:              "Remove a clone and clean up all its Docker resources, git worktree, and project registration.",
+	ValidArgsFunction: ddevapp.GetCloneNamesFunc(1),
+	Example: `ddev clone remove feature-x
+ddev clone remove feature-x --force`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cloneName := args[0]
+
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Unable to get active project: %v", err)
+		}
+
+		force, _ := cmd.Flags().GetBool("force")
+
+		if err := ddevapp.CloneRemove(app, cloneName, force); err != nil {
+			util.Failed("Failed to remove clone: %v", err)
+		}
+	},
+}
+
+func init() {
+	CloneCmd.AddCommand(CloneRemoveCmd)
+	CloneRemoveCmd.Flags().Bool("force", false, "Skip confirmation for dirty worktrees")
+}

--- a/docs/content/users/usage/clone.md
+++ b/docs/content/users/usage/clone.md
@@ -1,0 +1,156 @@
+# Clone
+
+DDEV clone creates independent copies of your project environment using git worktrees and Docker volume duplication. Each clone has its own code worktree, database, and containers while sharing git history with the source project.
+
+## Commands
+
+### `ddev clone create`
+
+Create a clone of the current DDEV project:
+
+```shell
+# Create a clone with a new branch
+ddev clone create feature-x
+
+# Clone using an existing branch
+ddev clone create feature-x --branch existing-branch
+
+# Create a clone without starting it
+ddev clone create feature-x --no-start
+```
+
+This command:
+
+1. Creates a git worktree at `../<project>-clone-<name>`
+2. Copies all Docker volumes (database, config, snapshots)
+3. Configures a new DDEV project
+4. Starts the cloned project
+
+The database container in the source project is temporarily stopped during volume copy to ensure data consistency.
+
+### `ddev clone list`
+
+List all clones of the current project:
+
+```shell
+ddev clone list
+```
+
+Displays a table of all clones with their name, path, branch, and status. The current clone (if running from a clone directory) is marked with `*`.
+
+This command works from the source project or any of its clones.
+
+JSON output is supported:
+
+```shell
+ddev clone list -j
+```
+
+### `ddev clone remove`
+
+Remove a clone and clean up all its resources:
+
+```shell
+# Remove a clone
+ddev clone remove feature-x
+
+# Force removal (skip dirty worktree confirmation)
+ddev clone remove feature-x --force
+```
+
+This stops containers, removes Docker volumes and networks, removes the git worktree, and unregisters the project. If the worktree has uncommitted changes, you'll be asked for confirmation unless `--force` is used.
+
+### `ddev clone prune`
+
+Clean up stale clone references:
+
+```shell
+# Show what would be cleaned up
+ddev clone prune --dry-run
+
+# Clean up stale clones
+ddev clone prune
+```
+
+Detects clones whose worktree directories have been manually deleted and cleans up their Docker resources and project registrations.
+
+## How It Works
+
+Each clone consists of:
+
+- **Git worktree**: A separate working directory sharing the same git repository. Changes in one worktree do not affect others.
+- **Docker volumes**: Independent copies of all project volumes (database, config, snapshots). The clone has its own database with the same data as the source at the time of cloning.
+- **DDEV project**: A fully independent DDEV project with its own containers, network, and hostname.
+
+### Naming Convention
+
+Clone projects follow the naming pattern `<source>-clone-<name>`:
+
+- Source project: `mysite`
+- Clone: `mysite-clone-feature-x`
+- Clone URL: `https://mysite-clone-feature-x.ddev.site`
+
+### Volume Cloning
+
+Volumes are cloned using an ephemeral Docker container with tar:
+
+- Database volume (MariaDB, MySQL, or PostgreSQL)
+- Config volume
+- Snapshot volume
+- Mutagen volume (if enabled)
+
+## Hooks
+
+Clone operations support DDEV hooks in `.ddev/config.yaml`:
+
+```yaml
+hooks:
+  pre-clone-create:
+    - exec-host: echo "About to create a clone"
+  post-clone-create:
+    - exec: drush cr
+  pre-clone-remove:
+    - exec-host: echo "About to remove a clone"
+  post-clone-remove:
+    - exec-host: echo "Clone removed"
+```
+
+| Hook | Trigger |
+|------|---------|
+| `pre-clone-create` | Before clone creation (source project context) |
+| `post-clone-create` | After clone is created and started (clone context) |
+| `pre-clone-remove` | Before clone removal |
+| `post-clone-remove` | After clone removal |
+
+## CI Best Practices
+
+For CI environments, consider the stopped source pattern:
+
+```shell
+# Stop the source project before cloning (faster, no DB restart needed)
+ddev stop
+ddev clone create ci-test --no-start
+cd ../mysite-clone-ci-test
+ddev start
+# Run tests...
+ddev clone remove ci-test --force
+```
+
+## Mutagen Considerations
+
+If the source project uses Mutagen for file sync:
+
+- The Mutagen volume is cloned along with other volumes
+- When the clone starts, DDEV automatically creates a new Mutagen sync session for the clone's worktree
+- Each clone has an independent Mutagen sync
+
+## Configuration
+
+The volume cloning strategy can be configured globally:
+
+```yaml
+# ~/.ddev/global_config.yaml
+volume_clone_strategy: tar-copy  # default
+```
+
+Currently, `tar-copy` is the only available strategy. Future versions may add additional strategies for filesystems that support efficient cloning (btrfs, zfs).

--- a/pkg/ddevapp/clone.go
+++ b/pkg/ddevapp/clone.go
@@ -1,0 +1,718 @@
+package ddevapp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// CloneInfo holds metadata about a single DDEV-managed clone.
+// Derived dynamically from git worktree list output, not persisted to a file.
+type CloneInfo struct {
+	CloneName         string `json:"clone_name"`
+	SourceProjectName string `json:"source_project_name"`
+	ProjectName       string `json:"project_name"`
+	WorktreePath      string `json:"path"`
+	Branch            string `json:"branch"`
+	Status            string `json:"status"`
+	Current           bool   `json:"current"`
+}
+
+// cloneInfix is the naming convention separator used to identify clone projects.
+const cloneInfix = "-clone-"
+
+// getCloneProjectName returns the DDEV project name for a clone.
+// Format: <sourceProjectName>-clone-<cloneName>
+func getCloneProjectName(sourceProjectName, cloneName string) string {
+	return sourceProjectName + cloneInfix + cloneName
+}
+
+// getCloneWorktreePath returns the expected worktree path for a clone.
+// Clones are placed as sibling directories of the source project.
+func getCloneWorktreePath(app *DdevApp, cloneName string) string {
+	return filepath.Join(filepath.Dir(app.AppRoot), app.Name+cloneInfix+cloneName)
+}
+
+// getSourceProjectName determines the source project name from the current project.
+// If the current project is itself a clone, it returns the original source project name.
+func getSourceProjectName(app *DdevApp) string {
+	name := app.Name
+	if idx := strings.Index(name, cloneInfix); idx != -1 {
+		return name[:idx]
+	}
+	return name
+}
+
+// getCloneNameFromProjectName extracts the clone name from a clone project name.
+// Returns empty string if the project name does not match the clone pattern.
+func getCloneNameFromProjectName(sourceProjectName, projectName string) string {
+	prefix := sourceProjectName + cloneInfix
+	if strings.HasPrefix(projectName, prefix) {
+		return projectName[len(prefix):]
+	}
+	return ""
+}
+
+// getGitRoot returns the git root directory for the given path.
+func getGitRoot(appRoot string) (string, error) {
+	out, err := exec.RunHostCommand("git", "-C", appRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", fmt.Errorf("not a git repository (or git is not installed): %v, output: %s", err, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// isCloneWorktree checks if a worktree path matches the clone naming convention
+// for the given source project. Returns the clone name if it matches.
+func isCloneWorktree(sourceProjectName, worktreePath string) (bool, string) {
+	base := filepath.Base(worktreePath)
+	prefix := sourceProjectName + cloneInfix
+	if strings.HasPrefix(base, prefix) {
+		cloneName := base[len(prefix):]
+		if cloneName != "" {
+			return true, cloneName
+		}
+	}
+	return false, ""
+}
+
+// discoverClones returns all DDEV-managed clones by parsing git worktree list.
+// It can be called from either the source project or any clone.
+func discoverClones(app *DdevApp) ([]CloneInfo, error) {
+	sourceProjectName := getSourceProjectName(app)
+
+	// Get the git root (works from either source or clone worktree)
+	gitRoot, err := getGitRoot(app.AppRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse git worktree list --porcelain
+	out, err := exec.RunHostCommand("git", "-C", gitRoot, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list git worktrees: %v, output: %s", err, out)
+	}
+
+	var clones []CloneInfo
+	var currentPath, currentBranch string
+
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "worktree ") {
+			// Save previous entry if it was a clone
+			if currentPath != "" {
+				if isClone, cloneName := isCloneWorktree(sourceProjectName, currentPath); isClone {
+					clones = append(clones, CloneInfo{
+						CloneName:         cloneName,
+						SourceProjectName: sourceProjectName,
+						ProjectName:       getCloneProjectName(sourceProjectName, cloneName),
+						WorktreePath:      currentPath,
+						Branch:            currentBranch,
+					})
+				}
+			}
+			currentPath = strings.TrimPrefix(line, "worktree ")
+			currentBranch = ""
+		} else if strings.HasPrefix(line, "branch ") {
+			ref := strings.TrimPrefix(line, "branch ")
+			// refs/heads/branch-name -> branch-name
+			currentBranch = strings.TrimPrefix(ref, "refs/heads/")
+		} else if line == "" {
+			// End of a worktree block
+			if currentPath != "" {
+				if isClone, cloneName := isCloneWorktree(sourceProjectName, currentPath); isClone {
+					clones = append(clones, CloneInfo{
+						CloneName:         cloneName,
+						SourceProjectName: sourceProjectName,
+						ProjectName:       getCloneProjectName(sourceProjectName, cloneName),
+						WorktreePath:      currentPath,
+						Branch:            currentBranch,
+					})
+				}
+			}
+			currentPath = ""
+			currentBranch = ""
+		}
+	}
+
+	// Handle the last entry if the output doesn't end with a blank line
+	if currentPath != "" {
+		if isClone, cloneName := isCloneWorktree(sourceProjectName, currentPath); isClone {
+			clones = append(clones, CloneInfo{
+				CloneName:         cloneName,
+				SourceProjectName: sourceProjectName,
+				ProjectName:       getCloneProjectName(sourceProjectName, cloneName),
+				WorktreePath:      currentPath,
+				Branch:            currentBranch,
+			})
+		}
+	}
+
+	return clones, nil
+}
+
+// getProjectVolumes returns the list of source->target volume name pairs
+// that need to be cloned for a project.
+func getProjectVolumes(app *DdevApp, cloneProjectName string) []volumePair {
+	var pairs []volumePair
+
+	sourceProjectName := app.Name
+
+	// Database volume (based on configured type)
+	switch app.Database.Type {
+	case "postgres":
+		pairs = append(pairs, volumePair{
+			source: app.GetPostgresVolumeName(),
+			target: cloneProjectName + "-postgres",
+		})
+	default:
+		// MariaDB or MySQL
+		pairs = append(pairs, volumePair{
+			source: app.GetMariaDBVolumeName(),
+			target: cloneProjectName + "-mariadb",
+		})
+	}
+
+	// Snapshot volume (optional)
+	snapshotSource := "ddev-" + sourceProjectName + "-snapshots"
+	snapshotTarget := "ddev-" + cloneProjectName + "-snapshots"
+	pairs = append(pairs, volumePair{source: snapshotSource, target: snapshotTarget})
+
+	// Config volume (optional)
+	configSource := sourceProjectName + "-ddev-config"
+	configTarget := cloneProjectName + "-ddev-config"
+	pairs = append(pairs, volumePair{source: configSource, target: configTarget})
+
+	// Mutagen volume (optional, only if Mutagen is enabled)
+	if app.IsMutagenEnabled() {
+		mutagenSource := GetMutagenVolumeName(app)
+		mutagenTarget := cloneProjectName + "_project_mutagen"
+		pairs = append(pairs, volumePair{source: mutagenSource, target: mutagenTarget})
+	}
+
+	return pairs
+}
+
+// volumePair holds a source and target volume name for cloning.
+type volumePair struct {
+	source string
+	target string
+}
+
+// CloneCreate creates a clone of the given DDEV project.
+func CloneCreate(app *DdevApp, cloneName string, branch string, noStart bool) error {
+	sourceProjectName := getSourceProjectName(app)
+	cloneProjectName := getCloneProjectName(sourceProjectName, cloneName)
+
+	// Check if we're running from a clone (redirect to source)
+	if sourceProjectName != app.Name {
+		// We're in a clone, resolve the source
+		sourceProject := globalconfig.GetProject(sourceProjectName)
+		if sourceProject == nil {
+			return fmt.Errorf("source project '%s' not found in DDEV project list", sourceProjectName)
+		}
+		sourceApp := &DdevApp{}
+		if err := sourceApp.Init(sourceProject.AppRoot); err != nil {
+			return fmt.Errorf("failed to initialize source project '%s': %v", sourceProjectName, err)
+		}
+		app = sourceApp
+	}
+
+	// Validate git repo
+	gitRoot, err := getGitRoot(app.AppRoot)
+	if err != nil {
+		return fmt.Errorf("project '%s' is not in a git repository: %v", app.Name, err)
+	}
+
+	// Check for conflicts
+	if existingProject := globalconfig.GetProject(cloneProjectName); existingProject != nil {
+		return fmt.Errorf("a project named '%s' already exists. Use 'ddev clone remove %s' to remove it first", cloneProjectName, cloneName)
+	}
+
+	worktreePath := getCloneWorktreePath(app, cloneName)
+
+	// Run pre-clone-create hook
+	if err := app.ProcessHooks("pre-clone-create"); err != nil {
+		return fmt.Errorf("failed to process pre-clone-create hooks: %v", err)
+	}
+
+	util.Success("Creating clone '%s' of project '%s'...", cloneName, app.Name)
+
+	// Create git worktree
+	util.Success("  Creating git worktree at %s...", worktreePath)
+	var gitArgs []string
+	if branch != "" {
+		// Use existing branch
+		gitArgs = []string{"-C", gitRoot, "worktree", "add", worktreePath, branch}
+	} else {
+		// Create new branch with the clone name
+		gitArgs = []string{"-C", gitRoot, "worktree", "add", "-b", cloneName, worktreePath}
+	}
+	out, err := exec.RunHostCommand("git", gitArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to create git worktree: %v, output: %s", err, out)
+	}
+
+	// Track cleanup needed on error
+	worktreeCreated := true
+	var createdVolumes []string
+	defer func() {
+		if err != nil {
+			// Rollback: clean up on failure
+			util.Warning("Clone creation failed, cleaning up...")
+			for _, vol := range createdVolumes {
+				_ = removeVolumeIfExists(vol)
+			}
+			if worktreeCreated {
+				_, _ = exec.RunHostCommand("git", "-C", gitRoot, "worktree", "remove", "--force", worktreePath)
+				_, _ = exec.RunHostCommand("git", "-C", gitRoot, "worktree", "prune")
+			}
+			_ = globalconfig.RemoveProjectInfo(cloneProjectName)
+		}
+	}()
+
+	// Write .ddev/config.yaml in the clone with the clone project name
+	cloneDdevDir := filepath.Join(worktreePath, ".ddev")
+	cloneConfigPath := filepath.Join(cloneDdevDir, "config.yaml")
+	err = writeCloneConfig(app, cloneConfigPath, cloneProjectName)
+	if err != nil {
+		return fmt.Errorf("failed to write clone config: %v", err)
+	}
+
+	// Determine volumes to clone
+	volumePairs := getProjectVolumes(app, cloneProjectName)
+
+	// Check source site status and stop DB if running
+	status, _ := app.SiteStatus()
+	dbWasRunning := status == SiteRunning
+
+	if dbWasRunning {
+		util.Success("  Stopping database container for consistent copy...")
+		if _, _, composeErr := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
+			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
+			Action:       []string{"stop", "db"},
+		}); composeErr != nil {
+			return fmt.Errorf("failed to stop source database container: %v", composeErr)
+		}
+		defer func() {
+			util.Success("  Resuming database container...")
+			if _, _, composeErr := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
+				ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
+				Action:       []string{"start", "db"},
+			}); composeErr != nil {
+				util.Warning("Failed to restart source database container: %v", composeErr)
+			}
+		}()
+	}
+
+	// Clone each volume
+	cloner := GetVolumeCloner()
+	for _, vp := range volumePairs {
+		if !dockerutil.VolumeExists(vp.source) {
+			util.Debug("Skipping volume %s (does not exist)", vp.source)
+			continue
+		}
+		util.Success("  Cloning volume %s -> %s...", vp.source, vp.target)
+		if cloneErr := cloner.CloneVolume(vp.source, vp.target); cloneErr != nil {
+			err = fmt.Errorf("failed to clone volume %s: %v", vp.source, cloneErr)
+			return err
+		}
+		createdVolumes = append(createdVolumes, vp.target)
+	}
+
+	// Init the clone app
+	cloneApp := &DdevApp{}
+	if initErr := cloneApp.Init(worktreePath); initErr != nil {
+		err = fmt.Errorf("failed to initialize clone project: %v", initErr)
+		return err
+	}
+
+	// Resolve host port conflicts before starting.
+	// The clone inherits port settings from the source config, and in
+	// devcontainer mode DockerEnv() assigns default ports (3306, 80, etc.)
+	// that would collide with the already-running source project.
+	if resolveErr := resolveClonePortConflicts(cloneApp); resolveErr != nil {
+		err = fmt.Errorf("failed to resolve port conflicts for clone: %v", resolveErr)
+		return err
+	}
+
+	// Register the clone project
+	if regErr := globalconfig.SetProjectAppRoot(cloneProjectName, worktreePath); regErr != nil {
+		err = fmt.Errorf("failed to register clone project: %v", regErr)
+		return err
+	}
+
+	// Start the clone (unless --no-start)
+	if !noStart {
+		util.Success("  Starting clone project %s...", cloneProjectName)
+		if startErr := cloneApp.Start(); startErr != nil {
+			err = fmt.Errorf("failed to start clone project: %v", startErr)
+			return err
+		}
+	}
+
+	// Run post-clone-create hook (in clone context)
+	if hookErr := cloneApp.ProcessHooks("post-clone-create"); hookErr != nil {
+		util.Warning("post-clone-create hook failed: %v", hookErr)
+	}
+
+	util.Success("Successfully created clone '%s'", cloneName)
+	if !noStart {
+		util.Success("Clone URL: https://%s.ddev.site", cloneProjectName)
+	}
+
+	// Clear the error so deferred cleanup doesn't trigger
+	err = nil
+	return nil
+}
+
+// CloneList returns all clones for the given project with enriched status information.
+func CloneList(app *DdevApp) ([]CloneInfo, error) {
+	clones, err := discoverClones(app)
+	if err != nil {
+		return nil, err
+	}
+
+	// Enrich each clone with DDEV status
+	for i := range clones {
+		project := globalconfig.GetProject(clones[i].ProjectName)
+		if project == nil {
+			clones[i].Status = "unregistered"
+			continue
+		}
+
+		cloneApp := &DdevApp{}
+		if initErr := cloneApp.Init(project.AppRoot); initErr != nil {
+			clones[i].Status = "unknown"
+			continue
+		}
+
+		status, _ := cloneApp.SiteStatus()
+		if status == "" {
+			clones[i].Status = SiteStopped
+		} else {
+			clones[i].Status = status
+		}
+
+		// Mark the current clone if we're running from its directory
+		if clones[i].WorktreePath == app.AppRoot {
+			clones[i].Current = true
+		}
+	}
+
+	return clones, nil
+}
+
+// CloneRemove removes a clone and all its resources.
+func CloneRemove(sourceApp *DdevApp, cloneName string, force bool) error {
+	sourceProjectName := getSourceProjectName(sourceApp)
+	cloneProjectName := getCloneProjectName(sourceProjectName, cloneName)
+
+	// Resolve the source app if needed
+	if sourceProjectName != sourceApp.Name {
+		sourceProject := globalconfig.GetProject(sourceProjectName)
+		if sourceProject == nil {
+			return fmt.Errorf("source project '%s' not found in DDEV project list", sourceProjectName)
+		}
+		resolvedApp := &DdevApp{}
+		if err := resolvedApp.Init(sourceProject.AppRoot); err != nil {
+			return fmt.Errorf("failed to initialize source project '%s': %v", sourceProjectName, err)
+		}
+		sourceApp = resolvedApp
+	}
+
+	gitRoot, err := getGitRoot(sourceApp.AppRoot)
+	if err != nil {
+		return fmt.Errorf("project '%s' is not in a git repository: %v", sourceApp.Name, err)
+	}
+
+	// Find the clone
+	clones, err := discoverClones(sourceApp)
+	if err != nil {
+		return nil
+	}
+
+	var cloneInfo *CloneInfo
+	for i := range clones {
+		if clones[i].CloneName == cloneName {
+			cloneInfo = &clones[i]
+			break
+		}
+	}
+
+	// If clone not found in worktrees, try to clean up by project name alone
+	if cloneInfo == nil {
+		project := globalconfig.GetProject(cloneProjectName)
+		if project == nil {
+			return fmt.Errorf("clone '%s' not found", cloneName)
+		}
+		// Graceful partial cleanup
+		return cleanupOrphanedClone(cloneProjectName, project.AppRoot, gitRoot)
+	}
+
+	// Run pre-clone-remove hook
+	if err := sourceApp.ProcessHooks("pre-clone-remove"); err != nil {
+		return fmt.Errorf("failed to process pre-clone-remove hooks: %v", err)
+	}
+
+	// Check for dirty worktree
+	if !force {
+		dirtyOutput, dirtyErr := exec.RunHostCommand("git", "-C", cloneInfo.WorktreePath, "status", "--porcelain")
+		if dirtyErr == nil && strings.TrimSpace(dirtyOutput) != "" {
+			fmt.Printf("Clone '%s' has uncommitted changes:\n%s\n", cloneName, strings.TrimSpace(dirtyOutput))
+			if !util.Confirm("Remove anyway?") {
+				return fmt.Errorf("clone removal cancelled")
+			}
+		}
+	}
+
+	util.Success("Removing clone '%s' of project '%s'...", cloneName, sourceProjectName)
+
+	// Init clone app and stop with full cleanup
+	util.Success("  Stopping and removing Docker resources...")
+	cloneApp := &DdevApp{}
+	if initErr := cloneApp.Init(cloneInfo.WorktreePath); initErr != nil {
+		// Graceful partial cleanup if init fails
+		util.Warning("Unable to initialize clone app, performing manual cleanup: %v", initErr)
+		return cleanupOrphanedClone(cloneProjectName, cloneInfo.WorktreePath, gitRoot)
+	}
+
+	// Stop with removeData=true to clean up all Docker resources
+	if stopErr := cloneApp.Stop(true, false); stopErr != nil {
+		util.Warning("Failed to fully stop clone: %v, attempting manual cleanup", stopErr)
+	}
+
+	// Remove git worktree
+	util.Success("  Removing git worktree...")
+	if out, removeErr := exec.RunHostCommand("git", "-C", gitRoot, "worktree", "remove", "--force", cloneInfo.WorktreePath); removeErr != nil {
+		util.Warning("Failed to remove git worktree: %v, output: %s", removeErr, out)
+	}
+	if out, pruneErr := exec.RunHostCommand("git", "-C", gitRoot, "worktree", "prune"); pruneErr != nil {
+		util.Warning("Failed to prune git worktrees: %v, output: %s", pruneErr, out)
+	}
+
+	// Run post-clone-remove hook
+	if hookErr := sourceApp.ProcessHooks("post-clone-remove"); hookErr != nil {
+		util.Warning("post-clone-remove hook failed: %v", hookErr)
+	}
+
+	util.Success("Successfully removed clone '%s'", cloneName)
+	return nil
+}
+
+// ClonePrune detects and cleans up stale clones whose worktree directories no longer exist.
+func ClonePrune(app *DdevApp, dryRun bool) ([]string, error) {
+	sourceProjectName := getSourceProjectName(app)
+	prefix := sourceProjectName + cloneInfix
+
+	gitRoot, err := getGitRoot(app.AppRoot)
+	if err != nil {
+		return nil, fmt.Errorf("project '%s' is not in a git repository: %v", app.Name, err)
+	}
+
+	var pruned []string
+
+	// Check all DDEV projects matching the clone pattern
+	for name, project := range globalconfig.DdevProjectList {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+
+		// Check if the worktree path still exists
+		if fileExists(project.AppRoot) {
+			continue
+		}
+
+		cloneName := getCloneNameFromProjectName(sourceProjectName, name)
+
+		if dryRun {
+			util.Success("Would remove stale clone '%s' (worktree %s no longer exists)", cloneName, project.AppRoot)
+			pruned = append(pruned, cloneName)
+			continue
+		}
+
+		util.Success("Pruning stale clone '%s'...", cloneName)
+
+		// Try to clean up Docker resources
+		util.Success("  Removing Docker resources for %s...", name)
+		cloneApp := &DdevApp{}
+		if initErr := cloneApp.Init(project.AppRoot); initErr == nil {
+			if stopErr := cloneApp.Stop(true, false); stopErr != nil {
+				util.Warning("Failed to stop stale clone: %v", stopErr)
+			}
+		} else {
+			// Manual cleanup: remove project from global list
+			if removeErr := globalconfig.RemoveProjectInfo(name); removeErr != nil {
+				util.Warning("Failed to remove project info for %s: %v", name, removeErr)
+			}
+		}
+
+		pruned = append(pruned, cloneName)
+	}
+
+	// Run git worktree prune to clean git state
+	util.Success("  Pruning git worktree references...")
+	if out, pruneErr := exec.RunHostCommand("git", "-C", gitRoot, "worktree", "prune"); pruneErr != nil {
+		util.Warning("Failed to prune git worktrees: %v, output: %s", pruneErr, out)
+	}
+
+	return pruned, nil
+}
+
+// cleanupOrphanedClone handles cleanup when a clone's app cannot be properly initialized.
+func cleanupOrphanedClone(cloneProjectName, worktreePath, gitRoot string) error {
+	// Remove project from global list
+	if removeErr := globalconfig.RemoveProjectInfo(cloneProjectName); removeErr != nil {
+		util.Warning("Failed to remove project info: %v", removeErr)
+	}
+
+	// Try to remove git worktree
+	if out, removeErr := exec.RunHostCommand("git", "-C", gitRoot, "worktree", "remove", "--force", worktreePath); removeErr != nil {
+		util.Warning("Failed to remove git worktree: %v, output: %s", removeErr, out)
+	}
+	if out, pruneErr := exec.RunHostCommand("git", "-C", gitRoot, "worktree", "prune"); pruneErr != nil {
+		util.Warning("Failed to prune git worktrees: %v, output: %s", pruneErr, out)
+	}
+
+	util.Success("Cleaned up orphaned clone '%s'", cloneProjectName)
+	return nil
+}
+
+// writeCloneConfig reads the source project's config.yaml and writes a modified
+// version to the clone with the clone's project name.
+func writeCloneConfig(sourceApp *DdevApp, cloneConfigPath, cloneProjectName string) error {
+	// Read existing config content
+	sourceConfigPath := filepath.Join(sourceApp.AppRoot, ".ddev", "config.yaml")
+	configBytes, err := os.ReadFile(sourceConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to read source config: %v", err)
+	}
+
+	// Parse and modify the name field
+	configStr := string(configBytes)
+	// Replace the name line in the YAML
+	lines := strings.Split(configStr, "\n")
+	nameFound := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "name:") {
+			lines[i] = "name: " + cloneProjectName
+			nameFound = true
+			break
+		}
+	}
+	if !nameFound {
+		// Prepend name if not found
+		lines = append([]string{"name: " + cloneProjectName}, lines...)
+	}
+
+	return os.WriteFile(cloneConfigPath, []byte(strings.Join(lines, "\n")), 0644)
+}
+
+// resolveClonePortConflicts clears host port settings that were inherited
+// from the source project's config to prevent bind conflicts. In devcontainer
+// environments, it allocates unique ephemeral ports because DockerEnv() would
+// otherwise assign the same well-known defaults to every project.
+func resolveClonePortConflicts(app *DdevApp) error {
+	// Clear any explicitly configured host ports inherited from the source.
+	// For non-devcontainer environments this is sufficient: empty ports mean
+	// the services are only accessible through the Docker network / ddev-router.
+	app.HostDBPort = ""
+	app.HostWebserverPort = ""
+	app.HostHTTPSPort = ""
+	app.HostMailpitPort = ""
+
+	// In devcontainer/Codespaces mode DockerEnv() assigns well-known default
+	// host ports (80, 3306, 8443, 8027 …) when the fields are empty.
+	// Pre-assign unique ephemeral ports so the clone does not collide with
+	// the source project that already holds those defaults.
+	if nodeps.IsDevcontainer() {
+		localIP := "127.0.0.1"
+
+		port, err := globalconfig.GetFreePort(localIP)
+		if err != nil {
+			return fmt.Errorf("allocating host DB port: %v", err)
+		}
+		app.HostDBPort = port
+
+		port, err = globalconfig.GetFreePort(localIP)
+		if err != nil {
+			return fmt.Errorf("allocating host webserver port: %v", err)
+		}
+		app.HostWebserverPort = port
+
+		port, err = globalconfig.GetFreePort(localIP)
+		if err != nil {
+			return fmt.Errorf("allocating host HTTPS port: %v", err)
+		}
+		app.HostHTTPSPort = port
+
+		port, err = globalconfig.GetFreePort(localIP)
+		if err != nil {
+			return fmt.Errorf("allocating host Mailpit port: %v", err)
+		}
+		app.HostMailpitPort = port
+	}
+
+	// Persist the updated port configuration so subsequent restarts
+	// keep using the same ports.
+	if err := app.WriteConfig(); err != nil {
+		return fmt.Errorf("writing updated clone config: %v", err)
+	}
+
+	return nil
+}
+
+// removeVolumeIfExists removes a Docker volume if it exists.
+func removeVolumeIfExists(volumeName string) error {
+	if dockerutil.VolumeExists(volumeName) {
+		return dockerutil.RemoveVolume(volumeName)
+	}
+	return nil
+}
+
+// fileExists checks if a path exists on disk.
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// GetSourceProjectNameExported is an exported wrapper for getSourceProjectName.
+func GetSourceProjectNameExported(app *DdevApp) string {
+	return getSourceProjectName(app)
+}
+
+// GetCloneNamesFunc returns a ValidArgsFunction that provides tab completion
+// for clone names based on discoverClones().
+func GetCloneNamesFunc(numArgs int) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if numArgs > 0 && len(args)+1 > numArgs {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		app, err := GetActiveApp("")
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		clones, err := discoverClones(app)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		var names []string
+		for _, c := range clones {
+			names = append(names, c.CloneName)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/pkg/ddevapp/clone_volume.go
+++ b/pkg/ddevapp/clone_volume.go
@@ -1,0 +1,87 @@
+package ddevapp
+
+import (
+	"fmt"
+
+	ddevImages "github.com/ddev/ddev/pkg/docker"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
+)
+
+// VolumeCloner abstracts volume duplication strategies.
+type VolumeCloner interface {
+	// CloneVolume copies all data from source Docker volume to target.
+	// The target volume is created if it does not exist.
+	CloneVolume(sourceVol, targetVol string) error
+	// Name returns the strategy name for logging.
+	Name() string
+}
+
+// TarCopyCloner clones volumes using an ephemeral container with tar pipe.
+type TarCopyCloner struct{}
+
+// CloneVolume copies all data from sourceVol to targetVol using an ephemeral
+// container that mounts both volumes and pipes tar between them.
+func (c *TarCopyCloner) CloneVolume(sourceVol, targetVol string) error {
+	track := util.TimeTrackC(fmt.Sprintf("CloneVolume %s -> %s", sourceVol, targetVol))
+	defer track()
+
+	// Create the target volume if it doesn't exist
+	if !dockerutil.VolumeExists(targetVol) {
+		_, err := dockerutil.CreateVolume(targetVol, "local", nil, map[string]string{"com.ddev.site-name": ""})
+		if err != nil {
+			return fmt.Errorf("failed to create target volume %s: %v", targetVol, err)
+		}
+	}
+
+	containerName := "ddev-clone-vol-" + nodeps.RandomString(6)
+
+	labels := map[string]string{"com.ddev.site-name": ""}
+	if dockerutil.IsPodmanRootless() {
+		labels["com.ddev.userns"] = "keep-id"
+	}
+
+	cmd := []string{"sh", "-c", "cd /source && tar cf - . | (cd /target && tar xpf -)"}
+	binds := []string{sourceVol + ":/source", targetVol + ":/target"}
+
+	_, _, err := dockerutil.RunSimpleContainer(
+		ddevImages.GetWebImage(),
+		containerName,
+		cmd,
+		nil, // entrypoint
+		nil, // env
+		binds,
+		"0",   // uid (root for full volume access)
+		true,  // removeContainerAfterRun
+		false, // detach
+		labels,
+		nil, // portBindings
+		nil, // healthConfig
+	)
+	if err != nil {
+		return fmt.Errorf("failed to clone volume %s to %s: %v", sourceVol, targetVol, err)
+	}
+
+	return nil
+}
+
+// Name returns the strategy name.
+func (c *TarCopyCloner) Name() string {
+	return "tar-copy"
+}
+
+// GetVolumeCloner returns the appropriate cloner based on configuration.
+// If a strategy is configured in global config but not available, it logs a
+// warning and falls back to the default TarCopyCloner.
+func GetVolumeCloner() VolumeCloner {
+	strategy := globalconfig.DdevGlobalConfig.VolumeCloneStrategy
+	if strategy == "" || strategy == "tar-copy" {
+		return &TarCopyCloner{}
+	}
+
+	// Future strategies would be matched here
+	util.Warning("Volume clone strategy '%s' is not available, falling back to tar-copy", strategy)
+	return &TarCopyCloner{}
+}

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -74,6 +74,7 @@ type GlobalConfig struct {
 	UseDockerComposeFromPath bool                    `yaml:"use_docker_compose_from_path,omitempty"`
 	UseHardenedImages        bool                    `yaml:"use_hardened_images"`
 	UseLetsEncrypt           bool                    `yaml:"use_letsencrypt"`
+	VolumeCloneStrategy      string                  `yaml:"volume_clone_strategy,omitempty"`
 	WSL2NoWindowsHostsMgt    bool                    `yaml:"wsl2_no_windows_hosts_mgt"`
 	WebEnvironment           []string                `yaml:"web_environment"`
 	XdebugIDELocation        string                  `yaml:"xdebug_ide_location"`


### PR DESCRIPTION
## The Issue

- Fixes #8187

This PR is intended as a working sketch for a `ddev clone` command, to give an idea of how this could work.

I understand this may not be something DDEV wants to support, or that it might warrant a very different implementation approach. I'm sharing it early to get feedback on whether the concept and direction are useful.

## How This PR Solves The Issue

### High-Level Approach

Each clone is a combination of:

1. A git worktree for the code (shares object store with the source repo — fast, disk-efficient)
2. Cloned Docker volumes for the database and other persistent data
3. A separate DDEV project with its own containers and network ports

The clone is discovered at runtime by parsing `git worktree list --porcelain`, so the source project doesn't need to track its clones in config.

### Subcommands

- **`ddev clone create <name> [--branch <branch>] [--no-start]`** — Creates a worktree, clones volumes via tar-pipe, writes a config with unique project name (`<source>-clone-<name>`), resolves port conflicts, runs pre/post-clone-create hooks, and starts the clone.
- **`ddev clone list [--json-output]`** — Discovers all clones via `git worktree list`, shows status table with `*` indicator for current directory.
- **`ddev clone remove <name> [--force]`** — Stops containers, removes volumes/images, removes the git worktree.
- **`ddev clone prune [--dry-run]`** — Finds clones whose worktrees have been manually deleted and cleans up their Docker resources.

### Pluggable Volume Cloning

The idea here is that future backends might want to work differently (e.g., filesystem snapshots, ZFS clones).
Volume cloning is behind a `VolumeCloner` interface (clone_volume.go):

```go
type VolumeCloner interface {
    CloneVolume(sourceVolume, targetVolume string) error
}
```

The default implementation (`TarCopyCloner`) uses an ephemeral Alpine container with a tar pipe (`tar cf - . | tar xf -`). The `VolumeCloneStrategy` field in global config is a hook point.

### Port Conflict Resolution

Clones inherit the source's config but can't share host-published ports. `resolveClonePortConflicts()` clears inherited explicit ports. In devcontainer/CI environments, it allocates ephemeral ports via `GetFreePort()` to avoid the default port assignments that `DockerEnv()` would otherwise apply.

### Open Questions

- Git command execution: The implementation shells out to `git worktree add/remove/list`. This couples the feature to git. It might be worth making git operations pluggable or optional, so the concept could work with non-git projects or alternative VCS. Could also look at switching to go-git or similar.
- Naming conventions: Clone projects are named `<source>-clone-<name>`. This is simple but could collide with existing projects in edge cases.

## Manual Testing Instructions

Tested end-to-end with a Drupal site:

1. Create a source project:
   ```bash
   mkdir ~/tmp/testsite && cd ~/tmp/testsite
   git init && ddev config --project-type=drupal --docroot=web
   ddev start
   ```

2. Create a clone:
   ```bash
   ddev clone create feature1
   # Verify: separate containers, ephemeral ports, DB isolation
   ```

3. List clones:
   ```bash
   ddev clone list
   ddev clone list --json-output
   ```

4. Remove a clone:
   ```bash
   ddev clone remove feature1 --force
   # Verify: containers, volumes, images, and worktree all removed
   ```

5. Prune stale clones:
   ```bash
   ddev clone prune --dry-run
   ```

**What was tested**: Drupal project on Linux (devcontainer). Both source and clone served HTTP 200 simultaneously. Database isolation confirmed (table created in source was not present in clone).

**What needs more testing**: Different CMS types (WordPress, Laravel, TYPO3), different databases (PostgreSQL, MariaDB versions), macOS/Windows, non-devcontainer environments, projects with/without Mutagen, projects with add-on services.

## Automated Testing Overview

No automated tests are included in this sketch. The feature was validated through manual end-to-end testing. Proper test coverage would be needed before this could be merged — likely integration tests in ddevapp following the existing patterns.

## Release/Deployment Notes

**This is a sketch / proof of concept.** It is not intended to be merged as-is.

**Dependencies**: Git CLI is required only if the feature is used. Uses only existing DDEV packages and the standard library.

**Backward compatibility**: No existing behavior is changed. The only modification to an existing file is a single field addition to `GlobalConfig`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>