### PR TITLE
test(lagoon): use new amazee.io testing environment for Lagoon integration (#8270) [skip ci]

### DIFF
--- a/pkg/ddevapp/providerLagoon_test.go
+++ b/pkg/ddevapp/providerLagoon_test.go
@@ -22,14 +22,12 @@ import (
  * These tests rely on an external test account.
  */
 
-const lagoonProjectName = "amazeeio-ddev"
+const lagoonProjectName = "test-amazeeio-lagoon"
 
-// TODO: Change to use the  "pull" environment when we have one
 const lagoonPullTestSiteEnvironment = "pull"
 const lagoonPushTestSiteEnvironment = "push"
 
-// TODO: Change this to the actual dedicated pull environment
-const lagoonPullSiteURL = "https://nginx.pull.amazeeio-ddev.us2.amazee.io/"
+const lagoonPullSiteURL = "https://nginx.pull.test-amazeeio-lagoon.us2.amazee.io/"
 const lagoonSiteExpectation = "Super easy vegetarian pasta"
 
 // These tests won't run with GitHub actions on a forked PR.


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

The cloud environment used for testing the Lagoon provider is deprecated.

## How This PR Solves The Issue

I created a new environment hosted at amazee.io which builds from the repo https://github.com/ddev/test-amazeeio-lagoon. This PR changes the tests to push/pull from the new environment.

## Manual Testing Instructions

Manual testing requires an SSH key with access to the cloud environment.

## Automated Testing Overview

Automated tests likely won't run or will fail since this is a forked PR that doesn't have access to necessary secrets.

## Release/Deployment Notes

n/a
