### PR TITLE
refactor: detect custom files in `ddev utility diagnose`

### DIFF
--- a/cmd/ddev/cmd/scripts/diagnose_ddev.sh
+++ b/cmd/ddev/cmd/scripts/diagnose_ddev.sh
@@ -311,17 +311,9 @@ if ddev describe >/dev/null 2>&1; then
 
   # Check for customizations
   if [ -d .ddev ]; then
-    custom_files=$(grep -rL "#ddev-generated" .ddev/docker-compose.*.yaml .ddev/php .ddev/nginx* .ddev/*-build .ddev/apache .ddev/mysql .ddev/postgres .ddev/.env 2>/dev/null | grep -v '\.example$')
-    if [ -n "$custom_files" ]; then
-      custom_count=$(echo "$custom_files" | wc -l | tr -d ' ')
-    else
-      custom_count=0
-    fi
-    if [ "$custom_count" -gt 0 ]; then
-      warn "Found ${custom_count} customized configuration file(s):"
-      while IFS= read -r file; do
-        [ -n "$file" ] && info "  - ${file#./}"
-      done <<< "$custom_files"
+    custom_config_warnings=$(ddev utility check-custom-config --all 2>&1 >/dev/null)
+    if [ -n "$custom_config_warnings" ]; then
+      warn "$custom_config_warnings"
       suggestion "Customizations can cause issues. Try temporarily removing them for testing."
     else
       success "No custom configurations detected"
@@ -335,6 +327,8 @@ if ddev describe >/dev/null 2>&1; then
       while IFS= read -r addon; do
         [ -n "$addon" ] && info "  - ${addon}"
       done <<< "$addons"
+    else
+      success "No add-ons installed"
     fi
   fi
 

--- a/cmd/ddev/cmd/utility-diagnose_test.go
+++ b/cmd/ddev/cmd/utility-diagnose_test.go
@@ -65,7 +65,7 @@ func TestUtilityDiagnoseCmd(t *testing.T) {
 
 		out, err := exec.RunHostCommand(DdevBin, "utility", "diagnose")
 		require.NoError(t, err)
-		require.Contains(t, out, "customized configuration file(s)")
+		require.Contains(t, out, "Custom configuration detected")
 		require.Contains(t, out, ".ddev/.env")
 	})
 


### PR DESCRIPTION
## The Issue

There's a new command added in:

- #8218

We already use it in `ddev utility test` but not in `ddev utility diagnose`.

## How This PR Solves The Issue

Refactors the logic to use `ddev utility check-custom-config --all` inside `ddev utility diagnose`

## Manual Testing Instructions

Check the output for customizations:

```bash
ddev utility diagnose

ddev dotenv set .ddev/.env --test-env=true
ddev utility diagnose
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
