### PR TITLE
fix: ensure up-to-date images for ddev-ssh-agent and ddev-router (#8305) [skip ci]

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -74,10 +74,9 @@ func RemoveRouterContainer() error {
 
 // StartDdevRouter ensures the router is running.
 func StartDdevRouter() error {
-	// If the router is not healthy/running, we'll kill it so it
-	// starts over again.
+	// Kill the router if not running or if its image is outdated, so it restarts fresh.
 	router, err := FindDdevRouter()
-	if router != nil && err == nil && router.State != "running" {
+	if router != nil && err == nil && (router.State != "running" || router.Image != ddevImages.GetRouterImage()) {
 		err = dockerutil.RemoveContainer(nodeps.RouterContainer)
 		if err != nil {
 			return err
@@ -159,8 +158,9 @@ func StartDdevRouter() error {
 
 		// Run docker-compose up -d against the ddev-router full compose file
 		_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
+			ProjectName:  RouterComposeProjectName,
 			ComposeFiles: []string{routerComposeFullPath},
-			Action:       []string{"-p", RouterComposeProjectName, "up", "--build", "-d"},
+			Action:       []string{"up", "--build", "-d"},
 		})
 		if err != nil {
 			return fmt.Errorf("failed to start ddev-router: %v", err)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -75,8 +75,9 @@ func RemoveRouterContainer() error {
 // StartDdevRouter ensures the router is running.
 func StartDdevRouter() error {
 	// Kill the router if not running or if its image is outdated, so it restarts fresh.
+	// Use HasSuffix to handle registry prefixes (e.g. docker.io/) that Podman includes in image names.
 	router, err := FindDdevRouter()
-	if router != nil && err == nil && (router.State != "running" || router.Image != ddevImages.GetRouterImage()) {
+	if router != nil && err == nil && (router.State != "running" || !strings.HasSuffix(router.Image, ddevImages.GetRouterImage())) {
 		err = dockerutil.RemoveContainer(nodeps.RouterContainer)
 		if err != nil {
 			return err

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -1,3 +1,5 @@
+name: ddev-router
+
 services:
   ddev-router:
     image: {{ .router_image }}

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	ddevImages "github.com/ddev/ddev/pkg/docker"
@@ -41,8 +42,9 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 		return err
 	}
 	// Nothing to do if the ssh container is running with the current image.
+	// Use HasSuffix to handle registry prefixes (e.g. docker.io/) that Podman includes in image names.
 	if sshContainer != nil &&
-		sshContainer.Image == ddevImages.GetSSHAuthImage()+"-built" &&
+		strings.HasSuffix(sshContainer.Image, ddevImages.GetSSHAuthImage()+"-built") &&
 		(sshContainer.State == "running" || sshContainer.State == "starting") {
 		return nil
 	}

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -40,8 +40,10 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 	if err != nil {
 		return err
 	}
-	// If we already have a running ssh container, there's nothing to do.
-	if sshContainer != nil && (sshContainer.State == "running" || sshContainer.State == "starting") {
+	// Nothing to do if the ssh container is running with the current image.
+	if sshContainer != nil &&
+		sshContainer.Image == ddevImages.GetSSHAuthImage()+"-built" &&
+		(sshContainer.State == "running" || sshContainer.State == "starting") {
 		return nil
 	}
 
@@ -55,6 +57,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 	_ = app.DockerEnv()
 
 	_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
+		ProjectName:  SSHAuthName,
 		ComposeFiles: []string{composeFile},
 		Action:       []string{"down"},
 	})
@@ -69,8 +72,9 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 
 	// Now restart ddev-ssh-agent
 	_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
+		ProjectName:  SSHAuthName,
 		ComposeFiles: []string{composeFile},
-		Action:       []string{"-p", SSHAuthName, "up", "--build", "-d"},
+		Action:       []string{"up", "--build", "-d"},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start ddev-ssh-agent: %v", err)

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -1,3 +1,5 @@
+name: ddev-ssh-agent
+
 volumes:
   dot_ssh:
     name: "ddev-ssh-agent_dot_ssh"

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -113,7 +113,7 @@ func TestSSHAuth(t *testing.T) {
 		Cmd:     "rm -f /home/.ssh-agent/known_hosts; ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
-	assert.Equal(stdout, "/root")
+	assert.Equal("/root", stdout)
 	assert.NoError(err)
 
 	err = app.Stop(true, false)
@@ -129,7 +129,7 @@ func TestSSHAuth(t *testing.T) {
 		Cmd:     "rm -f /home/.ssh-agent/known_hosts; ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
-	assert.Equal(stdout, "/root")
+	assert.Equal("/root", stdout)
 	assert.NoError(err)
 
 	err = app.Stop(true, false)


### PR DESCRIPTION
## The Issue

Using DDEV v1.25.0:

```text
$ ddev poweroff
$ docker rmi ddev/ddev-ssh-agent:v1.25.0 ddev/ddev-ssh-agent:v1.25.0-built ddev/ddev-ssh-agent:v1.25.1 ddev/ddev-ssh-agent:v1.25.1-built
$ docker builder prune -f
$ ddev start
$ ddev stop
$ docker ps --format "table {{.Image}}\t{{.Status}}\t{{.Names}}"
IMAGE                               STATUS                   NAMES
ddev/ddev-traefik-router:v1.25.0    Up 3 minutes (healthy)   ddev-router
ddev/ddev-ssh-agent:v1.25.0-built   Up 3 minutes (healthy)   ddev-ssh-agent
```

Then switch to DDEV v1.25.1, but do not accept to run poweroff, v1.25.0 will still be in use:

```text
$ ddev start
You seem to have a new DDEV version (new=v1.25.1, old=v1.25.0) 
During an upgrade it's important to `ddev poweroff`.
May I do `ddev poweroff` before continuing?
This does no harm and loses no data. [Y/n] (yes): n
...
$ docker ps --format "table {{.Image}}\t{{.Status}}\t{{.Names}}"
IMAGE                                            STATUS                    NAMES
ddev/ddev-dbserver-mysql-8.0:v1.25.1-d11-built   Up 13 seconds (healthy)   ddev-d11-db
ddev/ddev-webserver:v1.25.1-d11-built            Up 13 seconds (healthy)   ddev-d11-web
ddev/ddev-traefik-router:v1.25.0                 Up 5 minutes (healthy)    ddev-router
ddev/ddev-ssh-agent:v1.25.0-built                Up 5 minutes (healthy)    ddev-ssh-agent
```

Now run:
```text
$ ddev auth ssh
Adding 1 SSH private key(s)... 
[+] pull 1/1
 ✘ Image ddev/ddev-ssh-agent:v1.25.1-built Error failed to resolve reference "docker.io/ddev/ddev-ssh-agent:v1.25.1-b... 0.7s
Error response from daemon: failed to resolve reference "docker.io/ddev/ddev-ssh-agent:v1.25.1-built": docker.io/ddev/ddev-ssh-agent:v1.25.1-built: not found
Failed to execute command `ddev auth ssh`: failed to pull image ddev/ddev-ssh-agent:v1.25.1-built: exit status 1 
```

I suppose this is one of those errors that @rfay and I had seen in recent months and that is easy to solve with `ddev poweroff`, but we can handle it better.

## How This PR Solves The Issue

Ensures that we don't have leftovers for `ddev-ssh-agent` and `ddev-router` on `ddev start`.

## Manual Testing Instructions

Using DDEV v1.25.0:

```text
$ ddev poweroff
$ docker rmi ddev/ddev-ssh-agent:v1.25.0 ddev/ddev-ssh-agent:v1.25.0-built ddev/ddev-ssh-agent:v1.25.1 ddev/ddev-ssh-agent:v1.25.1-built
$ docker builder prune -f
$ ddev start
$ ddev stop
$ docker ps --format "table {{.Image}}\t{{.Status}}\t{{.Names}}"
IMAGE                               STATUS                        NAMES
ddev/ddev-traefik-router:v1.25.0    Up 42 seconds (healthy)       ddev-router
ddev/ddev-ssh-agent:v1.25.0-built   Up About a minute (healthy)   ddev-ssh-agent
```

Then switch to this PR, but do not accept to run poweroff, no v1.25.0 in use:

```text
$ ddev start
You seem to have a new DDEV version (new=v1.25.1-64-g130f80b88, old=v1.25.0) 
During an upgrade it's important to `ddev poweroff`.
May I do `ddev poweroff` before continuing?
This does no harm and loses no data. [Y/n] (yes): n
...
$ docker ps --format "table {{.Image}}\t{{.Status}}\t{{.Names}}"
IMAGE                                                             STATUS                    NAMES
ddev/ddev-traefik-router:v1.25.1                                  Up 9 seconds (healthy)    ddev-router
ddev/ddev-dbserver-mysql-8.0:v1.25.1-d11-built                    Up 22 seconds (healthy)   ddev-d11-db
ddev/ddev-webserver:20260331_stasadev_php85_memcached-d11-built   Up 22 seconds (healthy)   ddev-d11-web
ddev/ddev-ssh-agent:v1.25.1-built                                 Up 41 seconds (healthy)   ddev-ssh-agent
```

Now run:

```
$ ddev auth ssh
Adding 1 SSH private key(s)...
...
Successfully added 1 SSH private key(s).
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
