### PR TITLE
fix(buildkite): use proper check for skip

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -3,8 +3,11 @@
 
 set -eu -o pipefail
 
+# Disable git pager
+export GIT_PAGER=""
+
 # We can skip builds with commit message of [skip buildkite] or [skip ci]
-DDEV_COMMIT_MESSAGE=$(GIT_PAGER="" git log -1 --pretty=%s 2>/dev/null || echo "")
+DDEV_COMMIT_MESSAGE=$(git log -1 --pretty=%s 2>/dev/null || echo "")
 if [[ ${BUILDKITE_MESSAGE:-} == *"[skip buildkite]"* ]] || [[ ${BUILDKITE_MESSAGE:-} == *"[skip ci]"* ]] || [[ ${DDEV_COMMIT_MESSAGE} == *"[skip buildkite]"* ]] || [[ ${DDEV_COMMIT_MESSAGE} == *"[skip ci]"* ]]; then
   echo "Skipping build because message has '[skip buildkite]' or '[skip ci]':"
   echo "BUILDKITE_MESSAGE=${BUILDKITE_MESSAGE:-}"
@@ -314,7 +317,7 @@ if [ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]; then
   # Find the merge base between the PR branch and the base branch
   MERGE_BASE=$(git merge-base HEAD refs/remotes/origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-})
   # Check if there are any changes in the specified directories or files since the merge base
-  if ! git diff --name-only "$MERGE_BASE" | egrep -q '^(?:\.buildkite/|Makefile$|pkg/|cmd/|vendor/|winpkg/|go\.)'; then
+  if ! git diff --name-only "$MERGE_BASE" | grep -E '^(\.buildkite/|Makefile$|pkg/|cmd/|vendor/|winpkg/|go\.)' >/dev/null; then
     echo "Skipping buildkite build since no code changes found"
     exit 0
   fi

--- a/.github/workflows/test-wsl2.yml
+++ b/.github/workflows/test-wsl2.yml
@@ -59,7 +59,28 @@ env:
   GIT_REF: ${{ github.event.pull_request.number && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref_name }}
 
 jobs:
+  check-skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - id: check
+        run: |
+          MESSAGE=$(git log -1 --pretty=%B)
+          if [[ "$MESSAGE" == *"[skip github]"* ]]; then
+            echo "Found [skip github] in commit message, skipping tests"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          fi
+
   test-wsl2:
+    needs: check-skip
+    if: needs.check-skip.outputs.should_skip != 'true'
     runs-on: windows-2025
     timeout-minutes: 300
 


### PR DESCRIPTION
## The Issue

While working on:

- #8198

I noticed that buildkite tests were skipped all the time due to exit code 141 in this pipe:

https://github.com/ddev/ddev/blob/6d46cb0e5065e4ea9c34932ae3cca3f0911ba8b9/.buildkite/test.sh#L316-L320

## How This PR Solves The Issue

- Sets `export GIT_PAGER=""`, so Buildkite works properly with too many changes in `git diff`
- Uses `grep -E` instead of `egrep`, which is deprecated.
- Replaces `-q` with `>/dev/null` which affected pipe check.
- Adds proper skip in WSL2 tests.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
