### PR TITLE
fix(installer): fix malformed WSLENV on Windows install/uninstall, fixes #8324 (#8325) [skip ci]

### DIFF
--- a/winpkg/ddev_windows_installer.nsi
+++ b/winpkg/ddev_windows_installer.nsi
@@ -14,6 +14,7 @@
 !insertmacro WordFind
 ${StrStr}
 ${StrRep}
+${UnStrRep}
 ${StrTrimNewLines}
 ${StrCase}
 ; Remove the Trim macro since we're using our own TrimWhitespace function
@@ -1847,44 +1848,32 @@ Function SetupWindowsCAROOT
             ; Store original value for debugging
             StrCpy $R4 $R2
 
-            ; Clean up any existing CAROOT/up entries first
+            ; Clean up any existing CAROOT/up entries first (handles both : and ; separators)
             StrCpy $R3 $R2  ; Copy to working variable
 
-            ; Remove all instances of CAROOT/up; (with semicolon)
-            ${Do}
-                ${StrStr} $R5 $R3 "CAROOT/up;"
-                ${If} $R5 == ""
-                    ${Break}
-                ${EndIf}
-                ${StrRep} $R3 $R3 "CAROOT/up;" ""
-            ${Loop}
+            ; Remove all instances of CAROOT/up with colon separator (correct WSLENV format)
+            ${StrRep} $R3 $R3 "CAROOT/up:" ""
+            ${StrRep} $R3 $R3 ":CAROOT/up" ""
 
-            ; Remove all instances of ;CAROOT/up (with leading semicolon)
-            ${Do}
-                ${StrStr} $R5 $R3 ";CAROOT/up"
-                ${If} $R5 == ""
-                    ${Break}
-                ${EndIf}
-                ${StrRep} $R3 $R3 ";CAROOT/up" ""
-            ${Loop}
+            ; Remove all instances of CAROOT/up with semicolon separator (legacy/incorrect format)
+            ${StrRep} $R3 $R3 "CAROOT/up;" ""
+            ${StrRep} $R3 $R3 ";CAROOT/up" ""
 
             ; Remove if it's exactly "CAROOT/up" by itself
             ${If} $R3 == "CAROOT/up"
                 StrCpy $R3 ""
             ${EndIf}
 
-            ; Clean up any double semicolons that might have been created
-            ${Do}
-                ${StrStr} $R5 $R3 ";;"
-                ${If} $R5 == ""
-                    ${Break}
-                ${EndIf}
-                ${StrRep} $R3 $R3 ";;" ";"
-            ${Loop}
+            ; Clean up any double separators that might have been created
+            ${StrRep} $R3 $R3 "::" ":"
+            ${StrRep} $R3 $R3 ";;" ";"
 
-            ; Remove leading or trailing semicolons
+            ; Remove leading or trailing separators (: or ;)
             ${If} $R3 != ""
                 StrCpy $R5 $R3 1  ; Get first character
+                ${If} $R5 == ":"
+                    StrCpy $R3 $R3 "" 1  ; Remove first character
+                ${EndIf}
                 ${If} $R5 == ";"
                     StrCpy $R3 $R3 "" 1  ; Remove first character
                 ${EndIf}
@@ -1892,15 +1881,18 @@ Function SetupWindowsCAROOT
                     StrLen $R6 $R3
                     IntOp $R6 $R6 - 1
                     StrCpy $R5 $R3 1 $R6  ; Get last character
+                    ${If} $R5 == ":"
+                        StrCpy $R3 $R3 $R6  ; Remove last character
+                    ${EndIf}
                     ${If} $R5 == ";"
                         StrCpy $R3 $R3 $R6  ; Remove last character
                     ${EndIf}
                 ${EndIf}
             ${EndIf}
 
-            ; Now add CAROOT/up to the cleaned string
+            ; Now add CAROOT/up to the cleaned string using colon separator (WSLENV standard)
             ${If} $R3 != ""
-                StrCpy $R2 "CAROOT/up;$R3"
+                StrCpy $R2 "$R3:CAROOT/up"
             ${Else}
                 StrCpy $R2 "CAROOT/up"
             ${EndIf}
@@ -1915,8 +1907,39 @@ Function SetupWindowsCAROOT
             EnVar::AddValue "WSLENV" "$R2"
             Pop $0  ; Get error code from AddValue
 
-            ; Verify by reading from registry
+            ; Verify by reading back from registry and validate
             ReadRegStr $R5 HKCU "Environment" "WSLENV"
+
+            Push "WSLENV after update: [$R5]"
+            Call LogPrint
+
+            ; Validate: WSLENV must contain CAROOT and must not contain semicolons
+            ${StrStr} $R6 $R5 "CAROOT"
+            ${If} $R6 == ""
+                Push "WARNING: WSLENV does not contain CAROOT after update - WSL2 certificate sharing may not work"
+                Call LogPrint
+                ${IfNot} ${Silent}
+                    MessageBox MB_ICONEXCLAMATION|MB_OK "Warning: WSLENV was not set correctly. WSL2 certificate sharing may not work. Check WSLENV in HKCU\Environment."
+                ${EndIf}
+            ${EndIf}
+            ${StrStr} $R6 $R5 ";"
+            ${If} $R6 != ""
+                Push "WARNING: WSLENV contains semicolons which are not valid WSLENV separators: [$R5]"
+                Call LogPrint
+                ${IfNot} ${Silent}
+                    MessageBox MB_ICONEXCLAMATION|MB_OK "Warning: WSLENV contains invalid semicolons. CAROOT may not propagate to WSL2. Current value: $R5"
+                ${EndIf}
+            ${EndIf}
+
+            ; Validate: CAROOT must be non-empty
+            ReadRegStr $R6 HKCU "Environment" "CAROOT"
+            ${If} $R6 == ""
+                Push "WARNING: CAROOT is empty after update - WSL2 certificate sharing may not work"
+                Call LogPrint
+            ${Else}
+                Push "CAROOT validated: [$R6]"
+                Call LogPrint
+            ${EndIf}
 
             Push "mkcert certificate sharing with WSL2 configured successfully."
             Call LogPrint
@@ -2377,19 +2400,41 @@ Function un.CleanupMkcertEnvironment
 
         DetailPrint "Current WSLENV: $R0"
 
-        ; Remove CAROOT/up; from the beginning
-        ${WordFind} "$R0" "CAROOT/up;" "E+1{" $R1
-        ${If} $R1 != $R0
-            StrCpy $R0 $R1
-        ${Else}
-            ; Remove ;CAROOT/up from anywhere else
-            ${WordFind} "$R0" ";CAROOT/up" "E+1{" $R1
-            ${If} $R1 != $R0
-                StrCpy $R0 $R1
-            ${Else}
-                ; Check if it's just CAROOT/up by itself
-                ${If} $R0 == "CAROOT/up"
-                    StrCpy $R0 ""
+        ; Remove all instances of CAROOT/up with colon separator (correct WSLENV format)
+        ${UnStrRep} $R0 $R0 "CAROOT/up:" ""
+        ${UnStrRep} $R0 $R0 ":CAROOT/up" ""
+
+        ; Remove all instances of CAROOT/up with semicolon separator (legacy/incorrect format)
+        ${UnStrRep} $R0 $R0 "CAROOT/up;" ""
+        ${UnStrRep} $R0 $R0 ";CAROOT/up" ""
+
+        ; Remove if it's exactly "CAROOT/up" by itself
+        ${If} $R0 == "CAROOT/up"
+            StrCpy $R0 ""
+        ${EndIf}
+
+        ; Clean up any double separators that might have been created
+        ${UnStrRep} $R0 $R0 "::" ":"
+        ${UnStrRep} $R0 $R0 ";;" ";"
+
+        ; Remove leading or trailing separators (: or ;)
+        ${If} $R0 != ""
+            StrCpy $R1 $R0 1  ; Get first character
+            ${If} $R1 == ":"
+                StrCpy $R0 $R0 "" 1  ; Remove first character
+            ${EndIf}
+            ${If} $R1 == ";"
+                StrCpy $R0 $R0 "" 1  ; Remove first character
+            ${EndIf}
+            ${If} $R0 != ""
+                StrLen $R2 $R0
+                IntOp $R2 $R2 - 1
+                StrCpy $R1 $R0 1 $R2  ; Get last character
+                ${If} $R1 == ":"
+                    StrCpy $R0 $R0 $R2  ; Remove last character
+                ${EndIf}
+                ${If} $R1 == ";"
+                    StrCpy $R0 $R0 $R2  ; Remove last character
                 ${EndIf}
             ${EndIf}
         ${EndIf}

--- a/winpkg/installer_test.go
+++ b/winpkg/installer_test.go
@@ -196,6 +196,20 @@ func TestWindowsInstallerWSL2(t *testing.T) {
 			userWslenvReg, userWslenvRegErr := exec.RunHostCommand("reg.exe", "query", "HKEY_CURRENT_USER\\Environment", "/v", "WSLENV")
 			t.Logf("Registry HKCU\\Environment WSLENV: %s (err: %v)", strings.TrimSpace(userWslenvReg), userWslenvRegErr)
 
+			// Assert CAROOT is set in registry
+			require.NoError(userCarootRegErr, "CAROOT should be set in registry after install")
+			caRootValue := parseRegQueryValue(userCarootReg)
+			require.NotEmpty(caRootValue, "CAROOT registry value should not be empty after install")
+			t.Logf("CAROOT registry value: %q", caRootValue)
+
+			// Assert WSLENV is set correctly: must contain CAROOT/up, must not contain semicolons
+			require.NoError(userWslenvRegErr, "WSLENV should be set in registry after WSL2 install")
+			wslenvValue := parseRegQueryValue(userWslenvReg)
+			require.NotEmpty(wslenvValue, "WSLENV registry value should not be empty after install")
+			require.Contains(wslenvValue, "CAROOT/up", "WSLENV should contain CAROOT/up after install")
+			require.NotContains(wslenvValue, ";", "WSLENV must not contain semicolons — they are not valid WSLENV separators and prevent CAROOT from propagating to WSL2")
+			t.Logf("WSLENV registry value: %q (valid)", wslenvValue)
+
 			// Check system environment variables in registry
 			systemCarootReg, systemCarootRegErr := exec.RunHostCommand("reg.exe", "query", "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", "/v", "CAROOT")
 			t.Logf("Registry HKLM\\System\\Environment CAROOT: %s (err: %v)", strings.TrimSpace(systemCarootReg), systemCarootRegErr)
@@ -324,6 +338,22 @@ func TestWindowsInstallerTraditional(t *testing.T) {
 
 	// Test basic ddev functionality on Windows
 	testBasicDdevTraditionalFunctionality(t)
+}
+
+// parseRegQueryValue parses the value from reg.exe query output.
+// reg.exe outputs lines like: "    VARNAME    REG_SZ    value"
+// Returns the value string or empty string if not found.
+func parseRegQueryValue(output string) string {
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "REG_SZ") {
+			parts := strings.SplitN(line, "REG_SZ", 2)
+			if len(parts) == 2 {
+				return strings.TrimSpace(parts[1])
+			}
+		}
+	}
+	return ""
 }
 
 // Helper functions


### PR DESCRIPTION
## The Issue

- Fixes #8324

Windows DDEV installer was corrupting WSLENV in two ways:
1. Used `;` as separator when appending `CAROOT/up` (WSLENV requires `:`)
2. Uninstaller used `${WordFind}` with the `E` flag which returns `"1"` as an error sentinel when the pattern is not found, overwriting WSLENV with `"1"` or producing values like `CAROOT/up;1`

## How This PR Solves The Issue

- Replace loop-based `;`-only cleanup in the installer with direct `${StrRep}` calls that strip `CAROOT/up` regardless of separator (`:` or `;`), then append with the correct `:` separator: `$existing:CAROOT/up`
- Fix the uninstaller by replacing the broken `${WordFind} ... "E+1{"` logic with `${UnStrRep}` calls (the StrFunc.nsh uninstaller variant, which generates `un.StrRep` — required because uninstall sections can only call `un.`-prefixed functions). Declare `${UnStrRep}` alongside `${StrRep}` at the top of the script.
- Add post-write validation: after setting WSLENV, read it back from the registry and warn (log + optional dialog) if it contains semicolons or does not contain `CAROOT`.
- Update `installer_test.go` to assert that after a WSL2 install: CAROOT is non-empty in the registry, WSLENV contains `CAROOT/up`, and WSLENV contains no semicolons.

## Manual Testing Instructions

1. Have Windows Terminal installed (sets `WT_SESSION:WT_PROFILE_ID` in WSLENV with `:` separators)
2. Run the DDEV Windows installer
3. Check `$env:WSLENV` in PowerShell — should contain `CAROOT/up` with `:` separators and no semicolons
4. Run the DDEV Windows uninstaller
5. Check `$env:WSLENV` — `CAROOT/up` should be removed cleanly, original entries restored
6. Reinstall — WSLENV should again be valid with no semicolons

## Automated Testing Overview

`winpkg/installer_test.go` `TestWindowsInstallerWSL2` now asserts (requires `DDEV_TEST_USE_REAL_INSTALLER=true`):
- `CAROOT` registry value is non-empty after install
- `WSLENV` registry value contains `CAROOT/up` after install
- `WSLENV` registry value contains no semicolons after install

## Release/Deployment Notes

Fixes silent HTTPS certificate trust failures in WSL2 after install/reinstall cycles where CAROOT was not propagating into WSL2. No configuration format changes.