### PR TITLE
test(wsl): fix CAROOT propagation for buildkite-agent on WSL2

### DIFF
--- a/cmd/ddev/cmd/utility-port-diagnose_test.go
+++ b/cmd/ddev/cmd/utility-port-diagnose_test.go
@@ -319,6 +319,12 @@ func TestFindWindowsPortProcesses(t *testing.T) {
 	if !hasCommand("powershell.exe") {
 		t.Skip("powershell.exe not available")
 	}
+	// In WSL2 mirrored networking mode, listeners created via WSL2 interop
+	// (exec.Command("powershell.exe")) are not visible to Get-NetTCPConnection.
+	// Native Windows applications are still detectable; this test setup is not.
+	if nodeps.IsWSL2MirroredMode() {
+		t.Skip("Get-NetTCPConnection cannot see WSL2-interop-created listeners in mirrored networking mode")
+	}
 
 	port := getFreePort(t)
 

--- a/cmd/ddev/cmd/utility-tls-diagnose_test.go
+++ b/cmd/ddev/cmd/utility-tls-diagnose_test.go
@@ -173,14 +173,14 @@ func TestTLSDiagnoseCommandRegistered(t *testing.T) {
 // on a machine where mkcert is properly installed (i.e. every DDEV dev/CI
 // machine). Verifies the function finds the CA files and returns no issues.
 func TestCheckMkcertInstallationHealthy(t *testing.T) {
-	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && nodeps.IsWSL2() {
-		// Especially on Buildkite runners, the CAROOT is not set
-		// to come through from Windows side (buildkite-agent does not inherit it)
-		// Unfortunately skip this, but it works on a properly configured Windows machine
-		t.Skip("mkcert installation checks are unreliable on WSL2 in CI — skip unless DDEV_RUN_TEST_ANYWAY=true")
-	}
-
 	caRoot := realCARoot(t)
+
+	if nodeps.IsWSL2() && !strings.HasPrefix(caRoot, "/mnt/") && nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") {
+		// buildkite-agent (systemd) doesn't inherit WSLENV, so CAROOT points to the
+		// Linux-local mkcert dir rather than the shared Windows one. Skip until the
+		// runner hooks/environment is configured to set CAROOT from the Windows registry.
+		t.Skipf("CAROOT (%s) doesn't point to Windows filesystem on WSL2 — hooks/environment not yet configured; skip unless DDEV_RUN_TEST_ANYWAY=true", caRoot)
+	}
 
 	// Verify the files mkcert -install creates actually exist before calling
 	// the function, so any failure is attributable to the function itself.
@@ -376,12 +376,16 @@ func TestCheckLiveConnectivityWithProject(t *testing.T) {
 	require.Contains(t, out, "TLS verified", "output must confirm Linux-side TLS success")
 
 	if nodeps.IsWSL2() {
-		// The Windows-side check must have run.
-		require.Contains(t, out, "Checking Windows trust", "Windows-side connectivity check must run on WSL2")
-		// Windows must also trust the certificate on a properly configured WSL2 machine
-		// (mkcert -install run on Windows, CAROOT shared via WSLENV).
-		require.False(t, windowsIssues, "Windows-side TLS connection to running project must succeed on WSL2")
-		require.Contains(t, out, "Windows Invoke-WebRequest: TRUSTED", "Windows must trust the DDEV certificate")
+		caRootIsWindowsMount := strings.HasPrefix(caRoot, "/mnt/")
+		if caRootIsWindowsMount || !nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") {
+			// Windows-side check: only assert when CAROOT points to the shared Windows CA
+			// (buildkite-agent with hooks/environment configured) or forced via env var.
+			require.Contains(t, out, "Checking Windows trust", "Windows-side connectivity check must run on WSL2")
+			require.False(t, windowsIssues, "Windows-side TLS connection to running project must succeed on WSL2")
+			require.Contains(t, out, "Windows Invoke-WebRequest: TRUSTED", "Windows must trust the DDEV certificate")
+		} else {
+			t.Logf("Skipping Windows connectivity assertions: CAROOT=%s is not a Windows mount — buildkite-agent likely lacks WSLENV propagation", caRoot)
+		}
 	}
 }
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -208,3 +208,28 @@ Then the Buildkite agent must be configured with tags `colima_vz=true`.
 3. `docker context use lima-lima-vz`
 
 Then the Buildkite agent must be configured with tags `lima=true`.
+
+## Running Targeted Builds on Specific Pipelines
+
+To test a branch against only selected pipelines (e.g. WSL2 only) or to run a subset of tests without waiting for the full matrix:
+
+1. Push your branch to upstream.
+2. In the [Buildkite dashboard](https://buildkite.com/ddev), open the pipeline you want (e.g. "wsl2-docker-inside").
+3. Click **New Build** and set the branch to your branch name.
+4. Expand **Environment Variables** and add:
+
+    ```
+    TESTARGS=-run TestCheck -failfast
+    ```
+
+    Adjust the `-run` pattern to match the tests you want. Use a common prefix where possible. If you need `|` for alternation, wrap the regex in single quotes so the shell does not interpret the pipe as a pipeline operator:
+
+    ```
+    TESTARGS=-run 'TestCheckLiveConnectivity|TestCheckMkcertInstallation' -failfast
+    ```
+
+    `TESTARGS` defaults to `-failfast` when not set, so include `-failfast` explicitly if you want it.
+
+5. Click **Create Build**.
+
+Use `[skip ci]` in your commit message to prevent all pipelines from triggering automatically when you push, then manually trigger only the pipelines you need.

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -55,15 +55,25 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     hostAddressLoopback=true
     ```
 
-7. In the Ubuntu distro:
+7. **Before running the setup script**, configure mkcert CAROOT on Windows (PowerShell as the testbot user). This must happen first so that `mkcert -install` in WSL2 installs the Windows CA (not a separate Linux-local one) into the Linux trust store:
+
+    ```powershell
+    choco install mkcert -y   # if not already installed
+    mkcert -install
+    setx CAROOT (mkcert -CAROOT)
+    setx WSLENV "CAROOT/up"
+    wsl --terminate Ubuntu    # restart distro so WSLENV takes effect
+    ```
+
+8. In the Ubuntu distro:
     1. `export BUILDKITE_AGENT_TOKEN=<token>` with the token from 1Password `BUILDKITE_AGENT_TOKEN`.
     2. `export BUILDKITE_DOCKER_TYPE=dockerforwindows` or `export BUILDKITE_DOCKER_TYPE=wsl2`
     3. Optionally `export NGROK_TOKEN=<token>` with the `NGROK_TOKEN` from 1Password ngrok.com `nopaid` account.
-    4. Run the script [wsl2-test-runner-setup.sh](scripts/wsl2-test-runner-setup.sh) in the Ubuntu distro.
-8. Restart the distro with `wsl.exe -t Ubuntu` and then restart it by opening the Ubuntu window.
-9. If using Docker Desktop, start Docker Desktop.
-10. In `~/workspace/ddev/.buildkite`, run `./testbot_maintenance.sh`.
-11. In `~/workspace/ddev/.buildkite`, run `./sanetestbot.sh` to check your work.
+    4. Run the script [wsl2-test-runner-setup.sh](scripts/wsl2-test-runner-setup.sh) in the Ubuntu distro. This script reads `CAROOT` from the Windows registry via `powershell.exe`, exports it before calling `mkcert -install`, and then creates `/etc/buildkite-agent/hooks/environment` to repeat this for every buildkite-agent job (since systemd does not propagate `WSLENV`).
+9. Restart the distro with `wsl.exe -t Ubuntu` and then restart it by opening the Ubuntu window.
+10. If using Docker Desktop, start Docker Desktop.
+11. In `~/workspace/ddev/.buildkite`, run `./testbot_maintenance.sh`.
+12. In `~/workspace/ddev/.buildkite`, run `./sanetestbot.sh` to check your work.
 
 ## Icinga2 monitoring setup for WSL2 instances
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -222,7 +222,7 @@ To test a branch against only selected pipelines (e.g. WSL2 only) or to run a su
     TESTARGS=-run TestCheck -failfast
     ```
 
-    Adjust the `-run` pattern to match the tests you want. Use a common prefix where possible. If you need `|` for alternation, wrap the regex in single quotes so the shell does not interpret the pipe as a pipeline operator:
+    Adjust the `-run` pattern to match the tests you want. Use a common prefix where possible. If you need `|` for alternation, wrap the regular expression in single quotes so the shell does not interpret the pipe as a pipeline operator:
 
     ```
     TESTARGS=-run 'TestCheckLiveConnectivity|TestCheckMkcertInstallation' -failfast

--- a/docs/content/developers/scripts/wsl2-test-runner-setup.sh
+++ b/docs/content/developers/scripts/wsl2-test-runner-setup.sh
@@ -78,7 +78,45 @@ else
   echo "NGROK_TOKEN not set so not doing ngrok authtoken"
 fi
 
+# Ensure Windows System32 is in PATH so powershell.exe is accessible from WSL2
+export PATH="$PATH:/mnt/c/Windows/System32:/mnt/c/Windows/System32/WindowsPowerShell/v1.0"
+
+# Resolve CAROOT from Windows User environment BEFORE mkcert -install.
+# mkcert -install must use the Windows CAROOT so it installs that CA (not a fresh
+# Linux-local one) into the Linux trust store. Without this, Windows and Linux end
+# up with different CAs and TLS verification fails cross-side.
+if command -v powershell.exe >/dev/null 2>&1; then
+  WIN_CAROOT=$(powershell.exe -NoProfile -NonInteractive -Command \
+    "[System.Environment]::GetEnvironmentVariable('CAROOT', 'User')" 2>/dev/null | tr -d '\r\n')
+  if [ -n "$WIN_CAROOT" ]; then
+    export CAROOT=$(wslpath "$WIN_CAROOT")
+    echo "Using Windows CAROOT: $CAROOT"
+  else
+    echo "WARNING: Could not read CAROOT from Windows environment. Ensure mkcert is installed on Windows and CAROOT/WSLENV are set before running this script." >&2
+  fi
+fi
+
 mkcert -install
+
+# Configure buildkite-agent hooks/environment so every CI job inherits CAROOT.
+# systemd does not propagate WSLENV, so the hook reads CAROOT directly from the
+# Windows User environment registry on each build.
+sudo mkdir -p /etc/buildkite-agent/hooks
+sudo tee /etc/buildkite-agent/hooks/environment > /dev/null <<'HOOKEOF'
+#!/bin/bash
+# Make Windows executables (powershell.exe, cmd.exe) accessible
+export PATH="$PATH:/mnt/c/Windows/System32:/mnt/c/Windows/System32/WindowsPowerShell/v1.0"
+
+# Propagate CAROOT from Windows registry — systemd does not inherit WSLENV.
+if command -v powershell.exe >/dev/null 2>&1 && [ -z "${CAROOT:-}" ]; then
+  WIN_CAROOT=$(powershell.exe -NoProfile -NonInteractive -Command \
+    "[System.Environment]::GetEnvironmentVariable('CAROOT', 'User')" 2>/dev/null | tr -d '\r\n')
+  if [ -n "$WIN_CAROOT" ]; then
+    export CAROOT=$(wslpath "$WIN_CAROOT")
+  fi
+fi
+HOOKEOF
+sudo chmod +x /etc/buildkite-agent/hooks/environment
 
 echo "In the editor, change the home directory of buildkite-agent to /var/lib/buildkite-agent"
 echo "Press any key to continue..."

--- a/docs/content/developers/scripts/wsl2-test-runner-setup.sh
+++ b/docs/content/developers/scripts/wsl2-test-runner-setup.sh
@@ -116,6 +116,7 @@ if command -v powershell.exe >/dev/null 2>&1 && [ -z "${CAROOT:-}" ]; then
   fi
 fi
 HOOKEOF
+sudo chown buildkite-agent:buildkite-agent /etc/buildkite-agent/hooks/environment
 sudo chmod +x /etc/buildkite-agent/hooks/environment
 
 echo "In the editor, change the home directory of buildkite-agent to /var/lib/buildkite-agent"


### PR DESCRIPTION
## The Issue

On WSL2 Buildkite runners, `buildkite-agent` runs via systemd and never inherits `WSLENV`, so `CAROOT` was unset or pointed to a Linux-local mkcert directory rather than the shared Windows CA. This caused two problems:

1. `mkcert -install` in the WSL2 setup script installed a fresh Linux-local CA instead of the Windows CA, so Linux and Windows ended up with different CAs
2. `TestCheckLiveConnectivityWithProject` unconditionally asserted Windows PowerShell connectivity on any WSL2 machine, failing whenever the buildkite-agent environment lacked the Windows CAROOT

## How This PR Solves The Issue

- `wsl2-test-runner-setup.sh` now reads `CAROOT` from the Windows User environment registry via `powershell.exe` before calling `mkcert -install`, ensuring the correct CA is installed into the Linux trust store. It then creates `/etc/buildkite-agent/hooks/environment` which repeats this on every CI job, bypassing the WSLENV/systemd propagation gap.
- `test.sh` uses `${TESTARGS:--failfast}` so targeted test runs can be triggered by setting `TESTARGS` in the Buildkite pipeline env or UI.
- `TestCheckLiveConnectivityWithProject`: Linux TLS assertions always run; Windows assertions only fire when `CAROOT` points to a Windows mount (`/mnt/...`) or `DDEV_RUN_TEST_ANYWAY=true`. GitHub Actions WSL2 (NAT mode, Linux-only mkcert) is handled gracefully by the same condition — headless Windows CA installation is not possible on GitHub Actions runners.
- `TestCheckMkcertInstallationHealthy`: same CAROOT-based conditional replaces the blanket WSL2 skip, so it runs fully on properly configured machines and skips gracefully elsewhere.
- `buildkite-testmachine-setup.md`: documents the Windows-side mkcert/CAROOT/WSLENV prerequisite and adds a "Running Targeted Builds" section explaining TESTARGS overrides and the single-quote workaround for `|` in test filters.

## Manual Testing Instructions

- Configured and validated `/etc/buildkite-agent/hooks/environment` on tb-wsl-12, tb-wsl-14, and tb-wsldd-16
- Triggered targeted Buildkite builds (`TESTARGS=-run TestCheck -failfast`) on wsl2-mirrored and wsl2-docker-inside pipelines — both `TestCheckMkcertInstallationHealthy` and `TestCheckLiveConnectivityWithProject` passed with Windows assertions firing

## Automated Testing Overview

Tests self-adjust based on whether `CAROOT` points to a Windows filesystem mount. No new test infrastructure required. GitHub Actions WSL2 (NAT mode) is handled by the existing skip condition — headless Windows CA trust installation is not feasible on GitHub Actions runners (confirmed via mkcert issue #358).

## Release/Deployment Notes

The three Buildkite WSL2 runners (tb-wsl-12, tb-wsl-14, tb-wsldd-16) have already had `/etc/buildkite-agent/hooks/environment` configured manually. The updated `wsl2-test-runner-setup.sh` ensures future runner setup does this automatically.
