### PR TITLE
chore: add link to blog about buildx requirement, for #8234 (#8310) [skip ci]

### DIFF
--- a/pkg/dockerutil/requirements.go
+++ b/pkg/dockerutil/requirements.go
@@ -184,7 +184,7 @@ func CheckDockerBuildxVersion(dockerVersionMatrix DockerVersionMatrix) error {
 
 	v, err := GetBuildxVersion()
 	if err != nil {
-		return fmt.Errorf("compose build requires buildx %s or later: %v.\nPlease install buildx: https://github.com/docker/buildx#installing", dockerVersionMatrix.BuildxVersion, err)
+		return fmt.Errorf("compose build requires buildx %s or later: %v.\nPlease install buildx: https://github.com/docker/buildx#installing\nMore details: https://ddev.com/blog/docker-buildx-requirement-v1-25-1/", dockerVersionMatrix.BuildxVersion, err)
 	}
 
 	pluginPath, err := GetBuildxLocation()
@@ -193,7 +193,7 @@ func CheckDockerBuildxVersion(dockerVersionMatrix DockerVersionMatrix) error {
 	}
 
 	if versions.LessThan(v, dockerVersionMatrix.BuildxVersion) {
-		return fmt.Errorf("compose build requires buildx %s or later.\nInstalled docker buildx: %s (plugin path: %s)\nPlease update buildx: https://github.com/docker/buildx#installing", dockerVersionMatrix.BuildxVersion, v, pluginPath)
+		return fmt.Errorf("compose build requires buildx %s or later.\nInstalled docker buildx: %s (plugin path: %s)\nPlease update buildx: https://github.com/docker/buildx#installing\nMore details: https://ddev.com/blog/docker-buildx-requirement-v1-25-1/", dockerVersionMatrix.BuildxVersion, v, pluginPath)
 	}
 
 	return nil


### PR DESCRIPTION
## The Issue

This error does not explain exactly how to install Docker Buildx on different platforms:

```
$ ddev start
Docker buildx check failed: compose build requires buildx 0.17.0 or later: docker CLI plugin "buildx" not found.
Please install buildx: https://github.com/docker/buildx#installing
```

We have this blog https://ddev.com/blog/docker-buildx-requirement-v1-25-1/ and draft PR to handle Buildx automatically #8234

## How This PR Solves The Issue

Until #8234 is merged, we should provide more details in the error message - for example, add a link to the blog.

## Manual Testing Instructions

Remove buildx, and run:

```
$ ddev start
Docker buildx check failed: compose build requires buildx 0.17.0 or later: docker CLI plugin "buildx" not found.
Please install buildx: https://github.com/docker/buildx#installing
More details: https://ddev.com/blog/docker-buildx-requirement-v1-25-1/
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
