### PR TITLE
fix: normalize path separators in check-custom-config output on Windows

### DIFF
--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -512,7 +512,7 @@ func filterCustomConfigFiles(files []string, expectedDdevFiles []string, addonFi
 
 // fileLabel returns the display string for a file, appending annotation tags as needed.
 func fileLabel(f fileInfo) string {
-	label := f.path
+	label := filepath.ToSlash(f.path)
 	if f.addonName != "" {
 		label += " (add-on " + f.addonName + ")"
 	}


### PR DESCRIPTION
## The Issue

- Introduced in #8218 (commit 7e9f1ab21)
- TestUtilityCheckCustomConfigCmd fails on Windows because fileLabel() emits native Windows backslash separators (e.g. traefik\config\mock-myservice.yaml), but the test checks for forward-slash substrings (e.g. traefik/config/mock-myservice.yaml)
- Buildkite failure: https://buildkite.com/ddev/ddev-windows-mutagen/builds/6171#019d54a3-fbe3-4041-9372-02fc27f0559a/L21682

## How This PR Solves The Issue

Use filepath.ToSlash in fileLabel() so paths always use forward slashes in the displayed output. This is a no-op on macOS/Linux and normalizes backslashes to forward slashes on Windows.

## Manual Testing Instructions

- Run TestUtilityCheckCustomConfigCmd on Windows (or verify via CI)
- On macOS/Linux: go test -v -run TestUtilityCheckCustomConfigCmd ./cmd/ddev/cmd/

## Automated Testing Overview

The existing TestUtilityCheckCustomConfigCmd test covers this — it was already failing on Windows due to this bug.

## Release/Deployment Notes

No user-visible behavior change on macOS/Linux. On Windows, ddev utility check-custom-config output paths will now use forward slashes consistently.