### PR TITLE
fix(webserver): always use webimage from app config (#8304) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/ddev/ddev/pkg/amplitude"
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/styles"
@@ -33,6 +34,11 @@ var versionCmd = &cobra.Command{
 		}
 
 		v := version.GetVersionInfo()
+
+		// If in a project context, show the project's actual web image instead of the default.
+		if app, err := ddevapp.GetActiveApp(""); err == nil {
+			v["web"] = app.WebImage
+		}
 
 		var out bytes.Buffer
 		t := table.NewWriter()

--- a/cmd/ddev/cmd/delete_test.go
+++ b/cmd/ddev/cmd/delete_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
-	ddevImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -65,7 +64,7 @@ func TestDeleteCmd(t *testing.T) {
 	imgs := []string{
 		"ddev-" + strings.ToLower(app.Name) + "-busybox:latest",
 		app.GetDBImage() + "-" + app.Name + "-built",
-		ddevImages.GetWebImage() + "-" + app.Name + "-built",
+		app.WebImage + "-" + app.Name + "-built",
 	}
 	for _, img := range imgs {
 		require.Contains(t, out, fmt.Sprintf("%s for project %s was deleted", img, app.Name))

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ddev/ddev/pkg/config/remoteconfig/downloader"
 	"github.com/ddev/ddev/pkg/config/remoteconfig/storage"
 	"github.com/ddev/ddev/pkg/config/remoteconfig/types"
-	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -300,7 +299,7 @@ func processPHPAction(action string, installDesc InstallDesc, app *DdevApp, verb
 	image := installDesc.Image
 	// Use the default ddev-webserver as the image if none is specified
 	if image == "" {
-		image = docker.GetWebImage()
+		image = app.WebImage
 	}
 
 	// Validate included/required files on the host (since we need to read from filesystem)
@@ -493,10 +492,10 @@ func injectPHPStrictMode(action string) string {
 
 // validatePHPSyntax validates PHP syntax by running php -l in a container
 // This is used only for validating included/required files
-func validatePHPSyntax(phpCode string, image string) error {
+func validatePHPSyntax(phpCode string, app *DdevApp, image string) error {
 	// Use the provided image or default
 	if image == "" {
-		image = docker.GetWebImage()
+		image = app.WebImage
 	}
 
 	// Create a shell script that writes the PHP code and validates it
@@ -659,7 +658,7 @@ func validateIncludedFile(filePath string, app *DdevApp, image string) error {
 	// Only validate files that appear to contain PHP code
 	content := string(includedContent)
 	if strings.Contains(content, "<?php") || filepath.Ext(fullPath) == ".php" {
-		err = validatePHPSyntax(content, image)
+		err = validatePHPSyntax(content, app, image)
 		if err != nil {
 			return fmt.Errorf("PHP syntax error in included file: %w", err)
 		}

--- a/pkg/ddevapp/commands.go
+++ b/pkg/ddevapp/commands.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	dockerImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/versionconstants"
 )
 
 // PopulateGlobalCustomCommandFiles sets up the custom command files in the project
@@ -63,5 +63,5 @@ func performTaskInContainer(command []string) (string, string, error) {
 	// If there is no running active site, use an anonymous container instead.
 	containerName := "performTaskInContainer" + nodeps.RandomString(12)
 	uid, _, _ := dockerutil.GetContainerUser()
-	return dockerutil.RunSimpleContainer(dockerImages.GetWebImage(), containerName, command, nil, nil, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, &dockerutil.NoHealthCheck)
+	return dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, containerName, command, nil, nil, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1753,7 +1753,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	util.Debug("Exec %s", chownCmd)
-	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "start-chown-"+util.RandString(6), []string{"sh", "-c", chownCmd}, []string{}, []string{}, volumeMounts, "", true, false, labels, nil, &dockerutil.NoHealthCheck)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "start-chown-"+util.RandString(6), []string{"sh", "-c", chownCmd}, []string{}, []string{}, volumeMounts, "", true, false, labels, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to '%s' inside volumes: %v, output=%s", chownCmd, err, out)
 	}
@@ -1826,7 +1826,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		return err
 	}
 
-	_, logStderrOutput, err := dockerutil.RunSimpleContainer(ddevImages.GetWebImage()+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
+	_, logStderrOutput, err := dockerutil.RunSimpleContainer(app.WebImage+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
 	// If the web image is dirty, try to rebuild it immediately
 	if err == nil && strings.TrimSpace(logStderrOutput) != "" && globalconfig.IsInternetActive() {
 		_, err = app.composeBuild("web", "--no-cache")
@@ -2215,8 +2215,12 @@ func (app *DdevApp) Restart() error {
 // We always need web image, and ddev-utilities for housekeeping.
 func PullBaseContainerImages(additionalImages []string, pullAlways bool) error {
 	base := []string{
-		ddevImages.GetWebImage(),
 		versionconstants.UtilitiesImage,
+	}
+	// Only pull the default web image when no project-specific images are provided,
+	// otherwise the project's actual web image is already in additionalImages.
+	if len(additionalImages) == 0 {
+		base = append(base, ddevImages.GetWebImage())
 	}
 	if globalconfig.DdevGlobalConfig.XHProfMode == types.XHProfModeXHGui {
 		base = append(base, ddevImages.GetXhguiImage())
@@ -3296,7 +3300,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	// for stopped project
 	c := fmt.Sprintf("rm -rf /mnt/ddev-global-cache/traefik/config/%[1]s_merged.yaml", app.Name)
 	util.Debug("Removing merged config for project with command '%s'", c)
-	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "remove-project-merged-config-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, &dockerutil.NoHealthCheck)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "remove-project-merged-config-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, nil)
 	if err != nil {
 		util.Warning("Unable to remove project merged traefik yaml: %v, output='%s'", err, out)
 	}
@@ -3308,7 +3312,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		// This would not remove extra certs that they had put in certs directory.
 		c := fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%[1]s-{web,db} /mnt/ddev-global-cache/traefik/*/%[1]s.{crt,key} /mnt/ddev-global-cache/traefik/config/%[1]s_merged.yaml", app.Name)
 		util.Debug("Cleaning ddev-global-cache with command '%s'", c)
-		_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "clean-ddev-global-cache-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, &dockerutil.NoHealthCheck)
+		_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "clean-ddev-global-cache-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, nil)
 		if err != nil {
 			util.Warning("Unable to clean up ddev-global-cache with command '%s': %v; output='%s'", c, err, out)
 		}
@@ -3429,7 +3433,7 @@ func deleteImages(app *DdevApp) {
 	// These images should already be deleted, but just in case, delete these two by name
 	dbBuilt := app.GetDBImage() + "-" + app.Name + "-built"
 	_ = dockerutil.RemoveImage(dbBuilt)
-	webBuilt := ddevImages.GetWebImage() + "-" + app.Name + "-built"
+	webBuilt := app.WebImage + "-" + app.Name + "-built"
 	_ = dockerutil.RemoveImage(webBuilt)
 }
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -560,9 +560,12 @@ func TestDdevStart(t *testing.T) {
 	})
 
 	// Make sure the -built Docker image exists before stop
-	webBuilt := ddevImages.GetWebImage() + "-" + site.Name + "-built"
-	dbBuilt := ddevImages.GetWebImage() + "-" + site.Name + "-built"
+	webBuilt := app.WebImage + "-" + site.Name + "-built"
 	exists, err := dockerutil.ImageExistsLocally(webBuilt)
+	assert.NoError(err)
+	assert.True(exists)
+	dbBuilt := ddevImages.GetDBImage(app.Database.Type, app.Database.Version) + "-" + site.Name + "-built"
+	exists, err = dockerutil.ImageExistsLocally(dbBuilt)
 	assert.NoError(err)
 	assert.True(exists)
 


### PR DESCRIPTION
## The Issue

Using DDEV HEAD:

```
$ ddev delete -Oy
$ docker builder prune -f
$ docker rmi ddev/ddev-webserver:20260331_stasadev_php85_memcached ddev/ddev-webserver:v1.25.1 
$ ddev config --web-image=ddev/ddev-webserver:v1.25.1
$ ddev start
Starting d11... 
[+] pull 2/2
 ✔ Image ddev/ddev-webserver:v1.25.1                           Pulled       1.3s
 ✔ Image ddev/ddev-webserver:20260331_stasadev_php85_memcached Pulled       1.3s
Building project images............
[+] pull 1/1
 ✘ Image ddev/ddev-webserver:20260331_stasadev_php85_memcached-d11... Error 0.8s
Error response from daemon: failed to resolve reference "docker.io/ddev/ddev-webserver:20260331_stasadev_php85_memcached-d11-built": docker.io/ddev/ddev-webserver:20260331_stasadev_php85_memcached-d11-built: not found
Project images built in 10s.
...
```

There are two problems:

1. The defaullt image should not be pulled `Image ddev/ddev-webserver:20260331_stasadev_php85_memcached Pulled` if I use something different
2. Unknown pull using incorrect image: `Error response from daemon: failed to resolve reference "docker.io/ddev/ddev-webserver:20260331_stasadev_php85_memcached-d11-built"`

## How This PR Solves The Issue

- Replaces `docker.GetWebImage()` with `app.WebImage` wherever I could find it.
- Doesn't pull the default webimage on `ddev start`, always rely on what is specified in the `.ddev/.ddev-docker-compose-full.yaml`
- Shows the correct web image in `ddev version`

## Manual Testing Instructions

Confirm no pull for `20260331_stasadev_php85_memcached`, no pull errors on build.

```
$ ddev delete -Oy
$ docker builder prune -f
$ docker rmi ddev/ddev-webserver:20260331_stasadev_php85_memcached ddev/ddev-webserver:v1.25.1 
$ ddev config --web-image=ddev/ddev-webserver:v1.25.1
$ ddev start
Starting d11... 
[+] pull 3/3
 ✔ Image ddev/ddev-webserver:v1.25.1 Pulled                                21.4s
Building project images...........
Project images built in 18s.
...
```

And check the `ddev version` inside and outside the project directory:

```bash
$ ddev version
 ITEM              VALUE
 web               ddev/ddev-webserver:v1.25.1

$ cd ~
$ ddev version
 ITEM              VALUE
 web               ddev/ddev-webserver:20260331_stasadev_php85_memcached
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
