### PR TITLE
feat(pantheon): Faster db pull for Pantheon

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
@@ -98,12 +98,10 @@ db_pull_command:
       echo "Downloading latest database backup from Pantheon..."
       terminus backup:get ${DDEV_PANTHEON_SITE}.${DDEV_PANTHEON_ENVIRONMENT} --element=database --to=db.sql.gz
     else
-      echo "Dumping and streaming fresh/current database dump (this may take several minutes)... (You can use DDEV_USE_PANTHEON_BACKUP=true to skip this step and use an existing backup)"
-      FRESH_DB_DUMP_STRING=$(terminus connection:info "${DDEV_PANTHEON_SITE}.${DDEV_PANTHEON_ENVIRONMENT}" --field=mysql_command | sed 's,^mysql,mysqldump --no-autocommit --single-transaction --opt -Q,')
-      if [ "${DDEV_DEBUG:-}" = "true" ]; then
-        echo "Debug: FRESH_DB_DUMP_STRING=$FRESH_DB_DUMP_STRING"
-      fi
-      eval "$FRESH_DB_DUMP_STRING | gzip" | dd bs=1M status=progress of=db.sql.gz
+      terminus ldb ${DDEV_PANTHEON_SITE} --overwrite --yes
+      # Gunzip works, but doesn't think it does, end silently.
+      gunzip -q $HOME/pantheon-local-copies/db/${DDEV_PANTHEON_SITE}-db.tgz | tar tvzf - &> /dev/null || true
+      mv $HOME/pantheon-local-copies/db/${DDEV_PANTHEON_SITE}-db.tar /var/www/html/.ddev/.downloads/db.sql
     fi
     echo "Database download complete"
 


### PR DESCRIPTION
Uses Terminus ldb to create a backup, then downloads with gunzip into ddev db directory, which then automatically imports.

<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER

The current Pantheon db pull take forever.

Test pull took 715s(12min), cancelled 260/kb second - probly had a long ways to go.

This method downloaded and imported in about 2 minutes(1.25g db).

This is at a 140mbps connection, so thats to be considered, however the main bottleneck is actually pantheon and the download method- 260/kb a second, it takes awhile.

You can basically manually backup, download, import, much faster. Making the command rather pointless.

## How This PR Solves The Issue

This method is much faster. Took about 2 minutes for a 1.25g db to backup on Pantheon and then download/import.

## Manual Testing Instructions

Run the old command, run the new, compare the completion times.

## Automated Testing Overview

No tests introduced, but perhaps there are existing tests that I'm unaware.

## Release/Deployment Notes

This only effects the db_pull_command.
