### PR TITLE
build(ci): remove pin for textlint, for #8300 (#8303) [skip ci]

### DIFF
--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install textlint
         run: |
           npm init -y
-          npm install textlint@15.5.2 textlint-filter-rule-comments textlint-rule-no-todo textlint-rule-stop-words textlint-rule-terminology
+          npm install textlint textlint-filter-rule-comments textlint-rule-no-todo textlint-rule-stop-words textlint-rule-terminology
       - name: Run textlint
         uses: tsuyoshicho/action-textlint@v3
         with:

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -129,7 +129,7 @@ install_node_tools() {
   npm install -g \
     markdownlint-cli \
     @umbrelladocs/linkspector \
-    textlint@15.5.2 \
+    textlint \
     textlint-filter-rule-comments \
     textlint-rule-no-todo \
     textlint-rule-stop-words \


### PR DESCRIPTION
## The Issue

- For #8300

`textlint` has a new release https://github.com/textlint/textlint/releases/tag/v15.5.4

## How This PR Solves The Issue

No need to pin it anymore.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
