### PR TITLE
fix(mutagen): tolerate transient staging files during volume chown

### DIFF
--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -40,10 +40,14 @@ func SetMutagenVolumeOwnership(app *DdevApp) error {
 	// Make sure that if we have a volume mount it's got proper ownership
 	uidStr, gidStr, _ := dockerutil.GetContainerUser()
 	util.Verbose("Chowning Mutagen Docker volume for user %s", uidStr)
+	// Use -f to suppress errors from transient .mutagen-temporary-staging-* files
+	// that may appear/disappear during an active or resuming sync session.
+	// Use || true because the Exec wrapper adds set -eu which would exit on
+	// chown's non-zero exit code even with -f.
 	_, _, err := app.Exec(
 		&ExecOpts{
 			Dir: "/tmp",
-			Cmd: fmt.Sprintf("sudo chown -R %s:%s /tmp/project_mutagen", uidStr, gidStr),
+			Cmd: fmt.Sprintf("sudo chown -Rf %s:%s /tmp/project_mutagen || true", uidStr, gidStr),
 		})
 	if err != nil {
 		util.Warning("Failed to chown Mutagen volume: %v", err)


### PR DESCRIPTION
## The Issue

On OrbStack (and potentially other Docker providers), `ddev start` can fail when chowning the Mutagen volume because transient `.mutagen-temporary-staging-*` files from a previously paused sync session appear or disappear mid-traversal.

Example failure from [Buildkite macos-orbstack build #6882](https://buildkite.com/ddev/macos-orbstack/builds/6882#019d533b-11c7-42e0-8af0-96bad3d7c3e7/L17142):

```
chown: cannot access '/tmp/project_mutagen/.mutagen-temporary-staging-sync_F25SKHwku0XRTG7okZMNqV3kCQI3M9JyFyolpAEcxbf-beta': No such file or directory
```

## How This PR Solves The Issue

- Uses `chown -Rf` instead of `chown -R`: the `-f` flag suppresses diagnostic messages for files that vanish during traversal
- Adds `|| true` to prevent the `set -eu` wrapper (injected by `Exec`) from treating chown's non-zero exit code as fatal
- The chown still processes all accessible files; only the transient mutagen-internal staging files are silently skipped

## Manual Testing Instructions

1. `ddev start` a mutagen-enabled project on OrbStack
2. Verify no chown warnings appear during startup

## Automated Testing Overview

No new tests needed — this is a resilience fix for a race condition that's difficult to reproduce deterministically. The existing mutagen test suite covers the start/sync workflow.

## Release/Deployment Notes

No impact beyond fixing an intermittent startup failure on OrbStack and similar Docker providers.