### PR TITLE
test(wsl2): add cleanup for ddev/docker apt sources leftovers, for #8233

### DIFF
--- a/winpkg/installer_test.go
+++ b/winpkg/installer_test.go
@@ -360,8 +360,8 @@ func cleanupTestEnv(t *testing.T, distroName string) {
 		out, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", "if command -v mkcert >/dev/null 2>&1; then mkcert -uninstall; fi")
 		require.NoError(t, err)
 
-		// Now take away temp sudo
-		out, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "-u", "root", "rm", "/etc/sudoers.d/temp-mkcert-install")
+		// Now take away temp sudo and remove ddev/docker apt sources leftovers (*.list and *.sources create conflicts in apt-get)
+		out, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "-u", "root", "bash", "-c", "rm -f /etc/sudoers.d/temp-mkcert-install /etc/apt/sources.list.d/ddev.* /etc/apt/sources.list.d/docker.*")
 		require.NoError(t, err)
 
 		out, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "-u", "root", "bash", "-c", "(apt-get remove -y ddev ddev-wsl2 docker-ce-cli docker-ce 2>/dev/null)")


### PR DESCRIPTION
## The Issue

- For #8233

https://buildkite.com/ddev/ddev-windows-mutagen/builds/6160#019d4e8f-791b-4d43-9957-1bc346ed032c/L231

```
...
installer_test.go:368: distro cleanup: err=exit status 100, output:
...
WARNING: apt-get update returned non-zero exit code: 100, output: E: Conflicting values set for option Signed-By regarding source https://pkg.ddev.com/apt/ *: /etc/apt/keyrings/ddev.gpg != /etc/apt/keyrings/ddev.asc
E: Conflicting values set for option Signed-By regarding source https://download.docker.com/linux/ubuntu/ noble: /etc/apt/keyrings/docker.gpg != /etc/apt/keyrings/docker.asc
E: The list of sources could not be read.
...
```

## How This PR Solves The Issue

Cleans up potential conflicts in `/etc/apt/sources.list.d/` before running the Windows installer.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
