### PR TITLE
chore(drupal): add support for symfony_mailer 2.x to drupal settings.ddev.php

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -38,12 +38,20 @@ if (empty($settings['config_sync_directory'])) {
 }
 
 // Override drupal/symfony_mailer default config to use Mailpit.
+// Symfony Mailer 1.x
 $config['symfony_mailer.settings']['default_transport'] = 'sendmail';
 $config['symfony_mailer.mailer_transport.sendmail']['plugin'] = 'smtp';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['user'] = '';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass'] = '';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port'] = '1025';
+// Symfony Mailer 2.x
+$config['mailer_transport.settings']['default_transport'] = 'sendmail';
+$config['mailer_transport.mailer_transport.sendmail']['plugin'] = 'smtp';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['user'] = '';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['pass'] = '';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['port'] = '1025';
 
 // Enable verbose logging for errors.
 // https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode

--- a/pkg/ddevapp/drupal/drupal11/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal11/settings.ddev.php
@@ -35,12 +35,20 @@ if (empty($settings['config_sync_directory'])) {
 }
 
 // Override drupal/symfony_mailer default config to use Mailpit.
+// Symfony Mailer 1.x
 $config['symfony_mailer.settings']['default_transport'] = 'sendmail';
 $config['symfony_mailer.mailer_transport.sendmail']['plugin'] = 'smtp';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['user'] = '';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass'] = '';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port'] = '1025';
+// Symfony Mailer 2.x
+$config['mailer_transport.settings']['default_transport'] = 'sendmail';
+$config['mailer_transport.mailer_transport.sendmail']['plugin'] = 'smtp';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['user'] = '';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['pass'] = '';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['port'] = '1025';
 
 // Enable verbose logging for errors.
 // https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode

--- a/pkg/ddevapp/drupal/drupal12/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal12/settings.ddev.php
@@ -35,12 +35,20 @@ if (empty($settings['config_sync_directory'])) {
 }
 
 // Override drupal/symfony_mailer default config to use Mailpit.
+// Symfony Mailer 1.x
 $config['symfony_mailer.settings']['default_transport'] = 'sendmail';
 $config['symfony_mailer.mailer_transport.sendmail']['plugin'] = 'smtp';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['user'] = '';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass'] = '';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port'] = '1025';
+// Symfony Mailer 2.x
+$config['mailer_transport.settings']['default_transport'] = 'sendmail';
+$config['mailer_transport.mailer_transport.sendmail']['plugin'] = 'smtp';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['user'] = '';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['pass'] = '';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
+$config['mailer_transport.mailer_transport.sendmail']['configuration']['port'] = '1025';
 
 // Enable verbose logging for errors.
 // https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #8273

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

It adds support for the Symfony Mailer 2.x config names.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
