### PR TITLE
fix: prevent path traversal (ZipSlip) in Untar and Unzip

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -234,6 +234,11 @@ func Untar(source string, dest string, extractionDir string) error {
 
 		fullPath := filepath.Join(dest, file.Name)
 
+		// Prevent path traversal (ZipSlip): ensure fullPath stays within dest
+		if !strings.HasPrefix(filepath.Clean(fullPath)+string(os.PathSeparator), filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("archive entry %q escapes destination directory", file.Name)
+		}
+
 		// Handle directories, regular files, and symlinks
 		switch file.Typeflag {
 		case tar.TypeDir:
@@ -282,6 +287,20 @@ func Untar(source string, dest string, extractionDir string) error {
 			err = os.MkdirAll(fullPathDir, 0755)
 			if err != nil {
 				return fmt.Errorf("failed to create the directory %s, err: %v", fullPathDir, err)
+			}
+
+			// Validate symlink target doesn't escape dest.
+			// Absolute targets are rebased against dest (treating dest as root),
+			// so container paths like /var/www/html/... are accepted.
+			// Relative targets are resolved against the symlink's parent directory.
+			var resolvedTarget string
+			if filepath.IsAbs(file.Linkname) {
+				resolvedTarget = filepath.Join(dest, file.Linkname)
+			} else {
+				resolvedTarget = filepath.Join(fullPathDir, file.Linkname)
+			}
+			if !strings.HasPrefix(filepath.Clean(resolvedTarget)+string(os.PathSeparator), filepath.Clean(dest)+string(os.PathSeparator)) {
+				return fmt.Errorf("symlink target %q in archive entry %q escapes destination directory", file.Linkname, file.Name)
 			}
 
 			// Remove any existing file/symlink at this path
@@ -340,6 +359,11 @@ func Unzip(source string, dest string, extractionDir string) error {
 		}
 
 		fullPath := filepath.Join(dest, file.Name)
+
+		// Prevent path traversal (ZipSlip): ensure fullPath stays within dest
+		if !strings.HasPrefix(filepath.Clean(fullPath)+string(os.PathSeparator), filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("archive entry %q escapes destination directory", file.Name)
+		}
 
 		if strings.HasSuffix(file.Name, "/") {
 			err = os.MkdirAll(fullPath, 0777)

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -2,6 +2,7 @@ package archive_test
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"io"
 	"io/fs"
@@ -172,6 +173,93 @@ func TestDownloadAndExtractTarball(t *testing.T) {
 	require.FileExists(t, path.Join(dir, "install.yaml"))
 	cleanup()
 	require.NoDirExists(t, dir)
+}
+
+// TestUntarPathTraversal verifies that path traversal attempts in tar archives are rejected
+func TestUntarPathTraversal(t *testing.T) {
+	destDir := testcommon.CreateTmpDir(t.Name())
+	t.Cleanup(func() { _ = os.RemoveAll(destDir) })
+
+	buildTar := func(entryName string, linkname string, typeflag byte) string {
+		f, err := os.CreateTemp("", t.Name()+"_*.tar.gz")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+
+		gw := gzip.NewWriter(f)
+		tw := tar.NewWriter(gw)
+
+		hdr := &tar.Header{
+			Name:     entryName,
+			Typeflag: typeflag,
+			Linkname: linkname,
+			Mode:     0644,
+			Size:     0,
+		}
+		if typeflag == tar.TypeReg {
+			hdr.Size = 5
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		if typeflag == tar.TypeReg {
+			_, err = tw.Write([]byte("hello"))
+			require.NoError(t, err)
+		}
+		require.NoError(t, tw.Close())
+		require.NoError(t, gw.Close())
+		require.NoError(t, f.Close())
+		return f.Name()
+	}
+
+	t.Run("traversal_in_file_path", func(t *testing.T) {
+		tarball := buildTar("../../traversal_file.txt", "", tar.TypeReg)
+		err := archive.Untar(tarball, destDir, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "escapes destination directory")
+	})
+
+	t.Run("traversal_in_symlink_target", func(t *testing.T) {
+		tarball := buildTar("link.txt", "../../outside.txt", tar.TypeSymlink)
+		err := archive.Untar(tarball, destDir, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "escapes destination directory")
+	})
+
+	t.Run("absolute_symlink_target_with_traversal", func(t *testing.T) {
+		// Absolute path with .. traversal that escapes dest even when rebased
+		tarball := buildTar("link.txt", "/../../../etc/passwd", tar.TypeSymlink)
+		err := archive.Untar(tarball, destDir, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "escapes destination directory")
+	})
+
+	t.Run("absolute_symlink_container_path_allowed", func(t *testing.T) {
+		// Absolute container paths like /var/www/html/... should be allowed
+		tarball := buildTar("link.txt", "/var/www/html/lib/web/underscore.js", tar.TypeSymlink)
+		err := archive.Untar(tarball, destDir, "")
+		require.NoError(t, err)
+	})
+}
+
+// TestUnzipPathTraversal verifies that path traversal attempts in zip archives are rejected
+func TestUnzipPathTraversal(t *testing.T) {
+	destDir := testcommon.CreateTmpDir(t.Name())
+	t.Cleanup(func() { _ = os.RemoveAll(destDir) })
+
+	// Build a zip with a traversal entry
+	zipFile, err := os.CreateTemp("", t.Name()+"_*.zip")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(zipFile.Name()) })
+
+	zw := zip.NewWriter(zipFile)
+	w, err := zw.Create("../../traversal_file.txt")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("pwned"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, zipFile.Close())
+
+	err = archive.Unzip(zipFile.Name(), destDir, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "escapes destination directory")
 }
 
 // TestUntarSymlinks tests that symlinks are properly extracted from tarballs


### PR DESCRIPTION
## The Issue

- Fixes GHSA-x2xq-qhjf-5mvg

`filepath.Join(dest, file.Name)` resolves `../` sequences, allowing a crafted archive entry to write files outside the intended destination directory. Symlink targets in tar archives had the same issue.

The affected functions are used in `ddev import-db`, `ddev import-files`, and all CMS-specific file import handlers — a realistic attack vector when a developer receives a database dump or file archive from an untrusted or compromised source.

## How This PR Solves The Issue

Added path containment checks to both `Untar()` and `Unzip()` in `pkg/archive/archive.go`:

1. After computing `fullPath`, verify `filepath.Clean(fullPath)` is prefixed by `filepath.Clean(dest)+/`. Any entry that escapes the destination returns an error immediately.
2. For symlinks in tar archives, resolve the link target (relative targets resolved against the symlink parent directory; absolute targets used as-is) and apply the same containment check.

## Manual Testing Instructions

Run the new tests:

```
go test -v -run 'TestUntarPathTraversal|TestUnzipPathTraversal' ./pkg/archive/
```

## Automated Testing Overview

- `TestUntarPathTraversal`: three subtests covering `../` in file path, `../` in symlink target, and absolute symlink target outside dest
- `TestUnzipPathTraversal`: verifies zip traversal is blocked
- All existing archive tests continue to pass

## Release/Deployment Notes

Any archive containing entries that escape the destination directory will now return an error instead of writing outside it. Legitimate archives are unaffected.