### PR TITLE
test(quickstart): pause d12 bats test in github actions

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -35,7 +35,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Add tests you want to skip here, delimited by commas
+  # Add tests you want to skip here, delimited by pipe (e.g., symfony-composer|symfony-cli)
   # Search for _skip_if_embargoed to see how this is used
   DDEV_EMBARGO_TESTS: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || 'drupal12-composer' }}
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

https://github.com/ddev/ddev/actions/runs/22920482553/job/66532492775

```
not ok 10 Drupal 12 quickstart with ddev version v1.25.1-19-g686548242
# (from function `assert_success' in file /home/linuxbrew/.linuxbrew/lib/bats-assert/src/assert_success.bash, line 42,
#  in test file docs/tests/drupal.bats, line 31)
#   `assert_success' failed
# Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
#
# -- command failed --
# status : 1
# output (83 lines):
#   ./composer.json has been updated
#   Running composer update drush/drush
#   Loading composer repositories with package information
#   Updating dependencies
#   Your requirements could not be resolved to an installable set of packages.
#
#     Problem 1
#       - Root composer.json requires drupal/core-recommended ^12 -> satisfiable by drupal/core-recommended[12.x-dev (alias of dev-main)].
#       - Root composer.json requires drush/drush * -> satisfiable by drush/drush[dev-cim-module-install-req, ..., dev-php8, 6.0.0-rc1, ..., 6.x-dev, 7.0.0-alpha1, ..., 7.x-dev, 8.0.0-beta11, ..., 8.x-dev, 9.0.0-alpha1, ..., 9.x-dev, 10.0.0-alpha1, ..., 10.x-dev, 11.0.0-rc1, ..., 11.x-dev, 12.0.0-beta1, ..., 12.x-dev, 13.0.0-beta1, ..., 13.x-dev, 14.x-dev].
#       - drupal/core 12.x-dev conflicts with drush/drush 6.7.0.
#       - drupal/core 12.x-dev conflicts with drush/drush 6.1.0.
#       - drupal/core-recommended dev-main requires drupal/core 12.x-dev -> satisfiable by drupal/core[12.x-dev (alias of dev-main)].
#       - drush/drush[dev-inf-admin, dev-master, dev-greg-1-anderson-robo-2-partII, dev-robo-2, 9.0.0-beta8, ..., 9.x-dev, 10.0.0-alpha1, ..., 10.3.5] require composer/semver ^1.4 -> found composer/semver[1.4.0, ..., 1.x-dev] but the package is fixed to 3.4.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-reenable-cache-commands-testing, ..., dev-php8, 7.2.0, ..., 7.x-dev, 8.0.2, ..., 8.x-dev, 9.0.0-alpha1, ..., 9.0.0-beta7, 10.3.6, ..., 10.x-dev, 11.0.0-rc1, ..., 11.0.5] require psr/log ~1.0 -> found psr/log[1.0.0, ..., 1.1.4] but the package is fixed to 3.0.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-deprecate-global-config-cmds, dev-ignore-commands-in-parent, dev-no-irc, dev-single-autoloader-only, dev-d10-low-tests, dev-test-74, 11.0.6, ..., 11.x-dev] require symfony/event-dispatcher ^4.0 || ^5.0 || ^6.0 -> found symfony/event-dispatcher[v4.0.0-BETA1, ..., 4.4.x-dev, v5.0.0-BETA1, ..., 5.4.x-dev, v6.0.0-BETA1, ..., 6.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-cim-module-install-req, dev-cmds-to-static-create, dev-deprecate-io-trait, dev-si-with-recipes-12x, dev-config-check-12.x, dev-weitzman-patch-1, 12.0.0-beta1, ..., 12.x-dev] require symfony/event-dispatcher ^6 -> found symfony/event-dispatcher[v6.0.0-BETA1, ..., 6.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-revert-drush-bash-script, dev-requirements-compat, dev-requirements-deprecation, dev-test-on-8.4, dev-chunk/changes-1772775428089-1772775428089, dev-zActions, dev-revert-6192-actions, dev-autowire-params, 13.0.0-beta1, ..., 13.x-dev, 14.x-dev] require symfony/event-dispatcher ^6 || ^7 -> found symfony/event-dispatcher[v6.0.0-BETA1, ..., 6.4.x-dev, v7.0.0-BETA1, ..., 7.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[7.0.0-alpha5, ..., 7.1.0, 8.0.0-beta11, ..., 8.0.0-rc2] require symfony/yaml ~2.2 -> found symfony/yaml[v2.2.0, ..., 2.8.x-dev] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[7.0.0-alpha1, ..., 7.0.0-alpha4] require symfony/yaml 2.2.1 -> found symfony/yaml[v2.2.1] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[8.0.0-rc3, ..., 8.0.1] require symfony/yaml 2.7.* -> found symfony/yaml[v2.7.0-BETA1, ..., 2.7.x-dev] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush dev-formatting-juggle requires consolidation/output-formatters dev-use-command-directly-of as 4.x-dev -> found consolidation/output-formatters[dev-fields-came-from-default, ..., dev-property-parser, 0.1.0, ..., 0.2.3, 1.0.0-beta1, ..., 1.x-dev, 2.0.0-beta1, ..., 2.1.3, 3.0.0, ..., 3.x-dev, 4.0.0, ..., 4.x-dev] but it does not match the constraint.
#       - drush/drush dev-table-empty-message requires consolidation/output-formatters dev-table-empty-message as 4.3.1 -> found consolidation/output-formatters[dev-fields-came-from-default, ..., dev-property-parser, 0.1.0, ..., 0.2.3, 1.0.0-beta1, ..., 1.x-dev, 2.0.0-beta1, ..., 2.1.3, 3.0.0, ..., 3.x-dev, 4.0.0, ..., 4.x-dev] but it does not match the constraint.
#       - drupal/core-recommended 12.x-dev is an alias of drupal/core-recommended dev-main and thus requires it to be installed too.
#
#   Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
#   You can also try re-running composer require with an explicit version constraint, e.g. "composer require drush/drush:*" to figure out if any version is installable, or "composer require drush/drush:^2.1" if you know which you need.
#
#   Installation failed, reverting ./composer.json and ./composer.lock to their original content.
#   Composer [require drush/drush] failed, composer command failed: composeCmd failed to run 'COMPOSE_PROJECT_NAME=ddev-my-drupal12-site docker-compose -f /home/runner/tmp/my-drupal-site.KFogYO/my-drupal12-site/.ddev/.ddev-docker-compose-full.yaml exec -w /var/www/html -T -e XDEBUG_MODE=off web composer require drush/drush', action='[exec -w /var/www/html -T -e XDEBUG_MODE=off web composer require drush/drush]', err='exit status 2', stdout='', stderr='./composer.json has been updated
#   Running composer update drush/drush
#   Loading composer repositories with package information
#   Updating dependencies
#   Your requirements could not be resolved to an installable set of packages.
#
#     Problem 1
#       - Root composer.json requires drupal/core-recommended ^12 -> satisfiable by drupal/core-recommended[12.x-dev (alias of dev-main)].
#       - Root composer.json requires drush/drush * -> satisfiable by drush/drush[dev-cim-module-install-req, ..., dev-php8, 6.0.0-rc1, ..., 6.x-dev, 7.0.0-alpha1, ..., 7.x-dev, 8.0.0-beta11, ..., 8.x-dev, 9.0.0-alpha1, ..., 9.x-dev, 10.0.0-alpha1, ..., 10.x-dev, 11.0.0-rc1, ..., 11.x-dev, 12.0.0-beta1, ..., 12.x-dev, 13.0.0-beta1, ..., 13.x-dev, 14.x-dev].
#       - drupal/core 12.x-dev conflicts with drush/drush 6.7.0.
#       - drupal/core 12.x-dev conflicts with drush/drush 6.1.0.
#       - drupal/core-recommended dev-main requires drupal/core 12.x-dev -> satisfiable by drupal/core[12.x-dev (alias of dev-main)].
#       - drush/drush[dev-inf-admin, dev-master, dev-greg-1-anderson-robo-2-partII, dev-robo-2, 9.0.0-beta8, ..., 9.x-dev, 10.0.0-alpha1, ..., 10.3.5] require composer/semver ^1.4 -> found composer/semver[1.4.0, ..., 1.x-dev] but the package is fixed to 3.4.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-reenable-cache-commands-testing, ..., dev-php8, 7.2.0, ..., 7.x-dev, 8.0.2, ..., 8.x-dev, 9.0.0-alpha1, ..., 9.0.0-beta7, 10.3.6, ..., 10.x-dev, 11.0.0-rc1, ..., 11.0.5] require psr/log ~1.0 -> found psr/log[1.0.0, ..., 1.1.4] but the package is fixed to 3.0.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-deprecate-global-config-cmds, dev-ignore-commands-in-parent, dev-no-irc, dev-single-autoloader-only, dev-d10-low-tests, dev-test-74, 11.0.6, ..., 11.x-dev] require symfony/event-dispatcher ^4.0 || ^5.0 || ^6.0 -> found symfony/event-dispatcher[v4.0.0-BETA1, ..., 4.4.x-dev, v5.0.0-BETA1, ..., 5.4.x-dev, v6.0.0-BETA1, ..., 6.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-cim-module-install-req, dev-cmds-to-static-create, dev-deprecate-io-trait, dev-si-with-recipes-12x, dev-config-check-12.x, dev-weitzman-patch-1, 12.0.0-beta1, ..., 12.x-dev] require symfony/event-dispatcher ^6 -> found symfony/event-dispatcher[v6.0.0-BETA1, ..., 6.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-revert-drush-bash-script, dev-requirements-compat, dev-requirements-deprecation, dev-test-on-8.4, dev-chunk/changes-1772775428089-1772775428089, dev-zActions, dev-revert-6192-actions, dev-autowire-params, 13.0.0-beta1, ..., 13.x-dev, 14.x-dev] require symfony/event-dispatcher ^6 || ^7 -> found symfony/event-dispatcher[v6.0.0-BETA1, ..., 6.4.x-dev, v7.0.0-BETA1, ..., 7.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[7.0.0-alpha5, ..., 7.1.0, 8.0.0-beta11, ..., 8.0.0-rc2] require symfony/yaml ~2.2 -> found symfony/yaml[v2.2.0, ..., 2.8.x-dev] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[7.0.0-alpha1, ..., 7.0.0-alpha4] require symfony/yaml 2.2.1 -> found symfony/yaml[v2.2.1] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[8.0.0-rc3, ..., 8.0.1] require symfony/yaml 2.7.* -> found symfony/yaml[v2.7.0-BETA1, ..., 2.7.x-dev] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush dev-formatting-juggle requires consolidation/output-formatters dev-use-command-directly-of as 4.x-dev -> found consolidation/output-formatters[dev-fields-came-from-default, ..., dev-property-parser, 0.1.0, ..., 0.2.3, 1.0.0-beta1, ..., 1.x-dev, 2.0.0-beta1, ..., 2.1.3, 3.0.0, ..., 3.x-dev, 4.0.0, ..., 4.x-dev] but it does not match the constraint.
#       - drush/drush dev-table-empty-message requires consolidation/output-formatters dev-table-empty-message as 4.3.1 -> found consolidation/output-formatters[dev-fields-came-from-default, ..., dev-property-parser, 0.1.0, ..., 0.2.3, 1.0.0-beta1, ..., 1.x-dev, 2.0.0-beta1, ..., 2.1.3, 3.0.0, ..., 3.x-dev, 4.0.0, ..., 4.x-dev] but it does not match the constraint.
#       - drupal/core-recommended 12.x-dev is an alias of drupal/core-recommended dev-main and thus requires it to be installed too.
#
#   Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
#   You can also try re-running composer require with an explicit version constraint, e.g. "composer require drush/drush:*" to figure out if any version is installable, or "composer require drush/drush:^2.1" if you know which you need.
#
#   Installation failed, reverting ./composer.json and ./composer.lock to their original content.'. stderr=./composer.json has been updated
#   Running composer update drush/drush
#   Loading composer repositories with package information
#   Updating dependencies
#   Your requirements could not be resolved to an installable set of packages.
#
#     Problem 1
#       - Root composer.json requires drupal/core-recommended ^12 -> satisfiable by drupal/core-recommended[12.x-dev (alias of dev-main)].
#       - Root composer.json requires drush/drush * -> satisfiable by drush/drush[dev-cim-module-install-req, ..., dev-php8, 6.0.0-rc1, ..., 6.x-dev, 7.0.0-alpha1, ..., 7.x-dev, 8.0.0-beta11, ..., 8.x-dev, 9.0.0-alpha1, ..., 9.x-dev, 10.0.0-alpha1, ..., 10.x-dev, 11.0.0-rc1, ..., 11.x-dev, 12.0.0-beta1, ..., 12.x-dev, 13.0.0-beta1, ..., 13.x-dev, 14.x-dev].
#       - drupal/core 12.x-dev conflicts with drush/drush 6.7.0.
#       - drupal/core 12.x-dev conflicts with drush/drush 6.1.0.
#       - drupal/core-recommended dev-main requires drupal/core 12.x-dev -> satisfiable by drupal/core[12.x-dev (alias of dev-main)].
#       - drush/drush[dev-inf-admin, dev-master, dev-greg-1-anderson-robo-2-partII, dev-robo-2, 9.0.0-beta8, ..., 9.x-dev, 10.0.0-alpha1, ..., 10.3.5] require composer/semver ^1.4 -> found composer/semver[1.4.0, ..., 1.x-dev] but the package is fixed to 3.4.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-reenable-cache-commands-testing, ..., dev-php8, 7.2.0, ..., 7.x-dev, 8.0.2, ..., 8.x-dev, 9.0.0-alpha1, ..., 9.0.0-beta7, 10.3.6, ..., 10.x-dev, 11.0.0-rc1, ..., 11.0.5] require psr/log ~1.0 -> found psr/log[1.0.0, ..., 1.1.4] but the package is fixed to 3.0.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-deprecate-global-config-cmds, dev-ignore-commands-in-parent, dev-no-irc, dev-single-autoloader-only, dev-d10-low-tests, dev-test-74, 11.0.6, ..., 11.x-dev] require symfony/event-dispatcher ^4.0 || ^5.0 || ^6.0 -> found symfony/event-dispatcher[v4.0.0-BETA1, ..., 4.4.x-dev, v5.0.0-BETA1, ..., 5.4.x-dev, v6.0.0-BETA1, ..., 6.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-cim-module-install-req, dev-cmds-to-static-create, dev-deprecate-io-trait, dev-si-with-recipes-12x, dev-config-check-12.x, dev-weitzman-patch-1, 12.0.0-beta1, ..., 12.x-dev] require symfony/event-dispatcher ^6 -> found symfony/event-dispatcher[v6.0.0-BETA1, ..., 6.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[dev-revert-drush-bash-script, dev-requirements-compat, dev-requirements-deprecation, dev-test-on-8.4, dev-chunk/changes-1772775428089-1772775428089, dev-zActions, dev-revert-6192-actions, dev-autowire-params, 13.0.0-beta1, ..., 13.x-dev, 14.x-dev] require symfony/event-dispatcher ^6 || ^7 -> found symfony/event-dispatcher[v6.0.0-BETA1, ..., 6.4.x-dev, v7.0.0-BETA1, ..., 7.4.x-dev] but the package is fixed to v8.0.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[7.0.0-alpha5, ..., 7.1.0, 8.0.0-beta11, ..., 8.0.0-rc2] require symfony/yaml ~2.2 -> found symfony/yaml[v2.2.0, ..., 2.8.x-dev] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[7.0.0-alpha1, ..., 7.0.0-alpha4] require symfony/yaml 2.2.1 -> found symfony/yaml[v2.2.1] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush[8.0.0-rc3, ..., 8.0.1] require symfony/yaml 2.7.* -> found symfony/yaml[v2.7.0-BETA1, ..., 2.7.x-dev] but the package is fixed to v8.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#       - drush/drush dev-formatting-juggle requires consolidation/output-formatters dev-use-command-directly-of as 4.x-dev -> found consolidation/output-formatters[dev-fields-came-from-default, ..., dev-property-parser, 0.1.0, ..., 0.2.3, 1.0.0-beta1, ..., 1.x-dev, 2.0.0-beta1, ..., 2.1.3, 3.0.0, ..., 3.x-dev, 4.0.0, ..., 4.x-dev] but it does not match the constraint.
#       - drush/drush dev-table-empty-message requires consolidation/output-formatters dev-table-empty-message as 4.3.1 -> found consolidation/output-formatters[dev-fields-came-from-default, ..., dev-property-parser, 0.1.0, ..., 0.2.3, 1.0.0-beta1, ..., 1.x-dev, 2.0.0-beta1, ..., 2.1.3, 3.0.0, ..., 3.x-dev, 4.0.0, ..., 4.x-dev] but it does not match the constraint.
#       - drupal/core-recommended 12.x-dev is an alias of drupal/core-recommended dev-main and thus requires it to be installed too.
#
#   Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
#   You can also try re-running composer require with an explicit version constraint, e.g. "composer require drush/drush:*" to figure out if any version is installable, or "composer require drush/drush:^2.1" if you know which you need.
#
#   Installation failed, reverting ./composer.json and ./composer.lock to their original content.
# --
#
# Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
```

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
