### PR TITLE
fix(test): use local apt repo with fake packages to avoid flakiness in TestExtraPackages

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1246,14 +1246,51 @@ func TestExtraPackages(t *testing.T) {
 		_, _ = exec.RunCommand("bash", []string{"-c", command})
 	})
 
+	// Set up local apt repositories with fake packages so the test does not depend on external repos.
+	// pre.Dockerfile.fake-ddev-test runs after FROM but before the extra_packages apt-get install.
+	// dpkg-deb is part of the dpkg package (always present in Debian images) so no network is needed.
+	webBuildDir := app.GetConfigPath("web-build")
+	dbBuildDir := app.GetConfigPath("db-build")
+	err = os.MkdirAll(webBuildDir, 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(dbBuildDir, 0755)
+	require.NoError(t, err)
+
+	// fake-ddev-test-bind9-dnsutils: only needs to appear in the dpkg status database (dpkg -s check), no real binary required.
+	webPreDockerfile := `RUN mkdir -p /var/local-apt-repo /tmp/fakepkg/DEBIAN && \
+    printf 'Package: fake-ddev-test-bind9-dnsutils\nVersion: 1:9.18.0-1\nArchitecture: all\nMaintainer: fake\nDescription: fake\n' > /tmp/fakepkg/DEBIAN/control && \
+    dpkg-deb --build /tmp/fakepkg /var/local-apt-repo/fake-ddev-test-bind9-dnsutils.deb && \
+    size=$(stat -c%s /var/local-apt-repo/fake-ddev-test-bind9-dnsutils.deb) && \
+    md5=$(md5sum /var/local-apt-repo/fake-ddev-test-bind9-dnsutils.deb | awk '{print $1}') && \
+    sha256=$(sha256sum /var/local-apt-repo/fake-ddev-test-bind9-dnsutils.deb | awk '{print $1}') && \
+    printf "Package: fake-ddev-test-bind9-dnsutils\nVersion: 1:9.18.0-1\nArchitecture: all\nFilename: fake-ddev-test-bind9-dnsutils.deb\nSize: ${size}\nMD5sum: ${md5}\nSHA256: ${sha256}\nDescription: fake\n\n" > /var/local-apt-repo/Packages && \
+    printf 'Types: deb\nURIs: file:///var/local-apt-repo\nSuites: ./\nTrusted: yes\n' > /etc/apt/sources.list.d/fake-ddev-test.sources
+`
+	err = os.WriteFile(filepath.Join(webBuildDir, "pre.Dockerfile.fake-ddev-test"), []byte(webPreDockerfile), 0644)
+	require.NoError(t, err)
+
+	// fake-ddev-test-sudo: needs an actual binary at /usr/bin/fake-ddev-test-sudo because the test runs "command -v <pkg>".
+	dbPreDockerfile := `RUN mkdir -p /var/local-apt-repo /tmp/fakepkg/DEBIAN /tmp/fakepkg/usr/bin && \
+    printf 'Package: fake-ddev-test-sudo\nVersion: 1.9.0-1\nArchitecture: all\nMaintainer: fake\nDescription: fake\n' > /tmp/fakepkg/DEBIAN/control && \
+    printf '#!/bin/sh\nexec "$@"\n' > /tmp/fakepkg/usr/bin/fake-ddev-test-sudo && chmod 755 /tmp/fakepkg/usr/bin/fake-ddev-test-sudo && \
+    dpkg-deb --build /tmp/fakepkg /var/local-apt-repo/fake-ddev-test-sudo.deb && \
+    size=$(stat -c%s /var/local-apt-repo/fake-ddev-test-sudo.deb) && \
+    md5=$(md5sum /var/local-apt-repo/fake-ddev-test-sudo.deb | awk '{print $1}') && \
+    sha256=$(sha256sum /var/local-apt-repo/fake-ddev-test-sudo.deb | awk '{print $1}') && \
+    printf "Package: fake-ddev-test-sudo\nVersion: 1.9.0-1\nArchitecture: all\nFilename: fake-ddev-test-sudo.deb\nSize: ${size}\nMD5sum: ${md5}\nSHA256: ${sha256}\nDescription: fake\n\n" > /var/local-apt-repo/Packages && \
+    printf 'Types: deb\nURIs: file:///var/local-apt-repo\nSuites: ./\nTrusted: yes\n' > /etc/apt/sources.list.d/fake-ddev-test.sources
+`
+	err = os.WriteFile(filepath.Join(dbBuildDir, "pre.Dockerfile.fake-ddev-test"), []byte(dbPreDockerfile), 0644)
+	require.NoError(t, err)
+
 	// Start and make sure that the packages don't exist already
 	err = app.Start()
 	require.NoError(t, err)
 
-	addedDBPackage := "sudo"
-	addedWebPackage := "bind9-dnsutils"
+	addedDBPackage := "fake-ddev-test-sudo"
+	addedWebPackage := "fake-ddev-test-bind9-dnsutils"
 
-	// Test db container to make sure no sudo in there at beginning
+	// Test db container to make sure the fake package is not in there at beginning
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
 		Cmd:     fmt.Sprintf("command -v %s 2>/dev/null", addedDBPackage),
@@ -1283,7 +1320,7 @@ func TestExtraPackages(t *testing.T) {
 
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
-		Cmd:     "command -v sudo",
+		Cmd:     "command -v " + addedDBPackage,
 	})
 	assert.NoError(err)
 	assert.Equal(fmt.Sprintf("/usr/bin/%s", addedDBPackage), strings.Trim(stdout, "\r\n"))

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1264,6 +1264,7 @@ func TestExtraPackages(t *testing.T) {
     md5=$(md5sum /var/local-apt-repo/fake-ddev-test-bind9-dnsutils.deb | awk '{print $1}') && \
     sha256=$(sha256sum /var/local-apt-repo/fake-ddev-test-bind9-dnsutils.deb | awk '{print $1}') && \
     printf "Package: fake-ddev-test-bind9-dnsutils\nVersion: 1:9.18.0-1\nArchitecture: all\nFilename: fake-ddev-test-bind9-dnsutils.deb\nSize: ${size}\nMD5sum: ${md5}\nSHA256: ${sha256}\nDescription: fake\n\n" > /var/local-apt-repo/Packages && \
+    gzip -c /var/local-apt-repo/Packages > /var/local-apt-repo/Packages.gz && \
     printf 'Types: deb\nURIs: file:///var/local-apt-repo\nSuites: ./\nTrusted: yes\n' > /etc/apt/sources.list.d/fake-ddev-test.sources
 `
 	err = os.WriteFile(filepath.Join(webBuildDir, "pre.Dockerfile.fake-ddev-test"), []byte(webPreDockerfile), 0644)
@@ -1278,6 +1279,7 @@ func TestExtraPackages(t *testing.T) {
     md5=$(md5sum /var/local-apt-repo/fake-ddev-test-sudo.deb | awk '{print $1}') && \
     sha256=$(sha256sum /var/local-apt-repo/fake-ddev-test-sudo.deb | awk '{print $1}') && \
     printf "Package: fake-ddev-test-sudo\nVersion: 1.9.0-1\nArchitecture: all\nFilename: fake-ddev-test-sudo.deb\nSize: ${size}\nMD5sum: ${md5}\nSHA256: ${sha256}\nDescription: fake\n\n" > /var/local-apt-repo/Packages && \
+    gzip -c /var/local-apt-repo/Packages > /var/local-apt-repo/Packages.gz && \
     printf 'Types: deb\nURIs: file:///var/local-apt-repo\nSuites: ./\nTrusted: yes\n' > /etc/apt/sources.list.d/fake-ddev-test.sources
 `
 	err = os.WriteFile(filepath.Join(dbBuildDir, "pre.Dockerfile.fake-ddev-test"), []byte(dbPreDockerfile), 0644)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1265,6 +1265,7 @@ func TestExtraPackages(t *testing.T) {
     sha256=$(sha256sum /var/local-apt-repo/fake-ddev-test-bind9-dnsutils.deb | awk '{print $1}') && \
     printf "Package: fake-ddev-test-bind9-dnsutils\nVersion: 1:9.18.0-1\nArchitecture: all\nFilename: fake-ddev-test-bind9-dnsutils.deb\nSize: ${size}\nMD5sum: ${md5}\nSHA256: ${sha256}\nDescription: fake\n\n" > /var/local-apt-repo/Packages && \
     gzip -c /var/local-apt-repo/Packages > /var/local-apt-repo/Packages.gz && \
+    rm -rf /etc/apt/sources.list /etc/apt/sources.list.d && mkdir -p /etc/apt/sources.list.d && \
     printf 'Types: deb\nURIs: file:///var/local-apt-repo\nSuites: ./\nTrusted: yes\n' > /etc/apt/sources.list.d/fake-ddev-test.sources
 `
 	err = os.WriteFile(filepath.Join(webBuildDir, "pre.Dockerfile.fake-ddev-test"), []byte(webPreDockerfile), 0644)
@@ -1280,6 +1281,7 @@ func TestExtraPackages(t *testing.T) {
     sha256=$(sha256sum /var/local-apt-repo/fake-ddev-test-sudo.deb | awk '{print $1}') && \
     printf "Package: fake-ddev-test-sudo\nVersion: 1.9.0-1\nArchitecture: all\nFilename: fake-ddev-test-sudo.deb\nSize: ${size}\nMD5sum: ${md5}\nSHA256: ${sha256}\nDescription: fake\n\n" > /var/local-apt-repo/Packages && \
     gzip -c /var/local-apt-repo/Packages > /var/local-apt-repo/Packages.gz && \
+    rm -rf /etc/apt/sources.list /etc/apt/sources.list.d && mkdir -p /etc/apt/sources.list.d && \
     printf 'Types: deb\nURIs: file:///var/local-apt-repo\nSuites: ./\nTrusted: yes\n' > /etc/apt/sources.list.d/fake-ddev-test.sources
 `
 	err = os.WriteFile(filepath.Join(dbBuildDir, "pre.Dockerfile.fake-ddev-test"), []byte(dbPreDockerfile), 0644)


### PR DESCRIPTION
## The Issue

- Refs https://github.com/ddev/ddev/actions/runs/24502796076/job/71627009789
	```
	 > [db 4/4] RUN (timeout 120 apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests sudo:
	123.9 Need to get 998 kB of archives.
	123.9 After this operation, 3669 kB of additional disk space will be used.
	123.9 Err:1 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libapparmor1 amd64 4.0.1really4.0.1-0ubuntu0.24.04.5
	123.9   404  Not Found [IP: 91.189.91.83 80]
	123.9 Ign:2 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 sudo amd64 1.9.15p5-3ubuntu5.24.04.1
	127.8 Err:2 http://security.ubuntu.com/ubuntu noble-updates/main amd64 sudo amd64 1.9.15p5-3ubuntu5.24.04.1
	127.8   404  Not Found [IP: 91.189.91.83 80]
	127.8 E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/a/apparmor/libapparmor1_4.0.1really4.0.1-0ubuntu0.24.04.5_amd64.deb  404  Not Found [IP: 91.189.91.83 80]
	127.8 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/s/sudo/sudo_1.9.15p5-3ubuntu5.24.04.1_amd64.deb  404  Not Found [IP: 91.189.91.83 80]
	127.8 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
	------
	', stderr=' Image ddev/ddev-dbserver-mariadb-11.8:v1.25.1-TestPkgDrupal11-built Building 
	 Image ddev/ddev-webserver:20260410_stasadev_yarn_timeout-TestPkgDrupal11-built Building 
	Dockerfile:25
	```
- When upstream Debian/Ubuntu apt repositories are down (e.g. https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQG-0Dp5D6IWR-Dw5G2pjG-aXrj_4QfzB2lRNFJhfuReyQ== incident), TestExtraPackages fails because it tries to install real packages (`sudo`, `bind9-dnsutils`) from the network during the Docker image build.

## How This PR Solves The Issue

A `pre.Dockerfile.fake-ddev-test` is written to `web-build/` and `db-build/` before the test starts. It runs inside the container build after `FROM $BASE_IMAGE` but before the injected `apt-get install` step.

The Dockerfile fragment uses `dpkg-deb` (part of the `dpkg` package, always present in Debian images — no network needed) to create minimal fake `.deb` packages and registers them as a local deb822 apt source (`file:///var/local-apt-repo`). When the extra_packages `apt-get install` runs it finds the packages locally regardless of external repo availability.

The test packages are renamed `fake-ddev-test-sudo` / `fake-ddev-test-bind9-dnsutils` so they cannot be mistaken for real system packages.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
