### PR TITLE
fix(webserver): add timeout to `yarn config set` in start.sh (#8309) [skip ci]

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -35,17 +35,17 @@ fi
 
 # Set PHP timezone to configured $TZ if there is one
 if [ ! -z ${TZ} ]; then
-    perl -pi -e "s%date.timezone *=.*$%date.timezone = $TZ%g" $(find /etc/php -name php.ini)
+  perl -pi -e "s%date.timezone *=.*$%date.timezone = $TZ%g" $(find /etc/php -name php.ini)
 fi
 
 # If the user has provided custom PHP configuration, copy it into a directory
 # where PHP will automatically include it.
 if [ -d /mnt/ddev_config/php ] ; then
-    # If there are files in the mount
-    if [ -n "$(ls -A /mnt/ddev_config/php/*.ini 2>/dev/null)" ]; then
-        cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/cli/conf.d/
-        cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/fpm/conf.d/
-    fi
+  # If there are files in the mount
+  if [ -n "$(ls -A /mnt/ddev_config/php/*.ini 2>/dev/null)" ]; then
+    cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/cli/conf.d/
+    cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/fpm/conf.d/
+  fi
 fi
 
 if [ -d /mnt/ddev_config/nginx_full ]; then
@@ -58,8 +58,8 @@ if [ -d /mnt/ddev_config/apache ]; then
 fi
 
 if [ "$DDEV_PROJECT_TYPE" = "backdrop" ] ; then
-    # Start can be executed when the container is already running.
-    mkdir -p ~/.drush/commands && ln -sf /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
+  # Start can be executed when the container is already running.
+  mkdir -p ~/.drush/commands && ln -sf /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
 fi
 
 if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7" ] || [ "${DDEV_PROJECT_TYPE}" = "backdrop" ]; then
@@ -73,9 +73,9 @@ a2enmod access_compat alias auth_basic authn_core authn_file authz_core authz_ho
 a2enconf charset localized-error-pages other-vhosts-access-log security serve-cgi-bin
 
 if [ "$DDEV_WEBSERVER_TYPE" = "apache-fpm" ] ; then
-    a2enmod proxy_fcgi
-    a2enconf php${DDEV_PHP_VERSION}-fpm
-    a2dissite 000-default
+  a2enmod proxy_fcgi
+  a2enconf php${DDEV_PHP_VERSION}-fpm
+  a2dissite 000-default
 fi
 
 # Disable xdebug by default. Users can enable with /usr/local/bin/enable_xdebug
@@ -106,7 +106,7 @@ fi
 # enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
 # global folder.
 (if cd ~ || (echo "unable to cd to home directory"; exit 22); then
-  yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic >/dev/null || true
+  timeout 1 yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic >/dev/null || echo 'cache-folder "/mnt/ddev-global-cache/yarn/classic"' >> ~/.yarnrc || true
 fi)
 # ensure default yarn berry global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
@@ -117,7 +117,7 @@ ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 # should all be set up with both global and local
 # either way.
 if [ -d /mnt/ddev_config/.homeadditions ]; then
-    cp -r /mnt/ddev_config/.homeadditions/. ~/
+  cp -r /mnt/ddev_config/.homeadditions/. ~/
 fi
 
 # It's possible CAROOT does not exist or is not writeable (if host-side mkcert -install not run yet)
@@ -141,8 +141,8 @@ ddev_custom_init_scripts
 # Make sure /var/tmp/logpipe gets logged; only for standalone non-ddev usages
 logpipe=/var/tmp/logpipe
 if [[ ! -p ${logpipe} ]]; then
-    mkfifo ${logpipe}
-    cat < ${logpipe} >/proc/1/fd/1 &
+  mkfifo ${logpipe}
+  cat < ${logpipe} >/proc/1/fd/1 &
 fi
 
 exec /usr/bin/supervisord -n -c "/etc/supervisor/supervisord-${DDEV_WEBSERVER_TYPE}.conf"

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -35,17 +35,17 @@ fi
 
 # Set PHP timezone to configured $TZ if there is one
 if [ ! -z ${TZ} ]; then
-    perl -pi -e "s%date.timezone *=.*$%date.timezone = $TZ%g" $(find /etc/php -name php.ini)
+  perl -pi -e "s%date.timezone *=.*$%date.timezone = $TZ%g" $(find /etc/php -name php.ini)
 fi
 
 # If the user has provided custom PHP configuration, copy it into a directory
 # where PHP will automatically include it.
 if [ -d /mnt/ddev_config/php ] ; then
-    # If there are files in the mount
-    if [ -n "$(ls -A /mnt/ddev_config/php/*.ini 2>/dev/null)" ]; then
-        cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/cli/conf.d/
-        cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/fpm/conf.d/
-    fi
+  # If there are files in the mount
+  if [ -n "$(ls -A /mnt/ddev_config/php/*.ini 2>/dev/null)" ]; then
+    cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/cli/conf.d/
+    cp /mnt/ddev_config/php/*.ini /etc/php/${DDEV_PHP_VERSION}/fpm/conf.d/
+  fi
 fi
 
 if [ -d /mnt/ddev_config/nginx_full ]; then
@@ -58,8 +58,8 @@ if [ -d /mnt/ddev_config/apache ]; then
 fi
 
 if [ "$DDEV_PROJECT_TYPE" = "backdrop" ] ; then
-    # Start can be executed when the container is already running.
-    mkdir -p ~/.drush/commands && ln -sf /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
+  # Start can be executed when the container is already running.
+  mkdir -p ~/.drush/commands && ln -sf /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
 fi
 
 if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7" ] || [ "${DDEV_PROJECT_TYPE}" = "backdrop" ]; then
@@ -73,9 +73,9 @@ a2enmod access_compat alias auth_basic authn_core authn_file authz_core authz_ho
 a2enconf charset localized-error-pages other-vhosts-access-log security serve-cgi-bin
 
 if [ "$DDEV_WEBSERVER_TYPE" = "apache-fpm" ] ; then
-    a2enmod proxy_fcgi
-    a2enconf php${DDEV_PHP_VERSION}-fpm
-    a2dissite 000-default
+  a2enmod proxy_fcgi
+  a2enconf php${DDEV_PHP_VERSION}-fpm
+  a2dissite 000-default
 fi
 
 # Disable xdebug by default. Users can enable with /usr/local/bin/enable_xdebug
@@ -102,7 +102,7 @@ fi
 # enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
 # global folder.
 (if cd ~ || (echo "unable to cd to home directory"; exit 22); then
-  yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic >/dev/null || true
+  timeout 1 yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic >/dev/null || echo 'cache-folder "/mnt/ddev-global-cache/yarn/classic"' >> ~/.yarnrc || true
 fi)
 # ensure default yarn berry global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
@@ -112,7 +112,7 @@ ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/
 
 if [ -d /mnt/ddev_config/.homeadditions ]; then
-    cp -r /mnt/ddev_config/.homeadditions/. ~/
+  cp -r /mnt/ddev_config/.homeadditions/. ~/
 fi
 
 # It's possible CAROOT does not exist or is not writeable (if host-side mkcert -install not run yet)
@@ -133,8 +133,8 @@ ddev_custom_init_scripts
 # Make sure /var/tmp/logpipe gets logged; only for standalone non-ddev usages
 logpipe=/var/tmp/logpipe
 if [[ ! -p ${logpipe} ]]; then
-    mkfifo ${logpipe}
-    cat < ${logpipe} >/proc/1/fd/1 &
+  mkfifo ${logpipe}
+  cat < ${logpipe} >/proc/1/fd/1 &
 fi
 
 exec /usr/bin/supervisord -n -c "/etc/supervisor/supervisord-${DDEV_WEBSERVER_TYPE}.conf"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260331_stasadev_php85_memcached" // Note that this can be overridden by make
+var WebTag = "20260410_stasadev_yarn_timeout" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

From Discord: https://discord.com/channels/664580571770388500/1466532425655124036

`yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic` just got stuck, causing `ddev start` to timeout:

https://github.com/ddev/ddev/actions/runs/21492400046/job/61918113073

```
2026-01-29T19:58:19.135 Logs from failed ddev-TestPkgDrupal11-web container:
+ set -eu -o pipefail
+ logpipe=/var/tmp/logpipe
+ [[ ! -p /var/tmp/logpipe ]]
+ mkfifo /var/tmp/logpipe
+ trap 'trap - SIGTERM && kill -- -1' SIGINT SIGTERM EXIT SIGHUP SIGQUIT
+ cat
+ set -o errexit nounset pipefail
+ rm -f /tmp/healthy
+ pkill -0 supervisord
+ rm -f /var/run/supervisor.sock
+ export DDEV_WEB_ENTRYPOINT=/mnt/ddev_config/web-entrypoint.d
+ DDEV_WEB_ENTRYPOINT=/mnt/ddev_config/web-entrypoint.d
+ source /functions.sh
+ '[' '!' -f /home/runner/.gitconfig ']'
+ DDEV_PHP_VERSION=8.4
+ DDEV_WEBSERVER_TYPE=apache-fpm
+ '[' -n 8.4 ']'
+ update-alternatives --set php /usr/bin/php8.4
+ ln -sf /usr/sbin/php-fpm8.4 /usr/sbin/php-fpm
+ export PHP_INI=/etc/php/8.4/fpm/php.ini
+ PHP_INI=/etc/php/8.4/fpm/php.ini
+ '[' '!' -z Etc/UTC ']'
++ find /etc/php -name php.ini
+ perl -pi -e 's%date.timezone *=.*$%date.timezone = Etc/UTC%g' /etc/php/8.2/cli/php.ini /etc/php/8.2/fpm/php.ini /etc/php/7.4/cli/php.ini /etc/php/7.4/fpm/php.ini /etc/php/8.4/cli/php.ini /etc/php/8.4/fpm/php.ini /etc/php/7.0/cli/php.ini /etc/php/7.0/fpm/php.ini /etc/php/5.6/cli/php.ini /etc/php/5.6/fpm/php.ini /etc/php/7.1/cli/php.ini /etc/php/7.1/fpm/php.ini /etc/php/8.5/cli/php.ini /etc/php/8.5/fpm/php.ini /etc/php/7.3/cli/php.ini /etc/php/7.3/fpm/php.ini /etc/php/8.0/cli/php.ini /etc/php/8.0/fpm/php.ini /etc/php/8.3/cli/php.ini /etc/php/8.3/fpm/php.ini /etc/php/8.1/cli/php.ini /etc/php/8.1/fpm/php.ini /etc/php/7.2/cli/php.ini /etc/php/7.2/fpm/php.ini
+ '[' -d /mnt/ddev_config/php ']'
++ ls -A '/mnt/ddev_config/php/*.ini'
+ '[' -n '' ']'
+ '[' -d /mnt/ddev_config/nginx_full ']'
+ rm -rf /etc/nginx/sites-enabled
+ cp -r /mnt/ddev_config/nginx_full /etc/nginx/sites-enabled/
+ '[' -d /mnt/ddev_config/apache ']'
+ rm -rf /etc/apache2/sites-enabled
+ cp -r /mnt/ddev_config/apache /etc/apache2/sites-enabled
+ '[' drupal11 = backdrop ']'
+ '[' drupal11 = drupal6 ']'
+ '[' drupal11 = drupal7 ']'
+ '[' drupal11 = backdrop ']'
++ id -un
++ id -gn
+ printf '\nexport APACHE_RUN_USER=runner\nexport APACHE_RUN_GROUP=runner\n'
+ a2enmod access_compat alias auth_basic authn_core authn_file authz_core authz_host authz_user autoindex deflate dir env filter mime mpm_event negotiation reqtimeout rewrite setenvif status
Considering dependency authn_core for access_compat:
Module authn_core already enabled
Module access_compat already enabled
Module alias already enabled
Considering dependency authn_core for auth_basic:
Module authn_core already enabled
Module auth_basic already enabled
Module authn_core already enabled
Module authn_file already enabled
Module authz_core already enabled
Considering dependency authz_core for authz_host:
Module authz_core already enabled
Module authz_host already enabled
Considering dependency authz_core for authz_user:
Module authz_core already enabled
Module authz_user already enabled
Module autoindex already enabled
Considering dependency filter for deflate:
Module filter already enabled
Module deflate already enabled
Module dir already enabled
Module env already enabled
Module filter already enabled
Module mime already enabled
Considering conflict mpm_worker for mpm_event:
Considering conflict mpm_prefork for mpm_event:
Enabling module mpm_event.
Module negotiation already enabled
Module reqtimeout already enabled
Enabling module rewrite.
Module setenvif already enabled
Module status already enabled
To activate the new configuration, you need to run:
  service apache2 restart
+ a2enconf charset localized-error-pages other-vhosts-access-log security serve-cgi-bin
Conf charset already enabled
Conf localized-error-pages already enabled
Conf other-vhosts-access-log already enabled
Conf security already enabled
Conf serve-cgi-bin already enabled
+ '[' apache-fpm = apache-fpm ']'
+ a2enmod proxy_fcgi
Considering dependency proxy for proxy_fcgi:
Enabling module proxy.
Enabling module proxy_fcgi.
To activate the new configuration, you need to run:
  service apache2 restart
+ a2enconf php8.4-fpm
Enabling conf php8.4-fpm.
To activate the new configuration, you need to run:
  service apache2 reload
+ a2dissite 000-default
Site 000-default already disabled
+ '[' false = true ']'
+ disable_xdebug
Disabled xdebug
+ phpenmod assert
+ ls /var/www/html
+ sudo mkdir -p /mnt/ddev-global-cache/terminus/cache
+ sudo mkdir -p /mnt/ddev-global-cache/bashhistory/TestPkgDrupal11-web /mnt/ddev-global-cache/mysqlhistory/TestPkgDrupal11-web /mnt/ddev-global-cache/n_prefix/TestPkgDrupal11-web /mnt/ddev-global-cache/npm /mnt/ddev-global-cache/yarn/classic /mnt/ddev-global-cache/yarn/berry /mnt/ddev-global-cache/corepack
++ id -u
++ id -g
+ sudo chown -R 1001:1001 /mnt/ddev-global-cache/ /var/lib/php
+ '[' '' '!=' '' ']'
+ cd /home/runner
+ yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic

2026-01-29T19:58:19.135 Health log from failed ddev-TestPkgDrupal11-web container:
/var/www/html:OK mailpit:FAILED phpstatus:FAILED


2026-01-29T19:58:19.521 Copied /home/runner/.config/ddev/commands:CopyIntoVolume_wwyuxjsevztq into /mnt/v/global-commands in 53.363889ms
2026-01-29T19:58:19.570 Exec chown -R 1001 /mnt/v/global-commands stdout=, stderr=, err=<nil>
Failed waiting for web/db containers to become ready: web container failed: log=, err=health check timed out after 2m0s: labels map[com.ddev.site-name:TestPkgDrupal11 com.docker.compose.oneoff:False com.docker.compose.service:web] timed out without becoming healthy, status=, detail= ddev-TestPkgDrupal11-web:starting

Troubleshoot this with these commands:

  - ddev logs -s web
  - docker logs ddev-TestPkgDrupal11-web
  - docker inspect --format "{{ json .State.Health }}" ddev-TestPkgDrupal11-web | docker run -i --rm ddev/ddev-utilities jq -r

If your internet connection is slow, consider increasing the timeout by running this:

  - ddev config --default-container-timeout=240 && ddev restart
```

## How This PR Solves The Issue

I noticed that sometimes `yarn` tries to access the internet on any command, and it adds `lastUpdateCheck` to `~/.yarnrc`. I couldn't find a way to stop `yarn` from doing this, so I added `timeout 1 yarn config set cache-folder` with a fallback.

## Manual Testing Instructions

```bash
$ ddev start

$ ddev exec yarn config get cache-folder
/mnt/ddev-global-cache/yarn/classic

$ ddev exec 'cat ~/.yarnrc'             
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1


cache-folder "/mnt/ddev-global-cache/yarn/classic"
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
