### PR TITLE
refactor(debug): improve reporting for RunSimpleContainer timeout, for #8311

### DIFF
--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -3,6 +3,7 @@ package dockerutil
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -599,7 +600,16 @@ func RunSimpleContainer(image string, name string, cmd []string, entrypoint []st
 	if !detach {
 		timeout = 10 * time.Minute
 	}
-	return RunSimpleContainerExtended(name, config, hostConfig, removeContainerAfterRun, timeout)
+	containerID, out, returnErr = RunSimpleContainerExtended(name, config, hostConfig, removeContainerAfterRun, timeout)
+	// On Lima/Colima, ContainerInspect may report State.Running=true even after
+	// the container has exited, causing the polling loop to exhaust the deadline.
+	// Observed only in tests, not reported by users; possibly a Lima/Colima bug.
+	// Retry once on DeadlineExceeded to recover.
+	if returnErr != nil && removeContainerAfterRun && errors.Is(returnErr, context.DeadlineExceeded) && (IsLima() || IsColima()) {
+		util.Debug("RunSimpleContainer: attempt 1 timed out on Lima/Colima, retrying: %v", returnErr)
+		containerID, out, returnErr = RunSimpleContainerExtended(name, config, hostConfig, removeContainerAfterRun, timeout)
+	}
+	return
 }
 
 // RunSimpleContainerExtended runs a container and captures the stdout/stderr.
@@ -772,43 +782,41 @@ func RunSimpleContainerExtended(name string, config *container.Config, hostConfi
 	exitCode := 0
 
 	if timeout > 0 {
-		// Poll container state instead of using the streaming ContainerWait API,
-		// which hangs indefinitely on proxied Docker sockets (e.g. Colima).
-		// Use a context deadline so in-flight ContainerInspect calls are also
-		// canceled when the timeout expires, not just the select case.
 		waitCtx, waitCancel := context.WithTimeout(ctx, timeout)
 		defer waitCancel()
 		tickChan := time.NewTicker(500 * time.Millisecond)
 		defer tickChan.Stop()
+		var lastKnownState *container.State
+		attempt := 0
 		for {
+			attempt++
+			inspectStartTime := time.Now()
 			info, err := apiClient.ContainerInspect(waitCtx, c.ID, client.ContainerInspectOptions{})
-			if err != nil {
-				if waitCtx.Err() != nil {
-					var health any = "none"
-					if s := info.Container.State; s != nil && s.Health != nil {
-						health = *s.Health
-					}
-					util.Debug("RunSimpleContainer: container %s (%s) state=%+v health=%+v, err=%v, waitErr=%v", name, TruncateID(c.ID), info.Container.State, health, err, waitCtx.Err())
-					return c.ID, "", fmt.Errorf("timed out after %s waiting for container %s (%s) to stop", timeout, name, TruncateID(c.ID))
-				}
+			inspectElapsedTime := time.Since(inspectStartTime)
+			if err != nil && waitCtx.Err() == nil {
 				return c.ID, "", fmt.Errorf("failed to inspect container %s (%s): %v", name, TruncateID(c.ID), err)
 			}
-			if info.Container.State == nil {
-				return c.ID, "", fmt.Errorf("container %s (%s) has <nil> state", name, TruncateID(c.ID))
-			}
-			if !info.Container.State.Running {
-				exitCode = info.Container.State.ExitCode
-				break
+			if err == nil {
+				if info.Container.State == nil {
+					return c.ID, "", fmt.Errorf("container %s (%s) has <nil> state", name, TruncateID(c.ID))
+				}
+				lastKnownState = info.Container.State
+				if !info.Container.State.Running {
+					exitCode = info.Container.State.ExitCode
+					break
+				}
 			}
 			select {
 			case <-waitCtx.Done():
-				var health any = "none"
-				if s := info.Container.State; s != nil && s.Health != nil {
-					health = *s.Health
-				}
-				util.Debug("RunSimpleContainer: container %s (%s) state=%+v health=%+v, err=%v", name, TruncateID(c.ID), info.Container.State, health, err)
-				return c.ID, "", fmt.Errorf("timed out after %s waiting for container %s (%s) to stop", timeout, name, TruncateID(c.ID))
 			case <-tickChan.C:
+			}
+			if waitCtx.Err() != nil {
+				var lastKnownHealth any = "<nil>"
+				if lastKnownState != nil && lastKnownState.Health != nil {
+					lastKnownHealth = *lastKnownState.Health
+				}
+				util.Debug("RunSimpleContainer: container %s (%s) attempt=%d inspectElapsedTime=%v inspectErr=%v lastKnownState=%+v lastKnownHealth=%+v", name, TruncateID(c.ID), attempt, inspectElapsedTime, err, lastKnownState, lastKnownHealth)
+				return c.ID, "", fmt.Errorf("timed out after %s waiting for container %s (%s) to stop: %w", timeout, name, TruncateID(c.ID), waitCtx.Err())
 			}
 		}
 

--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -3,7 +3,6 @@ package dockerutil
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -600,16 +599,7 @@ func RunSimpleContainer(image string, name string, cmd []string, entrypoint []st
 	if !detach {
 		timeout = 10 * time.Minute
 	}
-	containerID, out, returnErr = RunSimpleContainerExtended(name, config, hostConfig, removeContainerAfterRun, timeout)
-	// On Lima/Colima, ContainerInspect may report State.Running=true even after
-	// the container has exited, causing the polling loop to exhaust the deadline.
-	// Observed only in tests, not reported by users; possibly a Lima/Colima bug.
-	// Retry once on DeadlineExceeded to recover.
-	if returnErr != nil && removeContainerAfterRun && errors.Is(returnErr, context.DeadlineExceeded) && (IsLima() || IsColima()) {
-		util.Debug("RunSimpleContainer: attempt 1 timed out on Lima/Colima, retrying: %v", returnErr)
-		containerID, out, returnErr = RunSimpleContainerExtended(name, config, hostConfig, removeContainerAfterRun, timeout)
-	}
-	return
+	return RunSimpleContainerExtended(name, config, hostConfig, removeContainerAfterRun, timeout)
 }
 
 // RunSimpleContainerExtended runs a container and captures the stdout/stderr.
@@ -782,6 +772,9 @@ func RunSimpleContainerExtended(name string, config *container.Config, hostConfi
 	exitCode := 0
 
 	if timeout > 0 {
+		// On Lima/Colima, ContainerInspect may report State.Running=true even after
+		// the container has exited, causing the polling loop to exhaust the deadline.
+		// Observed only in tests, not reported by users; possibly a Lima/Colima bug.
 		waitCtx, waitCancel := context.WithTimeout(ctx, timeout)
 		defer waitCancel()
 		tickChan := time.NewTicker(500 * time.Millisecond)


### PR DESCRIPTION
## The Issue

- #8311

On Lima/Colima, ContainerInspect may report State.Running=true even after the container has exited, causing the polling loop to exhaust the deadline. Observed only in Buildkite tests, not reported by users; possibly a Lima/Colima bug.

Log 1 https://buildkite.com/ddev/macos-colima-vz/builds/6285#019d6e9f-e060-4adf-bd07-07fa74ff0c4f:

ContainerInspect ran 1200 times in 10 minutes

```
2026-04-08T15:49:46.356 RunSimpleContainer: ContainerInspect attempt #1200 for ddev/ddev-utilities:latest (container=a1ca73bda170)
2026-04-08T15:49:46.360 RunSimpleContainer: ContainerInspect #1200 returned after 3.572625ms for a1ca73bda170, err=<nil>
2026-04-08T15:49:46.360 RunSimpleContainer: container a1ca73bda170 state: Running=true Status=running ExitCode=0 StartedAt=2026-04-08T21:39:46.909522953Z
2026-04-08T15:49:46.856 RunSimpleContainer: ContainerInspect attempt #1201 for ddev/ddev-utilities:latest (container=a1ca73bda170)
2026-04-08T15:49:46.856 RunSimpleContainer: ContainerInspect #1201 returned after 309.917µs for a1ca73bda170, err=Get "http://%2FUsers%2Ftestbot%2F.colima%2Fvz%2Fdocker.sock/v1.53/containers/a1ca73bda17028305a83e1d8055568d19c2895bee77f8310fc730849b1b40835/json": context deadline exceeded
    mailpit_test.go:128:
        	Error Trace:	/Users/testbot/tmp/buildkite-agent/builds/tb-macos-arm64-5/ddev/macos-colima-vz/pkg/ddevapp/mailpit_test.go:128
        	Error:      	Received unexpected error:
        	            	failed to 'chown -R 501:20 /mnt/ddev-global-cache /var/lib/mysql' inside volumes: timed out after 10m0s waiting for container a1ca73bda17028305a83e1d8055568d19c2895bee77f8310fc730849b1b40835 to stop, output=
        	Test:       	TestMailpit
```

Log 2 https://buildkite.com/ddev/macos-colima-vz/builds/6353#019d9190-fae8-4cb1-849c-6541789a726e/L11650-L11655 (done after #8311)

```
2026-04-15T09:46:51.604 RunSimpleContainer: container start-chown-rdzbbF (81efa50e6cd2) state=<nil> health=none, err=Get "http://%2FUsers%2Ftestbot%2F.colima%2Fvz%2Fdocker.sock/v1.54/containers/81efa50e6cd29a1f2abfd304b40415c2c69f3f17cb66b7ea58e5e8f468e75f06/json": context deadline exceeded, waitErr=context deadline exceeded
    providerGit_test.go:68:
        	Error Trace:	/Users/testbot/tmp/buildkite-agent/builds/tb-macos-arm64-6/ddev/macos-colima-vz/pkg/ddevapp/providerGit_test.go:68
        	Error:      	Received unexpected error:
        	            	failed to 'chown -R 501:20 /mnt/ddev-global-cache /var/lib/mysql' inside volumes: timed out after 10m0s waiting for container start-chown-rdzbbF (81efa50e6cd2) to stop, output=
        	Test:       	TestGitPull
```

## How This PR Solves The Issue

- Refactors the polling loop in `RunSimpleContainerExtended` to track `lastKnownState`, attempt counter, and inspect elapsed time for richer debug output.
- Consolidates the two timeout exit paths into one (`if waitCtx.Err() != nil` after the select), eliminating duplicated debug/error logic.
- Wraps the timeout error with `%w` so callers can use `errors.Is`.

## Manual Testing Instructions

## Automated Testing Overview

## Release/Deployment Notes