### PR TITLE
fix: bump action-linkspector from v1.3.5 to v1.4.0 to resolve setup-node@v4 warning [skip ci]

### DIFF
--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Run linkspector to check external links
-        uses: umbrelladocs/action-linkspector@v1.3.5
+        uses: umbrelladocs/action-linkspector@v1.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check


### PR DESCRIPTION
## The Issue

- The docscheck workflow produces a warning about setup-node@v4 because
  action-linkspector@v1.3.5 internally uses actions/setup-node@v4.

## How This PR Solves The Issue

- Bumps umbrelladocs/action-linkspector from v1.3.5 to v1.4.0, which
  upgrades its internal setup-node dependency to v5 with Node 24 support.
- v1.4.1 is avoided due to a reported issue (umbrelladocs/action-linkspector#54).

## Manual Testing Instructions

- Verify the docscheck workflow runs without setup-node@v4 warnings.

## Automated Testing Overview

- No new tests needed; this is a CI dependency bump.

## Release/Deployment Notes

- No impact on DDEV itself; only affects the docscheck CI workflow.