### PR TITLE
feat(asterios): Add Asterios project type (#8313) [skip ci]

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -9,6 +9,7 @@ amazee.io
 amazeeio
 Autocompletion
 Available
+Asterios
 Bash
 Bluesky
 CakePHP

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -196,6 +196,17 @@ func TestCustomCommands(t *testing.T) {
 		assert.Error(err, "found command %s when it should not have been there (no error) app.Type=%s", c, app.Type)
 	}
 
+	// asterios commands should only be available for type asterios
+	app.Type = nodeps.AppTypeAsterios
+	_ = app.WriteConfig()
+	_, _ = exec.RunHostCommand(DdevBin)
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
+	for _, c := range []string{"asterios"} {
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
+		assert.NoError(err)
+	}
+
 	// TYPO3 commands should only be available for type typo3
 	app.Type = nodeps.AppTypeTYPO3
 	_ = app.WriteConfig()

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -621,7 +621,7 @@ The DDEV-specific project type.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | `php` | Can be `backdrop`, `cakephp`, `codeigniter`, `craftcms`, `drupal`, `drupal6`, `drupal7`, `drupal8`, `drupal9`, `drupal10`, `drupal11`, `drupal12`, `generic`, `laravel`, `magento`, `magento2`, `php`, `shopware6`, `silverstripe`, `symfony`, `typo3`, `wordpress`, or `wp-bedrock`.
+| :octicons-file-directory-16: project | `php` | Can be `asterios`, `backdrop`, `cakephp`, `codeigniter`, `craftcms`, `drupal`, `drupal6`, `drupal7`, `drupal8`, `drupal9`, `drupal10`, `drupal11`, `drupal12`, `generic`, `laravel`, `magento`, `magento2`, `php`, `shopware6`, `silverstripe`, `symfony`, `typo3`, `wordpress`, or `wp-bedrock`.
 
 The `php` type doesn’t attempt [CMS configuration](../../users/quickstart.md) or settings file management and can work with any project.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -4,6 +4,56 @@ DDEV is [ready to go](./project.md) with generic project types for PHP framework
 
 Before proceeding, make sure your installation of DDEV is up to date. In a new and empty project folder, using your favorite shell, run the following commands:
 
+## Asterios
+
+Use a new or existing Composer project, or clone a Git repository.
+
+The Asterios project type can be used for [Scaffolding](https://github.com/asteriosframework/asterios-app) and others, as it is used with basic Asterios. DDEV automatically updates or creates the `.env` file with the database information.
+
+=== "Composer"
+
+    Create the project directory and configure DDEV:
+
+    ```bash
+    mkdir -p my-asterios-site && cd my-asterios-site
+    ddev config --project-type=asterios --docroot=public
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start
+    ```
+
+    Install Asterios via Composer:
+
+    ```bash
+    ddev composer create-project asterios/app
+    ```
+
+    Launch the site:
+
+    ```bash
+    ddev launch
+    ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-asterios.sh << 'EOF'
+        #!/usr/bin/env bash
+        set -euo pipefail
+        mkdir -p my-asterios-site && cd my-asterios-site
+        ddev config --project-type=asterios --docroot=public
+        ddev start -y
+        ddev composer create-project asterios/app
+        ddev launch
+        EOF
+        chmod +x setup-asterios.sh
+        ./setup-asterios.sh
+        ```
+
 ## Backdrop
 
 You can start a new [Backdrop](https://backdropcms.org) project or configure an existing one.

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -61,6 +61,7 @@ The dashboard automatically detects your terminal's color capabilities and adapt
 * [`ddev xhgui`](../usage/commands.md#xhgui) enables XHGui, `ddev xhgui off` disables it, and `ddev xhgui status` shows status.
 * [`ddev drush`](../usage/commands.md#drush) (Drupal and Backdrop only) gives direct access to the `drush` CLI.
 * [`ddev artisan`](../usage/commands.md#artisan) (Laravel only) gives direct access to the Laravel `artisan` CLI.
+* [`ddev asterios`](../usage/commands.md#asterios) (Asterios only) gives direct access to the Asterios `asterios` CLI.
 * [`ddev magento`](../usage/commands.md#magento) (Magento2 only) gives access to the `magento` CLI.
 * [`ddev console`](../usage/commands.md#console) (Symfony only) gives access to the `symfony console` CLI.
 * [`ddev craft`](../usage/commands.md#craft) (Craft CMS only) gives access to the `craft` CLI.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -240,6 +240,15 @@ Run the `artisan` command; available only in projects of type `laravel`, and onl
 ddev artisan list
 ```
 
+## `asterios`
+
+Run the `asterios` command; available only in projects of type `asterios`, and only available if `asterios` is in the project root.
+
+```shell
+# Show all asterios subcommands
+ddev asterios list
+```
+
 ## `auth`
 
 Authentication commands.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -242,6 +242,8 @@ ddev artisan list
 
 ## `asterios`
 
+*Alias: `ast`.*
+
 Run the `asterios` command; available only in projects of type `asterios`, and only available if `asterios` is in the project root.
 
 ```shell

--- a/docs/tests/asterios.bats
+++ b/docs/tests/asterios.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-asterios-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "Asterios composer based quickstart with $(ddev --version)" {
+  _skip_if_embargoed "asterios-composer"
+
+  run mkdir -p my-asterios-site && cd my-asterios-site
+  assert_success
+
+  run ddev config --project-type=asterios --docroot=public
+  assert_success
+
+  run ddev start -y
+  assert_success
+
+  run ddev composer create-project asterios/app
+  assert_success
+
+  DDEV_DEBUG=true run ddev launch
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+
+  # validate running project - check status code
+  run curl -sf -o /dev/null -w "%{http_code}" https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output "200"
+
+  # validate running project - check content
+  run curl -sf https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "AsteriosPHP Framework"
+}

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -78,6 +78,11 @@ var appTypeMatrix map[string]appTypeFuncs
 
 func init() {
 	appTypeMatrix = map[string]appTypeFuncs{
+		nodeps.AppTypeAsterios: {
+			appTypeDetect:   isAsteriosApp,
+			postStartAction: asteriosPostStartAction,
+		},
+
 		nodeps.AppTypeBackdrop: {
 			settingsCreator:            createBackdropSettingsFile,
 			uploadDirs:                 getBackdropUploadDirs,

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -64,6 +64,7 @@ func TestConfigOverrideAction(t *testing.T) {
 	origDir, _ := os.Getwd()
 
 	appTypes := map[string]string{
+		nodeps.AppTypeAsterios:     nodeps.PHPDefault,
 		nodeps.AppTypeBackdrop:     nodeps.PHPDefault,
 		nodeps.AppTypeWPBedrock:    nodeps.PHPDefault,
 		nodeps.AppTypeCakePHP:      nodeps.PHPDefault,

--- a/pkg/ddevapp/asterios.go
+++ b/pkg/ddevapp/asterios.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 )
 

--- a/pkg/ddevapp/asterios.go
+++ b/pkg/ddevapp/asterios.go
@@ -47,6 +47,11 @@ func asteriosPostStartAction(app *DdevApp) error {
 	// Only set database configuration if db container is not omitted
 	shouldManageDB := !slices.Contains(app.OmitContainers, "db")
 
+	// PostgreSQL is not supported at the time
+	if app.Database.Type == nodeps.Postgres {
+		shouldManageDB = false
+	}
+
 	if shouldManageDB {
 		port := "3306"
 

--- a/pkg/ddevapp/asterios.go
+++ b/pkg/ddevapp/asterios.go
@@ -1,0 +1,65 @@
+package ddevapp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/util"
+)
+
+// isAsteriosApp returns true if the app is of type asterios
+func isAsteriosApp(app *DdevApp) bool {
+	return fileutil.FileExists(filepath.Join(app.AppRoot, app.ComposerRoot, "asterios"))
+}
+
+// asteriosPostStartAction checks to see if the .env file is set up
+func asteriosPostStartAction(app *DdevApp) error {
+	// We won't touch env if disable_settings_management: true
+	if app.DisableSettingsManagement {
+		return nil
+	}
+	envFilePath := filepath.Join(app.AppRoot, app.ComposerRoot, ".env")
+	_, envText, err := ReadProjectEnvFile(envFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("unable to read .env file: %v", err)
+	}
+	if os.IsNotExist(err) {
+		err = fileutil.CopyFile(filepath.Join(app.AppRoot, app.ComposerRoot, ".env.example"), filepath.Join(app.AppRoot, app.ComposerRoot, ".env"))
+		if err != nil {
+			util.Debug("Asterios: .env.example does not exist yet, not trying to process it")
+			return nil
+		}
+		_, envText, err = ReadProjectEnvFile(envFilePath)
+		if err != nil {
+			return err
+		}
+	}
+	envMap := map[string]string{
+		"APP_URL":     app.GetPrimaryURL(),
+		"MAIL_MAILER": "smtp",
+		"MAIL_HOST":   "127.0.0.1",
+		"MAIL_PORT":   "1025",
+	}
+
+	// Only set database configuration if db container is not omitted
+	shouldManageDB := !slices.Contains(app.OmitContainers, "db")
+
+	if shouldManageDB {
+		port := "3306"
+
+		envMap["DB_HOST"] = "db"
+		envMap["DB_PORT"] = port
+		envMap["DB_DATABASE"] = "db"
+		envMap["DB_USERNAME"] = "db"
+		envMap["DB_PASSWORD"] = "db"
+	}
+	err = WriteProjectEnvFile(envFilePath, envMap, envText)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/asterios
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/asterios
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run asterios CLI inside the web container
+## Usage: asterios [flags] [args]
+## Example: "ddev asterios list" or "ddev asterios view:clear"
+## ProjectTypes: asterios
+## ExecRaw: true
+## MutagenSync: true
+
+cd "${DDEV_COMPOSER_ROOT:-/var/www/html}" || exit 1
+php ./asterios "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/asterios
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/asterios
@@ -4,9 +4,16 @@
 ## Description: Run asterios CLI inside the web container
 ## Usage: asterios [flags] [args]
 ## Example: "ddev asterios list" or "ddev asterios view:clear"
+## Aliases: ast
 ## ProjectTypes: asterios
 ## ExecRaw: true
 ## MutagenSync: true
 
 cd "${DDEV_COMPOSER_ROOT:-/var/www/html}" || exit 1
-php ./asterios "$@"
+
+if [ ! -x "./asterios" ]; then
+  echo "Error: ./asterios is not executable or missing"
+  exit 1
+fi
+
+asterios "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/asterios
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/asterios
@@ -9,10 +9,11 @@
 ## ExecRaw: true
 ## MutagenSync: true
 
-cd "${DDEV_COMPOSER_ROOT:-/var/www/html}" || exit 1
+# Ignore anything we find in the mounted global commands
+PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
 
-if [ ! -x "./asterios" ]; then
-  echo "Error: ./asterios is not executable or missing"
+if ! command -v asterios >/dev/null; then
+  echo "asterios is not available. You may need to 'ddev composer require asterios/core'"
   exit 1
 fi
 

--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -617,6 +617,7 @@
       "description": "Provide the project type.",
       "type": "string",
       "enum": [
+        "asterios",
         "backdrop",
         "cakephp",
         "codeigniter",

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -9,7 +9,7 @@ const ConfigInstructions = `
 # If the name is omitted, the project will take the name of the enclosing directory,
 # which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress, wp-bedrock
+# type: <projecttype>  # asterios, backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress, wp-bedrock
 # See https://docs.ddev.com/en/stable/users/quickstart/ for more
 # information on the different project types
 

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-asterios.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-asterios.conf
@@ -1,0 +1,76 @@
+# ddev asterios config
+
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
+
+server {
+    listen 80 default_server;
+    listen 443 ssl default_server;
+
+    root {{ .Docroot }};
+
+    ssl_certificate /etc/ssl/certs/master.crt;
+    ssl_certificate_key /etc/ssl/certs/master.key;
+
+    include /etc/nginx/monitoring.conf;
+
+    index index.html index.htm index.php;
+
+    charset utf-8;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    location / {
+        absolute_redirect off;
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    error_page 404 /index.php;
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors off;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 10m;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
+    }
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    include /etc/nginx/common.d/*.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -88,6 +88,7 @@ const AppTypeDrupalLatestStable = AppTypeDrupal11
 // App types
 const (
 	AppTypeNone        = ""
+	AppTypeAsterios    = "asterios"
 	AppTypeBackdrop    = "backdrop"
 	AppTypeCakePHP     = "cakephp"
 	AppTypeCodeIgniter = "codeigniter"


### PR DESCRIPTION
## Description

 Add new project type for the php framework asterios.

- Add app type detection
- Add post-start action
- Add composer create-project support
- Add basic tests and documentation

## Manual Testing Instructions
    mkdir my-asterios-app
    cd my-asterios-app
    ddev config --project-type=asterios --docroot=public
    ddev composer create-project asterios/app
    ddev asterios
    ddev launch

## Automated Testing Overview

  I added the AppTypeAsterios to the appTypes inside the pkg/ddevapp/apptypes_test.go file.


## Release/Deployment Notes

My changes only affect the available app types.