### PR TITLE
chore: remove obsolete commands, fixes #8291 (#8292) [skip ci]

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -692,8 +692,8 @@ Run 'ddev config --auto' to remove this Composer warning.`, app.Name)
 
 // FixObsolete removes files that may be obsolete, etc.
 func (app *DdevApp) FixObsolete() {
-	// Remove old in-project commands (which have been moved to global)
-	for _, command := range []string{"db/mysql", "host/launch", "host/xhgui", "web/xdebug"} {
+	// Remove old in-project commands (which have been moved to global) and remove other leftovers
+	for _, command := range []string{"db/mysql", "host/launch", "host/xhgui", "web/xdebug", "host/solrtail.example", "solr/README.txt", "solr/solrtail.example"} {
 		cmdPath := app.GetConfigPath(filepath.Join("commands", command))
 		signatureFound, err := fileutil.FgrepStringInFile(cmdPath, nodeps.DdevFileSignature)
 		if err == nil && signatureFound {
@@ -714,7 +714,7 @@ func (app *DdevApp) FixObsolete() {
 	}
 
 	// Remove old global commands
-	for _, command := range []string{"host/yarn", "host/xhgui", "web/nvm", "web/autocomplete/nvm"} {
+	for _, command := range []string{"host/yarn", "host/xhgui", "web/nvm", "web/autocomplete/nvm", "web/python", "web/typo3cms"} {
 		cmdPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/", command)
 		signatureFound, err := fileutil.FgrepStringInFile(cmdPath, nodeps.DdevFileSignature)
 		if err == nil && signatureFound {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1765,16 +1765,16 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 
-	// Warn the user if there is any custom configuration in use.
-	if message, hasWarnings := app.CheckCustomConfig(false); hasWarnings {
-		util.Warning(message)
-	}
-
 	// Warn user if there are deprecated items used in the config
 	app.CheckDeprecations()
 
 	// Fix any obsolete things like old shell commands, etc.
 	app.FixObsolete()
+
+	// Warn the user if there is any custom configuration in use.
+	if message, hasWarnings := app.CheckCustomConfig(false); hasWarnings {
+		util.Warning(message)
+	}
 
 	if _, err = app.CreateSettingsFile(); err != nil {
 		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)


### PR DESCRIPTION
## The Issue

- Fixes #8291

## How This PR Solves The Issue

- Removes commands that are no longer used by DDEV but were previously provided by DDEV.
- Moves check for custom files *after* deleting obsolete files so that users don't see warnings on `ddev start` about files that have already been deleted.

## Manual Testing Instructions

```bash
ddev config --auto
mkdir -p .ddev/commands/host .ddev/commands/solr
echo '#ddev-generated' > .ddev/commands/host/solrtail.example
echo '#ddev-generated' > .ddev/commands/solr/README.txt
echo '#ddev-generated' > .ddev/commands/solr/solrtail.example
echo '#ddev-generated' > ~/.ddev/commands/web/python
echo '#ddev-generated' > ~/.ddev/commands/web/typo3cms
ddev start
ls -l .ddev/commands/host/solrtail.example .ddev/commands/solr/README.txt .ddev/commands/solr/solrtail.example ~/.ddev/commands/web/python ~/.ddev/commands/web/typo3cms
```

Before:

```bash
$ ddev start
...
Custom configuration detected in project 'laravel':
  • Commands (global):
    - /home/stas/.ddev/commands/web/python (unexpected #ddev-generated)
    - /home/stas/.ddev/commands/web/typo3cms (unexpected #ddev-generated)
...
$ ls -l .ddev/commands/host/solrtail.example .ddev/commands/solr/README.txt .ddev/commands/solr/solrtail.example ~/.ddev/commands/web/python ~/.ddev/commands/web/typo3cms
-rw-r--r-- 1 stas stas 16 Apr  6 18:19 .ddev/commands/host/solrtail.example
-rw-r--r-- 1 stas stas 16 Apr  6 18:19 .ddev/commands/solr/README.txt
-rw-r--r-- 1 stas stas 16 Apr  6 18:19 .ddev/commands/solr/solrtail.example
-rwxr-xr-x 1 stas stas 16 Apr  6 18:19 /home/stas/.ddev/commands/web/python
-rwxr-xr-x 1 stas stas 16 Apr  6 18:19 /home/stas/.ddev/commands/web/typo3cms
```

After:

```bash
$ ddev start
$ ls -l .ddev/commands/host/solrtail.example .ddev/commands/solr/README.txt .ddev/commands/solr/solrtail.example ~/.ddev/commands/web/python ~/.ddev/commands/web/typo3cms
ls: cannot access '.ddev/commands/host/solrtail.example': No such file or directory
ls: cannot access '.ddev/commands/solr/README.txt': No such file or directory
ls: cannot access '.ddev/commands/solr/solrtail.example': No such file or directory
ls: cannot access '/home/stas/.ddev/commands/web/python': No such file or directory
ls: cannot access '/home/stas/.ddev/commands/web/typo3cms': No such file or directory
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
