### PR TITLE
docs: clarify usage for TUI

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -387,6 +387,14 @@ Whether to skip mounting project into web container.
 !!!warning "Advanced users only!"
     When `true`, project will not be mounted by DDEV into the web container. Enables experimentation with alternate file mounting strategies.
 
+## `no_tui`
+
+Whether to disable the TUI (terminal user interface) when running the `ddev` command without any arguments.
+
+| Type | Default | Usage
+| -- | -- | --
+| :octicons-globe-16: global | `false` | Can be `true` or `false`.
+
 ## `nodejs_version`
 
 Node.js version for the web container’s “system” version. [`n`](https://www.npmjs.com/package/n) tool is under the hood.

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -1,6 +1,6 @@
 # Using the `ddev` Command
 
-Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [commands](../usage/commands.md). There are commands to configure a project, start, stop, describe, etc. Each command also has help using `ddev help <command>` or `ddev command -h`. For example, `ddev help snapshot` will show help and examples for the snapshot command.
+Type `ddev help` or `ddev --help` or `ddev -h` in a terminal window to see the available DDEV [commands](../usage/commands.md). There are commands to configure a project, start, stop, describe, etc. Each command also has help using `ddev help <command>` or `ddev command -h`. For example, `ddev help snapshot` will show help and examples for the snapshot command.
 
 ## Interactive Dashboard
 
@@ -23,7 +23,7 @@ Running `ddev` with no arguments launches an interactive terminal dashboard. The
 | <kbd>?</kbd> | Show full help |
 | <kbd>q</kbd> | Quit |
 
-To disable the dashboard and show the classic help text instead, set [`no_tui: true`](../configuration/config.md) in your global configuration (`~/.ddev/global_config.yaml`), or set the environment variable `DDEV_NO_TUI=true`.
+To disable the dashboard and show the classic help text instead, set [`no_tui: true`](../configuration/config.md#no_tui) in your global configuration (`$HOME/.ddev/global_config.yaml`), or set the environment variable `DDEV_NO_TUI=true`.
 
 ### Terminal Compatibility
 
@@ -32,7 +32,7 @@ The dashboard automatically detects your terminal's color capabilities and adapt
 * **Disable colors**: Run `NO_COLOR=1 ddev` or `export NO_COLOR=1` in your shell. This follows the [NO_COLOR](https://no-color.org/) standard and disables all color output while keeping the dashboard functional.
 * **Use simple formatting globally**: Run `ddev config global --simple-formatting=true` to disable colors and table formatting across all DDEV commands, including the dashboard. See [`simple_formatting`](../configuration/config.md#simple_formatting).
 * **Set `TERM` appropriately**: If your terminal supports color but DDEV doesn't detect it, make sure your `TERM` environment variable is set correctly (e.g., `xterm-256color`). Some SSH clients or multiplexers like `tmux` or `screen` may need explicit configuration.
-* **Disable the dashboard entirely**: If the interactive dashboard doesn't work well in your environment (e.g., a very limited terminal or CI), use `DDEV_NO_TUI=true` or set `no_tui: true` in `~/.ddev/global_config.yaml` to fall back to the classic help output.
+* **Disable the dashboard entirely**: If the interactive dashboard doesn't work well in your environment (e.g., a very limited terminal or CI), use `DDEV_NO_TUI=true` or set [`no_tui: true`](../configuration/config.md#no_tui) in `$HOME/.ddev/global_config.yaml` to fall back to the classic help output.
 
 * [`ddev config`](../usage/commands.md#config) configures a project’s type and docroot, either interactively or with flags.
 * [`ddev start`](../usage/commands.md#start) starts up a project.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -2,10 +2,15 @@
 
 You can tell DDEV what to do by running its commands. This page details each of the available commands and their options, or flags.
 
-Run DDEV without any commands or flags to see this list in your terminal:
+!!!tip "Using TUI (Terminal UI)"
+    Running `ddev` without any arguments will launch the [interactive dashboard](../usage/cli.md#interactive-dashboard) in your terminal.
+
+    To disable the dashboard and show the classic help text instead, set [`no_tui: true`](../configuration/config.md#no_tui) in your global configuration (`$HOME/.ddev/global_config.yaml`), or set the environment variable `DDEV_NO_TUI=true`.
+
+Type `ddev help` or `ddev --help` or `ddev -h` to see this list in your terminal:
 
 ```
-→  ddev
+→  ddev help
 Create and maintain a local web development environment.
 Docs: https://docs.ddev.com
 Support: https://docs.ddev.com/en/stable/users/support
@@ -1432,6 +1437,17 @@ Example:
 ```shell
 # Open the current project’s database in TablePlus
 ddev tableplus
+```
+
+## `tui`
+
+Launch the [interactive TUI dashboard](../usage/cli.md#interactive-dashboard).
+
+Example:
+
+```shell
+# Launch DDEV TUI
+ddev tui
 ```
 
 ## `typo3`

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -395,6 +395,9 @@ func WriteGlobalConfig(config GlobalConfig) error {
 # no_bind_mounts: false
 # Whether to disable Docker bind mounts
 
+# no_tui: false
+# Whether to disable the TUI (terminal user interface) when running the 'ddev' command without arguments
+
 # omit_project_name_by_default: false
 # If true, 'ddev config' will not write a 'name'' field
 # in '.ddev/config.yaml' unless you use --name=NAME.

--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -93,6 +93,10 @@
       "description": "Whether to not use Docker bind mounts.",
       "type": "boolean"
     },
+    "no_tui": {
+      "description": "Whether to disable the TUI (terminal user interface) when running the \"ddev\" command without arguments.",
+      "type": "boolean"
+    },
     "omit_containers": {
       "description": "List of container types that should not be started when the project is started.",
       "type": "array",


### PR DESCRIPTION
## The Issue

We still say to use `ddev` without arguments in several places, but it's replaced by TUI.

## How This PR Solves The Issue

- Clarifies `ddev` / `ddev help` usage
- Adds missing `ddev tui` to the docs
- Adds missing `no_tui` option in the config docs
- Adds missing `no_tui` to the global `schema.json`

## Manual Testing Instructions

- https://ddev--8203.org.readthedocs.build/en/8203/users/usage/commands/#tui
- https://ddev--8203.org.readthedocs.build/en/8203/users/configuration/config/#no_tui

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
