### PR TITLE
feat(docker): set ddev labels for images, containers, networks, fixes #7389

### DIFF
--- a/cmd/ddev/cmd/testdata/TestCmdAddon/example-repo/docker-compose.example.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddon/example-repo/docker-compose.example.yaml
@@ -8,10 +8,6 @@ services:
     # memcached is available at this port inside the container.
     expose:
       - 11211
-    # These labels ensure this service is discoverable by ddev.
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
 
     # Arguments passed to the memcached binary.
     command: ["-m", "128"]

--- a/cmd/ddev/cmd/testdata/TestCmdAddonGetWithDotEnv/bare-busybox/docker-compose.bare-busybox.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonGetWithDotEnv/bare-busybox/docker-compose.bare-busybox.yaml
@@ -5,10 +5,6 @@ services:
     image: busybox:stable
     command: tail -f /dev/null
     restart: "no"
-    # These labels ensure this service is discoverable by ddev.
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
     # This service checks if env variables from .env.* files are added to environment
     # when the "environment" section is not defined in the yaml file
     #environment:

--- a/cmd/ddev/cmd/testdata/TestCmdAddonGetWithDotEnv/busybox/docker-compose.busybox.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonGetWithDotEnv/busybox/docker-compose.busybox.yaml
@@ -5,10 +5,6 @@ services:
     image: busybox:${BUSYBOX_TAG:-stable}
     command: tail -f /dev/null
     restart: "no"
-    # These labels ensure this service is discoverable by ddev.
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
     environment:
       # This variable can be overridden with .env.busybox file
       - THIS_VARIABLE_CAN_BE_CHANGED_FROM_ENV=true

--- a/cmd/ddev/cmd/testdata/TestCmdAddonPHP/ComplexPHPAddon/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonPHP/ComplexPHPAddon/install.yaml
@@ -62,3 +62,15 @@ pre_install_actions:
 
 project_files:
   - config.complex-php-addon.yaml
+
+removal_actions:
+  - |
+    #ddev-description:Remove generated docker-compose.complex-php-addon.yaml
+    file="${DDEV_APPROOT}/.ddev/docker-compose.complex-php-addon.yaml"
+    if [ -f "$file" ]; then
+      if grep -q '#ddev-generated' "$file"; then
+        rm -f "$file"
+      else
+        echo "Unwilling to remove '$file' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+      fi
+    fi

--- a/cmd/ddev/cmd/testdata/TestCmdAddonPHP/PHPRemovalActions/docker-compose.varnish.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonPHP/PHPRemovalActions/docker-compose.varnish.yaml
@@ -3,10 +3,6 @@ services:
   varnish:
     container_name: ddev-${DDEV_SITENAME}-varnish
     image: ${VARNISH_DOCKER_IMAGE:-varnish:6.0}
-    # These labels ensure this service is discoverable by ddev.
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
     environment:
       # This defines the host name the service should be accessible from. This
       # will be sitename.ddev.site.

--- a/cmd/ddev/cmd/testdata/TestCmdAddonPHP/VarnishPHPAddon/docker-compose.varnish.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonPHP/VarnishPHPAddon/docker-compose.varnish.yaml
@@ -3,10 +3,6 @@ services:
   varnish:
     container_name: ddev-${DDEV_SITENAME}-varnish
     image: ${VARNISH_DOCKER_IMAGE:-varnish:6.0}
-    # These labels ensure this service is discoverable by ddev.
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
     environment:
       # This defines the host name the service should be accessible from. This
       # will be sitename.ddev.site.

--- a/cmd/ddev/cmd/testdata/TestCmdDescribe/docker-compose.override.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdDescribe/docker-compose.override.yaml
@@ -19,18 +19,12 @@ services:
     image: busybox
     command: tail -f /dev/null
     container_name: ddev-${DDEV_SITENAME}-busybox1
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
   busybox2:
     expose:
       - 3333
     image: busybox
     command: tail -f /dev/null
     container_name: ddev-${DDEV_SITENAME}-busybox2
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     x-ddev:
       describe-url-port: "url-port Test service description for busybox2"
       describe-info: |

--- a/cmd/ddev/cmd/testdata/TestCmdStartOptionalProfiles/docker-compose.busybox.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdStartOptionalProfiles/docker-compose.busybox.yaml
@@ -5,9 +5,6 @@ services:
     profiles:
       - busybox1
     container_name: ddev-${DDEV_SITENAME}-busybox1
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     # ports from optional profiles should be exposed for Traefik
     # and used as entryPoints, if it doesn't work, router fails
     environment:
@@ -20,6 +17,3 @@ services:
     profiles:
       - busybox2
     container_name: ddev-${DDEV_SITENAME}-busybox2
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}

--- a/cmd/ddev/cmd/testdata/TestDeleteCmd/busybox/docker-compose.busybox.yaml
+++ b/cmd/ddev/cmd/testdata/TestDeleteCmd/busybox/docker-compose.busybox.yaml
@@ -6,10 +6,6 @@ services:
       context: busybox
     command: tail -f /dev/null
     restart: "no"
-    # These labels ensure this service is discoverable by ddev.
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
     volumes:
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"

--- a/cmd/ddev/cmd/utility-dockercheck.go
+++ b/cmd/ddev/cmd/utility-dockercheck.go
@@ -156,7 +156,7 @@ ddev ut dockercheck`,
 		}
 
 		uid, _, _ := dockerutil.GetContainerUser()
-		_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "dockercheck-runcontainer--"+util.RandString(6), []string{"ls", "/mnt/ddev-global-cache"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
+		_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "dockercheck-runcontainer--"+util.RandString(6), []string{"ls", "/mnt/ddev-global-cache"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, uid, true, false, nil, nil, nil)
 		if err != nil {
 			util.Warning("Unable to run simple container: %v; output=%s", err, out)
 			hasWarnings = true
@@ -164,7 +164,7 @@ ddev ut dockercheck`,
 			util.Success("Able to run simple container that mounts a volume.")
 		}
 
-		_, _, err = dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "dockercheck-curl--"+util.RandString(6), []string{"curl", "-sfLI", "https://google.com"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache/bashhistory"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
+		_, _, err = dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "dockercheck-curl--"+util.RandString(6), []string{"curl", "-sfLI", "https://google.com"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache/bashhistory"}, uid, true, false, nil, nil, nil)
 		if err != nil {
 			util.Warning("Unable to run use internet inside container, many things will fail: %v", err)
 			hasWarnings = true

--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -24,6 +24,7 @@ For most HTTP-based services, use `expose` with `HTTP_EXPOSE` and `HTTPS_EXPOSE`
 services:
   dummy-service:
     container_name: "ddev-${DDEV_SITENAME}-dummy-service"
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
@@ -89,6 +90,7 @@ When defining additional services for your project, we recommend following these
     services:
       dummy-service:
         image: ${YOUR_DOCKER_IMAGE:-example/example:latest}
+        # These two labels are added automatically since DDEV v1.25.2+
         labels:
           com.ddev.site-name: ${DDEV_SITENAME}
           com.ddev.approot: ${DDEV_APPROOT}
@@ -184,6 +186,7 @@ services:
     # Tip: external_links are not needed anymore in DDEV v1.24.10+
     external_links:
       - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.approot: ${DDEV_APPROOT}
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -236,6 +239,7 @@ services:
   example:
     container_name: ddev-${DDEV_SITENAME}-example
     image: ${YOUR_DOCKER_IMAGE:-example/example:latest}
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.approot: ${DDEV_APPROOT}
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -266,6 +270,7 @@ services:
         username: ${DDEV_USER}
         uid: ${DDEV_UID}
         gid: ${DDEV_GID}
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.approot: ${DDEV_APPROOT}
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -317,6 +322,7 @@ services:
     profiles:
       - busybox
     container_name: ddev-${DDEV_SITENAME}-busybox
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}

--- a/docs/content/users/extend/custom-docker-services.md
+++ b/docs/content/users/extend/custom-docker-services.md
@@ -40,6 +40,7 @@ services:
   myservice:
     container_name: "ddev-${DDEV_SITENAME}-myservice"
     image: nginx:alpine
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
@@ -61,6 +62,7 @@ services:
 Always include these labels for proper DDEV integration:
 
 ```yaml
+# These two labels are added automatically since DDEV v1.25.2+
 labels:
   com.ddev.site-name: ${DDEV_SITENAME}
   com.ddev.approot: ${DDEV_APPROOT}
@@ -129,6 +131,7 @@ services:
   rabbitmq:
     container_name: "ddev-${DDEV_SITENAME}-rabbitmq"
     image: rabbitmq:3-management-alpine
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
@@ -169,6 +172,7 @@ services:
   sqlsrv:
     container_name: "ddev-${DDEV_SITENAME}-sqlsrv"
     image: mcr.microsoft.com/mssql/server:2022-latest
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
@@ -203,6 +207,7 @@ services:
   elasticsearch:
     container_name: "ddev-${DDEV_SITENAME}-elasticsearch"
     image: elasticsearch:8.11.0
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
@@ -234,6 +239,7 @@ services:
   redis:
     container_name: "ddev-${DDEV_SITENAME}-redis"
     image: redis:7-alpine
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
@@ -244,6 +250,7 @@ services:
   memcached:
     container_name: "ddev-${DDEV_SITENAME}-memcached"
     image: memcached:alpine
+    # These two labels are added automatically since DDEV v1.25.2+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -516,7 +516,7 @@ if [ $exit_code -ne 0 ]; then
 fi
 `, phpCode)
 
-	_, out, err := dockerutil.RunSimpleContainer(image, "php-validate-"+util.RandString(6), []string{"sh", "-c", shellScript}, []string{}, []string{}, []string{}, "", true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
+	_, out, err := dockerutil.RunSimpleContainer(image, "php-validate-"+util.RandString(6), []string{"sh", "-c", shellScript}, []string{}, []string{}, []string{}, "", true, false, nil, nil, nil)
 	out = strings.TrimSpace(out)
 
 	if err != nil {

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -3,7 +3,7 @@ name: ${COMPOSE_PROJECT_NAME}
 services:
   {{ if not .OmitDB }}
   db:
-    container_name: {{ .Plugin }}-${DDEV_SITENAME}-db
+    container_name: ddev-${DDEV_SITENAME}-db
     build:
       context: '{{ .DBBuildContext }}'
       args:
@@ -37,11 +37,6 @@ services:
     hostname: {{ .Name }}-db
     ports:
       - "{{ .DockerIP }}:$DDEV_HOST_DB_PORT:{{ .DBPort }}"
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.platform: {{ .Plugin }}
-      com.ddev.app-type: {{ .AppType }}
-      com.ddev.approot: $DDEV_APPROOT
     environment:
       - COLUMNS
       - BITNAMI_VOLUME_DIR={{ .BitnamiVolumeDir }}
@@ -94,7 +89,7 @@ services:
   {{ end }} {{/* end if not .OmitDB */}}
 
   web:
-    container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
+    container_name: ddev-${DDEV_SITENAME}-web
     build:
       context: '{{ .WebBuildContext }}'
       args:
@@ -254,11 +249,6 @@ services:
     - START_SCRIPT_TIMEOUT={{ sub .DefaultContainerTimeout 5 }}
     {{ range $env := .WebEnvironment }}- "{{ $env }}"
     {{ end }}
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.platform: {{ .Plugin }}
-      com.ddev.app-type: {{ .AppType }}
-      com.ddev.approot: $DDEV_APPROOT
 
     healthcheck:
       test: "/healthcheck.sh"
@@ -273,9 +263,6 @@ services:
   xhgui:
     image: {{ .XhguiImage }}
     container_name: ddev-${DDEV_SITENAME}-xhgui
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
     profiles:
       - xhgui
     restart: "no"
@@ -313,8 +300,6 @@ networks:
     external: true
   default:
     name: ${COMPOSE_PROJECT_NAME}_default
-    labels:
-      com.ddev.platform: ddev
 
 volumes:
   {{ if not .OmitDB }}

--- a/pkg/ddevapp/commands.go
+++ b/pkg/ddevapp/commands.go
@@ -63,5 +63,5 @@ func performTaskInContainer(command []string) (string, string, error) {
 	// If there is no running active site, use an anonymous container instead.
 	containerName := "performTaskInContainer" + nodeps.RandomString(12)
 	uid, _, _ := dockerutil.GetContainerUser()
-	return dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, containerName, command, nil, nil, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
+	return dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, containerName, command, nil, nil, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, uid, true, false, nil, nil, nil)
 }

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -3,6 +3,7 @@ package ddevapp
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -176,6 +177,52 @@ func (app *DdevApp) GetXDdevExtension(serviceName string) XDdevExtension {
 	return xDdev
 }
 
+// GetDdevLabels returns labels for DDEV resources. If app is nil, only global
+// labels are returned. If app is provided, project-specific labels are added.
+func GetDdevLabels(app *DdevApp) map[string]string {
+	labels := dockerutil.GlobalDdevLabels()
+	if app != nil {
+		// Overrides the empty global value; used by poweroff, router, and db
+		// to find containers belonging to this project.
+		labels["com.ddev.site-name"] = app.GetName()
+		// Used by GetActiveProjects to restore app.Type when NewApp() fails.
+		labels["com.ddev.app-type"] = app.GetType()
+		// Used to verify the running container matches the current project root
+		// and to recover the project directory from a container's labels.
+		labels["com.ddev.approot"] = app.GetAppRoot()
+	}
+	return labels
+}
+
+// injectDdevLabels stamps DDEV labels onto all services, build sections, and
+// non-external networks in the project. If app is nil, global labels are used.
+func injectDdevLabels(project *composeTypes.Project, app *DdevApp) {
+	labels := GetDdevLabels(app)
+	for name, service := range project.Services {
+		if service.Labels == nil {
+			service.Labels = composeTypes.Labels{}
+		}
+		maps.Copy(service.Labels, labels)
+		if service.Build != nil {
+			if service.Build.Labels == nil {
+				service.Build.Labels = composeTypes.Labels{}
+			}
+			maps.Copy(service.Build.Labels, labels)
+		}
+		project.Services[name] = service
+	}
+	for name, network := range project.Networks {
+		if network.External {
+			continue
+		}
+		if network.Labels == nil {
+			network.Labels = composeTypes.Labels{}
+		}
+		maps.Copy(network.Labels, labels)
+		project.Networks[name] = network
+	}
+}
+
 // fixupComposeYaml makes minor changes to the `docker-compose config` output
 // to make sure extra services are always compatible with ddev.
 func fixupComposeYaml(yamlStr string, app *DdevApp) (*composeTypes.Project, error) {
@@ -204,14 +251,10 @@ func fixupComposeYaml(yamlStr string, app *DdevApp) (*composeTypes.Project, erro
 			network.Name = app.GetDefaultNetworkName()
 			network.External = false
 		}
-		if !network.External {
-			if network.Labels == nil {
-				network.Labels = composeTypes.Labels{}
-			}
-			network.Labels["com.ddev.platform"] = "ddev"
-		}
 		project.Networks[name] = network
 	}
+
+	injectDdevLabels(project, app)
 
 	bindIP, err := dockerutil.GetDockerIP()
 	if err != nil {

--- a/pkg/ddevapp/compose_yaml_test.go
+++ b/pkg/ddevapp/compose_yaml_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -227,7 +228,7 @@ func TestFixupComposeYaml(t *testing.T) {
 	require.NotEmpty(t, app.ComposeYaml)
 	require.NotEmpty(t, app.ComposeYaml.Services)
 
-	expectedServices := []string{"web", "db", "dummy1"}
+	expectedServices := []string{"web", "db", "dummy1", "dummy2"}
 	for _, serviceName := range expectedServices {
 		_, ok := app.ComposeYaml.Services[serviceName]
 		require.True(t, ok, "%s service not found in app.ComposeYaml.Services", serviceName)
@@ -242,6 +243,8 @@ func TestFixupComposeYaml(t *testing.T) {
 
 	hostDockerInternal := dockerutil.GetHostDockerInternal()
 
+	totalPortsChecked := 0
+	buildServicesChecked := 0
 	for serviceName, service := range app.ComposeYaml.Services {
 		t.Run("service_"+serviceName, func(t *testing.T) {
 			require.Contains(t, service.Networks, "ddev_default", "service %s missing ddev_default network", serviceName)
@@ -257,10 +260,26 @@ func TestFixupComposeYaml(t *testing.T) {
 			}
 
 			for portIndex, port := range service.Ports {
+				totalPortsChecked++
 				require.Equal(t, "127.0.0.1", port.HostIP, "service %s port %d should have HostIP set to 127.0.0.1", serviceName, portIndex)
+			}
+
+			for k, v := range ddevapp.GetDdevLabels(app) {
+				require.Contains(t, service.Labels, k, "service %s missing label %s", serviceName, k)
+				require.Equal(t, v, service.Labels[k], "service %s label %s value incorrect", serviceName, k)
+			}
+
+			if service.Build != nil {
+				buildServicesChecked++
+				for k, v := range ddevapp.GetDdevLabels(app) {
+					require.Contains(t, service.Build.Labels, k, "service %s build missing label %s", serviceName, k)
+					require.Equal(t, v, service.Build.Labels[k], "service %s build label %s value incorrect", serviceName, k)
+				}
 			}
 		})
 	}
+	require.Positive(t, buildServicesChecked, "build label check never ran")
+	require.Positive(t, totalPortsChecked, "port HostIP check never ran")
 
 	hasPort12345 := false
 	for _, port := range webService.Ports {
@@ -299,4 +318,33 @@ func TestFixupComposeYaml(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetDdevLabels verifies that GetDdevLabels returns the correct labels
+// for both global (nil app) and project-specific contexts.
+func TestGetDdevLabels(t *testing.T) {
+	// nil app: only global labels, no project-specific keys
+	labels := ddevapp.GetDdevLabels(nil)
+	require.Contains(t, labels, "com.ddev.platform")
+	require.Equal(t, "ddev", labels["com.ddev.platform"])
+	require.Contains(t, labels, "com.ddev.site-name")
+	require.Equal(t, "", labels["com.ddev.site-name"])
+	require.Contains(t, labels, "com.ddev.webtag")
+	require.Equal(t, versionconstants.WebTag, labels["com.ddev.webtag"])
+	require.NotContains(t, labels, "com.ddev.app-type")
+	require.NotContains(t, labels, "com.ddev.approot")
+
+	// with app: project-specific labels are added/overridden
+	app := &ddevapp.DdevApp{Name: "mysite", Type: "php", AppRoot: "/tmp/mysite"}
+	labels = ddevapp.GetDdevLabels(app)
+	require.Contains(t, labels, "com.ddev.platform")
+	require.Equal(t, "ddev", labels["com.ddev.platform"])
+	require.Contains(t, labels, "com.ddev.site-name")
+	require.Equal(t, "mysite", labels["com.ddev.site-name"])
+	require.Contains(t, labels, "com.ddev.app-type")
+	require.Equal(t, "php", labels["com.ddev.app-type"])
+	require.Contains(t, labels, "com.ddev.approot")
+	require.Equal(t, "/tmp/mysite", labels["com.ddev.approot"])
+	require.Contains(t, labels, "com.ddev.webtag")
+	require.Equal(t, versionconstants.WebTag, labels["com.ddev.webtag"])
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -781,7 +781,6 @@ func (app *DdevApp) FixObsolete() {
 
 type composeYAMLVars struct {
 	Name                      string
-	Plugin                    string
 	AppType                   string
 	WebserverType             string
 	MailpitPort               string
@@ -882,7 +881,6 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 
 	templateVars := composeYAMLVars{
 		Name:                      app.Name,
-		Plugin:                    "ddev",
 		AppType:                   app.Type,
 		WebserverType:             app.WebserverType,
 		MailpitPort:               GetInternalPort(app, "mailpit"),

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -310,15 +310,28 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	err = app.WriteDockerComposeYAML()
 	assert.NoError(err)
 
-	// Ensure we can read from the file and that it's a regular file with the expected name.
+	// Ensure we can read from the base file and that it's a regular file with the expected name.
 	fileinfo, err := os.Stat(app.DockerComposeYAMLPath())
 	assert.NoError(err)
 	assert.False(fileinfo.IsDir())
-	assert.Equal(fileinfo.Name(), filepath.Base(app.DockerComposeYAMLPath()))
+	assert.Equal(".ddev-docker-compose-base.yaml", fileinfo.Name())
 
 	composeBytes, err := os.ReadFile(app.DockerComposeYAMLPath())
 	assert.NoError(err)
 	contentString := string(composeBytes)
+	assert.Contains(contentString, "ddev_default")
+	assert.Contains(contentString, "IS_DDEV_PROJECT")
+
+	// Ensure we can read from the full file and that it's a regular file with the expected name.
+	fileinfo, err = os.Stat(app.DockerComposeFullRenderedYAMLPath())
+	assert.NoError(err)
+	assert.False(fileinfo.IsDir())
+	assert.Equal(".ddev-docker-compose-full.yaml", fileinfo.Name())
+
+	composeBytes, err = os.ReadFile(app.DockerComposeFullRenderedYAMLPath())
+	assert.NoError(err)
+	contentString = string(composeBytes)
+	assert.Contains(contentString, app.GetComposeProjectName())
 	assert.Contains(contentString, app.Type)
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1736,7 +1736,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	// Build list of volume mounts and their target paths for chown
 	volumeMounts := []string{"ddev-global-cache:/mnt/ddev-global-cache"}
 	chownCmd := fmt.Sprintf("chown -R %s:%s /mnt/ddev-global-cache", uid, gid)
-	labels := map[string]string{"com.ddev.site-name": ""}
+	labels := map[string]string{}
 	if dockerutil.IsPodmanRootless() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
@@ -1826,7 +1826,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		return err
 	}
 
-	_, logStderrOutput, err := dockerutil.RunSimpleContainer(app.WebImage+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
+	_, logStderrOutput, err := dockerutil.RunSimpleContainer(app.WebImage+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, nil, nil, nil)
 	// If the web image is dirty, try to rebuild it immediately
 	if err == nil && strings.TrimSpace(logStderrOutput) != "" && globalconfig.IsInternetActive() {
 		_, err = app.composeBuild("web", "--no-cache")

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -285,7 +285,16 @@ func generateRouterCompose(activeApps []*DdevApp) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_, err = fullHandle.WriteString(fullContents)
+	project, err := dockerutil.CreateComposeProject(fullContents)
+	if err != nil {
+		return "", err
+	}
+	injectDdevLabels(project, nil)
+	fullContentsBytes, err := project.MarshalYAML()
+	if err != nil {
+		return "", err
+	}
+	_, err = fullHandle.Write(fullContentsBytes)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -34,9 +34,6 @@ services:
       # Use hardcoded 127.0.0.1 instead of $dockerIP because on remote Docker
       # hosts, $dockerIP is the remote IP which cannot be used as a bind address
       - "127.0.0.1:{{.TraefikMonitorPort}}:{{.TraefikMonitorPort}}"
-    labels:
-      # For cleanup on ddev poweroff
-      com.ddev.site-name: ""
     volumes:
       - ddev-global-cache:/mnt/ddev-global-cache:rw
       {{ if .letsencrypt }}

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -37,6 +37,7 @@ func FullRenderedSSHAuthComposeYAMLPath() string {
 
 // EnsureSSHAgentContainer ensures the ssh-auth container is running.
 func (app *DdevApp) EnsureSSHAgentContainer() error {
+	util.Debug("Ensuring ddev-ssh-agent container is running with the current image")
 	sshContainer, err := findDdevSSHAuth()
 	if err != nil {
 		return err
@@ -167,7 +168,16 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_, err = fullHandle.WriteString(fullContents)
+	project, err := dockerutil.CreateComposeProject(fullContents)
+	if err != nil {
+		return "", err
+	}
+	injectDdevLabels(project, nil)
+	fullContentsBytes, err := project.MarshalYAML()
+	if err != nil {
+		return "", err
+	}
+	_, err = fullHandle.Write(fullContentsBytes)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.intervalandretriesset.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.intervalandretriesset.yaml
@@ -3,9 +3,6 @@ services:
     container_name: "ddev-${DDEV_SITENAME}-longtimeout"
     image: debian:12
     command: sleep infinity
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     healthcheck:
       interval: "60s"
       retries: 11

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.intervalset.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.intervalset.yaml
@@ -3,8 +3,5 @@ services:
     container_name: "ddev-${DDEV_SITENAME}-longtimeout"
     image: debian:12
     command: sleep infinity
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     healthcheck:
       interval: "45s"

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.longtimeout.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.longtimeout.yaml
@@ -3,8 +3,5 @@ services:
     container_name: "ddev-${DDEV_SITENAME}-longtimeout"
     image: debian:12
     command: sleep infinity
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     healthcheck:
       timeout: "1000s"

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.nohealthcheck.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.nohealthcheck.yaml
@@ -3,6 +3,3 @@ services:
     container_name: "ddev-${DDEV_SITENAME}-longtimeout"
     image: debian:12
     command: sleep infinity
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.withlongstartperiod.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.withlongstartperiod.yaml
@@ -3,8 +3,5 @@ services:
     container_name: "ddev-${DDEV_SITENAME}-longtimeout"
     image: debian:12
     command: sleep infinity
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     healthcheck:
       start_period: "1350s"

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.withshortstartperiod.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.withshortstartperiod.yaml
@@ -3,8 +3,5 @@ services:
     container_name: "ddev-${DDEV_SITENAME}-longtimeout"
     image: debian:12
     command: sleep infinity
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     healthcheck:
       start_period: "10s"

--- a/pkg/ddevapp/testdata/TestDdevApp_StartOptionalProfiles/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevApp_StartOptionalProfiles/docker-compose.busybox.yaml
@@ -5,15 +5,9 @@ services:
     profiles:
       - busybox-first
     container_name: ddev-${DDEV_SITENAME}-busybox1
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
   busybox2:
     image: busybox:stable
     command: tail -f /dev/null
     profiles:
       - busybox-second
     container_name: ddev-${DDEV_SITENAME}-busybox2
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}

--- a/pkg/ddevapp/testdata/TestDdevDescribe/docker-compose.testservice.yaml
+++ b/pkg/ddevapp/testdata/TestDdevDescribe/docker-compose.testservice.yaml
@@ -3,9 +3,6 @@ services:
     image: busybox:latest
     container_name: ddev-${DDEV_SITENAME}-testservice
     command: tail -f /dev/null
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     restart: "no"
     expose:
       - "8888"

--- a/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
+++ b/pkg/ddevapp/testdata/TestDdevExec/docker-compose.busybox.yaml
@@ -3,6 +3,3 @@ services:
     image: busybox:stable
     command: tail -f /dev/null
     container_name: ddev-${DDEV_SITENAME}-busybox
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT

--- a/pkg/ddevapp/testdata/TestFixupComposeYaml/.ddev/docker-compose.dummy2.yaml
+++ b/pkg/ddevapp/testdata/TestFixupComposeYaml/.ddev/docker-compose.dummy2.yaml
@@ -1,0 +1,8 @@
+services:
+  dummy2:
+    build:
+      context: .
+    environment:
+      - HTTP_EXPOSE=9103
+      - HTTPS_EXPOSE=9104
+      - VIRTUAL_HOST=$DDEV_HOSTNAME

--- a/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
+++ b/pkg/ddevapp/testdata/TestSSHAuth/.ddev/docker-compose.sshserver.yaml
@@ -7,5 +7,3 @@ services:
     # Port is published for debugging reasons only. ssh -p 3333 root@localhost
     - published: 3333
       target: 22
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}

--- a/pkg/ddevapp/testdata/TestTraefikVirtualHost/docker-compose.extra.yaml
+++ b/pkg/ddevapp/testdata/TestTraefikVirtualHost/docker-compose.extra.yaml
@@ -3,9 +3,6 @@ services:
   nginx:
     image: nginx
     container_name: ddev-${DDEV_SITENAME}-nginx
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
     ports:
       - 80
     environment:

--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -685,9 +685,11 @@ func RunSimpleContainerExtended(name string, config *container.Config, hostConfi
 	if config.Labels == nil {
 		config.Labels = make(map[string]string)
 	}
-	// Assign a default label so this container can be removed with 'ddev poweroff'
-	if _, exists := config.Labels["com.ddev.site-name"]; !exists {
-		config.Labels["com.ddev.site-name"] = ""
+	// Ensure all global DDEV labels are present; caller-provided values take precedence.
+	for k, v := range GlobalDdevLabels() {
+		if _, exists := config.Labels[k]; !exists {
+			config.Labels[k] = v
+		}
 	}
 
 	// Set up host.docker.internal based on DDEV's standard approach

--- a/pkg/dockerutil/labels.go
+++ b/pkg/dockerutil/labels.go
@@ -1,0 +1,23 @@
+package dockerutil
+
+import "github.com/ddev/ddev/pkg/versionconstants"
+
+// GlobalDdevLabels returns labels applied to all DDEV-managed Docker resources.
+// Resources tied to a specific project should add project-specific labels on top
+// via ddevapp.GetDdevLabels.
+func GlobalDdevLabels() map[string]string {
+	return map[string]string{
+		// Marks the resource as DDEV-managed; used by poweroff to find and remove
+		// all DDEV networks (FindNetworksWithLabel) and by GetActiveProjects to
+		// filter web containers.
+		"com.ddev.platform": "ddev",
+		// Project name; empty for global resources. Used by poweroff to remove
+		// straggling containers (FindContainersByLabels) and by router to list
+		// containers belonging to a site.
+		"com.ddev.site-name": "",
+		// Stamps the DDEV web image tag on the resource. Not actively used yet,
+		// but intended to allow pruning stale resources or triggering rebuilds
+		// when switching to a different DDEV version.
+		"com.ddev.webtag": versionconstants.WebTag,
+	}
+}

--- a/pkg/dockerutil/networks.go
+++ b/pkg/dockerutil/networks.go
@@ -39,7 +39,7 @@ func EnsureDdevNetwork() {
 	netOptions := client.NetworkCreateOptions{
 		Driver:   "bridge",
 		Internal: false,
-		Labels:   map[string]string{"com.ddev.platform": "ddev"},
+		Labels:   GlobalDdevLabels(),
 	}
 	err := EnsureNetwork(NetName, netOptions)
 	if err != nil {

--- a/pkg/dockerutil/requirements.go
+++ b/pkg/dockerutil/requirements.go
@@ -143,7 +143,7 @@ func CanRunWithoutDocker() bool {
 
 // CheckAvailableSpace outputs a warning if Docker space is low
 func CheckAvailableSpace() {
-	_, out, _ := RunSimpleContainer(versionconstants.UtilitiesImage, "check-available-space-"+util.RandString(6), []string{"sh", "-c", `df / | awk '!/Mounted/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
+	_, out, _ := RunSimpleContainer(versionconstants.UtilitiesImage, "check-available-space-"+util.RandString(6), []string{"sh", "-c", `df / | awk '!/Mounted/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, nil, nil, nil)
 	out = strings.Trim(out, "% \r\n")
 	parts := strings.Split(out, " ")
 	if len(parts) != 2 {

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -23,6 +23,12 @@ services:
       VIRTUAL_HOST: junk.ddev.site
     image: TEST-COMPOSE-WITH-STREAMS-IMAGE
     user: "33:33"
+    labels:
+      com.ddev.app-type: php
+      com.ddev.app-url: http://test-compose-with-streams.ddev.site
+      com.ddev.approot: .
+      com.ddev.platform: ddev
+      com.ddev.site-name: TestComposeWithStreams
     restart: "no"
     healthcheck:
       test: "/healthcheck.sh"

--- a/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
+++ b/pkg/dockerutil/testdata/TestComposeWithStreams/test-compose-with-streams.yaml
@@ -23,12 +23,6 @@ services:
       VIRTUAL_HOST: junk.ddev.site
     image: TEST-COMPOSE-WITH-STREAMS-IMAGE
     user: "33:33"
-    labels:
-      com.ddev.app-type: php
-      com.ddev.app-url: http://test-compose-with-streams.ddev.site
-      com.ddev.approot: .
-      com.ddev.platform: ddev
-      com.ddev.site-name: TestComposeWithStreams
     restart: "no"
     healthcheck:
       test: "/healthcheck.sh"

--- a/pkg/dockerutil/testdata/TestNetworkAmbiguity/docker-compose.test.yaml
+++ b/pkg/dockerutil/testdata/TestNetworkAmbiguity/docker-compose.test.yaml
@@ -3,6 +3,3 @@ services:
     container_name: ddev-${DDEV_SITENAME}-test
     image: "busybox:stable"
     command: "tail -f /dev/null"
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT

--- a/pkg/dockerutil/volumes.go
+++ b/pkg/dockerutil/volumes.go
@@ -116,7 +116,7 @@ func CopyIntoVolume(sourcePath string, volumeName string, targetSubdir string, u
 	}
 	c = c + "mkdir -p " + targetSubdirFullPath + " && sleep infinity "
 
-	labels := map[string]string{"com.ddev.site-name": ""}
+	labels := map[string]string{}
 	if IsPodmanRootless() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
@@ -228,7 +228,7 @@ func PurgeDirectoryContentsInVolume(volumeName string, subdirs []string, uid str
 	}
 	c := fmt.Sprintf("mkdir -p %s && rm -rf %s", strings.Join(mkdirs, " "), strings.Join(rmPaths, " "))
 
-	labels := map[string]string{"com.ddev.site-name": ""}
+	labels := map[string]string{}
 	if IsPodmanRootless() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
@@ -257,7 +257,7 @@ func ListFilesInVolume(volumeName string, subdir string) ([]string, error) {
 	// List files, suppress errors if directory doesn't exist
 	c := fmt.Sprintf(`ls -1 "%s" 2>/dev/null || true`, fullPath)
 
-	labels := map[string]string{"com.ddev.site-name": ""}
+	labels := map[string]string{}
 	if IsPodmanRootless() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
@@ -302,7 +302,7 @@ func RemoveFilesFromVolume(volumeName string, subdir string, files []string) err
 	}
 	c := fmt.Sprintf("rm -f %s", strings.Join(rmPaths, " "))
 
-	labels := map[string]string{"com.ddev.site-name": ""}
+	labels := map[string]string{}
 	if IsPodmanRootless() {
 		labels["com.ddev.userns"] = "keep-id"
 	}


### PR DESCRIPTION
## The Issue

- Fixes #7389

DDEV labels (`com.ddev.platform`, `com.ddev.site-name`, `com.ddev.approot`, `com.ddev.app-type`) were previously set inconsistently - some were only in docker-compose YAML templates using environment variable substitution, others were hardcoded in Go, and some resources (router, ssh-agent, build sections, networks) were missing labels entirely.

## How This PR Solves The Issue

- Centralizes DDEV labels in `GlobalDdevLabels()` and `GetDdevLabels(app)`, then injects them automatically into all services, build sections, and non-external networks via `injectDdevLabels()` - covering the main project, router, and ssh-agent compose files.
- Removes hardcoded label blocks from YAML templates and test fixtures.
- Documents that `com.ddev.site-name` and `com.ddev.approot` are now injected automatically; existing manual definitions in user compose files are harmless.

**Note:** Volumes were intentionally left out - adding labels to volumes causes Docker Compose to prompt interactively to recreate them, making `ddev start` appear to hang silently. May be revisited separately.

## Manual Testing Instructions

1. Start a DDEV project: `ddev start`
2. Verify containers have DDEV labels:
   ```bash
   docker inspect ddev-<project>-web | grep -A20 Labels
   ```
   Expect `com.ddev.platform=ddev`, `com.ddev.site-name=<project>`, `com.ddev.app-type`, `com.ddev.approot`, `com.ddev.webtag`.
3. Verify the router container has global labels:
   ```bash
   docker inspect ddev-router | grep -A25 Labels
   ```
   Expect `com.ddev.platform=ddev`, `com.ddev.site-name=` (empty).
4. Verify the ddev-ssh-agent container has global labels similarly.
5. Verify networks:
   ```bash
   docker network inspect ddev-<project>_default | grep -A10 Labels
   ```
6. Add a custom docker-compose service without labels and confirm it still gets labels injected automatically.
7. Run `ddev poweroff` and verify cleanup still works correctly.

## Automated Testing Overview

- `TestGetDdevLabels` - unit test verifying `GetDdevLabels(nil)` returns only global labels and `GetDdevLabels(app)` returns the full set with correct project values.
- `TestFixupComposeYaml` - extended to assert that every service and every build section in the processed compose project contains all expected DDEV labels. Added a `dummy2` fixture service with a build section to exercise the build label path. Guards (`require.Positive`) ensure the label/port checks actually ran.

## Release/Deployment Notes

- Users who already have `com.ddev.site-name` and `com.ddev.approot` in their custom docker-compose files will see no change - injected labels merge with existing ones.
- The `com.ddev.webtag` label is new on all resources; it is not yet used for logic but is intended to enable pruning stale resources or triggering rebuilds on DDEV version changes in the future.
- Volumes are not labeled in this PR (see note above); that may be addressed in a follow-up.