### PR TITLE
fix(composer): remove `composer update` from create-project, for #7864 (#8315) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/composer-create-project.go
+++ b/cmd/ddev/cmd/composer-create-project.go
@@ -246,47 +246,13 @@ ddev composer create-project --prefer-dist --no-interaction --no-dev psr/log .
 				RawCmd:  composerCmd,
 				Dir:     getComposerRootInContainer(app),
 				Tty:     isatty.IsTerminal(os.Stdin.Fd()),
-				Env:     []string{"XDEBUG_MODE=off"},
+				// Disable security blocking to allow installing any packages,
+				// this is a new feature in Composer 2.9+
+				Env: []string{"XDEBUG_MODE=off", "COMPOSER_NO_SECURITY_BLOCKING=1"},
 			})
 
 			if err != nil {
-				util.Warning("Failed to install project: %v\nstderr=%v", err, stderr)
-				// Try to run composer update instead.
-				output.UserOut.Println("Trying 'composer update' instead of 'composer install'...")
-
-				composerCmd = []string{
-					"composer",
-					"update",
-				}
-
-				for i, validCreateArg := range validCreateArgs {
-					if isValidComposerOption(app, "update", validCreateArg) {
-						composerCmd = append(composerCmd, validCreateArg)
-					} else if strings.HasPrefix(validCreateArg, "-") && i+1 < len(validCreateArgs) && !strings.HasPrefix(validCreateArgs[i+1], "-") {
-						// If this is an option with a value, add it.
-						if isValidComposerOption(app, "update", validCreateArg+" "+validCreateArgs[i+1]) {
-							composerCmd = append(composerCmd, validCreateArg, validCreateArgs[i+1])
-						}
-					}
-				}
-
-				composerCmd = wrapTTYCommandWithStdin(inputData, composerCmd)
-				// Run update command.
-				output.UserOut.Printf("Executing Composer command: %v\n", composerCmd)
-
-				stdout, stderr, err = app.Exec(&ddevapp.ExecOpts{
-					Service: "web",
-					RawCmd:  composerCmd,
-					Dir:     getComposerRootInContainer(app),
-					Tty:     isatty.IsTerminal(os.Stdin.Fd()),
-					// Disable security blocking to allow installing any packages,
-					// this is a new feature in Composer 2.9+, which may break `composer install`.
-					Env: []string{"XDEBUG_MODE=off", "COMPOSER_NO_SECURITY_BLOCKING=1"},
-				})
-
-				if err != nil {
-					util.Failed("Failed to install project: %v\nstderr=%v", err, stderr)
-				}
+				util.Failed("Failed to install project: %v\nstderr=%v", err, stderr)
 			}
 
 			if len(stdout) > 0 {

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -46,7 +46,7 @@ When using `ddev composer create-project` your project should be essentially emp
 
 1. `composer create-project --no-plugins --no-scripts --no-install` clones a bare Composer package without any additional actions.
 2. `composer run-script post-root-package-install` runs if `--no-scripts` is not given as a flag to `ddev composer create-project`.
-3. `composer install` runs if `--no-install` is not given as a flag to `ddev composer create-project`. If `composer install` fails, DDEV runs `COMPOSER_NO_SECURITY_BLOCKING=1 composer update` to attempt installation of older package versions that may have security advisories.
+3. `composer install` runs if `--no-install` is not given as a flag to `ddev composer create-project`.
 4. `composer run-script post-create-project-cmd` runs if `--no-scripts` is not given as a flag to `ddev composer create-project`.
 
 All flags that you provide to `ddev composer create-project` are checked for validity. All invalid flags will be ignored. If they are valid for `composer create-project`, they will be also passed to `composer run-script` and `composer install`, but only if these commands support these flags.

--- a/docs/tests/ee.bats
+++ b/docs/tests/ee.bats
@@ -36,17 +36,6 @@ teardown() {
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin.php"
   assert_success
 
-  run bash -c '
-  docker ps -q \
-    --filter "label=com.ddev.platform=ddev" \
-    --filter "label=com.docker.compose.service=web" \
-    --filter "label=com.docker.compose.oneoff=False" |
-  xargs -r docker inspect --format "{{.Name}} {{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}no-health{{end}}"
-'
-  assert_output --partial "${PROJNAME}-web running healthy"
-  assert_success
-  echo "# Existing containers: $output" >&3
-
   # Diagnostic: show traefik config files in volume
   # run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
   # echo "# Traefik config files:" >&3

--- a/docs/tests/nodejs.bats
+++ b/docs/tests/nodejs.bats
@@ -59,17 +59,6 @@ EOF
   assert_success
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
 
-  run bash -c '
-  docker ps -q \
-    --filter "label=com.ddev.platform=ddev" \
-    --filter "label=com.docker.compose.service=web" \
-    --filter "label=com.docker.compose.oneoff=False" |
-  xargs -r docker inspect --format "{{.Name}} {{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}no-health{{end}}"
-'
-  assert_output --partial "${PROJNAME}-web running healthy"
-  assert_success
-  echo "# Existing containers: $output" >&3
-
   # Diagnostic: show traefik config files in volume
 #  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
 #  echo "# Traefik config files: $output" >&3

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -36,17 +36,6 @@ teardown() {
 #  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
 #  echo "# Traefik routers: $output"
 
-  run bash -c '
-  docker ps -q \
-    --filter "label=com.ddev.platform=ddev" \
-    --filter "label=com.docker.compose.service=web" \
-    --filter "label=com.docker.compose.oneoff=False" |
-  xargs -r docker inspect --format "{{.Name}} {{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}no-health{{end}}"
-'
-  assert_output --partial "${PROJNAME}-web running healthy"
-  assert_success
-  echo "# Existing containers: $output" >&3
-
   # Diagnostic: show traefik config files in volume
   run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
   echo "# Traefik config files: $output" >&3

--- a/docs/tests/sveltekit.bats
+++ b/docs/tests/sveltekit.bats
@@ -56,24 +56,6 @@ EOF
   DDEV_DEBUG=true run ddev restart -y
   assert_success
 
-  # Diagnostic: show traefik config files in volume
-  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
-  echo "# Traefik config files: $output"
-  # Diagnostic: show traefik router API response (just router names)
-  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
-  echo "# Traefik routers: $output"
-
-  run bash -c '
-  docker ps -q \
-    --filter "label=com.ddev.platform=ddev" \
-    --filter "label=com.docker.compose.service=web" \
-    --filter "label=com.docker.compose.oneoff=False" |
-  xargs -r docker inspect --format "{{.Name}} {{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}no-health{{end}}"
-'
-  assert_output --partial "${PROJNAME}-web running healthy"
-  assert_success
-  echo "# Existing containers: $output" >&3
-
   # ddev launch
   DDEV_DEBUG=true run ddev launch
   assert_output "FULLURL https://${PROJNAME}.ddev.site"


### PR DESCRIPTION
## The Issue

Quickstart fails https://github.com/ddev/ddev/actions/runs/24387884401/job/71233864831?pr=8312

```
not ok 8 Craft CMS New Projects quickstart with ddev version v1.25.1-76-gd8b294d05
```

```
$ printf "admin\nadmin@example.com\nPassword123\nPassword123\nCraftCMS\n\n\n" | ddev composer create-project craftcms/craft
Executing Composer command: [composer create-project --no-plugins --no-scripts --no-install craftcms/craft /tmp/jAeEsB]

Creating a "craftcms/craft" project at "/tmp/jAeEsB"
Installing craftcms/craft (5.7.0)
Plugins have been disabled.
Created project in /tmp/jAeEsB
Creating a "craftcms/craft" project at "/tmp/jAeEsB"
Installing craftcms/craft (5.7.0)
Plugins have been disabled.
  - Installing craftcms/craft (5.7.0): Extracting archive
Created project in /tmp/jAeEsB
Moving install to Composer root
Executing Composer command: [script -q -c composer install /dev/null]

admin
admin@example.com
Password123
Password123
CraftCMS


No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires craftcms/cms ^5.9.0 -> satisfiable by craftcms/cms[5.9.14, ..., 5.x-dev].
    - craftcms/cms[5.9.14, ..., 5.x-dev] require webonyx/graphql-php ~14.11.10 -> found webonyx/graphql-php[v14.11.10] but these were not loaded, because they are affected by security advisories ("PKSA-7h5p-prw9-w5nr"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.


Executing Composer command: [script -q -c composer run-script post-create-project-cmd /dev/null]

admin
admin@example.com
Password123
Password123
CraftCMS


> @php -r "file_exists('.env') || copy('.env.example.dev', '.env');"
> @php -r "unlink('composer.json');"
> @php -r "rename('composer.json.default', 'composer.json');"
> @php craft install
PHP Warning:  require_once(/var/www/html/vendor/autoload.php): Failed to open stream: No such file or directory in /var/www/html/bootstrap.php on line 14

Warning: require_once(/var/www/html/vendor/autoload.php): Failed to open stream: No such file or directory in /var/www/html/bootstrap.php on line 14
PHP Fatal error:  Uncaught Error: Failed opening required '/var/www/html/vendor/autoload.php' (include_path='.:/usr/share/php') in /var/www/html/bootstrap.php:14
Stack trace:
#0 /var/www/html/craft(8): require()
#1 {main}
  thrown in /var/www/html/bootstrap.php on line 14

Fatal error: Uncaught Error: Failed opening required '/var/www/html/vendor/autoload.php' (include_path='.:/usr/share/php') in /var/www/html/bootstrap.php:14
Stack trace:
#0 /var/www/html/craft(8): require()
#1 {main}
  thrown in /var/www/html/bootstrap.php on line 14
Script @php craft install handling the post-create-project-cmd event returned with error code 255
```

I added an extra step with `composer update` in:

- #7864

This was a workaround (added in November 2025), because `composer install` and `composer update` were inconsistent:

- https://github.com/composer/composer/pull/12617#discussion_r2528061698

But it turned out that this behavior was changed in a month (in December 2025):

- https://github.com/composer/composer/issues/12677

So we can pass `COMPOSER_NO_SECURITY_BLOCKING=1` to `composer install`, and remove `composer update` to make the code simpler.

## How This PR Solves The Issue

- Removes `composer update` from `ddev composer create-project`
- Adds `COMPOSER_NO_SECURITY_BLOCKING=1` to `composer install`
- Removes Traefik debugging leftovers from quickstart bats

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
