### PR TITLE
perf(router): reduce fresh-router healthcheck wait, refs #8096

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -82,7 +82,7 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
-      {{ if templateCanUse "healthcheck.start_interval" -}}
+      {{- if templateCanUse "healthcheck.start_interval" }}
       start_interval: "1s"
       {{- end }}
       timeout: "70s"
@@ -287,7 +287,7 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
-      {{ if templateCanUse "healthcheck.start_interval" -}}
+      {{- if templateCanUse "healthcheck.start_interval" }}
       start_interval: "1s"
       {{- end }}
       timeout: "70s"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -82,9 +82,7 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
-      {{ if templateCanUse "healthcheck.start_interval" -}}
       start_interval: "1s"
-      {{- end }}
       timeout: "70s"
   {{ end }} {{/* end if not .OmitDB */}}
 
@@ -255,9 +253,7 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
-      {{- if templateCanUse "healthcheck.start_interval" }}
       start_interval: "1s"
-      {{- end }}
       timeout: "70s"
   {{ if (not .OmitDB) }}
   xhgui:
@@ -287,9 +283,7 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
-      {{ if templateCanUse "healthcheck.start_interval" -}}
       start_interval: "1s"
-      {{- end }}
       timeout: "70s"
     x-ddev:
       describe-url-port: "Launch: ddev xhgui"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -82,7 +82,9 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
+      {{ if templateCanUse "healthcheck.start_interval" -}}
       start_interval: "1s"
+      {{- end }}
       timeout: "70s"
   {{ end }} {{/* end if not .OmitDB */}}
 
@@ -253,7 +255,9 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
+      {{- if templateCanUse "healthcheck.start_interval" }}
       start_interval: "1s"
+      {{- end }}
       timeout: "70s"
   {{ if (not .OmitDB) }}
   xhgui:
@@ -283,7 +287,9 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
+      {{ if templateCanUse "healthcheck.start_interval" -}}
       start_interval: "1s"
+      {{- end }}
       timeout: "70s"
     x-ddev:
       describe-url-port: "Launch: ddev xhgui"

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -254,7 +254,7 @@ func generateRouterCompose(activeApps []*DdevApp) (string, error) {
 		"IsRootless":                 dockerutil.IsRootless(),
 	}
 
-	t, err := template.New("router_compose_template.yaml").ParseFS(bundledAssets, "router_compose_template.yaml")
+	t, err := template.New("router_compose_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "router_compose_template.yaml")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -55,6 +55,7 @@ services:
       interval: 1s
       retries: 120
       start_period: 120s
+      start_interval: "500ms"
       timeout: 120s
 
 networks:

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -55,7 +55,7 @@ services:
       interval: 1s
       retries: 120
       start_period: 120s
-      {{ if templateCanUse "healthcheck.start_interval" -}}
+      {{- if templateCanUse "healthcheck.start_interval" }}
       start_interval: "500ms"
       {{- end }}
       timeout: 120s

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -55,7 +55,9 @@ services:
       interval: 1s
       retries: 120
       start_period: 120s
+      {{ if templateCanUse "healthcheck.start_interval" -}}
       start_interval: "500ms"
+      {{- end }}
       timeout: 120s
 
 networks:

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -142,7 +142,7 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 		"BuildContext":     context,
 		"IsPodmanRootless": dockerutil.IsPodmanRootless(),
 	}
-	t, err := template.New("ssh_auth_compose_template.yaml").ParseFS(bundledAssets, "ssh_auth_compose_template.yaml")
+	t, err := template.New("ssh_auth_compose_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "ssh_auth_compose_template.yaml")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -36,7 +36,9 @@ services:
       interval: 1s
       retries: 2
       start_period: 10s
+      {{ if templateCanUse "healthcheck.start_interval" -}}
       start_interval: "500ms"
+      {{- end }}
       timeout: 62s
 networks:
   ddev_default:

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -36,6 +36,7 @@ services:
       interval: 1s
       retries: 2
       start_period: 10s
+      start_interval: "500ms"
       timeout: 62s
 networks:
   ddev_default:

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -36,7 +36,7 @@ services:
       interval: 1s
       retries: 2
       start_period: 10s
-      {{ if templateCanUse "healthcheck.start_interval" -}}
+      {{- if templateCanUse "healthcheck.start_interval" }}
       start_interval: "500ms"
       {{- end }}
       timeout: 62s

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -169,8 +169,22 @@ func getTemplateFuncMap() map[string]any {
 
 	// Add helpful utilities on top of it
 	m["joinPath"] = path.Join
+	m["templateCanUse"] = templateCanUse
 
 	return m
+}
+
+// templateCanUse will return true if the given feature is available.
+// This is used in YAML templates to determine whether to use a feature or not.
+func templateCanUse(feature string) bool {
+	// healthcheck.start_interval requires Docker Engine v25 or later
+	// See https://github.com/docker/compose/pull/10939
+	if feature == "healthcheck.start_interval" {
+		if err := dockerutil.CheckDockerVersion(dockerutil.DockerVersionMatrix{APIVersion: "1.44", Version: "25.0"}); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // gitIgnoreTemplate will write a .gitignore file.

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -169,22 +169,8 @@ func getTemplateFuncMap() map[string]any {
 
 	// Add helpful utilities on top of it
 	m["joinPath"] = path.Join
-	m["templateCanUse"] = templateCanUse
 
 	return m
-}
-
-// templateCanUse will return true if the given feature is available.
-// This is used in YAML templates to determine whether to use a feature or not.
-func templateCanUse(feature string) bool {
-	// healthcheck.start_interval requires Docker Engine v25 or later
-	// See https://github.com/docker/compose/pull/10939
-	if feature == "healthcheck.start_interval" {
-		if err := dockerutil.CheckDockerVersion(dockerutil.DockerVersionMatrix{APIVersion: "1.44", Version: "25.0"}); err == nil {
-			return true
-		}
-	}
-	return false
 }
 
 // gitIgnoreTemplate will write a .gitignore file.


### PR DESCRIPTION
## The Issue

- Refs #8096
- Followup to #8145 but not dependent on it

On a fresh `ddev-router` start (`ddev poweroff && ddev start`, router image upgrade, first start after reboot), the log consistently shows:

```
Waiting for ddev-router to become ready... ready in 5.5s
```

`docker inspect ddev-router` confirms the router's own healthcheck passes on its very first invocation in ~85ms. The ~5s gap is Docker Engine deferring the first probe when `start_interval` is unset on the healthcheck — a quirk of `start_period + interval` without `start_interval`. The healthcheck script itself (including `wait_for_routers`) is not at fault.

## How This PR Solves The Issue

Two commits:

1. **`refactor: remove templateCanUse healthcheck.start_interval guards`**

   DDEV already requires Docker Engine 25.0+ (`DockerRequirements.Version` in `pkg/dockerutil/requirements.go`), which is the minimum version that supports `healthcheck.start_interval`. The three `{{ if templateCanUse "healthcheck.start_interval" }}` wrappers in `app_compose_template.yaml` (web/db/xhgui) therefore always evaluate true on supported installs. Remove them along with the now-unused `templateCanUse` helper and its `getTemplateFuncMap` registration.

2. **`perf(router): add healthcheck start_interval to reduce fresh-start wait`**

   Add `start_interval: "500ms"` to the router healthcheck in `router_compose_template.yaml`. With this, Docker fires the first router probe ~500ms after container start, it passes immediately, and `ContainerWait` sees healthy at its next 500ms poll tick. The total "Waiting for ddev-router" phase drops from ~5.5s to ~1.0s on a fresh start, which is the long pole in the post-wait goroutine group — so it pulls the whole `poweroff → start` cycle down with it.

## Manual Testing Instructions

1. Start a project with any configuration: `ddev start`. Note router ready time
2. Try it with `ddev restart`
3. Try it with `ddev poweroff && ddev start`

## Automated Testing Overview

No new tests. This is a compose-template change that is covered by existing router and startup tests. The removal of `templateCanUse` is safe because:

- `DockerRequirements.Version` is `25.0`, so the guard was always true.
- `compose_yaml.go:307` still strips `start_interval` at runtime for Podman (which doesn't support it in its compose layer), so Podman users are unaffected.

## Release/Deployment Notes

- User-visible: `ddev start` and `ddev poweroff && ddev start` are noticeably faster; `ddev-router` healthy state is reported within ~1s instead of ~5.5s.
- No config or API changes. No migration required.
- Fully backwards-compatible: rendered compose adds one line; the router image's baked-in `HEALTHCHECK` is unchanged; the `start_interval: 500ms` just tells Docker how often to probe during the existing 120s `start_period`.
- Podman: runtime stripping in `compose_yaml.go` remains in place, so no behavioral change for Podman users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
