### PR TITLE
test: update moodle quickstart

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1759,16 +1759,14 @@ ddev magento setup:upgrade
     Run Moodle installation:
 
     ```bash
-    ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
+    ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminemail=admin@example.com --adminpass=password'
     ```
 
-    Launch Moodle:
+    Launch Moodle (login with `admin` and `password`)::
 
     ```bash
     ddev launch /login
     ```
-
-    In the web browser, log into your account using `admin` and `password`.
 
     Visit the [Moodle Admin Quick Guide](https://docs.moodle.org/400/en/Admin_quick_guide) for more information.
 
@@ -1786,7 +1784,7 @@ ddev magento setup:upgrade
         ddev config --docroot=public --webserver-type=apache-fpm
         ddev start -y
         ddev composer create-project moodle/moodle
-        ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
+        ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminemail=admin@example.com --adminpass=password'
         ddev launch /login
         EOF
         chmod +x setup-moodle.sh

--- a/docs/tests/moodle.bats
+++ b/docs/tests/moodle.bats
@@ -16,20 +16,34 @@ teardown() {
 
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
+
   run ddev config --docroot=public --webserver-type=apache-fpm
   assert_success
+
   run ddev start -y
   assert_success
+
   run ddev composer create-project moodle/moodle
   assert_success
-  run ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
+
+  run ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminemail=admin@example.com --adminpass=password'
   assert_success
+
   DDEV_DEBUG=true run ddev launch /login
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/login"
+  assert_line "FULLURL https://${PROJNAME}.ddev.site/login"
   assert_success
+
   # validate running project
   run curl -sfIv https://${PROJNAME}.ddev.site
+  assert_output --partial "HTTP/2 303"
+  assert_line --regexp "location: .*/login/index.php"
+  assert_output --partial "set-cookie: MoodleSession="
+  assert_output --partial "server: Apache"
+  assert_success
+
+  run curl -sfIv https://${PROJNAME}.ddev.site/login/index.php
   assert_output --partial "HTTP/2 200"
   assert_output --partial "set-cookie: MoodleSession="
+  assert_output --partial "server: Apache"
   assert_success
 }

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -37,11 +37,12 @@ teardown() {
 #  echo "# Traefik routers: $output"
 
   # Diagnostic: show traefik config files in volume
-  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
-  echo "# Traefik config files: $output" >&3
+  #run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
+  #echo "# Traefik config files: $output" >&3
   # Diagnostic: show traefik router API response (just router names)
-  run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
-  echo "# Traefik routers: $output"
+  #run docker exec ddev-router curl -s http://127.0.0.1:10999/api/http/routers
+  #echo "# Traefik routers: $output"
+
   # validate running project
   run curl -sfIv https://${PROJNAME}.ddev.site
   assert_output --partial "server: Apache"


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/24499349559/job/71601876393

```
not ok 27 Moodle quickstart with ddev version v1.25.1-78-gcce743fd1
# (from function `assert_output' in file /home/linuxbrew/.linuxbrew/lib/bats-assert/src/assert_output.bash, line 186,
#  in test file docs/tests/moodle.bats, line 32)
#   `assert_output --partial "HTTP/2 200"' failed
# Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
#
# -- output does not contain substring --
# substring (1 lines):
#   HTTP/2 200
# output (80 lines):
#   * Host my-moodle-site.ddev.site:443 was resolved.
#   * IPv6: (none)
#   * IPv4: 127.0.0.1
#   *   Trying 127.0.0.1:443...
#   * Connected to my-moodle-site.ddev.site (127.0.0.1) port 443
#   * ALPN: curl offers h2,http/1.1
#   } [5 bytes data]
#   * TLSv1.3 (OUT), TLS handshake, Client hello (1):
#   } [512 bytes data]
#   *  CAfile: /etc/ssl/certs/ca-certificates.crt
#   *  CApath: /etc/ssl/certs/
#   { [5 bytes data]
#   * TLSv1.3 (IN), TLS handshake, Server hello (2):
#   { [122 bytes data]
#   * TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
#   { [19 bytes data]
#   * TLSv1.3 (IN), TLS handshake, Certificate (11):
#   { [1182 bytes data]
#   * TLSv1.3 (IN), TLS handshake, CERT verify (15):
#   { [264 bytes data]
#   * TLSv1.3 (IN), TLS handshake, Finished (20):
#   { [36 bytes data]
#   * TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
#   } [1 bytes data]
#   * TLSv1.3 (OUT), TLS handshake, Finished (20):
#   } [36 bytes data]
#   * SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519 / RSASSA-PSS
#   * ALPN: server accepted h2
#   * Server certificate:
#   *  subject: O=mkcert development certificate; OU=runner@runnervmeorf1
#   *  start date: Apr 16 08:39:23 2026 GMT
#   *  expire date: Jul 16 08:39:23 2028 GMT
#   *  subjectAltName: host "my-moodle-site.ddev.site" matched cert's "*.ddev.site"
#   *  issuer: O=mkcert development CA; OU=runner@runnervmeorf1; CN=mkcert runner@runnervmeorf1
#   *  SSL certificate verify ok.
#   *   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
#   *   Certificate level 1: Public key type RSA (3072/128 Bits/secBits), signed using sha256WithRSAEncryption
#   { [5 bytes data]
#   * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
#   { [122 bytes data]
#   * using HTTP/2
#   * [HTTP/2] [1] OPENED stream for https://my-moodle-site.ddev.site/
#   * [HTTP/2] [1] [:method: HEAD]
#   * [HTTP/2] [1] [:scheme: https]
#   * [HTTP/2] [1] [:authority: my-moodle-site.ddev.site]
#   * [HTTP/2] [1] [:path: /]
#   * [HTTP/2] [1] [user-agent: curl/8.5.0]
#   * [HTTP/2] [1] [accept: */*]
#   } [5 bytes data]
#   > HEAD / HTTP/2
#   > Host: my-moodle-site.ddev.site
#   > User-Agent: curl/8.5.0
#   > Accept: */*
#   > 
#   { [5 bytes data]
#   < HTTP/2 303 
#   < cache-control: no-store, no-cache, must-revalidate
#   < content-language: en
#   < content-type: text/html; charset=utf-8
#   < date: Thu, 16 Apr 2026 08:41:17 GMT
#   < expires: Thu, 19 Nov 1981 08:52:00 GMT
#   < location: https://my-moodle-site.ddev.site/login/index.php
#   < pragma: no-cache
#   < server: Apache/2.4.66 (Debian)
#   < set-cookie: MoodleSession=3ed159864aba3056bf093ba54716d514; path=/; secure; HttpOnly
#   < x-redirect-by: Moodle
#   < 
#   * Connection #0 to host my-moodle-site.ddev.site left intact
#   HTTP/2 303 
#   cache-control: no-store, no-cache, must-revalidate
#   content-language: en
#   content-type: text/html; charset=utf-8
#   date: Thu, 16 Apr 2026 08:41:17 GMT
#   expires: Thu, 19 Nov 1981 08:52:00 GMT
#   location: https://my-moodle-site.ddev.site/login/index.php
#   pragma: no-cache
#   server: Apache/2.4.66 (Debian)
#   set-cookie: MoodleSession=3ed159864aba3056bf093ba54716d514; path=/; secure; HttpOnly
#   x-redirect-by: Moodle
```

## How This PR Solves The Issue

- Updates the Moodle test to check for new redirect properly
- Updates the Moodle quickstart by adding `--adminemail=admin@example.com` - email is a required field, I noticed this when I logged into Moodle.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
