### PR TITLE
fix: lowercase PHP_IDE_CONFIG serverName for uppercase project names, fixes #8225 (#8248) [skip ci]

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -243,7 +243,7 @@ services:
     - PGHOST=db
     - PGPASSWORD=db
     - PGUSER=db
-    - PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}
+    - PHP_IDE_CONFIG=serverName={{ .Name | lower }}.${DDEV_TLD}
     - SSH_AUTH_SOCK=/home/.ssh-agent/socket
     - TZ={{ .Timezone }}
     - USER={{ .Username }}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -256,6 +256,44 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	assert.Contains(contentString, app.Type)
 }
 
+// TestPHPIDEConfigLowercase verifies that PHP_IDE_CONFIG uses a lowercase project name,
+// ensuring PhpStorm server name matching works for projects with uppercase names.
+// See https://github.com/ddev/ddev/issues/8225.
+func TestPHPIDEConfigLowercase(t *testing.T) {
+	assert := asrt.New(t)
+	origDir, _ := os.Getwd()
+	testDir := testcommon.CreateTmpDir(t.Name())
+
+	app, err := ddevapp.NewApp(testDir, true)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		_ = os.RemoveAll(testDir)
+	})
+
+	app.Name = "ISSUE-123"
+	app.Type = ddevapp.GetValidAppTypes()[0]
+
+	err = app.WriteConfig()
+	require.NoError(t, err)
+	_ = app.DockerEnv()
+	err = app.WriteDockerComposeYAML()
+	require.NoError(t, err)
+
+	composeBytes, err := os.ReadFile(app.DockerComposeYAMLPath())
+	require.NoError(t, err)
+	contentString := string(composeBytes)
+
+	// PHP_IDE_CONFIG serverName must be lowercase to match the server name nginx sends,
+	// so PhpStorm can match CLI and web-request debugging sessions to the same server.
+	assert.Contains(contentString, "PHP_IDE_CONFIG=serverName=issue-123.")
+	assert.NotContains(contentString, "PHP_IDE_CONFIG=serverName=ISSUE-123.")
+}
+
 // TestConfigCommand tests the interactive config options.
 func TestConfigCommand(t *testing.T) {
 	// Set up tests and give ourselves a working directory.


### PR DESCRIPTION
## The Issue

- Fixes #8225

When a DDEV project name contains uppercase letters (e.g. `ISSUE-123`),
CLI-based PHP debugging fails in PhpStorm. The web server (nginx) lowercases
`SERVER_NAME`, so PhpStorm registers the server as `issue-123.ddev.site`.
But `PHP_IDE_CONFIG` was set using `${DDEV_SITENAME}` which preserves the
original case, giving `serverName=ISSUE-123.ddev.site` — a case-sensitive
mismatch that causes PhpStorm to immediately detach.

## How This PR Solves The Issue

Change `PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}` in
`app_compose_template.yaml` to use `{{ .Name | lower }}` (sprig's `lower`
function, already available in the template FuncMap) so the server name is
always lowercase and consistent with what nginx reports.

## Manual Testing Instructions

1. Create a project with an uppercase name: `ddev config --project-name=ISSUE-123`
2. `ddev start`
3. In PhpStorm, confirm the auto-configured server name is `issue-123.ddev.site`
4. Enable Xdebug: `ddev xdebug on`
5. Run a CLI PHP script with Xdebug: `ddev exec php -r "echo 1;"`
6. Confirm PhpStorm connects and does not immediately detach

## Automated Testing Overview

Added `TestPHPIDEConfigLowercase` in `pkg/ddevapp/config_test.go`. It creates
an app with `Name = "ISSUE-123"`, renders the compose template via
`WriteDockerComposeYAML()`, and asserts the base YAML contains
`PHP_IDE_CONFIG=serverName=issue-123.` (lowercase) and not `ISSUE-123.`.
No Docker start required — exercises the Go template rendering path only.

## Release/Deployment Notes

Projects with uppercase names will have their `PHP_IDE_CONFIG` serverName
lowercased going forward. This is a fix-only change; lowercase names are
unaffected.