### PR TITLE
fix(traefik): don't mark README.txt as stale (#8329) [skip ci]

### DIFF
--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -247,8 +247,8 @@ func PushGlobalTraefikConfig(activeApps []*DdevApp) error {
 	}
 
 	// Track expected files in the volume for later sync
-	expectedConfigs := map[string]bool{"default_config.yaml": true}
-	expectedCerts := map[string]bool{}
+	expectedConfigs := map[string]bool{"default_config.yaml": true, "README.txt": true}
+	expectedCerts := map[string]bool{"README.txt": true}
 
 	// Add default certs to expected list if not using Let's Encrypt
 	if !globalconfig.DdevGlobalConfig.UseLetsEncrypt && globalconfig.GetCAROOT() != "" {


### PR DESCRIPTION
## The Issue

There are always two unnecessary `dockerutil.RemoveFilesFromVolume` calls on each `ddev start`, because of `README.txt`:

```
$ ddev poweroff

$ DDEV_DEBUG=true ddev start
...
2026-04-17T10:48:16.997 Copied cert php-2023.crt from project php-2023 to global traefik certs dir 
2026-04-17T10:48:16.998 Copied cert php-2023.key from project php-2023 to global traefik certs dir 
2026-04-17T10:48:17.466 Copied /home/stas/.ddev/traefik:CopyIntoVolume_nztgskqyutze into /mnt/v/traefik in 70.423919ms 
2026-04-17T10:48:17.525 Exec chown -R 1000 /mnt/v/traefik stdout=, stderr=, err=<nil> 
2026-04-17T10:48:18.049 Copied global Traefik config in /home/stas/.ddev/traefik to ddev-global-cache/traefik volume 
2026-04-17T10:48:19.910 Removed stale traefik configs from volume: [README.txt] 
2026-04-17T10:48:21.929 Removed stale traefik certs from volume: [README.txt] 
 Container ddev-router Started
...

$ DDEV_DEBUG=true ddev start
...
2026-04-17T10:48:59.074 Copied cert php-2023.crt from project php-2023 to global traefik certs dir 
2026-04-17T10:48:59.076 Copied cert php-2023.key from project php-2023 to global traefik certs dir 
2026-04-17T10:48:59.127 Copied /home/stas/.ddev/traefik:ddev-router into /mnt/ddev-global-cache/traefik in 43.733036ms 
2026-04-17T10:48:59.163 Copied global Traefik config in /home/stas/.ddev/traefik directly to router container ddev-router 
2026-04-17T10:49:01.213 Removed stale traefik configs from volume: [README.txt] 
2026-04-17T10:49:02.689 Removed stale traefik certs from volume: [README.txt] 
2026-04-17T10:49:02.700 Forcing router healthcheck to clear status 
Waiting for ddev-router to become ready...
...
```

## How This PR Solves The Issue

Adds `README.txt` to expected files.

## Manual Testing Instructions

No more "Removed stale traefik ...":

```
$ ddev poweroff

$ DDEV_DEBUG=true ddev start
...
2026-04-17T10:49:58.746 Copied cert php-2023.crt from project php-2023 to global traefik certs dir 
2026-04-17T10:49:58.748 Copied cert php-2023.key from project php-2023 to global traefik certs dir 
2026-04-17T10:49:59.259 Copied /home/stas/.ddev/traefik:CopyIntoVolume_yndnqlobudqr into /mnt/v/traefik in 43.385486ms 
2026-04-17T10:49:59.292 Exec chown -R 1000 /mnt/v/traefik stdout=, stderr=, err=<nil> 
2026-04-17T10:49:59.456 Copied global Traefik config in /home/stas/.ddev/traefik to ddev-global-cache/traefik volume 
 Container ddev-router Started
...

$ DDEV_DEBUG=true ddev start
...
2026-04-17T10:50:46.525 Copied cert php-2023.crt from project php-2023 to global traefik certs dir 
2026-04-17T10:50:46.526 Copied cert php-2023.key from project php-2023 to global traefik certs dir 
2026-04-17T10:50:46.576 Copied /home/stas/.ddev/traefik:ddev-router into /mnt/ddev-global-cache/traefik in 42.730371ms 
2026-04-17T10:50:46.612 Copied global Traefik config in /home/stas/.ddev/traefik directly to router container ddev-router 
2026-04-17T10:50:48.821 Forcing router healthcheck to clear status 
Waiting for ddev-router to become ready...
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
