### PR TITLE
fix(composer): ddev composer create-project can ignore .devcontainer [skip buildkite]

### DIFF
--- a/cmd/ddev/cmd/composer-create-project.go
+++ b/cmd/ddev/cmd/composer-create-project.go
@@ -369,7 +369,7 @@ ddev composer create-project --prefer-dist --no-interaction --no-dev psr/log .
 func checkForComposerCreateAllowedPaths(app *ddevapp.DdevApp) {
 	appRoot := app.GetAbsAppRoot(false)
 	composerRoot := filepath.Join(app.GetComposerRoot(false, false), composerDirectoryArg)
-	skipDirs := []string{".ddev", ".DS_Store", ".git", ".idea", ".tarballs", ".vscode"}
+	skipDirs := []string{".claude", ".ddev", ".devcontainer", ".DS_Store", ".git", ".idea", ".tarballs", ".vscode"}
 	composerCreateAllowedPaths, _ := app.GetComposerCreateAllowedPaths()
 	err := filepath.Walk(composerRoot,
 		func(walkPath string, walkInfo os.FileInfo, err error) error {


### PR DESCRIPTION

## The Issue

We had an emailed support question from someone trying to do a `ddev composer create-project` with Craft CMS on GitHub Codespaces, and they got stuck because there is already a .devcontainer directory there, and we don't allow that.

## How This PR Solves The Issue

Add .devcontainer (and review other possible skips for composer create-project)


## Manual Testing Instructions

* Try `ddev composer create-project` with a .devcontainer directory existing
* Try doing a Craft CMS project creation on Codespaces with this DDEV version.

