### PR TITLE
test(wsl): mkcert installation on Windows too hard for WSL

### DIFF
--- a/cmd/ddev/cmd/utility-tls-diagnose_test.go
+++ b/cmd/ddev/cmd/utility-tls-diagnose_test.go
@@ -173,6 +173,13 @@ func TestTLSDiagnoseCommandRegistered(t *testing.T) {
 // on a machine where mkcert is properly installed (i.e. every DDEV dev/CI
 // machine). Verifies the function finds the CA files and returns no issues.
 func TestCheckMkcertInstallationHealthy(t *testing.T) {
+	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && nodeps.IsWSL2() {
+		// Especially on Buildkite runners, the CAROOT is not set
+		// to come through from Windows side (buildkite-agent does not inherit it)
+		// Unfortunately skip this, but it works on a properly configured Windows machine
+		t.Skip("mkcert installation checks are unreliable on WSL2 in CI — skip unless DDEV_RUN_TEST_ANYWAY=true")
+	}
+
 	caRoot := realCARoot(t)
 
 	// Verify the files mkcert -install creates actually exist before calling


### PR DESCRIPTION

## The Issue

After the `ddev utility tls-diagnose` tests went in, we had a bunch of WSL test failures:
* https://github.com/ddev/ddev/actions/runs/24570248316/job/71841112544
* https://buildkite.com/ddev/wsl2-docker-desktop/builds/7029
* https://buildkite.com/ddev/wsl2-mirrored/builds/936

The problem are:
* buildkite-agent doesn't inherit WSL environment variables like CAROOT
* On the GitHub wsl test, we don't have adequate access to the Windows side to set CAROOT and WSLENV properly

## How This PR Solves The Issue

It's not worth chasing, and the buildite environment wouldn't be representative anyway.

Skip the test on WSL