### PR TITLE
fix(quickstart): do not use gunicorn for wagtail

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2748,7 +2748,7 @@ Create a Python virtual environment and install Wagtail:
 
 ```bash
 ddev exec python -m venv env
-ddev exec pip install wagtail gunicorn
+ddev exec pip install wagtail
 ```
 
 Initialize the Wagtail project:
@@ -2777,7 +2777,7 @@ Configure DDEV to run the Wagtail development server:
 cat <<'EOF' > .ddev/config.wagtail.yaml
 web_extra_daemons:
     - name: "wagtail"
-      command: "gunicorn mysite.wsgi:application -b 0.0.0.0:8000"
+      command: "python manage.py runserver 0.0.0.0:8000"
       directory: /var/www/html
 web_extra_exposed_ports:
     - name: "wagtail"
@@ -2819,7 +2819,7 @@ ddev launch /admin
     INNEREOF
     ddev start -y
     ddev exec python -m venv env
-    ddev exec pip install wagtail gunicorn
+    ddev exec pip install wagtail
     ddev exec wagtail start mysite .
     ddev exec pip install -r requirements.txt
     ddev exec "echo \"SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')\" >> mysite/settings/dev.py"
@@ -2828,7 +2828,7 @@ ddev launch /admin
     cat <<'INNEREOF' > .ddev/config.wagtail.yaml
     web_extra_daemons:
         - name: "wagtail"
-          command: "gunicorn mysite.wsgi:application -b 0.0.0.0:8000"
+          command: "python manage.py runserver 0.0.0.0:8000"
           directory: /var/www/html
     web_extra_exposed_ports:
         - name: "wagtail"

--- a/docs/tests/wagtail.bats
+++ b/docs/tests/wagtail.bats
@@ -12,7 +12,7 @@ teardown() {
 }
 
 @test "Wagtail quickstart with $(ddev --version)" {
-  _skip_if_embargoed "wagtail-gunicorn"
+  _skip_if_embargoed "wagtail-python"
 
   WAGTAIL_SITENAME=${PROJNAME}
   run mkdir -p ${WAGTAIL_SITENAME} && cd ${WAGTAIL_SITENAME}
@@ -39,7 +39,7 @@ DOCKERFILEEND
   run ddev exec python -m venv env
   assert_success
 
-  run ddev exec pip install wagtail gunicorn
+  run ddev exec pip install wagtail
   assert_success
 
   run ddev exec wagtail start mysite .
@@ -61,7 +61,7 @@ DOCKERFILEEND
   cat <<'EOF' > .ddev/config.wagtail.yaml
 web_extra_daemons:
     - name: "wagtail"
-      command: "gunicorn mysite.wsgi:application -b 0.0.0.0:8000"
+      command: "python manage.py runserver 0.0.0.0:8000"
       directory: /var/www/html
 web_extra_exposed_ports:
     - name: "wagtail"
@@ -81,26 +81,18 @@ EOF
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/admin"
   assert_success
 
-  # Wait for gunicorn (web_extra_daemon) to be ready - DDEV doesn't poll extra daemons for readiness
-  for i in $(seq 1 15); do
-    if ddev exec curl -sf --max-time 3 http://localhost:8000 >/dev/null 2>&1; then
-      break
-    fi
-    sleep 2
-  done
-
   # validate running project - check if Wagtail is responding
-  run curl -sfI --max-time 30 https://${PROJNAME}.ddev.site
-  assert_output --partial "server: gunicorn"
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_line --regexp 'server:.*WSGIServer.*CPython.*'
   assert_success
 
   # Verify main site is running
-  run curl -sf --max-time 30 https://${PROJNAME}.ddev.site
+  run curl -sf https://${PROJNAME}.ddev.site
   assert_output --partial "Welcome to your new Wagtail site"
   assert_success
 
   # Check if we can access the admin page (should redirect to login)
-  run curl -sfL --max-time 30 https://${PROJNAME}.ddev.site/admin
+  run curl -sfL https://${PROJNAME}.ddev.site/admin
   assert_output --partial "Sign in - Wagtail"
   assert_success
 }


### PR DESCRIPTION
## The Issue

Wagtail quickstart is flaky. This fix didn't help:

- #8164

---

https://github.com/ddev/ddev/actions/runs/23153267347/job/67260809737

```
not ok 49 Wagtail quickstart with ddev version v1.25.1-15-g5541feccf
# (from function `assert_output' in file /home/linuxbrew/.linuxbrew/lib/bats-assert/src/assert_output.bash, line 186,
#  in test file docs/tests/wagtail.bats, line 94)
#   `assert_output --partial "server: gunicorn"' failed
# Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
#
# -- output does not contain substring --
# substring : server: gunicorn
# output    :
# --
#
#  Container ddev-my-wagtail-site-web Stopping
#  Container ddev-my-wagtail-site-web Stopped
#  Container ddev-my-wagtail-site-web Stopping
#  Container ddev-my-wagtail-site-web Stopped
#  Container ddev-my-wagtail-site-web Removing
#  Container ddev-my-wagtail-site-web Removed
#  Network ddev-my-wagtail-site_default Removing
#  Network ddev-my-wagtail-site_default Removed
# Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
```

## How This PR Solves The Issue

Uses https://docs.wagtail.org/en/stable/getting_started/tutorial.html#start-the-server:

```diff
-gunicorn mysite.wsgi:application -b 0.0.0.0:8000
+python manage.py runserver 0.0.0.0:8000
```

Removes changes from:

- #8164

## Manual Testing Instructions

Follow Wagtail quickstart 

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
