### PR TITLE
docs(quickstart): Use mkdir -p and more descriptive names [skip buildkite]

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -13,7 +13,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-backdrop-site && cd my-backdrop-site
+    mkdir -p my-backdrop-site && cd my-backdrop-site
     ddev config --project-type=backdrop
     # Add the official Bee CLI add-on
     ddev add-on get backdrop-ops/ddev-backdrop-bee
@@ -48,7 +48,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
         cat > setup-backdrop.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-backdrop-site && cd my-backdrop-site
+        mkdir -p my-backdrop-site && cd my-backdrop-site
         ddev config --project-type=backdrop
         ddev add-on get backdrop-ops/ddev-backdrop-bee
         ddev start -y
@@ -67,7 +67,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
     Create project directory and clone your repository:
 
     ```bash
-    mkdir my-backdrop-site && cd my-backdrop-site
+    mkdir -p my-backdrop-site && cd my-backdrop-site
     git clone https://github.com/ddev/test-backdrop.git .
     ```
 
@@ -110,7 +110,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
         cat > setup-backdrop-existing.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-backdrop-site && cd my-backdrop-site
+        mkdir -p my-backdrop-site && cd my-backdrop-site
         git clone https://github.com/ddev/test-backdrop.git .
         ddev config --project-type=backdrop
         ddev add-on get backdrop-ops/ddev-backdrop-bee
@@ -137,7 +137,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-cakephp-site && cd my-cakephp-site
+    mkdir -p my-cakephp-composer-site && cd my-cakephp-composer-site
     ddev config --project-type=cakephp --docroot=webroot
     ```
 
@@ -166,7 +166,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
         cat > setup-cakephp.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-cakephp-site && cd my-cakephp-site
+        mkdir -p my-cakephp-composer-site && cd my-cakephp-composer-site
         ddev config --project-type=cakephp --docroot=webroot
         ddev start -y
         ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
@@ -181,8 +181,8 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     Clone the repository and configure DDEV:
 
     ```bash
-    git clone <my-cakephp-repo> my-cakephp-site
-    cd my-cakephp-site
+    git clone <my-cakephp-repo> my-cakephp-git-site
+    cd my-cakephp-git-site
     ddev config --project-type=cakephp --docroot=webroot
     ```
 
@@ -207,8 +207,8 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
         cat > setup-cakephp-git.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        git clone <my-cakephp-repo> my-cakephp-site
-        cd my-cakephp-site
+        git clone <my-cakephp-repo> my-cakephp-git-site
+        cd my-cakephp-git-site
         ddev config --project-type=cakephp --docroot=webroot
         ddev start -y
         ddev composer install
@@ -226,7 +226,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 Create the project directory and configure DDEV:
 
 ```bash
-mkdir my-civicrm-site && cd my-civicrm-site
+mkdir -p my-civicrm-site && cd my-civicrm-site
 ddev config --project-type=php --composer-root=core --upload-dirs=public/media
 ```
 
@@ -273,7 +273,7 @@ ddev launch
     cat > setup-civicrm.sh << 'EOF'
     #!/usr/bin/env bash
     set -euo pipefail
-    mkdir my-civicrm-site && cd my-civicrm-site
+    mkdir -p my-civicrm-site && cd my-civicrm-site
     ddev config --project-type=php --composer-root=core --upload-dirs=public/media
     ddev start -y
     ddev exec "curl -LsS https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz -o /tmp/civicrm-standalone.tar.gz"
@@ -303,7 +303,7 @@ DDEV automatically updates or creates the `.env` file with the database informat
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-ci4-site && cd my-ci4-site
+    mkdir -p my-ci4-site && cd my-ci4-site
     ddev config --project-type=codeigniter --docroot=public
     ```
 
@@ -332,7 +332,7 @@ DDEV automatically updates or creates the `.env` file with the database informat
         cat > setup-codeigniter.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-ci4-site && cd my-ci4-site
+        mkdir -p my-ci4-site && cd my-ci4-site
         ddev config --project-type=codeigniter --docroot=public
         ddev start -y
         ddev composer create-project codeigniter4/appstarter
@@ -351,7 +351,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-contao-site && cd my-contao-site
+    mkdir -p my-contao-composer-site && cd my-contao-composer-site
     ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
     ```
 
@@ -392,7 +392,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
         cat > setup-contao.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-contao-site && cd my-contao-site
+        mkdir -p my-contao-composer-site && cd my-contao-composer-site
         ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
         ddev composer create-project contao/managed-edition:5.3
         ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
@@ -411,7 +411,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-contao-site && cd my-contao-site
+    mkdir -p my-contao-manager-site && cd my-contao-manager-site
     ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
     ```
 
@@ -446,7 +446,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
         cat > setup-contao-manager.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-contao-site && cd my-contao-site
+        mkdir -p my-contao-manager-site && cd my-contao-manager-site
         ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
         ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
         ddev start -y
@@ -476,7 +476,7 @@ DDEV injects a number of special environment variables into the container (via `
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-craft-site && cd my-craft-site
+    mkdir -p my-craft-site && cd my-craft-site
     ddev config --project-type=craftcms --docroot=web
     ```
 
@@ -503,7 +503,7 @@ DDEV injects a number of special environment variables into the container (via `
         cat > setup-craft.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-craft-site && cd my-craft-site
+        mkdir -p my-craft-site && cd my-craft-site
         ddev config --project-type=craftcms --docroot=web
         ddev start -y
         ddev composer create-project craftcms/craft
@@ -578,7 +578,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-drupal-site && cd my-drupal-site
+    mkdir -p my-drupal11-site && cd my-drupal11-site
     ddev config --project-type=drupal11 --docroot=web
     ```
 
@@ -613,7 +613,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         cat > setup-drupal11.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-drupal-site && cd my-drupal-site
+        mkdir -p my-drupal11-site && cd my-drupal11-site
         ddev config --project-type=drupal11 --docroot=web
         ddev start -y
         ddev composer create-project drupal/recommended-project
@@ -630,7 +630,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-drupal-site && cd my-drupal-site
+    mkdir -p my-drupalcms-site && cd my-drupalcms-site
     ddev config --project-type=drupal11 --docroot=web
     ```
 
@@ -663,7 +663,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         cat > setup-drupal-cms.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-drupal-site && cd my-drupal-site
+        mkdir -p my-drupalcms-site && cd my-drupalcms-site
         ddev config --project-type=drupal11 --docroot=web
         ddev start -y
         ddev composer create-project drupal/cms
@@ -680,7 +680,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-drupal-site && cd my-drupal-site
+    mkdir -p my-drupal10-site && cd my-drupal10-site
     ddev config --project-type=drupal10 --docroot=web
     ```
 
@@ -715,7 +715,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         cat > setup-drupal10.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-drupal-site && cd my-drupal-site
+        mkdir -p my-drupal10-site && cd my-drupal10-site
         ddev config --project-type=drupal10 --docroot=web
         ddev start -y
         ddev composer create-project "drupal/recommended-project:^10"
@@ -776,8 +776,8 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
     ```bash
     PROJECT_GIT_URL=https://github.com/ddev/test-drupal11.git
-    git clone ${PROJECT_GIT_URL} my-drupal-site
-    cd my-drupal-site
+    git clone ${PROJECT_GIT_URL} my-drupal11-site
+    cd my-drupal11-site
     ```
 
     Configure and start DDEV:
@@ -810,8 +810,8 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         #!/usr/bin/env bash
         set -euo pipefail
         PROJECT_GIT_URL=https://github.com/ddev/test-drupal11.git
-        git clone ${PROJECT_GIT_URL} my-drupal-site
-        cd my-drupal-site
+        git clone ${PROJECT_GIT_URL} my-drupal11-site
+        cd my-drupal11-site
         ddev config --project-type=drupal11 --docroot=web
         ddev start -y
         ddev composer install
@@ -829,7 +829,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Create the project directory:
 
     ```bash
-    mkdir my-ee-site && cd my-ee-site
+    mkdir -p my-ee-zip-site && cd my-ee-zip-site
     ```
 
     Download and extract the latest ExpressionEngine release:
@@ -864,7 +864,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         cat > setup-ee.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-ee-site && cd my-ee-site
+        mkdir -p my-ee-zip-site && cd my-ee-zip-site
         DOWNLOAD_URL=$(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
         curl -o ee.zip -L "${DOWNLOAD_URL}"
         unzip ee.zip && rm -f ee.zip
@@ -883,7 +883,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Create the project directory and clone the repository:
 
     ```bash
-    mkdir my-ee-site && cd my-ee-site
+    mkdir -p my-ee-git-site && cd my-ee-git-site
     git clone https://github.com/ExpressionEngine/ExpressionEngine .
     ```
 
@@ -917,7 +917,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         cat > setup-ee-git.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-ee-site && cd my-ee-site
+        mkdir -p my-ee-git-site && cd my-ee-git-site
         git clone https://github.com/ExpressionEngine/ExpressionEngine .
         ddev config --database=mysql:8.0
         ddev start -y
@@ -947,7 +947,7 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
 
     ```bash
     export GENERIC_SITENAME=my-generic-site
-    mkdir ${GENERIC_SITENAME} && cd ${GENERIC_SITENAME}
+    mkdir -p ${GENERIC_SITENAME} && cd ${GENERIC_SITENAME}
     ddev config --project-type=php
     ```
 
@@ -994,7 +994,7 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
         #!/usr/bin/env bash
         set -euo pipefail
         export GENERIC_SITENAME=my-generic-site
-        mkdir ${GENERIC_SITENAME} && cd ${GENERIC_SITENAME}
+        mkdir -p ${GENERIC_SITENAME} && cd ${GENERIC_SITENAME}
         ddev config --project-type=php
         echo "<?php phpinfo(); ?>" > index.php
         cat <<'INNEREOF' > .ddev/config.php-server.yaml
@@ -1023,7 +1023,7 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-grav-site && cd my-grav-site
+    mkdir -p my-grav-composer-site && cd my-grav-composer-site
     ddev config --php-version=8.3 --omit-containers=db
     ```
 
@@ -1053,7 +1053,7 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
         cat > setup-grav.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-grav-site && cd my-grav-site
+        mkdir -p my-grav-composer-site && cd my-grav-composer-site
         ddev config --php-version=8.3 --omit-containers=db
         ddev start -y
         ddev composer create-project getgrav/grav
@@ -1069,7 +1069,7 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
     Create the project directory and clone Grav:
 
     ```bash
-    mkdir my-grav-site && cd my-grav-site
+    mkdir -p my-grav-git-site && cd my-grav-git-site
     git clone -b master https://github.com/getgrav/grav.git .
     ```
 
@@ -1106,7 +1106,7 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
         cat > setup-grav-git.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-grav-site && cd my-grav-site
+        mkdir -p my-grav-git-site && cd my-grav-git-site
         git clone -b master https://github.com/getgrav/grav.git .
         ddev config --php-version=8.3 --omit-containers=db
         ddev start -y
@@ -1141,7 +1141,7 @@ Install [Ibexa DXP](https://www.ibexa.co) OSS Edition.
 Create the project directory and configure DDEV:
 
 ```bash
-mkdir my-ibexa-site && cd my-ibexa-site
+mkdir -p my-ibexa-site && cd my-ibexa-site
 ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
 ```
 
@@ -1180,7 +1180,7 @@ Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/insta
     cat > setup-ibexa.sh << 'EOF'
     #!/usr/bin/env bash
     set -euo pipefail
-    mkdir my-ibexa-site && cd my-ibexa-site
+    mkdir -p my-ibexa-site && cd my-ibexa-site
     ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
     ddev start -y
     ddev composer create-project ibexa/oss-skeleton
@@ -1197,7 +1197,7 @@ Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/insta
 Create the project directory and download Joomla:
 
 ```bash
-mkdir my-joomla-site && cd my-joomla-site
+mkdir -p my-joomla-site && cd my-joomla-site
 # Download the latest version of Joomla! and unzip it.
 # This can be manually downloaded from https://downloads.joomla.org/ or done using curl as here.
 DOWNLOAD_URL=$(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
@@ -1231,7 +1231,7 @@ ddev launch /administrator
     cat > setup-joomla.sh << 'EOF'
     #!/usr/bin/env bash
     set -euo pipefail
-    mkdir my-joomla-site && cd my-joomla-site
+    mkdir -p my-joomla-site && cd my-joomla-site
     DOWNLOAD_URL=$(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
     curl -o joomla.zip -L "${DOWNLOAD_URL}"
     unzip joomla.zip && rm -f joomla.zip
@@ -1255,7 +1255,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-kirby-site && cd my-kirby-site
+    mkdir -p my-kirby-site && cd my-kirby-site
     ddev config --omit-containers=db --webserver-type=apache-fpm
     ```
 
@@ -1284,7 +1284,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
         cat > setup-kirby.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-kirby-site && cd my-kirby-site
+        mkdir -p my-kirby-site && cd my-kirby-site
         ddev config --omit-containers=db --webserver-type=apache-fpm
         ddev start -y
         ddev composer create-project getkirby/starterkit
@@ -1354,7 +1354,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-laravel-site && cd my-laravel-site
+    mkdir -p my-laravel-composer-site && cd my-laravel-composer-site
     ddev config --project-type=laravel --docroot=public
     ```
 
@@ -1383,7 +1383,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
         cat > setup-laravel.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-laravel-site && cd my-laravel-site
+        mkdir -p my-laravel-composer-site && cd my-laravel-composer-site
         ddev config --project-type=laravel --docroot=public
         ddev start -y
         ddev composer create-project "laravel/laravel:^12"
@@ -1400,7 +1400,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-laravel-site && cd my-laravel-site
+    mkdir -p my-laravel-sqlite-site && cd my-laravel-sqlite-site
     ddev config --project-type=laravel --docroot=public --omit-containers=db
     ```
 
@@ -1429,7 +1429,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
         cat > setup-laravel-sqlite.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-laravel-site && cd my-laravel-site
+        mkdir -p my-laravel-sqlite-site && cd my-laravel-sqlite-site
         ddev config --project-type=laravel --docroot=public --omit-containers=db
         ddev start -y
         ddev composer create-project "laravel/laravel:^12"
@@ -1485,7 +1485,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-laravel-site && cd my-laravel-site
+    mkdir -p my-laravel-installer-site && cd my-laravel-installer-site
     ddev config --project-type=laravel --docroot=public
     # For SQLite instead, use:
     # ddev config --project-type=laravel --docroot=public --omit-containers=db
@@ -1543,7 +1543,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
         cat > setup-laravel-installer.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-laravel-site && cd my-laravel-site
+        mkdir -p my-laravel-installer-site && cd my-laravel-installer-site
         ddev config --project-type=laravel --docroot=public
 
         cat <<'INNEREOF' >.ddev/web-build/Dockerfile.laravel
@@ -1570,8 +1570,8 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Clone your Laravel repository:
 
     ```bash
-    git clone <my-laravel-repo> my-laravel-site
-    cd my-laravel-site
+    git clone <my-laravel-repo> my-laravel-git-site
+    cd my-laravel-git-site
     ```
 
     Configure and start DDEV:
@@ -1602,8 +1602,8 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
         cat > setup-laravel-git.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        git clone <my-laravel-repo> my-laravel-site
-        cd my-laravel-site
+        git clone <my-laravel-repo> my-laravel-git-site
+        cd my-laravel-git-site
         ddev config --project-type=laravel --docroot=public
         ddev start -y
         ddev composer install
@@ -1653,7 +1653,7 @@ Create the project directory and configure DDEV:
 
 ```bash
 export MAGENTO_HOSTNAME=my-magento2-site
-mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
+mkdir -p ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
 ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
 ddev add-on get ddev/ddev-opensearch
 ```
@@ -1703,7 +1703,7 @@ Change the admin name and related information as needed.
     #!/usr/bin/env bash
     set -euo pipefail
     export MAGENTO_HOSTNAME=my-magento2-site
-    mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
+    mkdir -p ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
     ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
     ddev add-on get ddev/ddev-opensearch
     ddev start -y
@@ -1740,7 +1740,7 @@ ddev magento setup:upgrade
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-moodle-site && cd my-moodle-site
+    mkdir -p my-moodle-site && cd my-moodle-site
     ddev config --docroot=public --webserver-type=apache-fpm
     ```
 
@@ -1782,7 +1782,7 @@ ddev magento setup:upgrade
         cat > setup-moodle.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-moodle-site && cd my-moodle-site
+        mkdir -p my-moodle-site && cd my-moodle-site
         ddev config --docroot=public --webserver-type=apache-fpm
         ddev start -y
         ddev composer create-project moodle/moodle
@@ -1803,7 +1803,7 @@ ddev magento setup:upgrade
 
     ```bash
     export SVELTEKIT_SITENAME=my-sveltekit-site
-    mkdir ${SVELTEKIT_SITENAME} && cd ${SVELTEKIT_SITENAME}
+    mkdir -p ${SVELTEKIT_SITENAME} && cd ${SVELTEKIT_SITENAME}
     ddev config --project-type=generic --webserver-type=generic
     ddev start
 
@@ -1842,7 +1842,7 @@ ddev magento setup:upgrade
 
     ```bash
     export NODEJS_SITENAME=my-nodejs-site
-    mkdir ${NODEJS_SITENAME} && cd ${NODEJS_SITENAME}
+    mkdir -p ${NODEJS_SITENAME} && cd ${NODEJS_SITENAME}
     ddev config --project-type=generic --webserver-type=generic
     ddev start
     ddev npm install express
@@ -1876,7 +1876,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-openmage-site && cd my-openmage-site
+    mkdir -p my-openmage-composer-site && cd my-openmage-composer-site
     ddev config --project-type=magento --docroot=public_test --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
     ```
 
@@ -1929,7 +1929,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
         cat > setup-openmage.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-openmage-site && cd my-openmage-site
+        mkdir -p my-openmage-composer-site && cd my-openmage-composer-site
         ddev config --project-type=magento --docroot=public_test --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
         ddev start -y
         ddev composer init --name "openmage/composer-test" --description "OpenMage starter project" --type "project" -l "OSL-3.0" -s "dev" -q
@@ -1955,7 +1955,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     Create the project directory and clone the repository:
 
     ```bash
-    mkdir my-openmage-site && cd my-openmage-site
+    mkdir -p my-openmage-git-site && cd my-openmage-git-site
     git clone https://github.com/OpenMage/magento-lts .
     ```
 
@@ -1993,7 +1993,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
         cat > setup-openmage-git.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-openmage-site && cd my-openmage-site
+        mkdir -p my-openmage-git-site && cd my-openmage-git-site
         git clone https://github.com/OpenMage/magento-lts .
         ddev config --project-type=magento --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
         ddev start -y
@@ -2014,7 +2014,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     Create the project directory and configure DDEV:
 
     ``` bash
-    mkdir my-pimcore-site && cd my-pimcore-site
+    mkdir -p my-pimcore-site && cd my-pimcore-site
     ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
     ```
 
@@ -2065,7 +2065,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
         cat > setup-pimcore.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-pimcore-site && cd my-pimcore-site
+        mkdir -p my-pimcore-site && cd my-pimcore-site
         ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
         ddev start -y
         ddev composer create-project pimcore/skeleton
@@ -2096,7 +2096,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     Create the project directory:
 
     ```bash
-    mkdir my-processwire-site && cd my-processwire-site
+    mkdir -p my-processwire-zip-site && cd my-processwire-zip-site
     ```
 
     Download and extract ProcessWire:
@@ -2126,7 +2126,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
         cat > setup-processwire-zip.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-processwire-site && cd my-processwire-site
+        mkdir -p my-processwire-zip-site && cd my-processwire-zip-site
         curl -LJOf https://github.com/processwire/processwire/archive/master.zip
         unzip processwire-master.zip && rm -f processwire-master.zip && mv processwire-master/* . && mv processwire-master/.* . 2>/dev/null && rm -rf processwire-master
         ddev config --project-type=php --webserver-type=apache-fpm
@@ -2142,7 +2142,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-processwire-site && cd my-processwire-site
+    mkdir -p my-processwire-composer-site && cd my-processwire-composer-site
     ddev config --project-type=php --webserver-type=apache-fpm
     ```
 
@@ -2171,7 +2171,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
         cat > setup-processwire.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-processwire-site && cd my-processwire-site
+        mkdir -p my-processwire-composer-site && cd my-processwire-composer-site
         ddev config --project-type=php --webserver-type=apache-fpm
         ddev start -y
         ddev composer create-project "processwire/processwire:^3"
@@ -2186,7 +2186,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     Create the project directory:
 
     ```bash
-    mkdir my-processwire-site && cd my-processwire-site
+    mkdir -p my-processwire-git-site && cd my-processwire-git-site
     ```
 
     Clone ProcessWire (main branch for stable release):
@@ -2217,7 +2217,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
         cat > setup-processwire-git.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-processwire-site && cd my-processwire-site
+        mkdir -p my-processwire-git-site && cd my-processwire-git-site
         git clone https://github.com/processwire/processwire.git .
         ddev config --webserver-type=apache-fpm
         ddev start -y
@@ -2255,7 +2255,7 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-shopware-site && cd my-shopware-site
+    mkdir -p my-shopware-site && cd my-shopware-site
     ddev config --project-type=shopware6 --docroot=public
     ```
 
@@ -2292,7 +2292,7 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
         cat > setup-shopware.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-shopware-site && cd my-shopware-site
+        mkdir -p my-shopware-site && cd my-shopware-site
         ddev config --project-type=shopware6 --docroot=public
         ddev start -y
         ddev composer create-project shopware/production
@@ -2312,7 +2312,7 @@ Use a new or existing Composer project, or clone a Git repository.
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-silverstripe-site && cd my-silverstripe-site
+    mkdir -p my-silverstripe-composer-site && cd my-silverstripe-composer-site
     ddev config --project-type=silverstripe --docroot=public
     ```
 
@@ -2342,7 +2342,7 @@ Use a new or existing Composer project, or clone a Git repository.
         cat > setup-silverstripe.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-silverstripe-site && cd my-silverstripe-site
+        mkdir -p my-silverstripe-composer-site && cd my-silverstripe-composer-site
         ddev config --project-type=silverstripe --docroot=public
         ddev start -y
         ddev composer create-project --prefer-dist silverstripe/installer
@@ -2356,8 +2356,8 @@ Use a new or existing Composer project, or clone a Git repository.
 === "Git Clone"
 
     ```bash
-    git clone <my-silverstripe-repo> my-silverstripe-site
-    cd my-silverstripe-site
+    git clone <my-silverstripe-repo> my-silverstripe-git-site
+    cd my-silverstripe-git-site
     ddev config --project-type=silverstripe --docroot=public
     ddev start
     ddev composer install
@@ -2384,7 +2384,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-statamic-site && cd my-statamic-site
+    mkdir -p my-statamic-composer-site && cd my-statamic-composer-site
     ddev config --project-type=laravel --docroot=public
     ```
 
@@ -2408,7 +2408,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
         cat > setup-statamic.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-statamic-site && cd my-statamic-site
+        mkdir -p my-statamic-composer-site && cd my-statamic-composer-site
         ddev config --project-type=laravel --docroot=public
         ddev composer create-project --prefer-dist statamic/statamic
         ddev php please make:user admin@example.com --password=admin1234 --super --no-interaction
@@ -2421,8 +2421,8 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
 === "Git Clone"
 
     ```bash
-    git clone <my-statamic-repo> my-statamic-site
-    cd my-statamic-site
+    git clone <my-statamic-repo> my-statamic-git-site
+    cd my-statamic-git-site
     ddev config --project-type=laravel --docroot=public
     ddev start
     ddev composer install
@@ -2435,7 +2435,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
 Create the project directory and configure DDEV:
 
 ```bash
-mkdir my-sulu-site && cd my-sulu-site
+mkdir -p my-sulu-site && cd my-sulu-site
 ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
 ```
 
@@ -2506,7 +2506,7 @@ ddev launch /admin
     cat > setup-sulu.sh << 'EOF'
     #!/usr/bin/env bash
     set -euo pipefail
-    mkdir my-sulu-site && cd my-sulu-site
+    mkdir -p my-sulu-site && cd my-sulu-site
     ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
     ddev start -y
     ddev composer create-project sulu/skeleton
@@ -2534,7 +2534,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-symfony-site && cd my-symfony-site
+    mkdir -p my-symfony-composer-site && cd my-symfony-composer-site
     ddev config --project-type=symfony --docroot=public
     ```
 
@@ -2565,7 +2565,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
         cat > setup-symfony.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-symfony-site && cd my-symfony-site
+        mkdir -p my-symfony-composer-site && cd my-symfony-composer-site
         ddev config --project-type=symfony --docroot=public
         ddev start -y
         ddev composer create-project symfony/skeleton
@@ -2579,7 +2579,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 === "Symfony CLI"
 
     ```bash
-    mkdir my-symfony-site && cd my-symfony-site
+    mkdir -p my-symfony-cli-site && cd my-symfony-cli-site
     ddev config --project-type=symfony --docroot=public
     ddev start
     ddev exec symfony check:requirements
@@ -2593,8 +2593,8 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 === "Git Clone"
 
     ```bash
-    git clone <my-symfony-repo> my-symfony-site
-    cd my-symfony-site
+    git clone <my-symfony-repo> my-symfony-git-site
+    cd my-symfony-git-site
     ddev config --project-type=symfony --docroot=public
     ddev start
     ddev composer install
@@ -2623,7 +2623,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
     ```bash
     PROJECT_NAME=my-typo3-site
-    mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
+    mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
     ddev config --project-type=typo3 --docroot=public
     ```
 
@@ -2721,7 +2721,7 @@ Create the project directory and configure DDEV:
 
 ```bash
 export WAGTAIL_SITENAME=my-wagtail-site
-mkdir ${WAGTAIL_SITENAME} && cd ${WAGTAIL_SITENAME}
+mkdir -p ${WAGTAIL_SITENAME} && cd ${WAGTAIL_SITENAME}
 ddev config --project-type=generic --webserver-type=generic \
     --webimage-extra-packages=python3-pip,python3-venv \
     --web-environment-add=DJANGO_SETTINGS_MODULE=mysite.settings.dev \
@@ -2807,7 +2807,7 @@ ddev launch /admin
     #!/usr/bin/env bash
     set -euo pipefail
     export WAGTAIL_SITENAME=my-wagtail-site
-    mkdir ${WAGTAIL_SITENAME} && cd ${WAGTAIL_SITENAME}
+    mkdir -p ${WAGTAIL_SITENAME} && cd ${WAGTAIL_SITENAME}
     ddev config --project-type=generic --webserver-type=generic \
         --webimage-extra-packages=python3-pip,python3-venv \
         --web-environment-add=DJANGO_SETTINGS_MODULE=mysite.settings.dev \
@@ -2854,7 +2854,7 @@ There are several easy ways to use DDEV with WordPress:
     Create the project directory and configure DDEV:
 
     ```bash
-    mkdir my-wp-site && cd my-wp-site
+    mkdir -p my-wp-cli-site && cd my-wp-cli-site
     # Create a new DDEV project inside the newly-created folder
     # (Primary URL automatically set to `https://<folder>.ddev.site`)
     ddev config --project-type=wordpress
@@ -2895,7 +2895,7 @@ There are several easy ways to use DDEV with WordPress:
         cat > setup-wordpress.sh << 'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        mkdir my-wp-site && cd my-wp-site
+        mkdir -p my-wp-cli-site && cd my-wp-cli-site
         ddev config --project-type=wordpress
         ddev start -y
         ddev wp core download
@@ -2911,7 +2911,7 @@ There are several easy ways to use DDEV with WordPress:
     [Bedrock](https://roots.io/bedrock/) is a modern, Composer-based installation in WordPress:
 
     ```bash
-    mkdir my-wp-site && cd my-wp-site
+    mkdir -p my-wp-bedrock-site && cd my-wp-bedrock-site
     ddev config --project-type=wordpress --docroot=web
     ddev start
     ddev composer create-project roots/bedrock
@@ -2944,8 +2944,8 @@ There are several easy ways to use DDEV with WordPress:
 
     ```bash
     PROJECT_GIT_URL=https://github.com/ddev/test-wordpress.git
-    git clone ${PROJECT_GIT_URL} my-wp-site
-    cd my-wp-site
+    git clone ${PROJECT_GIT_URL} my-wp-git-site
+    cd my-wp-git-site
     ddev config --project-type=wordpress
     ddev start
     ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com

--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -14,7 +14,7 @@ teardown() {
 @test "backdrop new-project quickstart with $(ddev --version)" {
   _skip_if_embargoed "backdrop-new"
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=backdrop
@@ -63,7 +63,7 @@ teardown() {
 @test "backdrop existing project with $(ddev --version)" {
   _skip_if_embargoed "backdrop-existing"
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run git clone https://github.com/ddev/test-backdrop.git .

--- a/docs/tests/cakephp.bats
+++ b/docs/tests/cakephp.bats
@@ -13,20 +13,17 @@ teardown() {
 
 @test "CakePHP Composer quickstart with $(ddev --version)" {
   _skip_if_embargoed "cakephp-composer"
+  PROJNAME=my-cakephp-composer-site
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  # ddev config --project-type=cakephp --docroot=webroot
   run ddev config --project-type=cakephp --docroot=webroot
   assert_success
 
-  # ddev start -y
   run ddev start -y
   assert_success
 
-  # ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
   run ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
   assert_success
 

--- a/docs/tests/civicrm.bats
+++ b/docs/tests/civicrm.bats
@@ -14,7 +14,7 @@ teardown() {
 @test "CiviCRM quickstart with $(ddev --version)" {
   _skip_if_embargoed "civicrm-standalone"
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=php --composer-root=core --upload-dirs=public/media

--- a/docs/tests/codeigniter.bats
+++ b/docs/tests/codeigniter.bats
@@ -14,7 +14,7 @@ teardown() {
 @test "CodeIgniter composer based quickstart with $(ddev --version)" {
   _skip_if_embargoed "codeigniter-composer"
 
-  run mkdir my-codeigniter-site && cd my-codeigniter-site
+  run mkdir -p my-codeigniter-site && cd my-codeigniter-site
   assert_success
 
   run ddev config --project-type=codeigniter --docroot=public

--- a/docs/tests/contao.bats
+++ b/docs/tests/contao.bats
@@ -13,32 +13,28 @@ teardown() {
 
 @test "Contao Composer quickstart with $(ddev --version)" {
   _skip_if_embargoed "contao-composer"
+  PROJNAME=my-contao-composer-site
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+
   run ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
   assert_success
-  # ddev start -y
+
   run ddev start -y
   assert_success
-  # ddev composer create-project contao/managed-edition:5.3
+
   run ddev composer create-project contao/managed-edition:5.3
   assert_success
   # Set DATABASE_URL and MAILER_DSN in .env.local
-  # ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
   run ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
   assert_success
   # Create the database
-  # ddev exec contao-console contao:migrate --no-interaction
   run ddev exec contao-console contao:migrate --no-interaction
   assert_success
   # Create backend user
-  # ddev exec contao-console contao:user:create --username=admin --name=Administrator --email=admin@example.com --language=en --password=Password123 --admin
   run ddev exec contao-console contao:user:create --username=admin --name=Administrator --email=admin@example.com --language=en --password=Password123 --admin
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch contao
   assert_output "FULLURL https://${PROJNAME}.ddev.site/contao"
   assert_success
@@ -50,23 +46,19 @@ teardown() {
 
 @test "Contao Manager quickstart with $(ddev --version)" {
   _skip_if_embargoed "contao-manager"
+  PROJNAME=my-contao-manager-site
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
   run ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
   assert_success
   # set DATABASE_URL and MAILER_DSN in .env.local
-  # ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
   run ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
   run ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch contao-manager.phar.php
   assert_output "FULLURL https://${PROJNAME}.ddev.site/contao-manager.phar.php"
   assert_success

--- a/docs/tests/craftcms.bats
+++ b/docs/tests/craftcms.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "Craft CMS New Projects quickstart with $(ddev --version)" {
   _skip_if_embargoed "craftcms-new"
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=craftcms --docroot=web

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -13,8 +13,9 @@ teardown() {
 
 @test "Drupal 12 quickstart with $(ddev --version)" {
   _skip_if_embargoed "drupal12-composer"
+  PROJNAME=my-drupal12-site
 
-  run mkdir my-drupal-site && cd my-drupal-site
+  run mkdir -p my-drupal12-site && cd my-drupal12-site
   assert_success
 
   run ddev config --project-type=drupal12 --docroot=web
@@ -45,8 +46,9 @@ teardown() {
 
 @test "Drupal 11 quickstart with $(ddev --version)" {
   _skip_if_embargoed "drupal11-composer"
+  PROJNAME=my-drupal11-site
 
-  run mkdir my-drupal-site && cd my-drupal-site
+  run mkdir -p my-drupal11-site && cd my-drupal11-site
   assert_success
 
   run ddev config --project-type=drupal11 --docroot=web
@@ -77,8 +79,9 @@ teardown() {
 
 @test "Drupal 10 quickstart with $(ddev --version)" {
   _skip_if_embargoed "drupal10-composer"
+  PROJNAME=my-drupal10-site
 
-  run mkdir my-drupal-site && cd my-drupal-site
+  run mkdir -p my-drupal10-site && cd my-drupal10-site
   assert_success
 
   run ddev config --project-type=drupal10 --docroot=web
@@ -109,6 +112,7 @@ teardown() {
 
 @test "Drupal 11 git based quickstart with $(ddev --version)" {
   _skip_if_embargoed "drupal11-git"
+  PROJNAME=my-drupal11-site
 
   PROJECT_GIT_URL=https://github.com/ddev/test-drupal11.git
   run git clone ${PROJECT_GIT_URL} ${PROJNAME}
@@ -142,8 +146,9 @@ teardown() {
 
 @test "Drupal CMS composer quickstart with $(ddev --version)" {
   _skip_if_embargoed "drupal-cms-composer"
+  PROJNAME=my-drupalcms-site
 
-  run mkdir my-drupal-site && cd my-drupal-site
+  run mkdir -p my-drupalcms-site && cd my-drupalcms-site
   assert_success
 
   run ddev config --project-type=drupal11 --docroot=web

--- a/docs/tests/ee.bats
+++ b/docs/tests/ee.bats
@@ -13,8 +13,9 @@ teardown() {
 
 @test "Expression Engine Zip File Download quickstart with $(ddev --version)" {
   _skip_if_embargoed "ee-zip"
+  PROJNAME=my-ee-zip-site
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   # Download the latest version of Expression Engine
@@ -72,8 +73,9 @@ teardown() {
 
 @test "Expression Engine Git Clone quickstart with $(ddev --version)" {
   _skip_if_embargoed "ee-git"
+  PROJNAME=my-ee-git-site
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run git clone --depth=1 https://github.com/ExpressionEngine/ExpressionEngine .

--- a/docs/tests/generic.bats
+++ b/docs/tests/generic.bats
@@ -15,7 +15,7 @@ teardown() {
   _skip_if_embargoed "generic-php"
 
   GENERIC_SITENAME=${PROJNAME}
-  run mkdir ${GENERIC_SITENAME} && cd ${GENERIC_SITENAME}
+  run mkdir -p ${GENERIC_SITENAME} && cd ${GENERIC_SITENAME}
   assert_success
 
   run ddev config --project-type=php

--- a/docs/tests/grav.bats
+++ b/docs/tests/grav.bats
@@ -13,8 +13,9 @@ teardown() {
 
 @test "Grav Composer quickstart with $(ddev --version)" {
   _skip_if_embargoed "grav-composer"
+  PROJNAME=my-grav-composer-site
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --php-version=8.3 --omit-containers=db
@@ -44,8 +45,9 @@ teardown() {
 
 @test "Grav Git Clone quickstart with $(ddev --version)" {
   _skip_if_embargoed "grav-git"
+  PROJNAME=my-grav-git-site
 
-  run mkdir my-grav-site && cd my-grav-site
+  run mkdir -p my-grav-git-site && cd my-grav-git-site
   assert_success
 
   run git clone -b master https://github.com/getgrav/grav.git .

--- a/docs/tests/ibexa.bats
+++ b/docs/tests/ibexa.bats
@@ -14,22 +14,17 @@ teardown() {
 @test "Ibexa DXP quickstart with $(ddev --version)" {
   _skip_if_embargoed "ibexa-composer"
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  # mkdir -p ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
   run ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create-project ibexa/oss-skeleton
   run ddev composer create-project ibexa/oss-skeleton
   assert_success
-  # ddev exec console ibexa:install --no-interaction
   run ddev exec console ibexa:install --no-interaction
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch /admin/login
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin/login"
   assert_success

--- a/docs/tests/joomla.bats
+++ b/docs/tests/joomla.bats
@@ -14,8 +14,7 @@ teardown() {
 @test "Joomla quickstart with $(ddev --version)" {
   _skip_if_embargoed "joomla-zip"
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
   # Download the latest version of Joomla
   run _github_release_download "joomla/joomla-cms" "^Joomla.*Stable-Full_Package\\.zip$" "joomla.zip"
@@ -23,16 +22,12 @@ teardown() {
   # unzip joomla.zip && rm -f joomla.zip
   run unzip joomla.zip && rm -f joomla.zip
   assert_success
-  # ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
   run ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="Administrator" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@example.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
   run ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="Administrator" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@example.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch /administrator/
   assert_output "FULLURL https://${PROJNAME}.ddev.site/administrator/"
   assert_success

--- a/docs/tests/kirby.bats
+++ b/docs/tests/kirby.bats
@@ -14,19 +14,15 @@ teardown() {
 @test "Kirby new project quickstart with $(ddev --version)" {
   _skip_if_embargoed "kirby-composer"
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  # ddev config --omit-containers=db --webserver-type=apache-fpm
   run ddev config --omit-containers=db --webserver-type=apache-fpm
   assert_success
 
-  # ddev start -y
   run ddev start -y
   assert_success
 
-  # ddev composer create-project getkirby/starterkit
   run ddev composer create-project getkirby/starterkit
   assert_success
 

--- a/docs/tests/laravel.bats
+++ b/docs/tests/laravel.bats
@@ -13,8 +13,9 @@ teardown() {
 
 @test "Laravel composer based quickstart with $(ddev --version)" {
   _skip_if_embargoed "laravel-composer"
+  PROJNAME=my-laravel-composer-site
 
-  run mkdir my-laravel-site && cd my-laravel-site
+  run mkdir -p my-laravel-composer-site && cd my-laravel-composer-site
   assert_success
 
   run ddev config --project-type=laravel --docroot=public
@@ -47,8 +48,9 @@ teardown() {
 
 @test "Laravel composer (SQLite) based quickstart with $(ddev --version)" {
   _skip_if_embargoed "laravel-composer-sqlite"
+  PROJNAME=my-laravel-sqlite-site
 
-  run mkdir my-laravel-site && cd my-laravel-site
+  run mkdir -p my-laravel-sqlite-site && cd my-laravel-sqlite-site
   assert_success
 
   run ddev config --project-type=laravel --docroot=public --omit-containers=db
@@ -81,8 +83,9 @@ teardown() {
 
 @test "Laravel installer quickstart with $(ddev --version)" {
   _skip_if_embargoed "laravel-installer"
+  PROJNAME=my-laravel-installer-site
 
-  run mkdir my-laravel-site && cd my-laravel-site
+  run mkdir -p my-laravel-installer-site && cd my-laravel-installer-site
   assert_success
 
   run ddev config --project-type=laravel --docroot=public

--- a/docs/tests/magento2.bats
+++ b/docs/tests/magento2.bats
@@ -18,7 +18,7 @@ teardown() {
     skip "MAGENTO2_PUBLIC_ACCESS_KEY not provided (forked PR)"
   fi
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management

--- a/docs/tests/moodle.bats
+++ b/docs/tests/moodle.bats
@@ -14,20 +14,16 @@ teardown() {
 @test "Moodle quickstart with $(ddev --version)" {
   _skip_if_embargoed "moodle-composer"
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
   run ddev config --docroot=public --webserver-type=apache-fpm
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create-project moodle/moodle
   run ddev composer create-project moodle/moodle
   assert_success
   run ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch /login
   assert_output "FULLURL https://${PROJNAME}.ddev.site/login"
   assert_success

--- a/docs/tests/nodejs.bats
+++ b/docs/tests/nodejs.bats
@@ -15,7 +15,7 @@ teardown() {
   _skip_if_embargoed "nodejs-express"
 
   NODEJS_SITENAME=${PROJNAME}
-  run mkdir ${NODEJS_SITENAME} && cd ${NODEJS_SITENAME}
+  run mkdir -p ${NODEJS_SITENAME} && cd ${NODEJS_SITENAME}
   assert_success
 
   run ddev config --project-type=generic --webserver-type=generic
@@ -49,13 +49,12 @@ EOF
   assert_success
 
   # Diagnostic: show traefik config files in volume
-  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
-  echo "# Traefik config files: $output"
+#  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
+#  echo "# Traefik config files: $output"
   # Diagnostic: show traefik router API response (just router names)
-  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
-  echo "# Traefik routers: $output"
+#  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
+#  echo "# Traefik routers: $output"
 
-  # ddev launch
   DDEV_DEBUG=true run ddev launch
   assert_success
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
@@ -72,11 +71,11 @@ EOF
   echo "# Existing containers: $output" >&3
 
   # Diagnostic: show traefik config files in volume
-  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
-  echo "# Traefik config files: $output" >&3
+#  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
+#  echo "# Traefik config files: $output" >&3
   # Diagnostic: show traefik router API response (just router names)
-  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
-  echo "# Traefik routers: $output"
+#  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
+#  echo "# Traefik routers: $output"
 
   # validate running project
   run curl -sfv https://${PROJNAME}.ddev.site

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -13,8 +13,9 @@ teardown() {
 
 @test "OpenMage git based quickstart with $(ddev --version)" {
   _skip_if_embargoed "openmage-git"
+  PROJNAME=my-openmage-git-site
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run git clone --depth=1 https://github.com/OpenMage/magento-lts .
@@ -59,8 +60,9 @@ teardown() {
 
 @test "OpenMage composer based quickstart with $(ddev --version)" {
   _skip_if_embargoed "openmage-composer"
+  PROJNAME=my-openmage-composer-site
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=magento --docroot=public_test --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1

--- a/docs/tests/pimcore.bats
+++ b/docs/tests/pimcore.bats
@@ -16,16 +16,12 @@ teardown() {
 
   skip "Pimcore requires a license key"
 
-  # mkdir -p ${PROJNAME} && cd ${PROJNAME}
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
   run ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create-project pimcore/skeleton
   run ddev composer create-project pimcore/skeleton
   assert_success
   run ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin
@@ -39,10 +35,8 @@ teardown() {
        command: 'while true; do /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update --memory-limit=250M --time-limit=3600; done'
        directory: /var/www/html" >.ddev/config.pimcore.yaml
   assert_success
-  # ddev restart -y
   run ddev restart -y
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch /admin
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin"
   assert_success

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -13,8 +13,9 @@ teardown() {
 
 @test "processwire zipball with $(ddev --version)" {
   _skip_if_embargoed "processwire-zip"
+  PROJNAME=my-processwire-zip-site
 
-  run mkdir -p my-processwire-site && cd my-processwire-site
+  run mkdir -p my-processwire-zip-site && cd my-processwire-zip-site
   assert_success
   run _curl_github -LJOf https://github.com/processwire/processwire/archive/master.zip
   assert_success
@@ -29,11 +30,11 @@ teardown() {
   assert_success
 
   # Diagnostic: show traefik config files in volume
-  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
-  echo "# Traefik config files: $output"
+#  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
+#  echo "# Traefik config files: $output"
   # Diagnostic: show traefik router API response (just router names)
-  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
-  echo "# Traefik routers: $output"
+#  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
+#  echo "# Traefik routers: $output"
 
   run bash -c '
   docker ps -q \
@@ -63,29 +64,25 @@ teardown() {
 
 @test "processwire composer with $(ddev --version)" {
   _skip_if_embargoed "processwire-composer"
+  PROJNAME=my-processwire-composer-site
 
-  # mkdir my-processwire-site && cd my-processwire-site
-  run mkdir -p my-processwire-site && cd my-processwire-site
+  run mkdir -p my-processwire-composer-site && cd my-processwire-composer-site
   assert_success
-  # ddev config --project-type=php --webserver-type=apache-fpm
   run ddev config --project-type=php --webserver-type=apache-fpm
   assert_success
-  # ddev start -y
   DDEV_DEBUG=true run ddev start -y
   assert_success
-  # ddev composer create-project "processwire/processwire:^3"
   run ddev composer create-project "processwire/processwire:^3"
-  # ddev launch
   DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 
   # Diagnostic: show traefik config files in volume
-  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
-  echo "# Traefik config files: $output"
-  # Diagnostic: show traefik router API response (just router names)
-  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
-  echo "# Traefik routers: $output"
+#  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
+#  echo "# Traefik config files: $output"
+#  # Diagnostic: show traefik router API response (just router names)
+#  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
+#  echo "# Traefik routers: $output"
 
   # validate running project
   run curl -sfIv https://${PROJNAME}.ddev.site

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -14,7 +14,7 @@ teardown() {
 @test "Shopware Composer based quickstart with $(ddev --version)" {
   _skip_if_embargoed "shopware-composer"
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=shopware6 --docroot=public

--- a/docs/tests/silverstripe.bats
+++ b/docs/tests/silverstripe.bats
@@ -13,8 +13,9 @@ teardown() {
 
 @test "Silverstripe CMS Composer quickstart with $(ddev --version)" {
   _skip_if_embargoed "silverstripe-composer"
+  PROJNAME=my-silverstripe-composer-site
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=silverstripe --docroot=public

--- a/docs/tests/statamic.bats
+++ b/docs/tests/statamic.bats
@@ -13,16 +13,14 @@ teardown() {
 
 @test "Statamic Composer quickstart with $(ddev --version)" {
   _skip_if_embargoed "statamic-composer"
+  PROJNAME=my-statamic-composer-site
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  # ddev config --project-type=laravel --docroot=public
   run ddev config --project-type=laravel --docroot=public
   assert_success
 
-  # ddev composer create-project --prefer-dist statamic/statamic
   run ddev composer create-project --prefer-dist statamic/statamic
   assert_success
 

--- a/docs/tests/sulu.bats
+++ b/docs/tests/sulu.bats
@@ -14,41 +14,30 @@ teardown() {
 @test "Sulu quickstart with $(ddev --version)" {
   _skip_if_embargoed "sulu-composer"
 
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
   run ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
   assert_success
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create-project sulu/skeleton
   run ddev composer create-project sulu/skeleton
   assert_success
-  # export SULU_PROJECT_NAME="My Sulu Site"
   export SULU_PROJECT_NAME="My Sulu Site"
   assert_success
-  # export SULU_PROJECT_KEY="${PROJNAME}"
   export SULU_PROJECT_KEY="${PROJNAME}"
   assert_success
-  # export SULU_PROJECT_CONFIG_FILE="config/webspaces/my-sulu-site.xml"
   export SULU_PROJECT_CONFIG_FILE="config/webspaces/${PROJNAME}.xml"
   assert_success
-  # ddev exec "mv config/webspaces/website.xml ${SULU_PROJECT_CONFIG_FILE}"
   run ddev exec "mv config/webspaces/website.xml ${SULU_PROJECT_CONFIG_FILE}"
   assert_success
-  # ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 's|<key>.*</key>|<key>${SULU_PROJECT_KEY}</key>|g' ${SULU_PROJECT_CONFIG_FILE}"
   run ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 's|<key>.*</key>|<key>${SULU_PROJECT_KEY}</key>|g' ${SULU_PROJECT_CONFIG_FILE}"
   assert_success
   # Set APP_ENV and DATABASE_URL in .env.local
-  # ddev dotenv set .env.local --app-env=dev --database-url="mysql://db:db@db:3306/db?serverVersion=8.0&charset=utf8mb4"
   run ddev dotenv set .env.local --app-env=dev --database-url="mysql://db:db@db:3306/db?serverVersion=8.0&charset=utf8mb4"
   assert_success
-  # ddev exec bin/adminconsole sulu:build dev --no-interaction
   run ddev exec bin/adminconsole sulu:build dev --no-interaction
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch /admin
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/admin"
   assert_success

--- a/docs/tests/sveltekit.bats
+++ b/docs/tests/sveltekit.bats
@@ -15,7 +15,7 @@ teardown() {
   _skip_if_embargoed "sveltekit-demo"
 
   SVELTEKIT_SITENAME=${PROJNAME}
-  run mkdir ${SVELTEKIT_SITENAME} && cd ${SVELTEKIT_SITENAME}
+  run mkdir -p ${SVELTEKIT_SITENAME} && cd ${SVELTEKIT_SITENAME}
   assert_success
 
   run ddev config --project-type=generic --webserver-type=generic

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -13,8 +13,9 @@ teardown() {
 
 @test "Symfony Composer quickstart with $(ddev --version)" {
   _skip_if_embargoed "symfony-composer"
+  PROJNAME=my-symfony-composer-site
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=symfony --docroot=public --php-version=8.3
@@ -47,8 +48,9 @@ teardown() {
 
 @test "Symfony CLI quickstart with $(ddev --version)" {
   _skip_if_embargoed "symfony-cli"
+  PROJNAME=my-symfony-cli-site
 
-  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=symfony --docroot=public

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -192,7 +192,7 @@ teardown() {
 @test "TYPO3 XHGui composer test with $(ddev --version)" {
   _skip_if_embargoed "typo3-xhgui"
 
-  run mkdir my-typo3-site && cd my-typo3-site
+  run mkdir -p my-typo3-site && cd my-typo3-site
   assert_success
 
   run ddev config --project-type=typo3 --docroot=public --xhprof-mode=xhgui

--- a/docs/tests/wagtail.bats
+++ b/docs/tests/wagtail.bats
@@ -15,7 +15,7 @@ teardown() {
   _skip_if_embargoed "wagtail-gunicorn"
 
   WAGTAIL_SITENAME=${PROJNAME}
-  run mkdir ${WAGTAIL_SITENAME} && cd ${WAGTAIL_SITENAME}
+  run mkdir -p ${WAGTAIL_SITENAME} && cd ${WAGTAIL_SITENAME}
   assert_success
 
   run ddev config --project-type=generic --webserver-type=generic \

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -13,145 +13,125 @@ teardown() {
 
 @test "WordPress wp-cli based quickstart with $(ddev --version)" {
   _skip_if_embargoed "wordpress-cli"
+  PROJNAME=my-wp-cli-site
 
-  # mkdir my-wp-site && cd my-wp-site
-  run mkdir my-wp-site && cd my-wp-site
+  run mkdir -p my-wp-cli-site && cd my-wp-cli-site
   assert_success
-  # ddev config --project-type=wordpress
   run ddev config --project-type=wordpress
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev wp core download
   run ddev wp core download
   assert_success
   run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp 'link:.*my-wp-site\.ddev\.site.*rel="https://api\.w\.org/"'
+  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
-  assert_output --partial "location: https://my-wp-site.ddev.site/wp-login.php"
+  assert_output --partial "location: https://${PROJNAME}.ddev.site/wp-login.php"
   assert_output --partial "HTTP/2 302"
   assert_success
 }
 
 @test "WordPress wp-cli based quickstart (different docroot) with $(ddev --version)" {
   _skip_if_embargoed "wordpress-cli-docroot"
+  PROJNAME=my-wp-docroot-site
 
-  # mkdir my-wp-site && cd my-wp-site
-  run mkdir my-wp-site && cd my-wp-site
+  # mkdir -p my-wp-docroot-site && cd my-wp-docroot-site
+  run mkdir -p my-wp-docroot-site && cd my-wp-docroot-site
   assert_success
-  # ddev config --project-type=wordpress --docroot=web/wp
   run ddev config --project-type=wordpress --docroot=web/wp
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev wp core download
   run ddev wp core download
   assert_success
-  # ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp 'link:.*my-wp-site\.ddev\.site.*rel="https://api\.w\.org/"'
+  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
-  assert_output --partial "location: https://my-wp-site.ddev.site/wp-login.php"
+  assert_output --partial "location: https://${PROJNAME}.ddev.site/wp-login.php"
   assert_output --partial "HTTP/2 302"
   assert_success
 }
 
 @test "WordPress Bedrock based quickstart with $(ddev --version)" {
   _skip_if_embargoed "wordpress-bedrock"
+  PROJNAME=my-wp-bedrock-site
 
-  # mkdir my-wp-site && cd my-wp-site
-  run mkdir my-wp-site && cd my-wp-site
+  run mkdir -p my-wp-bedrock-site && cd my-wp-bedrock-site
   assert_success
-  # ddev config --project-type=wordpress --docroot=web
   run ddev config --project-type=wordpress --docroot=web
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create-project roots/bedrock
   run ddev composer create-project roots/bedrock
   assert_success
-  # cp .env.example .env
   run cp .env.example .env
   assert_success
   # Set database name to db in .env
-  # ddev dotenv set .env --db-name=db --db-user=db --db-password=db --db-host=db --wp-home=https://${PROJNAME}.ddev.site --wp-siteurl=https://${PROJNAME}.ddev.site/wp
   run ddev dotenv set .env --db-name=db --db-user=db --db-password=db --db-host=db --wp-home=https://${PROJNAME}.ddev.site --wp-siteurl=https://${PROJNAME}.ddev.site/wp
   assert_success
-  # ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp 'link:.*my-wp-site\.ddev\.site.*rel="https://api\.w\.org/"'
+  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
   # validate running project /wp-admin/
   # Some environments return 302 redirect to /wp/wp-admin/, others return 200
   run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
-  assert_line --regexp 'link:.*my-wp-site\.ddev\.site.*rel="https://api\.w\.org/"'
+  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
   assert_line --regexp 'HTTP/2 (200|302)'
   assert_success
 }
 
 @test "WordPress git based quickstart with $(ddev --version)" {
   _skip_if_embargoed "wordpress-git"
+  PROJNAME=my-wp-git-site
 
   # PROJECT_GIT_URL=https://github.com/ddev/test-wordpress.git
   PROJECT_GIT_URL=https://github.com/ddev/test-wordpress.git
-  # git clone ${PROJECT_GIT_URL} ${PROJNAME}
   run git clone ${PROJECT_GIT_URL} ${PROJNAME}
   assert_success
-  # cd my-typo3-site
   cd ${PROJNAME} || exit 2
   assert_success
-  # ddev config --project-type=wordpress
   run ddev config --project-type=wordpress
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
-  # ddev launch
   DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp 'link:.*my-wp-site\.ddev\.site.*rel="https://api\.w\.org/"'
+  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
   # validate running project /wp-admin
   run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
-  assert_output --partial "location: https://my-wp-site.ddev.site/wp-login.php?redirect_to=https%3A%2F%2Fmy-wp-site.ddev.site%2Fwp-admin%2F&reauth=1"
+  assert_output --partial "location: https://${PROJNAME}.ddev.site/wp-login.php?redirect_to=https%3A%2F%2F${PROJNAME}.ddev.site%2Fwp-admin%2F&reauth=1"
   assert_output --partial "HTTP/2 302"
   assert_success
 }


### PR DESCRIPTION


## The Issue

In testing, I often messed up by either using the quickstart script with an existing quickstart, `mkdir -p` would fail. Or I wouldn't be able to tell the difference between different variants that had the same name (all `my-drupal-project` for example)

## How This PR Solves The Issue

* Use `mkdir -p <dir>`
* Use descriptive name (`my-drupal11-site`, `my-drupalcms-site`)
* Remove a bunch of annoying comments from tests that didn't add value 

## Manual Testing Instructions

Take a quick read. See if it passes.

