### PR TITLE
build(pecl): add php8.5-memcached for ARM64, fixes ddev/ddev-memcached#20

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -55,11 +55,14 @@ RUN apt-get -qq update
 
 ### ------------------------ddev-php-extension-build------------------------------
 ### Uncomment the lines below to enable custom PHP extension builds:
-#FROM base AS ddev-php-extension-build
-#SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
+FROM base AS ddev-php-extension-build
+SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
 ### Use this section to add PHP extensions that need to be built manually.
 ### Example: The following line installs Xdebug version 3.2.2 for PHP 8.1:
 #RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
+# TODO: php8.5: memcached not yet available in Debian Trixie Sury arm64, we build it manually with build_php_extension.sh
+RUN apt-get -qq update && apt-get -qq install --no-install-recommends --no-install-suggests -y libmemcached-dev zlib1g-dev && \
+    /usr/local/bin/build_php_extension.sh "php8.5" "memcached" "latest" "/usr/lib/php/20250925/memcached.so"
 ### -----------------------END ddev-php-extension-build---------------------------
 
 ### ---------------------------ddev-php-base--------------------------------------
@@ -121,12 +124,23 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 ### Note: The dates in /usr/lib/php/YYYYMMDD/ represent PHP API versions.
 ### For more info, see: https://unix.stackexchange.com/a/591771
 #COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
+COPY --from=ddev-php-extension-build /usr/lib/php/20250925/memcached.so /usr/lib/php/20250925/memcached.so.bak
+RUN <<ENDMEMCACHED
+    set -eu -o pipefail
+    if [ ! -f /usr/lib/php/20250925/memcached.so ]; then
+        cp /usr/lib/php/20250925/memcached.so.bak /usr/lib/php/20250925/memcached.so
+        cp /etc/php/8.4/mods-available/memcached.ini /etc/php/8.5/mods-available/memcached.ini
+        phpenmod -v 8.5 memcached
+    fi
+    rm -f /usr/lib/php/20250925/memcached.so.bak
+ENDMEMCACHED
 ### -----------------------END ddev-php-extension-build---------------------------
 
 RUN phpdismod xhprof xdebug
 RUN apt-get -qq autoremove -y
 RUN curl -L --fail -o /usr/local/bin/composer -sSL https://getcomposer.org/composer-stable.phar && chmod ugo+wx /usr/local/bin/composer
 RUN <<ENDDRUSH
+    set -eu -o pipefail
     mkdir -p /usr/local/src/drush
     curl -sSfL -o /tmp/drush.tgz https://github.com/drush-ops/drush/archive/refs/tags/${DRUSH_VERSION}.tar.gz
     tar -C /usr/local/src/drush --strip-components=1 -zxf /tmp/drush.tgz

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -42,7 +42,7 @@ php84:
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
 
-# TODO: php8.5: memcached not yet available in Debian Trixie Sury arm64
+# TODO: php8.5: memcached not yet available in Debian Trixie Sury arm64, we build it manually with build_php_extension.sh
 # https://codeberg.org/oerdnj/deb.sury.org/issues/36
 php85:
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:v1.25.1 AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20260325_stasadev_php85_memcached AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -94,12 +94,8 @@
   7.4)
     extensions="$extensions json memcached redis xdebug"
     ;;
-  8.0|8.1|8.2|8.3|8.4)
+  8.0|8.1|8.2|8.3|8.4|8.5)
     extensions="$extensions memcached redis xdebug"
-    ;;
-  8.5)
-    # TODO: php8.5: memcached not yet available in Debian Trixie Sury arm64
-    extensions="$extensions redis xdebug"
     ;;
   *)
     # Default fallback for future PHP versions - assume redis available

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260303_akibaat_reduce_world_writeables" // Note that this can be overridden by make
+var WebTag = "20260325_stasadev_php85_memcached" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- https://codeberg.org/oerdnj/deb.sury.org/issues/36

- Fixes ddev/ddev-memcached#20

From Discord https://discord.com/channels/664580571770388500/1486338642891771975

## How This PR Solves The Issue

Adds `php8.5-memcached` for ARM64 from PECL.

## Manual Testing Instructions

Using ARM64 (macOS):

```bash
ddev config --php-version=8.5
ddev start
ddev exec 'php -m | grep memcached'
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

We need to remove this manual build once it's available upstream.