### PR TITLE
test: fix TestUseEphemeralPort flakiness on DockerRootless and Podman

### DIFF
--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -198,10 +198,11 @@ func TestAllocateAvailablePortForRouter(t *testing.T) {
 
 // Test that the app assigns an ephemeral port if the default one is not available.
 func TestUseEphemeralPort(t *testing.T) {
-	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop()) {
+	if os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() || dockerutil.IsDockerRootless() || dockerutil.IsPodman()) {
 		// Intermittent failures in CI due apparently to https://github.com/lima-vm/lima/issues/2536
+		// and similar port-release timing issues on Docker Rootless and Podman.
 		// Expected port is not available, so it allocates another one.
-		t.Skip("Skipping on Lima/Colima/Rancher as ports don't seem to be released properly in a timely fashion")
+		t.Skip("Skipping on Lima/Colima/Rancher/DockerRootless/Podman as ports don't seem to be released properly in a timely fashion")
 	}
 
 	// Stop all projects and the router first so we can occupy the ports they would normally use
@@ -246,12 +247,7 @@ func TestUseEphemeralPort(t *testing.T) {
 		_ = dockerutil.RemoveContainer(nodeps.RouterContainer)
 	})
 
-	for i, app := range apps {
-		// Predict which ephemeral ports the apps will use by using guess from starting point
-		// This is fragile, only works if no other projects are running and holding open the earlier ports
-		expectedEphemeralHTTPPort := ddevapp.MinEphemeralPort + i*4
-		expectedEphemeralHTTPSPort := ddevapp.MinEphemeralPort + i*4 + 1
-
+	for _, app := range apps {
 		err := app.Start()
 		require.NoError(t, err)
 
@@ -259,22 +255,22 @@ func TestUseEphemeralPort(t *testing.T) {
 		app, err = ddevapp.NewApp(app.GetAppRoot(), true)
 		require.NoError(t, err)
 
-		// app1 will not use the configured target ports, uses the assigned ephemeral ports.
+		// The app must not use the configured target ports, it must use ephemeral ports instead.
 		require.NotEqual(t, targetHTTPPort, app.GetPrimaryRouterHTTPPort())
 		require.NotEqual(t, targetHTTPSPort, app.GetPrimaryRouterHTTPSPort())
 
-		// Allow a margin of +2 for ephemeral port checks due to flakiness
+		// Verify the assigned ports are in the ephemeral range
 		actualHTTPPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPPort())
 		require.NoError(t, err)
 		require.Condition(t, func() bool {
-			return actualHTTPPort >= expectedEphemeralHTTPPort && actualHTTPPort <= expectedEphemeralHTTPPort+2
-		}, "HTTP port must be between %d and %d, got %d", expectedEphemeralHTTPPort, expectedEphemeralHTTPPort+2, actualHTTPPort)
+			return actualHTTPPort >= ddevapp.MinEphemeralPort && actualHTTPPort <= ddevapp.MaxEphemeralPort
+		}, "HTTP port %d must be in ephemeral range [%d, %d]", actualHTTPPort, ddevapp.MinEphemeralPort, ddevapp.MaxEphemeralPort)
 
 		actualHTTPSPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPSPort())
 		require.NoError(t, err)
 		require.Condition(t, func() bool {
-			return actualHTTPSPort >= expectedEphemeralHTTPSPort && actualHTTPSPort <= expectedEphemeralHTTPSPort+2
-		}, "HTTPS port must be between %d and %d, got %d", expectedEphemeralHTTPSPort, expectedEphemeralHTTPSPort+2, actualHTTPSPort)
+			return actualHTTPSPort >= ddevapp.MinEphemeralPort && actualHTTPSPort <= ddevapp.MaxEphemeralPort
+		}, "HTTPS port %d must be in ephemeral range [%d, %d]", actualHTTPSPort, ddevapp.MinEphemeralPort, ddevapp.MaxEphemeralPort)
 
 		// Make sure that both http and https URLs have proper content
 		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), testString, -1)


### PR DESCRIPTION
## The Issue

- Fixes #8293

Intermittent `TestUseEphemeralPort` failures seen on Docker Rootless and Podman CI runners, example: https://github.com/ddev/ddev/actions/runs/24002529679/job/70000819802

Two root causes:

1. **Fragile port prediction**: The test predicted which exact ephemeral port would be allocated (`MinEphemeralPort + i*4`) with only a +2 margin. This breaks whenever any port in the ephemeral range still appears active after `PowerOff()` - causing allocation to skip ports and land outside the predicted window.

2. **Slow port release**: Docker Rootless and Podman (like Lima/Colima/Rancher, which were already skipped) don't release ports fast enough after `PowerOff()`. So `IsPortActive()` sees those ports as still in use, shifting the ephemeral allocation unpredictably.

## How This PR Solves The Issue

- Adds `dockerutil.IsDockerRootless()` and `dockerutil.IsPodman()` to the skip condition, consistent with the existing Lima/Colima/Rancher skip for the same port-release timing reason.
- Replaces the fragile `MinEphemeralPort + i*4` prediction with a simple check that the assigned port falls anywhere within `[MinEphemeralPort, MaxEphemeralPort]`. The core thing being tested - that ephemeral ports ARE used when the target is occupied - is still fully verified, along with the URL content checks.

## Manual Testing Instructions

- Run `go test -v -run TestUseEphemeralPort ./pkg/ddevapp/` on standard Docker - should pass.
- Run on Docker Rootless or Podman - should now skip.

## Automated Testing Overview

The test itself is the affected test. No new tests added; existing logic made more robust.

## Release/Deployment Notes

Test-only change, no behavior impact on production code.
