### PR TITLE
fix(addons): sleep 500ms after creating config files on Lima/Colima/Rancher Desktop (#8288) [skip ci]

### DIFF
--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -318,6 +318,13 @@ func processPHPAction(action string, installDesc InstallDesc, app *DdevApp, verb
 		return fmt.Errorf("failed to create configuration files for PHP action: %w", err)
 	}
 
+	// On Lima/Colima/Rancher Desktop, VirtioFS bind mounts can have a brief propagation
+	// delay for newly created files. Add-on installation is infrequent so a short sleep
+	// is acceptable to avoid an intermittent "file not found" race.
+	if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
+		time.Sleep(500 * time.Millisecond)
+	}
+
 	// Create a shell script that validates original PHP syntax first, then executes with strict mode
 	shellScript := fmt.Sprintf(phpActionShellScriptTemplate, originalAction, action)
 


### PR DESCRIPTION
## The Issue

Intermittent failure on Colima VZ: `TestCmdAddonPHP/ConfigurationAccessAddon` fails with `PHP: ERROR - Project config file not found at .ddev-config/project_config.yaml`.

See: https://buildkite.com/ddev/macos-colima-vz/builds/6241#019d54b4-17a4-43c7-a85e-495a7ca62659

## How This PR Solves The Issue

On Lima/Colima/Rancher Desktop, VirtioFS mediates bind mounts between the macOS host and the container. Newly created files written on the host can have a brief propagation delay before they're visible inside the container.

`processPHPAction` calls `createConfigurationFiles` to write `.ddev-config/project_config.yaml` and `.ddev-config/global_config.yaml` to the host filesystem, then immediately starts a container with a bind mount of `app.AppRoot`. On Colima VZ, the new files sometimes aren't visible yet when PHP runs, causing an intermittent "file not found" error.

Since add-on installation is infrequent (one-time `ddev add-on get`), a 500ms sleep after `createConfigurationFiles` on these platforms is an acceptable fix.

## Manual Testing Instructions

- On Colima VZ (or Lima/Rancher Desktop), run `ddev add-on get` with an add-on that has PHP pre-install actions reading `.ddev-config/` files
- Verify no intermittent "file not found" failures
- Run `go test -v -run TestCmdAddonPHP ./cmd/ddev/cmd/` repeatedly on Colima VZ

## Automated Testing Overview

`TestCmdAddonPHP/ConfigurationAccessAddon` in `cmd/ddev/cmd/addon_test.go` exercises this path. The intermittent failure was observed on the `macos-colima-vz` Buildkite runner.

## Release/Deployment Notes

No breaking changes. The 500ms sleep only fires during `ddev add-on get` on Lima/Colima/Rancher Desktop.