### PR TITLE
fix: use Lstat in PurgeDirectory to handle symlinks without following them

### DIFF
--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -158,15 +158,24 @@ func PurgeDirectory(path string) error {
 	}
 
 	for _, file := range files {
-		err = util.Chmod(filepath.Join(path, file), 0777)
+		fullPath := filepath.Join(path, file)
+		fi, err := os.Lstat(fullPath)
 		if err != nil {
 			return err
 		}
-		err = os.RemoveAll(filepath.Join(path, file))
+		// Symlinks must be removed directly without chmod (following a symlink
+		// to chmod it may fail if the target no longer exists).
+		if fi.Mode()&os.ModeSymlink == 0 {
+			err = util.Chmod(fullPath, 0777)
+			if err != nil {
+				return err
+			}
+		}
+		err = os.RemoveAll(fullPath)
 		if err != nil {
 			// On Traditional Windows tests tests fail cleaning up:
 			// config\default_config.yaml: The process cannot access the file because it is being used by another process
-			util.Warning("unable to fully purge '%s': %v", filepath.Join(path, file), err)
+			util.Warning("unable to fully purge '%s': %v", fullPath, err)
 		}
 	}
 	return nil
@@ -191,13 +200,20 @@ func PurgeDirectoryExcept(path string, except map[string]bool) error {
 		if except[file] {
 			continue
 		}
-		err = util.Chmod(filepath.Join(path, file), 0777)
+		fullPath := filepath.Join(path, file)
+		fi, err := os.Lstat(fullPath)
 		if err != nil {
 			return err
 		}
-		err = os.RemoveAll(filepath.Join(path, file))
+		if fi.Mode()&os.ModeSymlink == 0 {
+			err = util.Chmod(fullPath, 0777)
+			if err != nil {
+				return err
+			}
+		}
+		err = os.RemoveAll(fullPath)
 		if err != nil {
-			util.Warning("unable to remove '%s': %v", filepath.Join(path, file), err)
+			util.Warning("unable to remove '%s': %v", fullPath, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## The Issue

A symlink in the TYPO3 v13.4.19 `files.tgz` (`test.txt -> README.txt`) caused intermittent failures in `TestDdevImportFilesDir` on CI: [failing run](https://github.com/ddev/ddev/actions/runs/23626570798/job/68886147305)

```
Error: failed to cleanup .../public/fileadmin before import:
    stat .../public/fileadmin/test.txt: no such file or directory
```

## How This PR Solves The Issue

`PurgeDirectory` (and `PurgeDirectoryExcept`) iterated directory entries and called `util.Chmod` before removing each entry. `util.Chmod` uses `os.Stat`, which **follows symlinks**. If the symlink's target had already been removed earlier in the loop, `os.Stat` would fail with `ENOENT`.

This PR switches to `os.Lstat` to inspect each entry without following symlinks. Symlinks are then removed directly via `os.RemoveAll` (which removes the symlink entry itself, not its target) without any chmod step — symlinks don't have meaningful permissions of their own.

### Relationship to the ZipSlip fix (#8213)

PR #8213 added `case tar.TypeSymlink` handling to `Untar`, so symlinks in archives are now properly extracted to the host filesystem. Before that PR, the `test.txt` symlink entry in TYPO3's `files.tgz` was silently skipped during extraction and never appeared on the host, so `PurgeDirectory` never encountered it.

After #8213, `test.txt` is extracted as a real symlink (`test.txt -> README.txt`). When `PurgeDirectory` later iterates `fileadmin`, `Readdirnames` returns entries in arbitrary filesystem/inode order. If `README.txt` is encountered first and removed, `test.txt` becomes a dangling symlink — and the subsequent `util.Chmod` call on it fails.

### Why it was intermittent

`Readdirnames` returns entries in inode order, which varies by runner and filesystem. The failure only occurs when `README.txt` sorts before `test.txt` in that order, making the bug dependent on the specific runner environment.

## Manual Testing Instructions

- Run `ddev import-files` against a TYPO3 project that has symlinks in its `fileadmin/` directory and confirm the import completes without error
- Confirm that tarballs containing symlinks are still extracted correctly (the `archive.Untar` path is unchanged)
- The intermittent `TestDdevImportFilesDir` CI failure for TYPO3 should be resolved; watch the next CI runs to confirm

## Automated Testing Overview

Existing `TestPurgeDirectory` and `TestPurgeDirectoryExcept` tests pass. The intermittent CI failure in `TestDdevImportFilesDir` for TYPO3 will need to be observed over subsequent CI runs to confirm the fix holds.

## Release/Deployment Notes

No impact on behavior for non-symlink files. Symlinks in upload directories are now removed cleanly during `ddev import-files` pre-import cleanup rather than causing an error.