### PR TITLE
build(ci): remove -failfast, support MAKE_TARGET/TESTPKG/TESTFILE for targeted test runs, increase timeout to 6h

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -362,7 +362,7 @@ if [ "${os:-}" = "windows" ]; then
   echo "Windows installer tests completed successfully"
 fi
 
-make test TESTARGS="${TESTARGS:-}" | sed -u 's/^--- /=== /; /\//!s/^=== RUN /--- RUN /'
+make ${MAKE_TARGET:-test} TESTARGS="${TESTARGS:-}" TESTPKG="${TESTPKG:-}" TESTFILE="${TESTFILE:-}" | sed -u 's/^--- /=== /; /\//!s/^=== RUN /--- RUN /'
 RV=$?
 echo "test.sh completed with status=$RV"
 ddev poweroff || true

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -353,7 +353,7 @@ echo "--- Running tests..."
 if [ "${os:-}" = "windows" ]; then
   echo "--- Running Windows installer tests first..."
   export DDEV_TEST_USE_REAL_INSTALLER=true
-  make testwininstaller TESTARGS="-failfast" | sed -u 's/^--- /=== /; /\//!s/^=== RUN /--- RUN /'
+  make testwininstaller TESTARGS="${TESTARGS:-}" | sed -u 's/^--- /=== /; /\//!s/^=== RUN /--- RUN /'
   INSTALLER_RV=$?
   if [ $INSTALLER_RV -ne 0 ]; then
     echo "Windows installer tests failed with status=$INSTALLER_RV"
@@ -362,7 +362,7 @@ if [ "${os:-}" = "windows" ]; then
   echo "Windows installer tests completed successfully"
 fi
 
-make test TESTARGS="-failfast" | sed -u 's/^--- /=== /; /\//!s/^=== RUN /--- RUN /'
+make test TESTARGS="${TESTARGS:-}" | sed -u 's/^--- /=== /; /\//!s/^=== RUN /--- RUN /'
 RV=$?
 echo "test.sh completed with status=$RV"
 ddev poweroff || true

--- a/.github/workflows/test-all-project-types.yml
+++ b/.github/workflows/test-all-project-types.yml
@@ -64,7 +64,7 @@ jobs:
             "TestPHPWebserverType"
             "TestWriteDrushConfig"
           )
-          TESTARGS="-failfast -run '($(IFS="|"; echo "${TP[*]}"))'"
+          TESTARGS="-run '($(IFS="|"; echo "${TP[*]}"))'"
           echo "testargs=${TESTARGS}"
           echo "testargs=${TESTARGS}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test-nginx-fpm.yml
+++ b/.github/workflows/test-nginx-fpm.yml
@@ -38,6 +38,6 @@ jobs:
     with:
       ddev_test_webserver_type: "nginx-fpm"
       ddev_skip_nodejs_test: "false"
-      testargs: "" # don't use "-failfast"
+      testargs: ""
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}

--- a/.github/workflows/test-podman-root-mutagen.yml
+++ b/.github/workflows/test-podman-root-mutagen.yml
@@ -37,7 +37,7 @@ jobs:
     secrets: inherit
     with:
       make_target: "testpkg"
-      testargs: "-failfast -run ^Test[A-G]"
+      testargs: "-run ^Test[A-G]"
       ddev_test_podman_root: "true"
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
@@ -48,7 +48,7 @@ jobs:
     secrets: inherit
     with:
       make_target: "testpkg"
-      testargs: "-failfast -run ^Test[H-Z]"
+      testargs: "-run ^Test[H-Z]"
       ddev_test_podman_root: "true"
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}

--- a/.github/workflows/test-podman-root.yml
+++ b/.github/workflows/test-podman-root.yml
@@ -37,7 +37,7 @@ jobs:
     secrets: inherit
     with:
       make_target: "testpkg"
-      testargs: "-failfast -run ^Test[A-G]"
+      testargs: "-run ^Test[A-G]"
       ddev_test_podman_root: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
@@ -47,7 +47,7 @@ jobs:
     secrets: inherit
     with:
       make_target: "testpkg"
-      testargs: "-failfast -run ^Test[H-Z]"
+      testargs: "-run ^Test[H-Z]"
       ddev_test_podman_root: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}

--- a/.github/workflows/test-podman-rootless-mutagen.yml
+++ b/.github/workflows/test-podman-rootless-mutagen.yml
@@ -37,7 +37,7 @@ jobs:
     secrets: inherit
     with:
       make_target: "testpkg"
-      testargs: "-failfast -run ^Test[A-G]"
+      testargs: "-run ^Test[A-G]"
       ddev_test_podman_rootless: "true"
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
@@ -48,7 +48,7 @@ jobs:
     secrets: inherit
     with:
       make_target: "testpkg"
-      testargs: "-failfast -run ^Test[H-Z]"
+      testargs: "-run ^Test[H-Z]"
       ddev_test_podman_rootless: "true"
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}

--- a/.github/workflows/test-podman-rootless.yml
+++ b/.github/workflows/test-podman-rootless.yml
@@ -37,7 +37,7 @@ jobs:
     secrets: inherit
     with:
       make_target: "testpkg"
-      testargs: "-failfast -run ^Test[A-G]"
+      testargs: "-run ^Test[A-G]"
       ddev_test_podman_rootless: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
@@ -47,7 +47,7 @@ jobs:
     secrets: inherit
     with:
       make_target: "testpkg"
-      testargs: "-failfast -run ^Test[H-Z]"
+      testargs: "-run ^Test[H-Z]"
       ddev_test_podman_rootless: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}

--- a/.github/workflows/test-pull-push-providers.yml
+++ b/.github/workflows/test-pull-push-providers.yml
@@ -38,6 +38,6 @@ jobs:
     secrets: inherit
     with:
       pull_push_providers: "true"
-      testargs: "-failfast -run 'Test.*(Push|Pull)'"
+      testargs: "-run 'Test.*(Push|Pull)'"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}

--- a/.github/workflows/test-race-detection.yml
+++ b/.github/workflows/test-race-detection.yml
@@ -38,7 +38,7 @@ jobs:
     with:
       cgo_enabled: "1"
       buildargs: "-race"
-      testargs: "-failfast -race"
+      testargs: "-race"
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -52,7 +52,7 @@ on:
         description: 'TESTARGS value'
         required: false
         type: string
-        default: '-failfast'
+        default: ''
       gotest_short:
         description: 'GOTEST_SHORT value'
         required: false

--- a/.github/workflows/test-wsl2.yml
+++ b/.github/workflows/test-wsl2.yml
@@ -23,7 +23,7 @@ on:
         description: 'TESTARGS value'
         type: string
         required: false
-        default: '-failfast'
+        default: ''
       gotest_short:
         description: 'GOTEST_SHORT value (16=drupal11 only)'
         type: string
@@ -49,7 +49,7 @@ permissions:
 
 env:
   GOTEST_SHORT: ${{ inputs.gotest_short || '16' }}
-  TESTARGS: ${{ inputs.testargs || '-failfast' }}
+  TESTARGS: ${{ inputs.testargs || '' }}
   MAKE_TARGET: ${{ inputs.make_target || 'test' }}
   DDEV_EMBARGO_TESTS: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
   DDEV_SKIP_NODEJS_TEST: 'true'

--- a/.github/workflows/wsl2-test.sh
+++ b/.github/workflows/wsl2-test.sh
@@ -19,7 +19,7 @@ export DOCKER_SCAN_SUGGEST=false
 export DOCKER_SCOUT_SUGGEST=false
 export CGO_ENABLED="${CGO_ENABLED:-0}"
 export BUILDARGS="${BUILDARGS:-}"
-export TESTARGS="${TESTARGS:--failfast}"
+export TESTARGS="${TESTARGS:-}"
 export MAKE_TARGET="${MAKE_TARGET:-test}"
 export PATH="/usr/local/go/bin:$PATH"
 

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ $(GOTMP)/bin/darwin_arm64/mkcert $(GOTMP)/bin/darwin_amd64/mkcert $(GOTMP)/bin/l
 	mkdir -p $(GOTMP)/bin/$${GOOS}_$${GOARCH} && \
 	$(CURL) --fail -JL -s -S --retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors -o $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert "https://github.com/FiloSottile/mkcert/releases/download/$${MKCERT_VERSION}/mkcert-$${MKCERT_VERSION}-$${GOOS}-$${GOARCH}" && chmod +x $(GOTMP)/bin/$${GOOS}_$${GOARCH}/mkcert
 
-TEST_TIMEOUT=4h
+TEST_TIMEOUT=6h
 BUILD_ARCH = $(shell go env GOARCH)
 
 DDEVNAME=ddev
@@ -130,15 +130,6 @@ SHASUM=shasum -a 256
 ifeq ($(BUILD_OS),windows)
 	DDEVNAME=ddev.exe
 	SHASUM=sha256sum
-	TEST_TIMEOUT=6h
-endif
-
-ifeq ($(DDEV_TEST_PODMAN_ROOTLESS),true)
-	TEST_TIMEOUT=6h
-endif
-
-ifeq ($(DDEV_TEST_PODMAN_ROOT),true)
-	TEST_TIMEOUT=6h
 endif
 
 DDEV_PATH=$(PWD)/$(GOTMP)/bin/$(BUILD_OS)_$(BUILD_ARCH)

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,24 @@ testfullsitesetup: $(DEFAULT_BUILD) setup
 	@$(DDEV_BINARY_FULLPATH) version
 	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " ./pkg/ddevapp -run TestDdevFullSiteSetup $(TESTARGS)
 
+testonepkg: $(DEFAULT_BUILD) setup
+	@echo "Running ddev version check..."
+	@$(DDEV_BINARY_FULLPATH) version
+	@if [ -z "$(TESTPKG)" ]; then echo "ERROR: TESTPKG must be set, e.g., make testonepkg TESTPKG=./pkg/dockerutil"; exit 1; fi
+	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " $(TESTPKG) $(TESTARGS)
+
+# testonefile runs all tests found in a single _test.go file.
+# Usage: make testonefile TESTFILE=./pkg/ddevapp/ddevapp_test.go [TESTARGS="-count=1"]
+testonefile: $(DEFAULT_BUILD) setup
+	@echo "Running ddev version check..."
+	@$(DDEV_BINARY_FULLPATH) version
+	@if [ -z "$(TESTFILE)" ]; then echo "ERROR: TESTFILE must be set, e.g., make testonefile TESTFILE=./cmd/ddev/cmd/utility-tls-diagnose_test.go"; exit 1; fi
+	@export TESTPKG_DIR=$$(dirname "$(TESTFILE)"); \
+	export TESTFUNCS=$$(grep -E '^func Test' "$(TESTFILE)" | sed 's/func \(Test[^(]*\).*/\1/' | tr '\n' '|' | sed 's/|$$//'); \
+	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); \
+	echo "Testing $$TESTPKG_DIR with -run $$TESTFUNCS"; \
+	go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " $$TESTPKG_DIR -run "$$TESTFUNCS" $(TESTARGS)
+
 testwininstaller: windows_amd64_install
 	@echo "Running Windows installer tests..."
 	export DDEV_TEST_USE_REAL_INSTALLER=true; go test -p 1 -timeout 30m -v ./winpkg -run TestWindowsInstaller $(TESTARGS)

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -281,6 +281,12 @@ Use `GOTEST_SHORT=true` to run one CMS in each test, or `GOTEST_SHORT=<integer>`
 
 To run a test (in the `cmd` package) against a individually-compiled DDEV binary, set the `DDEV_BINARY_FULLPATH` environment variable, for example `DDEV_BINARY_FULLPATH=$PWD/.gotmp/bin/linux_amd64/ddev make testcmd`.
 
+To run all tests in a specific package, use `make testonepkg TESTPKG=./pkg/dockerutil`. Combine with `TESTARGS` to filter further, for example `make testonepkg TESTPKG=./pkg/dockerutil TESTARGS="-run TestDockerUtils"`.
+
+To run all tests defined in a single `_test.go` file, use `make testonefile TESTFILE=./cmd/ddev/cmd/utility-tls-diagnose_test.go`. This automatically extracts the test function names from the file and builds the `-run` pattern.
+
+When triggering a custom Buildkite or GitHub Actions run, the same targets are available via environment variables: set `MAKE_TARGET=testonepkg` with `TESTPKG=./pkg/dockerutil`, or `MAKE_TARGET=testonefile` with `TESTFILE=./cmd/ddev/cmd/utility-tls-diagnose_test.go`.
+
 The easiest way to run tests is using GoLand (or VS Code) with their built-in test runners and debuggers. You can step through a specific test; you can stop at the point before the failure and experiment with the site that the test has set up.
 
 ## Automated Testing


### PR DESCRIPTION
## The Issue

There was no easy way to run a targeted subset of tests (a specific package or a single `_test.go` file) from the command line or from a custom Buildkite build. Additionally, `-failfast` was hard-coded throughout CI, preventing tests from running to completion and making it impossible to override via environment variable.

## How This PR Solves The Issue

- Removes `-failfast` as a hard-coded default from `.buildkite/test.sh`, `.github/workflows/wsl2-test.sh`, and all GitHub Actions workflow files that passed it via `testargs`. It can still be passed explicitly when needed.
- Adds two new Makefile targets:
  - `testonepkg` — runs all tests in a specified package (`TESTPKG=./pkg/dockerutil`)
  - `testonefile` — runs all tests found in a single `_test.go` file (`TESTFILE=./cmd/ddev/cmd/utility-tls-diagnose_test.go`), auto-extracting test function names into a `-run` pattern
- Updates `.buildkite/test.sh` to use `${MAKE_TARGET:-test}` and pass `TESTPKG`/`TESTFILE` through to make, matching the existing pattern in `.github/workflows/wsl2-test.sh`
- Documents the new targets and Buildkite env var usage in `docs/content/developers/building-contributing.md`
- Increases default timeout for all environments to 6h

## Manual Testing Instructions

**From the command line:**

1. Run a specific package:
   ```
   make testonepkg TESTPKG=./pkg/dockerutil
   ```

2. Run all tests in a single file:
   ```
   make testonefile TESTFILE=./cmd/ddev/cmd/utility-tls-diagnose_test.go
   ```
   Verify the output shows `Testing ./cmd/ddev/cmd with -run TestTLSDiagnose...|...` and only those tests run.

3. Combine with TESTARGS:
   ```
   TESTARGS="-run TestTLSDiagnoseCommandRegistered" make testcmd
   ```
   Verify only the one named test runs.

4. Verify normal `make test` still works without `-failfast`:
   ```
   make test
   ```
   Confirm tests run to completion even if one fails (no early exit).

**From a custom Buildkite build:**

1. Click "New Build" on the wsl2-mirrored pipeline (or any Buildkite pipeline using `.buildkite/test.sh`).
2. Set branch to this PR's branch.
3. In the Environment Variables box, enter:
   ```
   MAKE_TARGET=testonefile
   TESTFILE=./cmd/ddev/cmd/utility-tls-diagnose_test.go
   ```
4. Trigger the build and confirm only the tests from that file run.

5. Repeat with:
   ```
   MAKE_TARGET=testonepkg
   TESTPKG=./pkg/dockerutil
   ```
   Confirm only the `dockerutil` package tests run.

## Automated Testing Overview

No new automated tests added — the changes are to the test infrastructure itself. The new Makefile targets were verified locally: `make testonefile TESTFILE=./cmd/ddev/cmd/utility-tls-diagnose_test.go` ran all 26 tests in that file (1 skipped as expected on WSL2) in ~74s.

## Release/Deployment Notes

No user-facing changes. CI behavior change: tests no longer stop at the first failure by default, so CI runs will now report all failures in a run rather than just the first. Workflows that need failfast can still pass `testargs: "-failfast"` explicitly.