### PR TITLE
test(webserver): wait for FPM reload to settle after xdebug disable (#8272) [skip ci]

### DIFF
--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -159,6 +159,8 @@ setup() {
   assert_success
   run docker exec $CONTAINER_NAME disable_xdebug
   assert_success
+  # disable_xdebug triggers an FPM reload; wait for it to settle before the next test
+  sleep 2
 }
 
 @test "verify that both nginx logs and fpm logs are being tailed (${WEBSERVER_TYPE})" {


### PR DESCRIPTION
## The Issue

I refactored bats tests in #8268 to get more info why we see intermittent failures in the "Container tests":

https://github.com/ddev/ddev/actions/runs/23878158616/job/69625607038

```
ok 9 verify key php extensions are loaded on PHP8.4
not ok 10 verify that both nginx logs and fpm logs are being tailed (nginx-fpm)
# (from function `assert_output' in file /home/linuxbrew/.linuxbrew/lib/bats-assert/src/assert_output.bash, line 186,
#  in test file tests/ddev-webserver/php_webserver.bats, line 170)
#   `assert_output --partial "PHP Fatal error:  Fatal error in"' failed
#
# -- output does not contain substring --
# substring (1 lines):
#   PHP Fatal error:  Fatal error in
# output (183 lines):
...
#   [02-Apr-2026 00:55:43] NOTICE: Reloading in progress ...
#   [02-Apr-2026 00:55:43] NOTICE: reloading: execvp("/usr/sbin/php-fpm", {"/usr/sbin/php-fpm", "--nodaemonize", "--force-stderr", "--allow-to-run-as-root"})
#   [02-Apr-2026 00:55:47] NOTICE: using inherited socket fd=8, "/run/php-fpm.sock"
#   [02-Apr-2026 00:55:47] NOTICE: fpm is running, pid 1540
#   [02-Apr-2026 00:55:47] NOTICE: ready to handle connections
#   [02-Apr-2026 00:55:47] NOTICE: systemd monitor interval set to 10000ms
#   [02-Apr-2026 00:55:47] NOTICE: Reloading in progress ...
#   2026/04/02 00:55:47 [error] 1548#1548: *34 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 172.17.0.1, server: , request: "GET /test/fatal.php HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm.sock:", host: "127.0.0.1:8080"
#   [02-Apr-2026 00:55:47] NOTICE: reloading: execvp("/usr/sbin/php-fpm", {"/usr/sbin/php-fpm", "--nodaemonize", "--force-stderr", "--allow-to-run-as-root"})
#   2026/04/02 00:55:47 [info] 1548#1548: *34 client 172.17.0.1 closed keepalive connection
# --
#
ok 11 verify htaccess doesn't break nginx-fpm php8.4
bats tests failed for WEBSERVER_TYPE=nginx-fpm PHP_VERSION=8.4
```

## How This PR Solves The Issue

Adds `sleep 2` in the previous test to give FPM some time to be ready before the next test to avoid "Connection reset by peer" error.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
