### PR TITLE
fix(test): check for GitHub token in TestAddonGetCircularDependencies

### DIFF
--- a/cmd/ddev/cmd/addon-get_test.go
+++ b/cmd/ddev/cmd/addon-get_test.go
@@ -420,6 +420,9 @@ func TestAddonGetWithDependencies(t *testing.T) {
 
 // TestAddonGetCircularDependencies tests circular dependency detection
 func TestAddonGetCircularDependencies(t *testing.T) {
+	if !github.HasGitHubToken() {
+		t.Skip("Skipping because DDEV_GITHUB_TOKEN is not set")
+	}
 	origDir, _ := os.Getwd()
 	site := TestSites[0]
 	err := os.Chdir(site.Dir)


### PR DESCRIPTION
## The Issue

Test fails because of intermittent 403 from GitHub.

https://github.com/ddev/ddev/actions/runs/23680089387/job/68990449068#step:9:16094

```
=== RUN   TestAddonGetCircularDependencies
    addon-get_test.go:438: 
        	Error Trace:	/home/testuser/workspace/ddev/cmd/ddev/cmd/addon-get_test.go:438
        	Error:      	"\x1b[33mWarning: unable to get releases for test-dummy-self-referencing-addon: GET https://api.github.com/repos/ddev/test-dummy-self-referencing-addon/releases?per_page=100: 403 API rate limit exceeded for 135.232.216.48. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 44m01s]\nGitHub API Rate Limit: 0/60 remaining (resets in 44m1s)\nFalling back to cached add-on registry...\x1b[0m\n\x1b[31mUnable to get ddev/test-dummy-self-referencing-addon: add-on 'ddev/test-dummy-self-referencing-addon' not found in cached add-on registry\x1b[0m\n" does not contain "circular dependency detected"
        	Test:       	TestAddonGetCircularDependencies
        	Messages:   	Should mention circular dependency
--- FAIL: TestAddonGetCircularDependencies (1.43s)
```

## How This PR Solves The Issue

Adds a check for GitHub token.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
