### PR TITLE
feat: support bare variable names in web_environment for host env passthrough

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -89,6 +89,13 @@ You can set custom environment variables in several places:
         - MY_OTHER_ENV_VAR=someotherval
     ```
 
+    You can also pass through a variable from the host environment by listing just the variable name without a value. DDEV passes the bare name to docker-compose, which resolves it from the host at container start time:
+
+    ```yaml
+    web_environment:
+        - MY_HOST_VAR
+    ```
+
 If you’d rather use the CLI to set the project or global `web_environment` value, you can use the [`ddev config`](../usage/commands.md#config) command:
 
 ```sh

--- a/pkg/ddevapp/config_merge.go
+++ b/pkg/ddevapp/config_merge.go
@@ -1,7 +1,6 @@
 package ddevapp
 
 import (
-	"fmt"
 	"strings"
 
 	"dario.cat/mergo"
@@ -46,24 +45,22 @@ func (app *DdevApp) mergeAdditionalConfigIntoApp(configPath string) error {
 	return nil
 }
 
-// EnvToUniqueEnv() makes sure that only the last occurrence of an env (NAME=val)
-// slice is actually retained.
+// EnvToUniqueEnv() makes sure that only the last occurrence of an env (NAME=val or bare NAME)
+// slice is actually retained. Bare variable names without a value (e.g. "MY_VAR") are passed
+// through as-is; docker-compose resolves them from the host environment at container start time.
 func EnvToUniqueEnv(inSlice *[]string) []string {
 	mapStore := map[string]string{}
-	newSlice := []string{}
 
 	for _, s := range *inSlice {
-		// config.yaml vars look like ENV1=val1 and ENV2=val2
-		// Split them and then make sure the last one wins
-		k, v, found := strings.Cut(s, "=")
-		// If we didn't find the "=" delimiter, it wasn't an env
-		if !found {
-			continue
-		}
-		mapStore[k] = v
+		// Both "KEY=value" and bare "KEY" are supported.
+		// strings.Cut returns the part before "=" as the key in both cases.
+		// Last entry for a given key wins.
+		k, _, _ := strings.Cut(s, "=")
+		mapStore[k] = s
 	}
-	for k, v := range mapStore {
-		newSlice = append(newSlice, fmt.Sprintf("%s=%v", k, v))
+	newSlice := make([]string, 0, len(mapStore))
+	for _, v := range mapStore {
+		newSlice = append(newSlice, v)
 	}
 	if len(newSlice) == 0 {
 		return nil

--- a/pkg/ddevapp/config_merge_test.go
+++ b/pkg/ddevapp/config_merge_test.go
@@ -181,10 +181,19 @@ func TestEnvToUniqueEnv(t *testing.T) {
 
 	testBedSources := [][]string{
 		{"ONE=one", "ONE=two", "ONE=three", "TWO=two", "TWO=three", "TWO=four"},
+		// Bare variable names (no =value) should pass through for host env lookup by docker-compose
+		{"BARE_VAR", "KEY=value"},
+		// A later KEY=value entry should override an earlier bare KEY entry
+		{"MYVAR", "MYVAR=explicit"},
+		// A later bare KEY entry should override an earlier KEY=value entry
+		{"MYVAR=explicit", "MYVAR"},
 	}
 
 	testBedExpectations := [][]string{
 		{"ONE=three", "TWO=four"},
+		{"BARE_VAR", "KEY=value"},
+		{"MYVAR=explicit"},
+		{"MYVAR"},
 	}
 
 	for i := 0; i < len(testBedSources); i++ {


### PR DESCRIPTION
## The Issue

`web_environment` and `db_environment` entries without a value (e.g. `- MY_VAR`) were silently dropped by `EnvToUniqueEnv`, so docker-compose's host environment passthrough feature never worked, even though docker-compose supports it natively.

## How This PR Solves The Issue

`EnvToUniqueEnv` now stores the full original entry string keyed by variable name, rather than requiring `=` to be present. Bare names pass through as-is to docker-compose, which resolves them from the host environment at container start time. The `fmt` import is removed as it is no longer needed.

Test cases are added for bare variable names and for override precedence (last entry wins regardless of whether it is bare or `KEY=value`).

Documentation in `customization-extendibility.md` is updated to describe the bare variable passthrough syntax.

## Manual Testing Instructions

- Add a bare variable name to `web_environment` in `.ddev/config.yaml`:
  ```yaml
  web_environment:
    - MY_HOST_VAR
  ```
- Set `MY_HOST_VAR=hello` in the host shell
- Run `ddev restart && ddev exec env | grep MY_HOST_VAR`
- Expect: `MY_HOST_VAR=hello`

## Automated Testing Overview

`TestEnvToUniqueEnv` in `pkg/ddevapp/config_merge_test.go` is extended with cases for bare variable names and override precedence.

## Release/Deployment Notes

Backwards compatible. Existing `KEY=value` entries are unaffected.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>