### PR TITLE
fix(docker): use ddev-utilities for remaining RunSimpleContainer calls (#8282) [skip ci]

### DIFF
--- a/containers/ddev-ssh-agent/test/functions.sh
+++ b/containers/ddev-ssh-agent/test/functions.sh
@@ -13,7 +13,7 @@ function basic_setup {
     docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
 
     # Initialize the volume with the correct ownership
-    docker run --rm -v "${VOLUME}:/var/lib/mysql:nocopy" busybox:stable chown -R ${MOUNTUID}:${MOUNTGID} /var/lib/mysql
+    docker run --rm -v "${VOLUME}:/var/lib/mysql:nocopy" ddev/ddev-utilities:latest chown -R ${MOUNTUID}:${MOUNTGID} /var/lib/mysql
 }
 
 function teardown {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1752,7 +1752,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	util.Debug("Exec %s", chownCmd)
-	_, out, err := dockerutil.RunSimpleContainer(ddevImages.GetWebImage(), "start-chown-"+util.RandString(6), []string{"sh", "-c", chownCmd}, []string{}, []string{}, volumeMounts, "", true, false, labels, nil, &dockerutil.NoHealthCheck)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "start-chown-"+util.RandString(6), []string{"sh", "-c", chownCmd}, []string{}, []string{}, volumeMounts, "", true, false, labels, nil, &dockerutil.NoHealthCheck)
 	if err != nil {
 		return fmt.Errorf("failed to '%s' inside volumes: %v, output=%s", chownCmd, err, out)
 	}
@@ -3287,7 +3287,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	// for stopped project
 	c := fmt.Sprintf("rm -rf /mnt/ddev-global-cache/traefik/config/%[1]s_merged.yaml", app.Name)
 	util.Debug("Removing merged config for project with command '%s'", c)
-	_, out, err := dockerutil.RunSimpleContainer(ddevImages.GetWebImage(), "remove-project-merged-config-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, &dockerutil.NoHealthCheck)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "remove-project-merged-config-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, &dockerutil.NoHealthCheck)
 	if err != nil {
 		util.Warning("Unable to remove project merged traefik yaml: %v, output='%s'", err, out)
 	}
@@ -3299,7 +3299,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		// This would not remove extra certs that they had put in certs directory.
 		c := fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%[1]s-{web,db} /mnt/ddev-global-cache/traefik/*/%[1]s.{crt,key} /mnt/ddev-global-cache/traefik/config/%[1]s_merged.yaml", app.Name)
 		util.Debug("Cleaning ddev-global-cache with command '%s'", c)
-		_, out, err := dockerutil.RunSimpleContainer(ddevImages.GetWebImage(), "clean-ddev-global-cache-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, &dockerutil.NoHealthCheck)
+		_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "clean-ddev-global-cache-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, &dockerutil.NoHealthCheck)
 		if err != nil {
 			util.Warning("Unable to clean up ddev-global-cache with command '%s': %v; output='%s'", c, err, out)
 		}

--- a/pkg/dockerutil/volumes.go
+++ b/pkg/dockerutil/volumes.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	ddevImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
@@ -121,7 +120,7 @@ func CopyIntoVolume(sourcePath string, volumeName string, targetSubdir string, u
 	if IsPodmanRootless() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
-	containerID, _, err := RunSimpleContainer(ddevImages.GetWebImage(), containerName, []string{"bash", "-c", c}, nil, nil, []string{volumeName + ":" + volPath}, "0", false, true, labels, nil, nil)
+	containerID, _, err := RunSimpleContainer(versionconstants.UtilitiesImage, containerName, []string{"bash", "-c", c}, nil, nil, []string{volumeName + ":" + volPath}, "0", false, true, labels, nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## The Issue

- Follows up on #8271

Several `RunSimpleContainer` calls were still using `ddev-webserver` or `busybox` for trivial operations (chown, rm, CopyIntoVolume), causing 10-30 minute hangs on Lima/Colima. See [Buildkite failure](https://buildkite.com/ddev/macos-lima/builds/6060#019d5245-8b2c-49ca-805d-4c1706d1a7fc) where `TestPostgresConfigOverride` timed out after 10m waiting for a ddev-webserver chown container to stop on Lima.

## How This PR Solves The Issue

Switches the remaining `RunSimpleContainer` calls to use `versionconstants.UtilitiesImage` (`ddev/ddev-utilities`):

- `pkg/ddevapp/ddevapp.go`: chown call during `Start()`, rm of merged traefik config during `Stop()`, and global cache cleanup during `Stop()` with `removeData`
- `pkg/dockerutil/volumes.go`: `CopyIntoVolume()` which was the last call still using `ddevImages.GetWebImage()`
- `containers/ddev-ssh-agent/test/functions.sh`: test helper using `busybox:stable` → `ddev/ddev-utilities:latest`

Calls intentionally left using the web image:
- `pkg/ddevapp/commands.go:66` (`performTaskInContainer`) — fallback for arbitrary web container tasks
- `pkg/ddevapp/ddevapp.go:1828` — inspects the project-specific built web image
- `pkg/ddevapp/addons.go:513` — PHP syntax validation requires PHP

## Manual Testing Instructions

Run `ddev start` and `ddev stop` on a Lima/Colima-based environment and verify no hangs during volume chown or cleanup operations.

## Automated Testing Overview

No new tests; existing tests cover these code paths. The fix specifically addresses the Lima/Colima timeout seen in CI.

## Release/Deployment Notes

Requires the `ddev/ddev-utilities:latest` image to be available, which was already introduced in #8271.